### PR TITLE
feat(llc/frontend): render teams as a first-class canvas grouping, distinct from reporting units (#14596)

### DIFF
--- a/autobot-frontend/src/composables/llc/__tests__/orgCanvasGraph.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/orgCanvasGraph.test.ts
@@ -9,13 +9,18 @@
 import { describe, it, expect } from 'vitest'
 import {
   buildOrgCanvasGraph,
+  buildTeamCanvasNodes,
   flattenOrgNodes,
   orgLayoutKey,
   isOrgUnit,
   orgUnitRoots,
+  teamMemberOrgNodeId,
   ORG_GROUP_PREFIX,
+  TEAM_GROUP_PREFIX,
 } from '../orgCanvasGraph'
 import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+import { buildOrgPeople } from '../orgPeople'
+import type { CompanyTeam } from '../orgPeople'
 
 function node(id: string, children: OrgNode[] = []): OrgNode {
   return {
@@ -248,5 +253,97 @@ describe('grouping is by descendants, not root-ness (#13994)', () => {
     expect(isOrgUnit({ ...FOREST[1], children: undefined as unknown as OrgNode[] })).toBe(false)
     expect(orgUnitRoots([...FOREST, ...PEOPLE_ONLY]).map((r) => r.id)).toEqual(['ceo'])
     expect(orgUnitRoots(PEOPLE_ONLY)).toEqual([])
+  })
+})
+
+// GH#14596: teams as a first-class canvas grouping — a different question
+// than `isOrgUnit`'s reporting units ("who reports to whom" vs "who works
+// together"), read from the same `groupPeopleByTeam` the People list uses.
+describe('buildTeamCanvasNodes (#14596)', () => {
+  const alice = person('user:alice', 'Alice')
+  const bob = person('user:bob', 'Bob')
+  const charlie = node('agent:charlie') // an agent — never a team member (#13938)
+  const TEAM_FOREST: OrgNode[] = [alice, bob, charlie]
+  const teamPeople = buildOrgPeople(TEAM_FOREST, [])
+  const byId = flattenOrgNodes(TEAM_FOREST)
+  const teamLabel = (name: string) => `TEAM ${name}`
+  const UNGROUPED_LABEL = 'UNGROUPED'
+
+  const TWO_TEAMS: CompanyTeam[] = [
+    { id: 't1', name: 'Platform', member_user_ids: ['alice', 'bob'] },
+    { id: 't2', name: 'Growth', member_user_ids: ['alice'] },
+  ]
+
+  it('draws a team container in its own id namespace, distinct from a reporting-unit container', () => {
+    const graph = buildTeamCanvasNodes(byId, teamPeople, TWO_TEAMS, 0, teamLabel, UNGROUPED_LABEL)
+    const groups = graph.filter((n) => n.type === 'org-group')
+
+    expect(groups.map((g) => g.id).sort()).toEqual(
+      [`${TEAM_GROUP_PREFIX}t1`, `${TEAM_GROUP_PREFIX}t2`, `${TEAM_GROUP_PREFIX}__no_team__`].sort(),
+    )
+    // The discriminator a mutation would break: a team container never
+    // carries the reporting-unit prefix, and vice versa.
+    for (const group of groups) {
+      expect(group.id.startsWith(TEAM_GROUP_PREFIX)).toBe(true)
+      expect(group.id.startsWith(ORG_GROUP_PREFIX)).toBe(false)
+    }
+    expect(groups.map((g) => g.data.label).sort()).toEqual(
+      ['TEAM Growth', 'TEAM Platform', 'UNGROUPED'].sort(),
+    )
+  })
+
+  it('draws one node per (team, person) pair — a person on two teams appears in each, same identity', () => {
+    const graph = buildTeamCanvasNodes(byId, teamPeople, TWO_TEAMS, 0, teamLabel, UNGROUPED_LABEL)
+    const aliceNodes = graph.filter((n) => n.type === 'org-person' && n.data.label === 'Alice')
+
+    // Two distinct canvas nodes (t1 and t2 each get their own)…
+    expect(aliceNodes).toHaveLength(2)
+    expect(new Set(aliceNodes.map((n) => n.id)).size).toBe(2)
+    // …but both resolve back to the exact same real org-chart identity — the
+    // duplication is visual, not a second person invented from nothing.
+    for (const aliceNode of aliceNodes) {
+      expect(teamMemberOrgNodeId(aliceNode.id)).toBe('user:alice')
+    }
+  })
+
+  it('puts a person on no team in the honest ungrouped bucket, never dropped', () => {
+    const graph = buildTeamCanvasNodes(byId, teamPeople, TWO_TEAMS, 0, teamLabel, UNGROUPED_LABEL)
+    const ungroupedContainer = graph.find((n) => n.id === `${TEAM_GROUP_PREFIX}__no_team__`)!
+    const charlieNodes = graph.filter(
+      (n) => n.type === 'org-person' && teamMemberOrgNodeId(n.id) === 'agent:charlie',
+    )
+
+    expect(ungroupedContainer.data.label).toBe(UNGROUPED_LABEL)
+    // Alice and Bob are both claimed by a team, so charlie is the only
+    // member of the ungrouped bucket — and mutating either predicate above
+    // must not silently absorb charlie into a team he was never added to.
+    expect(charlieNodes).toHaveLength(1)
+  })
+
+  it('draws nothing when the company has zero teams — the caller states that fact in words instead', () => {
+    expect(buildTeamCanvasNodes(byId, teamPeople, [], 0, teamLabel, UNGROUPED_LABEL)).toEqual([])
+  })
+
+  it('still draws an empty team as an empty container, rather than dropping it', () => {
+    const emptyTeam: CompanyTeam[] = [{ id: 't3', name: 'Marketing', member_user_ids: [] }]
+    const graph = buildTeamCanvasNodes(byId, teamPeople, emptyTeam, 0, teamLabel, UNGROUPED_LABEL)
+    const marketing = graph.find((n) => n.id === `${TEAM_GROUP_PREFIX}t3`)!
+    // Nobody claims the team, so everyone (alice, bob, charlie) falls into
+    // the ungrouped bucket instead — that bucket's people are not what this
+    // assertion is about, so it is scoped to `t3`'s own roster alone.
+    const marketingMembers = graph.filter((n) => n.id.startsWith(`${TEAM_GROUP_PREFIX}t3:member:`))
+
+    expect(marketing).toBeDefined()
+    expect(marketing.data.label).toBe('TEAM Marketing')
+    expect(marketingMembers).toHaveLength(0)
+  })
+
+  it('resolves a team-member canvas id back to the real org-chart id, and rejects anything else', () => {
+    expect(teamMemberOrgNodeId(`${TEAM_GROUP_PREFIX}t1:member:user:alice`)).toBe('user:alice')
+    // Not a team-member id at all — a reporting-unit container, a bare
+    // person, a process node: none of these should resolve to anything.
+    expect(teamMemberOrgNodeId(`${ORG_GROUP_PREFIX}ceo`)).toBeNull()
+    expect(teamMemberOrgNodeId('ceo')).toBeNull()
+    expect(teamMemberOrgNodeId(`${TEAM_GROUP_PREFIX}t1`)).toBeNull()
   })
 })

--- a/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
@@ -26,6 +26,8 @@
 import type { CanvasNode } from '@/components/workflow/canvasNode'
 import { CANVAS_NODE_WIDTH } from '@/components/workflow/canvasNode'
 import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+import type { CompanyTeam, OrgPerson } from './orgPeople'
+import { UNGROUPED_TEAM_ID, groupPeopleByTeam } from './orgPeople'
 
 /** Horizontal distance between two depth levels. */
 const COLUMN_GAP = 80
@@ -297,4 +299,160 @@ export function workflowIdFromProcessNode(nodeId: string): string | null {
 /** Lowest edge of a laid-out graph, so later sections start below it. */
 export function canvasBottom(nodes: CanvasNode[]): number {
   return nodes.reduce((lowest, node) => Math.max(lowest, node.position.y + ROW_HEIGHT), 0)
+}
+
+/**
+ * Teams on the canvas (GH#14596, parent #13938).
+ *
+ * `isOrgUnit`/`org-group` above answers "who reports to whom", derived from
+ * the hierarchy. A team is a different question — "who works together" — and
+ * is read from `GET .../teams` via `groupPeopleByTeam` (`orgPeople.ts`), the
+ * same function the People list already groups by, so the canvas and the
+ * People list can never disagree about who is on a team.
+ *
+ * A team container reuses the `org-group` node type rather than inventing a
+ * new one: `WorkflowCanvas.vue` sizes and renders `org-group` generically
+ * already, so a team container needs no new branch there. It is visually
+ * distinct from a reporting-unit container by construction — a different id
+ * namespace (`TEAM_GROUP_PREFIX`, never `ORG_GROUP_PREFIX`), a different
+ * caption ("<name> team" vs "<name> unit", GH#14596), and its own section
+ * below the hierarchy — not a CSS variant of the same box, which would need
+ * a change to `WorkflowCanvas.vue` this composable does not make.
+ */
+
+/**
+ * Id prefix for a team's own container, and for every duplicate member node
+ * inside it. Deliberately not `ORG_GROUP_PREFIX`: a reporting unit and a team
+ * must never collide on id, and the prefix alone is enough for a reader of
+ * the graph (or a test) to tell which kind of container a node is.
+ */
+export const TEAM_GROUP_PREFIX = 'org-team:'
+
+/** Separates a team's id from the real org-chart id inside a composite id. */
+const TEAM_MEMBER_MARK = ':member:'
+
+/**
+ * A team member's canvas id: stable and unique per (team, person) pair.
+ *
+ * Not the person's own `orgNodeId` — the same person can be on several teams,
+ * and the canvas cannot draw two nodes that share an id. It is also not a
+ * fresh, disconnected identity: the real org-chart id is embedded whole, so
+ * `teamMemberOrgNodeId` can always recover exactly who this node is.
+ */
+function teamMemberNodeId(groupId: string, orgNodeId: string): string {
+  return `${TEAM_GROUP_PREFIX}${groupId}${TEAM_MEMBER_MARK}${orgNodeId}`
+}
+
+/**
+ * The real org-chart node id behind a team-member canvas node, or `null` when
+ * `nodeId` does not name one (a team container, an `org-person` from the
+ * reporting hierarchy, a process node, …).
+ *
+ * Lets a click on a person's roster card in a team open the same drawer a
+ * click on their reporting-hierarchy node opens — the two are the same
+ * person, not two identities that happen to share a name.
+ */
+export function teamMemberOrgNodeId(nodeId: string): string | null {
+  if (!nodeId.startsWith(TEAM_GROUP_PREFIX)) return null
+  const at = nodeId.indexOf(TEAM_MEMBER_MARK)
+  if (at < 0) return null
+  const orgNodeId = nodeId.slice(at + TEAM_MEMBER_MARK.length)
+  return orgNodeId.length > 0 ? orgNodeId : null
+}
+
+/**
+ * One team's (or the ungrouped bucket's) people, packed in a grid inside
+ * their own container — a team carries no hierarchy, so it lays out like the
+ * ungrouped grid above, not like a unit's tree (#13994's same reasoning,
+ * applied to a team instead of a bare root).
+ *
+ * @returns the next free top offset, so groups stack without overlapping.
+ */
+function layoutTeamGroup(
+  groupId: string,
+  label: string,
+  members: OrgNode[],
+  topOffset: number,
+  groups: CanvasNode[],
+  memberNodes: CanvasNode[],
+): number {
+  const columns = Math.min(UNGROUPED_COLUMNS, Math.max(1, members.length))
+  const rows = Math.max(1, Math.ceil(members.length / UNGROUPED_COLUMNS))
+  const contentTop = topOffset + GROUP_HEADER + GROUP_PADDING
+  members.forEach((member, index) => {
+    memberNodes.push({
+      id: teamMemberNodeId(groupId, member.id),
+      type: 'org-person',
+      position: {
+        x: GROUP_PADDING + (index % UNGROUPED_COLUMNS) * (CANVAS_NODE_WIDTH + COLUMN_GAP),
+        y: contentTop + Math.floor(index / UNGROUPED_COLUMNS) * ROW_HEIGHT,
+      },
+      data: {
+        label: member.name,
+        title: member.title,
+        status: member.status,
+        adapter_type: member.adapter_type,
+        is_human: member.is_human,
+      },
+      // A roster is not a reporting line: nobody in it reports to anyone
+      // else in it by virtue of team membership alone.
+      connections: [],
+    })
+  })
+  groups.push({
+    id: `${TEAM_GROUP_PREFIX}${groupId}`,
+    type: 'org-group',
+    position: { x: 0, y: topOffset },
+    data: {
+      label,
+      width: 2 * GROUP_PADDING + columns * CANVAS_NODE_WIDTH + (columns - 1) * COLUMN_GAP,
+      height: GROUP_HEADER + 2 * GROUP_PADDING + rows * ROW_HEIGHT,
+    },
+    connections: [],
+  })
+  return topOffset + GROUP_HEADER + 2 * GROUP_PADDING + rows * ROW_HEIGHT + GROUP_GAP
+}
+
+/**
+ * Build the canvas rendering of the company's teams.
+ *
+ * Every member becomes its own `org-person` canvas node inside its team's
+ * container — one node per (team, person) pair, so a person on several teams
+ * appears in each without duplicating their identity (`teamMemberNodeId`).
+ * The `UNGROUPED_TEAM_ID` bucket (`orgPeople.ts`) renders the same way, so a
+ * person on no team is still a first-class, visible, labelled node — never
+ * silently dropped the way a filtered-out node would be.
+ *
+ * Only people with an `orgNodeId` are placed — a contact has none and is
+ * already absent from the canvas everywhere else (#13938); this does not
+ * introduce a new exclusion, it stays consistent with the one that exists.
+ *
+ * Draws nothing at all when the company has zero teams — mirroring
+ * `OrgPeopleList.vue`'s own `v-if="hasTeams"` gate on its group headers. A
+ * company with no teams has no team *structure* to draw a boundary around;
+ * boxing everyone into a single "not in a team" container would assert a
+ * grouping that does not exist. The honest statement for that case is the
+ * "no teams are defined" banner the caller renders beside the canvas, not an
+ * empty-of-meaning box drawn here.
+ */
+export function buildTeamCanvasNodes(
+  orgNodesById: Map<string, OrgNode>,
+  people: OrgPerson[],
+  teams: CompanyTeam[],
+  topOffset: number,
+  teamLabel: (name: string) => string,
+  ungroupedLabel: string,
+): CanvasNode[] {
+  if (teams.length === 0) return []
+  const groups: CanvasNode[] = []
+  const memberNodes: CanvasNode[] = []
+  let cursor = topOffset
+  for (const group of groupPeopleByTeam(people, teams)) {
+    const members = group.people
+      .map((person) => (person.orgNodeId ? orgNodesById.get(person.orgNodeId) : undefined))
+      .filter((node): node is OrgNode => node !== undefined)
+    const label = group.id === UNGROUPED_TEAM_ID ? ungroupedLabel : teamLabel(group.name)
+    cursor = layoutTeamGroup(group.id, label, members, cursor, groups, memberNodes)
+  }
+  return [...groups, ...memberNodes]
 }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "لوحة",
       "canvasTabAll": "كل الوحدات",
       "canvasUnit": "وحدة {name}",
+      "canvasTeam": "فريق {name}",
       "canvasHint": "اضغط Shift واسحب للتحريك، ومرّر للتكبير، وانقر على عقدة لعرض التفاصيل.",
       "viewPeople": "الأشخاص",
       "peopleLegend": "أنواع الأشخاص",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Leinwand",
       "canvasTabAll": "Alle Einheiten",
       "canvasUnit": "Einheit {name}",
+      "canvasTeam": "Team {name}",
       "canvasHint": "Umschalt+Ziehen zum Verschieben, Scrollen zum Zoomen, Knoten anklicken für Details.",
       "viewPeople": "Personen",
       "peopleLegend": "Personenarten",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8227,6 +8227,7 @@
       "viewCanvas": "Canvas",
       "canvasTabAll": "All units",
       "canvasUnit": "{name} unit",
+      "canvasTeam": "{name} team",
       "canvasHint": "Shift-drag to pan, scroll to zoom, click a node for details.",
       "viewPeople": "People",
       "peopleLegend": "Person kinds",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Lienzo",
       "canvasTabAll": "Todas las unidades",
       "canvasUnit": "Unidad {name}",
+      "canvasTeam": "Equipo {name}",
       "canvasHint": "Mayús+arrastrar para desplazar, rueda para acercar, haz clic en un nodo para ver detalles.",
       "viewPeople": "Personas",
       "peopleLegend": "Tipos de persona",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "بوم",
       "canvasTabAll": "همه واحدها",
       "canvasUnit": "واحد {name}",
+      "canvasTeam": "تیم {name}",
       "canvasHint": "برای جابه‌جایی Shift را نگه دارید و بکشید، برای بزرگ‌نمایی اسکرول کنید و برای جزئیات روی گره کلیک کنید.",
       "viewPeople": "افراد",
       "peopleLegend": "انواع افراد",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Canevas",
       "canvasTabAll": "Toutes les unités",
       "canvasUnit": "Unité {name}",
+      "canvasTeam": "Équipe {name}",
       "canvasHint": "Maj+glisser pour déplacer, molette pour zoomer, cliquez sur un nœud pour les détails.",
       "viewPeople": "Personnes",
       "peopleLegend": "Types de personne",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "קנבס",
       "canvasTabAll": "כל היחידות",
       "canvasUnit": "יחידת {name}",
+      "canvasTeam": "צוות {name}",
       "canvasHint": "Shift+גרירה להזזה, גלילה לשינוי מרחק התצוגה, לחיצה על צומת לפרטים.",
       "viewPeople": "אנשים",
       "peopleLegend": "סוגי אנשים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Audekls",
       "canvasTabAll": "Visas vienības",
       "canvasUnit": "Vienība {name}",
+      "canvasTeam": "Komanda {name}",
       "canvasHint": "Shift+vilkšana pārvieto, ritināšana tuvina, uzklikšķini uz mezgla, lai redzētu detaļas.",
       "viewPeople": "Cilvēki",
       "peopleLegend": "Personu veidi",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Płótno",
       "canvasTabAll": "Wszystkie jednostki",
       "canvasUnit": "Jednostka {name}",
+      "canvasTeam": "Zespół {name}",
       "canvasHint": "Shift+przeciągnięcie przesuwa, przewijanie przybliża, kliknij węzeł, aby zobaczyć szczegóły.",
       "viewPeople": "Osoby",
       "peopleLegend": "Rodzaje osób",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "Tela",
       "canvasTabAll": "Todas as unidades",
       "canvasUnit": "Unidade {name}",
+      "canvasTeam": "Equipa {name}",
       "canvasHint": "Shift+arrastar para deslocar, rolar para ampliar, clique num nó para ver detalhes.",
       "viewPeople": "Pessoas",
       "peopleLegend": "Tipos de pessoa",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8239,6 +8239,7 @@
       "viewCanvas": "کینوس",
       "canvasTabAll": "تمام یونٹس",
       "canvasUnit": "{name} یونٹ",
+      "canvasTeam": "{name} ٹیم",
       "canvasHint": "پین کرنے کے لیے Shift دبا کر گھسیٹیں، زوم کے لیے اسکرول کریں، تفصیلات کے لیے نوڈ پر کلک کریں۔",
       "viewPeople": "افراد",
       "peopleLegend": "افراد کی اقسام",

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -17,10 +17,12 @@ import type { CanvasNode, CanvasTab } from '@/components/workflow/canvasNode'
 import {
   buildOrgCanvasGraph,
   buildProcessCanvasNodes,
+  buildTeamCanvasNodes,
   canvasBottom,
   flattenOrgNodes,
   orgLayoutKey,
   orgUnitRoots,
+  teamMemberOrgNodeId,
   workflowIdFromProcessNode,
   ORG_GROUP_PREFIX,
 } from '@/composables/llc/orgCanvasGraph'
@@ -84,6 +86,11 @@ const peopleLoaded = ref(false)
 // "nothing", so the list never states a fact it does not know (#14064).
 const contactsFailed = ref(false)
 const teamsFailed = ref(false)
+// #14596: distinguishes "the teams request has not answered yet" from "it
+// answered with zero teams" — `teams.value` is `[]` in both cases, and the
+// canvas must never say "this company has no teams" before the request that
+// would prove it has actually completed (#14064's failure shape).
+const teamsAttempted = ref(false)
 const peopleLoading = ref(false)
 
 /**
@@ -200,21 +207,48 @@ const processCanvasNodes = computed<CanvasNode[]>(() =>
   buildProcessCanvasNodes(processNodes.value, canvasBottom(canvasNodes.value)),
 )
 
-const lensedCanvasNodes = computed<CanvasNode[]>(() => [
-  ...applyRoleLens(canvasNodes.value, roleLens.value || null),
-  // Not lensed: the role lens filters *people* by role, and a process is not a
-  // person. Hiding processes when a lens is active would remove them for a
-  // reason that does not apply to them.
-  ...processCanvasNodes.value,
-])
-const lensCounts = computed(() => roleLensCounts(canvasNodes.value, roleLens.value || null))
-
 /** Everyone in the company, of all three kinds, in one list (#13938). */
 const people = computed(() => buildOrgPeople(tree.value, contacts.value))
 
 const peopleGroups = computed(() => groupPeopleByTeam(people.value, teams.value))
 
 const peopleCounts = computed(() => countByKind(people.value))
+
+/**
+ * Teams, drawn as their own section below the units/ungrouped/process areas
+ * (#14596, parent #13938) — a team answers a different question than the
+ * reporting hierarchy `canvasNodes` draws, so it gets a visually separate
+ * area rather than nesting inside a reporting unit's `org-group`.
+ *
+ * Derived, like `processCanvasNodes`, rather than stored in `canvasNodes`
+ * (#13996): a status change flows straight through because this recomputes
+ * from `tree.value` (via `flattenOrgNodes`) on every render, with nothing
+ * dragged here to lose.
+ */
+const teamCanvasNodes = computed<CanvasNode[]>(() =>
+  buildTeamCanvasNodes(
+    flattenOrgNodes(tree.value),
+    people.value,
+    teams.value,
+    canvasBottom([...canvasNodes.value, ...processCanvasNodes.value]),
+    (name) => t('llc.orgChart.canvasTeam', { name }),
+    t('llc.orgChart.peopleNoTeam'),
+  ),
+)
+
+const lensedCanvasNodes = computed<CanvasNode[]>(() => [
+  ...applyRoleLens(canvasNodes.value, roleLens.value || null),
+  // Not lensed: the role lens filters *people* by role, and a process is not a
+  // person. Hiding processes when a lens is active would remove them for a
+  // reason that does not apply to them.
+  ...processCanvasNodes.value,
+  // #14596: a team roster is a different grouping question than the role
+  // lens's own filter, and it is never the only place a person is drawn
+  // (they are always still on the reporting-hierarchy canvas too), so it is
+  // left unlensed for the same reason process nodes are.
+  ...teamCanvasNodes.value,
+])
+const lensCounts = computed(() => roleLensCounts(canvasNodes.value, roleLens.value || null))
 
 /**
  * Load the two sources the People list needs beyond the org chart.
@@ -266,6 +300,7 @@ async function loadPeopleSources(): Promise<void> {
     teamsFailed.value = true
     logger.error('Failed to fetch company teams:', teamsResult.reason)
   }
+  teamsAttempted.value = true
   // Only a complete answer is cached; a partial one retries on re-entry.
   peopleLoaded.value = !contactsFailed.value && !teamsFailed.value
   peopleLoading.value = false
@@ -281,6 +316,10 @@ function setViewMode(mode: OrgViewMode) {
     void fetchProcessNodes()
     // #14549: the attach picker needs the role list, same lazy trigger.
     void fetchRolesForAttach()
+    // #14596: teams render on the canvas too, sharing the same lazy fetch
+    // and the same guard the People list already uses — a second entry into
+    // canvas mode does not re-request them.
+    void loadPeopleSources()
   }
 }
 
@@ -304,7 +343,11 @@ function onCanvasNodeSelected(nodeId: string | null) {
     })
     return
   }
-  const node = flattenOrgNodes(tree.value).get(nodeId)
+  // #14596: a team roster card carries a composite id (team + real person),
+  // never the bare org-chart id, so it opens the same drawer the person's
+  // reporting-hierarchy node opens rather than silently doing nothing.
+  const realNodeId = teamMemberOrgNodeId(nodeId) ?? nodeId
+  const node = flattenOrgNodes(tree.value).get(realNodeId)
   if (node) openDrawer(node)
 }
 
@@ -784,6 +827,26 @@ onMounted(() => {
       >
         {{ processMutationError }}
       </div>
+
+      <!-- #14596: teams on the canvas carry the same honest-failure distinction
+           the People list already makes (#14064, #13617, #14556) — a request
+           that failed must never read as "this company has no teams". Shown
+           only once the teams request has actually answered (or failed), so
+           the banner cannot appear before there is anything to report. -->
+      <p
+        v-if="teamsFailed"
+        class="border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-xs text-autobot-text-muted"
+        data-testid="canvas-teams-unavailable"
+      >
+        {{ t('llc.orgChart.peopleTeamsUnavailable') }}
+      </p>
+      <p
+        v-else-if="teamsAttempted && teams.length === 0"
+        class="border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-xs text-autobot-text-muted"
+        data-testid="canvas-no-teams"
+      >
+        {{ t('llc.orgChart.peopleNoTeamsDefined') }}
+      </p>
 
       <!-- GH#13943: the lens's own affordance. Shown whenever a role is
            selected, independent of whether it still matches anything, so a

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.teamCanvas.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.teamCanvas.test.ts
@@ -1,0 +1,310 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+//
+// GH#14596: teams on the Company OS canvas. `org-group` (`isOrgUnit`) answers
+// "who reports to whom" — a team answers "who works together", and until now
+// it existed only as a grouping header in the People tab. These tests pin:
+//
+//  * a team renders as its own container, in a different id namespace than a
+//    reporting-unit container — never the same box under two names;
+//  * a person on no team is still a first-class, visible, labelled canvas
+//    node — never silently dropped;
+//  * a failed teams fetch reads as "could not load", never as "this company
+//    has no teams" (#14064, #13617, #14556 — the same defect three times);
+//  * the team label renders through an RTL locale, not an English fallback.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ params: { companyId: 'c1' }, query: {} }),
+}))
+
+vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
+  useLlcCompanyContext: () => ({
+    companyId: { value: 'c1' },
+    resolveCompanyId: () => Promise.resolve('c1'),
+  }),
+}))
+
+import OrgChart from '../OrgChart.vue'
+import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
+import { ORG_GROUP_PREFIX, TEAM_GROUP_PREFIX, teamMemberOrgNodeId } from '@/composables/llc/orgCanvasGraph'
+
+const AGENT_NAME = 'Ada'
+const USER_NAME = 'Grace'
+const SOLO_NAME = 'Hana'
+const USER_ID = '11111111-1111-1111-1111-111111111111'
+const SOLO_ID = '22222222-2222-2222-2222-222222222222'
+const TEAM_NAME = 'Platform'
+
+/** A reporting unit (`ceo` has a report) plus two bare members (#13994). */
+const ORG_NODES = [
+  {
+    id: 'ceo',
+    name: AGENT_NAME,
+    title: 'CEO',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [
+      {
+        id: 'dev',
+        name: 'Deputy',
+        title: 'worker',
+        status: 'idle',
+        adapter_type: 'claude',
+        is_human: false,
+        last_heartbeat: null,
+        budget_spent: 0,
+        budget_total: 0,
+        assigned_item_count: 0,
+        parent_id: 'ceo',
+        children: [],
+      },
+    ],
+  },
+  {
+    id: `user:${USER_ID}`,
+    node_id: USER_ID,
+    name: USER_NAME,
+    title: 'lead',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+  {
+    id: `user:${SOLO_ID}`,
+    node_id: SOLO_ID,
+    name: SOLO_NAME,
+    title: 'member',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+]
+
+const TEAMS = [{ id: 't1', name: TEAM_NAME, member_user_ids: [USER_ID] }]
+
+type Fixture = {
+  teams?: unknown[]
+  teamsFail?: boolean
+}
+
+function mockApi({ teams = TEAMS, teamsFail = false }: Fixture = {}) {
+  get.mockImplementation((url: string) => {
+    if (url === '/api/llc/companies/c1/org-chart') {
+      return Promise.resolve({ nodes: structuredClone(ORG_NODES) })
+    }
+    if (url === '/api/llc/companies/c1/work-items/executor-rollup') {
+      return Promise.resolve({ cells: [] })
+    }
+    if (url === '/api/llc/companies/c1/process-nodes') {
+      return Promise.resolve({ nodes: [] })
+    }
+    if (url === '/api/llc/roles/c1') {
+      return Promise.resolve([])
+    }
+    if (url === '/api/llc/contacts/c1/involved') {
+      return Promise.resolve({ with_role: [], unassigned: [] })
+    }
+    if (url === '/api/llc/companies/c1/teams') {
+      return teamsFail
+        ? Promise.reject(new Error('teams unavailable'))
+        : Promise.resolve({ teams: structuredClone(teams) })
+    }
+    throw new Error(`unexpected GET ${url}`)
+  })
+}
+
+function makeI18n() {
+  return createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en, ar } })
+}
+
+async function mountOnCanvas(fixture?: Fixture, i18n = makeI18n()) {
+  mockApi(fixture)
+  const wrapper = mount(OrgChart, { global: { plugins: [i18n], stubs: { HireAgentModal: true } } })
+  await flushPromises()
+  await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
+  await flushPromises()
+  return { wrapper, i18n }
+}
+
+function canvasNodeIds(wrapper: Awaited<ReturnType<typeof mountOnCanvas>>['wrapper']): string[] {
+  return wrapper.findComponent(WorkflowCanvas).props('nodes').map((n: { id: string }) => n.id)
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  push.mockReset()
+  post.mockResolvedValue({})
+})
+
+describe('Teams on the canvas are a first-class grouping (#14596)', () => {
+  it('draws a team container in a different id namespace than the reporting-unit container', async () => {
+    const { wrapper } = await mountOnCanvas()
+    const ids = canvasNodeIds(wrapper)
+
+    const unitContainer = ids.find((id) => id.startsWith(ORG_GROUP_PREFIX))
+    const teamContainer = ids.find((id) => id.startsWith(TEAM_GROUP_PREFIX))
+
+    expect(unitContainer).toBe(`${ORG_GROUP_PREFIX}ceo`)
+    expect(teamContainer).toBe(`${TEAM_GROUP_PREFIX}t1`)
+    // Never the same id under two prefixes — the discriminator a mutation of
+    // either prefix constant would collapse.
+    expect(unitContainer).not.toBe(teamContainer)
+  })
+
+  it("labels the team container with the team's own name, distinct from the unit's caption", async () => {
+    const { wrapper } = await mountOnCanvas()
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as {
+      id: string
+      data: { label?: string }
+    }[]
+
+    const teamContainer = nodes.find((n) => n.id === `${TEAM_GROUP_PREFIX}t1`)!
+    const unitContainer = nodes.find((n) => n.id === `${ORG_GROUP_PREFIX}ceo`)!
+
+    expect(teamContainer.data.label).toBe(en.llc.orgChart.canvasTeam.replace('{name}', TEAM_NAME))
+    expect(unitContainer.data.label).toBe(en.llc.orgChart.canvasUnit.replace('{name}', AGENT_NAME))
+  })
+
+  it('duplicates a team member as its own canvas node, resolving back to the same real person', async () => {
+    const { wrapper } = await mountOnCanvas()
+    const ids = canvasNodeIds(wrapper)
+
+    const graceInTeam = ids.find(
+      (id) => id.startsWith(`${TEAM_GROUP_PREFIX}t1`) && teamMemberOrgNodeId(id) === `user:${USER_ID}`,
+    )
+    expect(graceInTeam).toBeDefined()
+    // The reporting-hierarchy copy of the same person is also still there —
+    // the team view adds a node, it does not replace one.
+    expect(ids).toContain(`user:${USER_ID}`)
+  })
+
+  it('opens the same drawer for a team roster click as for the reporting-hierarchy node', async () => {
+    const { wrapper } = await mountOnCanvas()
+    const ids = canvasNodeIds(wrapper)
+    const graceInTeam = ids.find(
+      (id) => id.startsWith(`${TEAM_GROUP_PREFIX}t1`) && teamMemberOrgNodeId(id) === `user:${USER_ID}`,
+    )!
+
+    await wrapper.findComponent(WorkflowCanvas).vm.$emit('node-selected', graceInTeam)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain(USER_NAME)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('shows a person on no team, unmissed, in the honest ungrouped bucket', async () => {
+    const { wrapper } = await mountOnCanvas()
+    const ids = canvasNodeIds(wrapper)
+
+    const ungroupedContainer = ids.find((id) => id === `${TEAM_GROUP_PREFIX}__no_team__`)
+    const hanaOnCanvas = ids.find(
+      (id) =>
+        id.startsWith(`${TEAM_GROUP_PREFIX}__no_team__`) &&
+        teamMemberOrgNodeId(id) === `user:${SOLO_ID}`,
+    )
+
+    expect(ungroupedContainer).toBeDefined()
+    expect(hanaOnCanvas).toBeDefined()
+  })
+})
+
+describe('An honest "no teams" reads differently from a failed fetch (#14596, #14064)', () => {
+  it('says the company has none, once the teams request has actually answered that', async () => {
+    const { wrapper } = await mountOnCanvas({ teams: [] })
+
+    expect(wrapper.get('[data-testid="canvas-no-teams"]').text()).toBe(
+      en.llc.orgChart.peopleNoTeamsDefined,
+    )
+    expect(wrapper.find('[data-testid="canvas-teams-unavailable"]').exists()).toBe(false)
+    // Paired positive: the canvas is not merely blank — the reporting
+    // hierarchy still rendered, so an empty team section here is a fact
+    // about teams, not a crashed render coincidentally lacking a banner.
+    expect(canvasNodeIds(wrapper)).toContain(`${ORG_GROUP_PREFIX}ceo`)
+    expect(canvasNodeIds(wrapper).some((id) => id.startsWith(TEAM_GROUP_PREFIX))).toBe(false)
+  })
+
+  it('says the teams could not be loaded, never that the company has none', async () => {
+    const { wrapper } = await mountOnCanvas({ teamsFail: true })
+
+    expect(wrapper.get('[data-testid="canvas-teams-unavailable"]').text()).toBe(
+      en.llc.orgChart.peopleTeamsUnavailable,
+    )
+    expect(wrapper.find('[data-testid="canvas-no-teams"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(en.llc.orgChart.peopleNoTeamsDefined)
+    // Paired positive, same reasoning as above: the org chart itself is
+    // still intact — only the team grouping is the part that failed.
+    expect(canvasNodeIds(wrapper)).toContain(`${ORG_GROUP_PREFIX}ceo`)
+    expect(canvasNodeIds(wrapper)).toContain(`user:${USER_ID}`)
+  })
+})
+
+describe('Teams read correctly in an RTL locale (#14596)', () => {
+  it('labels the team container in Arabic, not with the English fallback', async () => {
+    const i18n = makeI18n()
+    const { wrapper } = await mountOnCanvas(undefined, i18n)
+    i18n.global.locale.value = 'ar'
+    await flushPromises()
+
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as {
+      id: string
+      data: { label?: string }
+    }[]
+    const teamContainer = nodes.find((n) => n.id === `${TEAM_GROUP_PREFIX}t1`)!
+
+    expect(teamContainer.data.label).toBe(ar.llc.orgChart.canvasTeam.replace('{name}', TEAM_NAME))
+    expect(teamContainer.data.label).not.toBe(en.llc.orgChart.canvasTeam.replace('{name}', TEAM_NAME))
+  })
+
+  it("labels the 'not in a team' bucket in Arabic when the locale is RTL", async () => {
+    const i18n = makeI18n()
+    const { wrapper } = await mountOnCanvas(undefined, i18n)
+    i18n.global.locale.value = 'ar'
+    await flushPromises()
+
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as {
+      id: string
+      data: { label?: string }
+    }[]
+    const ungrouped = nodes.find((n) => n.id === `${TEAM_GROUP_PREFIX}__no_team__`)!
+
+    expect(ungrouped.data.label).toBe(ar.llc.orgChart.peopleNoTeam)
+  })
+})


### PR DESCRIPTION
Part of #14596 · Parent #13935

**Does not close #14596** — see "What is still missing" below. Partial delivery does not close.

## Thinking Path

`org-group` on the canvas is not a team. `isOrgUnit()` returns true for *any root with children*, so a "group" is a reporting unit derived from the hierarchy — it answers *who reports to whom*. Real team data has existed since #13938 (`GET /api/llc/companies/{id}/teams`) and rendered only as grouping headers in the People list.

Both questions are worth showing and neither replaces the other: people work together across reporting lines.

## What Changed

- `buildTeamCanvasNodes()` in `orgCanvasGraph.ts`, reusing `groupPeopleByTeam` from `orgPeople.ts` rather than forking the grouping logic (repo rule 2).
- A team member's canvas node id is `org-team:<groupId>:member:<realOrgNodeId>` — the same underlying identity, unique per (team, person) pair, so someone on three teams appears in each without a second identity. `teamMemberOrgNodeId()` resolves it back so a click opens the same drawer.
- People in no team reuse the existing `UNGROUPED_TEAM_ID` bucket rather than a second concept.
- A company with **zero teams** draws no team section, and `OrgChart.vue` says so in words — with `canvas-teams-unavailable` and `canvas-no-teams` as *separate* banners, so a failed request can never read as "this company has no teams" (#14064's shape, hit again in #13617 and #14556).
- One new locale key in all 11, added one at a time.

## What is still missing

Teams are distinguished by **id namespace, caption text ("{name} team" vs "{name} unit"), and their own spatial section** — but they reuse `org-group`'s CSS, so a team box and a reporting-unit box look identical.

The issue asked for *visually* distinct. That needs `WorkflowCanvas.vue`, which is being edited concurrently for #14609 (keyboard accessibility), and adding a new `CanvasNodeType` member is a guaranteed `vue-tsc` failure until `nodeIcons` / `nodeLabels` in that file gain entries — it would have broken the 0-error baseline the moment the composable used it.

So the follow-up is one attribute plus one CSS rule (`:data-group-kind` on the container), once that file is free. Tracked on #14596, which stays open.

## Verification

Re-derived independently rather than accepted as reported. Every mutation asserts it actually applied before running:

| Mutation | Test that went red |
|---|---|
| team prefix collapsed onto the reporting-unit prefix | 3 tests — namespace distinction and the "no teams" banner |
| `teamMemberOrgNodeId` stops parsing the composite id | click resolution back to the real node |
| member id de-namespaced (collides across teams) | "person in no team is never dropped" |
| zero-teams guard removed *(my own, not the agent's)* | draws nothing for a teamless company · "no teams" banner |

- `vitest run src/composables/llc src/views/llc src/components/llc src/components/workflow` — **40 files, 433 tests, all passed**
- `vue-tsc --noEmit` — exit 0 · `eslint` / `oxlint` / `stylelint` — exit 0
- `WorkflowCanvas.vue` untouched — confirmed by `git diff --name-only`, and its own 67-test suite still passes

Two editorial calls worth a reviewer's eye: the team section is **not** filtered by the role lens (following the precedent set for process nodes — the lens filters *people* by role), and teams stack below the units/ungrouped/process areas in a 4-column grid.

## Model Used

Claude Opus 5 (1M context)
