### PR TITLE
a11y(llc/frontend): make the Company OS canvas keyboard-operable (#14609)

### DIFF
--- a/autobot-frontend/src/components/llc/CanvasNodeSidebar.vue
+++ b/autobot-frontend/src/components/llc/CanvasNodeSidebar.vue
@@ -17,7 +17,7 @@
   re-declaring them.
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onMounted, ref, useId } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
@@ -27,6 +27,7 @@ import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
 import type { WorkItem } from '@/views/llc/workItemTypes'
 import WorkItemBadge from './WorkItemBadge.vue'
 import HandoffModal from './HandoffModal.vue'
+import { useFocusTrap, useFocusRestore, useInitialFocus } from '@autobot/ui'
 import {
   SIDEBAR_RAIL_ICONS,
   NOTE_TABS,
@@ -61,6 +62,17 @@ const emit = defineEmits<{
 const logger = createLogger('CanvasNodeSidebar')
 const api = useApiClient()
 const { t } = useI18n()
+
+// #14609: the drawer traps Tab/Shift+Tab, moves focus into itself on open,
+// and restores focus to whatever was focused before it mounted — the
+// canvas/tree/people-list row that triggered it — on close. Mount-based:
+// this component only ever exists while the parent's `v-if` is true.
+const panelRef = ref<HTMLElement | null>(null)
+const { onKeydown: onFocusTrapKeydown } = useFocusTrap(panelRef)
+useFocusRestore()
+const { focusFirst } = useInitialFocus(panelRef)
+const _uid = useId()
+const titleId = `canvas-node-sidebar-title-${_uid}`
 
 const RAIL_ICON_CLASS: Record<SidebarRailIcon, string> = {
   info: 'fa-circle-info',
@@ -188,12 +200,29 @@ function formatTime(ts: string | null): string {
   if (!ts) return t('llc.orgChart.never')
   return new Date(ts).toLocaleString()
 }
+
+// #14609: fires after this component's own onMounted registration above
+// (useFocusRestore's save-focus onMounted), so the origin element is
+// captured before focus moves in here.
+onMounted(() => {
+  void focusFirst()
+})
 </script>
 
 <template>
-  <div class="flex flex-col h-full" data-testid="node-sidebar">
+  <div
+    ref="panelRef"
+    class="flex flex-col h-full"
+    data-testid="node-sidebar"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    tabindex="-1"
+    @keydown="onFocusTrapKeydown"
+    @keydown.escape="emit('close')"
+  >
     <div class="flex items-center justify-between px-5 py-4 border-b border-autobot-border">
-      <h2 class="text-lg font-semibold text-autobot-text-primary">
+      <h2 :id="titleId" class="text-lg font-semibold text-autobot-text-primary">
         {{ node.is_human ? t('llc.orgChart.personDetail') : t('llc.orgChart.agentDetail') }}
       </h2>
       <button

--- a/autobot-frontend/src/components/llc/__tests__/CanvasNodeSidebar.a11yFocus.test.ts
+++ b/autobot-frontend/src/components/llc/__tests__/CanvasNodeSidebar.a11yFocus.test.ts
@@ -1,0 +1,156 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// GH#14609: the Org Chart drawer (this component) is the destination of the
+// canvas's own new keyboard-selection path (Enter/Space on a node). It must
+// trap Tab/Shift+Tab while open, move focus into itself on mount, and give
+// focus back to whatever triggered it — the canvas node, in
+// `OrgChart.vue`'s usage — once it unmounts. `OrgChart.vue` gates this
+// component behind `v-if="drawerOpen && selectedNode"`, so "on close" is
+// "on unmount", which is exactly `useFocusRestore()`'s mount-based mode.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { defineComponent, h } from 'vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+
+vi.mock('@/plugins/api', () => ({ useApiClient: () => ({ get, post: vi.fn() }) }))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import CanvasNodeSidebar from '../CanvasNodeSidebar.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+const AGENT_NODE = {
+  id: 'dev',
+  node_id: 'pk-dev-1',
+  name: 'Grace',
+  title: 'Engineer',
+  status: 'idle' as const,
+  adapter_type: 'claude_code',
+  is_human: false,
+  last_heartbeat: null,
+  budget_spent: 0,
+  budget_total: 0,
+  assigned_item_count: 0,
+  parent_id: null,
+  children: [],
+}
+
+function mountSidebar() {
+  return mount(CanvasNodeSidebar, {
+    props: { node: AGENT_NODE, companyId: 'c1', terminating: false },
+    global: { plugins: [i18n], stubs: { HandoffModal: true } },
+    attachTo: document.body,
+  })
+}
+
+const getFocusables = (root: Element) =>
+  Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+    ),
+  )
+
+const dispatchTab = (el: Element, shiftKey = false) => {
+  const event = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true, shiftKey })
+  el.dispatchEvent(event)
+  return event
+}
+
+beforeEach(() => {
+  get.mockReset()
+  document.body.replaceChildren()
+})
+
+describe('CanvasNodeSidebar focus management (#14609)', () => {
+  it('moves focus to the first focusable element (the close button) on mount', async () => {
+    const wrapper = mountSidebar()
+    await flushPromises()
+
+    const panel = wrapper.get('[data-testid="node-sidebar"]').element as HTMLElement
+    const first = getFocusables(panel)[0]
+    expect(document.activeElement).toBe(first)
+    wrapper.unmount()
+  })
+
+  it('Tab on the last focusable wraps to the first', async () => {
+    const wrapper = mountSidebar()
+    await flushPromises()
+    const panel = wrapper.get('[data-testid="node-sidebar"]').element as HTMLElement
+    const focusables = getFocusables(panel)
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    last.focus()
+
+    const event = dispatchTab(panel, false)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(first)
+    wrapper.unmount()
+  })
+
+  it('Shift+Tab on the first focusable wraps to the last', async () => {
+    const wrapper = mountSidebar()
+    await flushPromises()
+    const panel = wrapper.get('[data-testid="node-sidebar"]').element as HTMLElement
+    const focusables = getFocusables(panel)
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    first.focus()
+
+    const event = dispatchTab(panel, true)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(last)
+    wrapper.unmount()
+  })
+
+  it('emits close on Escape', async () => {
+    const wrapper = mountSidebar()
+    await flushPromises()
+
+    await wrapper.get('[data-testid="node-sidebar"]').trigger('keydown', { key: 'Escape' })
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('restores focus to the triggering element once the parent unmounts it (v-if close, per OrgChart.vue)', async () => {
+    // Mirrors OrgChart.vue's own gate: `v-if="drawerOpen && selectedNode"`.
+    const Host = defineComponent({
+      props: { show: { type: Boolean, required: true } },
+      setup(props) {
+        return () =>
+          h('div', [
+            h('button', { id: 'origin-node' }, 'origin canvas node'),
+            props.show
+              ? h(CanvasNodeSidebar, { node: AGENT_NODE, companyId: 'c1', terminating: false })
+              : null,
+          ])
+      },
+    })
+    const wrapper = mount(Host, {
+      props: { show: false },
+      global: { plugins: [i18n], stubs: { HandoffModal: true } },
+      attachTo: document.body,
+    })
+    const origin = wrapper.get('#origin-node').element as HTMLElement
+    origin.focus()
+    expect(document.activeElement).toBe(origin)
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+    expect(document.activeElement).not.toBe(origin)
+
+    await wrapper.setProps({ show: false })
+    await flushPromises()
+
+    expect(document.activeElement).toBe(origin)
+    wrapper.unmount()
+  })
+})

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -86,6 +86,12 @@
     <div ref="canvasRef" class="canvas-area" @mousedown="startPan" @mousemove="onMouseMove"
          @mouseup="endInteraction" @wheel.prevent="handleWheel">
       <div class="canvas-content" :style="canvasTransform">
+        <!-- #14609: keyboard instructions for the canvas's own composite-widget
+             navigation (roving tabindex + arrow keys) — not discoverable from
+             markup alone, so a screen-reader user needs it stated. Visually
+             hidden; referenced from every node via aria-describedby. -->
+        <p :id="navInstructionsId" class="sr-only">{{ $t('workflow.canvas.a11yInstructions') }}</p>
+        <p v-if="!readonly" :id="moveInstructionsId" class="sr-only">{{ $t('workflow.canvas.a11yInstructionsMove') }}</p>
         <!-- Connection Lines SVG -->
         <svg class="connections-svg">
           <defs>
@@ -98,11 +104,29 @@
         </svg>
 
         <!-- Nodes -->
+        <!-- #14609: roving tabindex (WAI-ARIA APG composite-widget pattern) —
+             exactly one node is a Tab stop; arrow keys move focus between the
+             rest, Enter/Space selects (mirrors @click), Escape deselects, and
+             a modifier+arrow moves the node (drag's keyboard equivalent, only
+             when not readonly). `@keydown` guards `e.target === e.currentTarget`
+             so a keypress inside a node's own input/select/button — e.g. typing
+             a literal space into a step's description — reaches that control
+             instead of being hijacked as "select the node". -->
         <div v-for="node in nodes" :key="node.id" class="workflow-node"
+             :ref="(el) => registerNodeEl(node.id, el as Element | null)"
              :class="[node.type, { selected: selectedNodeId === node.id }, ...ruleClasses(node)]"
              :data-rule-id="nodeRuleId(node)"
+             :data-node-id="node.id"
              :style="nodeStyle(node)"
-             @mousedown="onNodeMouseDown(node, $event)" @click.stop="selectNode(node.id)">
+             role="button"
+             :tabindex="rovingTabStopId === node.id ? 0 : -1"
+             :aria-label="nodeAriaLabel(node)"
+             :aria-pressed="selectedNodeId === node.id"
+             :aria-describedby="instructionsId"
+             @mousedown="onNodeMouseDown(node, $event)"
+             @click.stop="selectNode(node.id)"
+             @focus="focusedNodeId = node.id"
+             @keydown="onNodeKeydown(node, $event)">
           <div class="node-header">
             <Icon :name="nodeIcons[node.type]" />
             <span>{{ nodeTitle(node) }}</span>
@@ -281,13 +305,16 @@
 
 <script setup lang="ts">
 import Icon, { type IconName } from '@/components/ui/Icon.vue'
-import { ref, reactive, computed } from 'vue';
+import { ref, reactive, computed, nextTick, useId } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
+import { CANVAS_NODE_WIDTH } from './canvasNode';
 import type { CanvasNode, CanvasNodeType, CanvasTab } from './canvasNode';
 import {
   SELECTABLE_RULE_DIMENSIONS,
+  STATUS_RULES,
+  OWNER_RULES,
   activeRules,
   matchRule,
   orgNodeFacts,
@@ -389,6 +416,40 @@ function nodeText(node: CanvasNode, key: string): string {
  *  flag read through it is always falsy and can never gate anything (GH#13936). */
 function nodeFlag(node: CanvasNode, key: string): boolean {
   return (node.data as Record<string, unknown>)[key] === true;
+}
+
+/**
+ * Accessible name for a node (#14609): kind, name and — for an org-person,
+ * the only node type carrying a status concept — its current state.
+ *
+ * Built from `STATUS_RULES`/`OWNER_RULES` directly rather than through
+ * `ruleForNode`/`nodeRuleLabel`: those read the *active* `colourMode`, and the
+ * announcement must not change depending on which dimension the sighted
+ * legend happens to be colouring by.
+ */
+function nodeAriaLabel(node: CanvasNode): string {
+  const kind = nodeKindLabel(node);
+  const name = nodeTitle(node);
+  const state = nodeStatusLabel(node);
+  return state
+    ? t('workflow.canvas.nodeAriaLabelWithState', { kind, name, state })
+    : t('workflow.canvas.nodeAriaLabel', { kind, name });
+}
+
+/** The "kind" component of a node's accessible name. */
+function nodeKindLabel(node: CanvasNode): string {
+  if (node.type === 'org-person') {
+    const facts = orgFacts.value.get(node.id);
+    if (facts) return ruleLabel(matchRule(OWNER_RULES, facts));
+  }
+  if (node.type === 'org-group') return t('llc.orgChart.canvasGroupKind');
+  return (nodeLabels.value as Record<string, string | undefined>)[node.type] ?? '';
+}
+
+/** The "state" component of a node's accessible name — '' when the node carries none. */
+function nodeStatusLabel(node: CanvasNode): string {
+  const facts = orgFacts.value.get(node.id);
+  return facts ? ruleLabel(matchRule(STATUS_RULES, facts)) : '';
 }
 
 /**
@@ -495,6 +556,57 @@ const showSaveDialog = ref(false);
 const saveName = ref('');
 const saveDesc = ref('');
 
+/* ------------------------------------------------------------------ *
+ * GH#14609: keyboard operation — a roving-tabindex node graph.
+ *
+ * `focusedNodeId` is only ever written by user-driven focus (Tab landing on
+ * the roving stop, or an arrow-key move) — never reset when `nodes` changes,
+ * so a canvas re-layout (same ids, new node objects/positions) keeps the
+ * focused DOM element focused: Vue's `:key="node.id"` patching reuses the
+ * existing element rather than recreating it, and native browser focus
+ * survives that unaffected. A naive index-based (rather than id-based)
+ * implementation loses this for free.
+ * ------------------------------------------------------------------ */
+
+const _uid = useId();
+const navInstructionsId = `workflow-canvas-nav-instructions-${_uid}`;
+const moveInstructionsId = `workflow-canvas-move-instructions-${_uid}`;
+/** Move instructions only apply when dragging itself is possible. */
+const instructionsId = computed(() =>
+  props.readonly ? navInstructionsId : `${navInstructionsId} ${moveInstructionsId}`,
+);
+
+const focusedNodeId = ref<string | null>(null);
+const nodeEls = new Map<string, HTMLElement>();
+
+function registerNodeEl(id: string, el: Element | null): void {
+  if (el instanceof HTMLElement) nodeEls.set(id, el);
+  else nodeEls.delete(id);
+}
+
+/** Row tolerance for the default (first-tab) reading order: nodes within this
+ *  many px of vertical offset are treated as the same visual row. */
+const NODE_ROW_TOLERANCE = 60;
+
+/** `nodes` sorted into a predictable top-to-bottom, start-to-end reading order —
+ *  used only to pick the initial roving tab stop before any focus has occurred. */
+const visualOrder = computed<CanvasNode[]>(() =>
+  [...props.nodes].sort((a, b) => {
+    const rowDelta = a.position.y - b.position.y;
+    if (Math.abs(rowDelta) > NODE_ROW_TOLERANCE) return rowDelta;
+    return a.position.x - b.position.x;
+  }),
+);
+
+/** The single node that is a Tab stop. Falls back to reading order when
+ *  nothing has been focused yet, or the previously-focused node is gone. */
+const rovingTabStopId = computed<string | null>(() => {
+  if (focusedNodeId.value && props.nodes.some((n) => n.id === focusedNodeId.value)) {
+    return focusedNodeId.value;
+  }
+  return visualOrder.value[0]?.id ?? null;
+});
+
 const canvasTransform = computed(() => ({ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom.value})` }));
 
 const connections = computed(() => {
@@ -594,6 +706,134 @@ function deleteNode(id: string) {
 }
 
 function selectNode(id: string) { emit('node-selected', id); }
+
+/** Fixed-size step for a keyboard-driven node move — matches the background grid. */
+const NODE_KEYBOARD_MOVE_STEP = 20;
+
+type SpatialDirection = 'up' | 'down' | 'left' | 'right';
+
+/**
+ * Resolve an arrow key to a canvas-space direction, folding in writing
+ * direction (#14609 acceptance): in an RTL locale, ArrowRight is "back" in
+ * reading order — the same node it would reach visually to the left — and
+ * ArrowLeft is "forward". ArrowUp/ArrowDown are direction-agnostic.
+ *
+ * Node positions themselves are never mirrored for RTL (`nodeStyle` always
+ * writes a physical `left`, see the #13939 pan/position tests) — only the
+ * *meaning* of the two horizontal keys flips, matching how a toolbar or
+ * listbox's horizontal arrow-key navigation is expected to behave per the
+ * writing-direction convention, independent of whether the widget's own
+ * visual layout mirrors.
+ */
+function resolveArrowDirection(key: string): SpatialDirection | null {
+  if (key === 'ArrowUp') return 'up';
+  if (key === 'ArrowDown') return 'down';
+  if (key === 'ArrowLeft') return isRtl() ? 'right' : 'left';
+  if (key === 'ArrowRight') return isRtl() ? 'left' : 'right';
+  return null;
+}
+
+/** Read fresh on every keypress — not a computed: `document.documentElement.dir`
+ *  is not a Vue-reactive source, so caching it would never pick up a runtime
+ *  locale switch (`setLocale` in `src/i18n/index.ts` flips the attribute). */
+function isRtl(): boolean {
+  return document.documentElement.dir === 'rtl';
+}
+
+/** A node's approximate visual centre, in canvas space — same anchor the
+ *  connection-line paths already use (`x + 240`, `y + 50`, see `connections`). */
+function nodeCenter(node: CanvasNode): { x: number; y: number } {
+  return { x: node.position.x + CANVAS_NODE_WIDTH / 2, y: node.position.y + 50 };
+}
+
+/**
+ * Nearest node in `direction` from `from`, by visual position rather than
+ * array order (#14609 acceptance) — a directional nearest-neighbour search:
+ * candidates strictly on the correct side of `from` are scored by distance
+ * along the primary axis plus a heavily-weighted cross-axis penalty, so
+ * movement favours a node roughly aligned with the current one (a laid-out
+ * grid or row) over one merely closer in Euclidean distance off-axis.
+ */
+function findNodeInDirection(from: CanvasNode, direction: SpatialDirection): CanvasNode | null {
+  const origin = nodeCenter(from);
+  let best: CanvasNode | null = null;
+  let bestScore = Infinity;
+  for (const candidate of props.nodes) {
+    if (candidate.id === from.id) continue;
+    const point = nodeCenter(candidate);
+    const dx = point.x - origin.x;
+    const dy = point.y - origin.y;
+    let primary: number;
+    let cross: number;
+    if (direction === 'left') { if (dx >= 0) continue; primary = -dx; cross = dy; }
+    else if (direction === 'right') { if (dx <= 0) continue; primary = dx; cross = dy; }
+    else if (direction === 'up') { if (dy >= 0) continue; primary = -dy; cross = dx; }
+    else { if (dy <= 0) continue; primary = dy; cross = dx; }
+    const score = primary + Math.abs(cross) * 2;
+    if (score < bestScore) { bestScore = score; best = candidate; }
+  }
+  return best;
+}
+
+/** Move focus (not the node) to the nearest node in `direction`, if any. */
+function focusNodeInDirection(from: CanvasNode, direction: SpatialDirection): void {
+  const target = findNodeInDirection(from, direction);
+  if (!target) return;
+  focusedNodeId.value = target.id;
+  void nextTick(() => nodeEls.get(target.id)?.focus());
+}
+
+/** Move the node itself (drag's keyboard equivalent, #14609) — only ever
+ *  called when `!readonly`, mirroring `onMouseMove`'s own drag emit. */
+function moveNodeByKeyboard(node: CanvasNode, direction: SpatialDirection): void {
+  const delta: Record<SpatialDirection, { x: number; y: number }> = {
+    up: { x: 0, y: -NODE_KEYBOARD_MOVE_STEP },
+    down: { x: 0, y: NODE_KEYBOARD_MOVE_STEP },
+    left: { x: -NODE_KEYBOARD_MOVE_STEP, y: 0 },
+    right: { x: NODE_KEYBOARD_MOVE_STEP, y: 0 },
+  };
+  const { x: dx, y: dy } = delta[direction];
+  emit('node-moved', node.id, {
+    x: Math.max(0, node.position.x + dx),
+    y: Math.max(0, node.position.y + dy),
+  });
+}
+
+/**
+ * Keyboard entry point for a node (#14609): Enter/Space selects — the same
+ * effect as `@click` — Escape deselects, a plain arrow moves focus, and a
+ * Ctrl/Cmd+arrow moves the node (only when not readonly; dragging is a
+ * mutation the read-only Company OS canvas must not offer).
+ *
+ * Guarded to `e.target === e.currentTarget`: a keypress that bubbled up from
+ * one of the node's own inputs/selects/buttons (typing, picking an option)
+ * must reach that control, not be reinterpreted as a node-level shortcut.
+ */
+function onNodeKeydown(node: CanvasNode, e: KeyboardEvent): void {
+  if (e.target !== e.currentTarget) return;
+
+  if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+    e.preventDefault();
+    selectNode(node.id);
+    return;
+  }
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    emit('node-selected', null);
+    return;
+  }
+
+  const direction = resolveArrowDirection(e.key);
+  if (!direction) return;
+  e.preventDefault();
+
+  if (e.ctrlKey || e.metaKey) {
+    if (props.readonly) return;
+    moveNodeByKeyboard(node, direction);
+    return;
+  }
+  focusNodeInDirection(node, direction);
+}
 
 async function clearCanvas() {
   if (props.nodes.length && (await confirm({ title: t('common.confirm'), message: t('workflow.canvas.clearConfirm') }))) {
@@ -698,6 +938,25 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: var(--radius-xl); box-shadow: var(--shadow-sm); cursor: move; user-select: none; }
 .workflow-node:hover { box-shadow: var(--shadow-md); }
 .workflow-node.selected { border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-bg); }
+/* #14609: keyboard focus indicator — nodes carry no native focus styling of
+   their own (a styled `<div>`), so this is the only visible cue a keyboard
+   user gets that a node is focused. */
+.workflow-node:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+
+/* #14609: visually hidden but readable by a screen reader — same rule as
+   LoadingSpinner.vue's `.sr-only`, kept in sync rather than shared, since
+   this file's styles are scoped. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: var(--spacing-0);
+  margin: var(--spacing-neg-px);
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .workflow-node.step .node-header { background: var(--color-primary); }
 .workflow-node.condition .node-header { background: var(--color-warning); }
 .workflow-node.switch .node-header { background: var(--wfcanvas-node-switch); }

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
@@ -1,0 +1,286 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * GH#14609: the canvas was entirely unreachable by keyboard — nodes were
+ * plain `<div>`s with no tabindex, role or key handler. This covers:
+ *   - roving tabindex (one Tab stop; the rest -1) and its `@focus` sync
+ *   - Enter/Space selects (same effect as `@click`), Escape deselects
+ *   - arrow keys move focus in visual order, RTL-aware for left/right
+ *   - a Ctrl/Cmd+arrow moves the focused node (readonly disables this)
+ *   - a keypress bubbling from a node's own input/select/button is left
+ *     alone, never hijacked as a node-level shortcut
+ *   - the accessible name states kind, name and (for org-person) state
+ *   - focus survives a canvas re-layout (new node objects, same ids)
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+
+/** Four org-person nodes on a clean 2x2 grid, far enough apart that the
+ *  directional nearest-neighbour search has one unambiguous answer per key. */
+function grid(): CanvasNode[] {
+  return [
+    { id: 'a', type: 'org-person', position: { x: 0, y: 0 }, data: { label: 'Ada', title: 'CEO', status: 'active', is_human: false, adapter_type: 'claude' }, connections: [] },
+    { id: 'b', type: 'org-person', position: { x: 400, y: 0 }, data: { label: 'Bea', title: 'CTO', status: 'idle', is_human: false, adapter_type: 'claude' }, connections: [] },
+    { id: 'c', type: 'org-person', position: { x: 0, y: 400 }, data: { label: 'Cid', title: 'COO', status: 'paused', is_human: true }, connections: [] },
+    { id: 'd', type: 'org-person', position: { x: 400, y: 400 }, data: { label: 'Dee', title: 'CFO', status: 'error', is_human: false, adapter_type: 'ollama' }, connections: [] },
+  ]
+}
+
+const WORKFLOW_NODES: CanvasNode[] = [
+  {
+    id: 'n1',
+    type: 'step',
+    position: { x: 10, y: 10 },
+    data: { command: '', description: '', risk_level: 'low', requires_confirmation: true },
+    connections: [],
+  },
+]
+
+function makeI18n(locale: 'en' | 'ar') {
+  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
+}
+
+function mountCanvas(
+  props: Record<string, unknown>,
+  opts: { locale?: 'en' | 'ar'; attach?: boolean } = {},
+) {
+  return mount(WorkflowCanvas, {
+    props: { selectedNodeId: null, ...props },
+    global: { plugins: [makeI18n(opts.locale ?? 'en')] },
+    ...(opts.attach ? { attachTo: document.body } : {}),
+  })
+}
+
+function nodeDiv(wrapper: VueWrapper, id: string) {
+  return wrapper.get(`[data-node-id="${id}"]`)
+}
+
+async function keydown(
+  wrapper: VueWrapper,
+  id: string,
+  key: string,
+  modifiers: Partial<KeyboardEventInit> = {},
+) {
+  await nodeDiv(wrapper, id).trigger('keydown', { key, ...modifiers })
+}
+
+afterEach(() => {
+  document.documentElement.removeAttribute('dir')
+})
+
+describe('WorkflowCanvas roving tabindex (#14609)', () => {
+  it('makes only the visually-first node a Tab stop', () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+
+    expect(nodeDiv(wrapper, 'a').attributes('tabindex')).toBe('0')
+    expect(nodeDiv(wrapper, 'b').attributes('tabindex')).toBe('-1')
+    expect(nodeDiv(wrapper, 'c').attributes('tabindex')).toBe('-1')
+    expect(nodeDiv(wrapper, 'd').attributes('tabindex')).toBe('-1')
+  })
+
+  it('moves the Tab stop to whichever node actually receives DOM focus', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+
+    await nodeDiv(wrapper, 'c').trigger('focus')
+
+    expect(nodeDiv(wrapper, 'c').attributes('tabindex')).toBe('0')
+    expect(nodeDiv(wrapper, 'a').attributes('tabindex')).toBe('-1')
+  })
+
+  it('carries role=button and aria-pressed reflecting selection', () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true, selectedNodeId: 'b' })
+
+    expect(nodeDiv(wrapper, 'a').attributes('role')).toBe('button')
+    expect(nodeDiv(wrapper, 'a').attributes('aria-pressed')).toBe('false')
+    expect(nodeDiv(wrapper, 'b').attributes('aria-pressed')).toBe('true')
+  })
+})
+
+describe('WorkflowCanvas accessible name states kind, name and state (#14609)', () => {
+  it('announces kind and name for a workflow authoring node with no status concept', () => {
+    const wrapper = mountCanvas({ nodes: WORKFLOW_NODES })
+    const expected = en.workflow.canvas.nodeAriaLabel
+      .replace('{kind}', en.workflow.canvas.stepLabel)
+      .replace('{name}', en.workflow.canvas.stepLabel)
+
+    expect(nodeDiv(wrapper, 'n1').attributes('aria-label')).toBe(expected)
+  })
+
+  it('announces kind, name and status for an org-person node', () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+    const expected = en.workflow.canvas.nodeAriaLabelWithState
+      .replace('{kind}', en.llc.orgChart.aiAgent)
+      .replace('{name}', 'Ada')
+      .replace('{state}', en.llc.canvasRules.status.active)
+
+    expect(nodeDiv(wrapper, 'a').attributes('aria-label')).toBe(expected)
+  })
+
+  it('announces the human owner kind for a human org-person node', () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+    const expected = en.workflow.canvas.nodeAriaLabelWithState
+      .replace('{kind}', en.llc.orgChart.human)
+      .replace('{name}', 'Cid')
+      .replace('{state}', en.llc.canvasRules.status.paused)
+
+    expect(nodeDiv(wrapper, 'c').attributes('aria-label')).toBe(expected)
+  })
+})
+
+describe('WorkflowCanvas Enter/Space/Escape (#14609)', () => {
+  it('Enter selects the focused node — the same effect as a click', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+    await keydown(wrapper, 'b', 'Enter')
+
+    expect(wrapper.emitted('node-selected')).toEqual([['b']])
+  })
+
+  it('Space selects the focused node', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+    await keydown(wrapper, 'b', ' ')
+
+    expect(wrapper.emitted('node-selected')).toEqual([['b']])
+  })
+
+  it('Escape deselects', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true, selectedNodeId: 'b' })
+    await keydown(wrapper, 'b', 'Escape')
+
+    expect(wrapper.emitted('node-selected')).toEqual([[null]])
+  })
+
+  it('does not hijack a space typed into the node’s own input', async () => {
+    const wrapper = mountCanvas({ nodes: WORKFLOW_NODES })
+    const input = wrapper.get('.workflow-node.step input')
+    await input.trigger('keydown', { key: ' ' })
+
+    expect(wrapper.emitted('node-selected')).toBeUndefined()
+  })
+})
+
+describe('WorkflowCanvas arrow-key focus movement follows visual order (#14609)', () => {
+  it('ArrowRight from the top-left node focuses the node to its right', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { attach: true })
+    await nodeDiv(wrapper, 'a').trigger('focus')
+
+    await keydown(wrapper, 'a', 'ArrowRight')
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'b').element)
+    wrapper.unmount()
+  })
+
+  it('ArrowDown from the top-left node focuses the node below it', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { attach: true })
+    await nodeDiv(wrapper, 'a').trigger('focus')
+
+    await keydown(wrapper, 'a', 'ArrowDown')
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'c').element)
+    wrapper.unmount()
+  })
+
+  it('ArrowLeft from the bottom-right node focuses the node to its left', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { attach: true })
+    await nodeDiv(wrapper, 'd').trigger('focus')
+
+    await keydown(wrapper, 'd', 'ArrowLeft')
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'c').element)
+    wrapper.unmount()
+  })
+})
+
+describe('WorkflowCanvas arrow-key direction follows writing direction in RTL (#14609)', () => {
+  it('ArrowRight moves focus toward the visually-left node in an RTL document', async () => {
+    document.documentElement.setAttribute('dir', 'rtl')
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { locale: 'ar', attach: true })
+    await nodeDiv(wrapper, 'b').trigger('focus')
+
+    // 'b' sits visually to the right of 'a'. In RTL, ArrowRight is "back" in
+    // reading order — the same node ArrowLeft would reach in LTR.
+    await keydown(wrapper, 'b', 'ArrowRight')
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'a').element)
+    wrapper.unmount()
+  })
+
+  it('ArrowLeft moves focus toward the visually-right node in an RTL document', async () => {
+    document.documentElement.setAttribute('dir', 'rtl')
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { locale: 'ar', attach: true })
+    await nodeDiv(wrapper, 'a').trigger('focus')
+
+    await keydown(wrapper, 'a', 'ArrowLeft')
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'b').element)
+    wrapper.unmount()
+  })
+})
+
+describe('WorkflowCanvas Ctrl+Arrow moves the focused node (#14609)', () => {
+  it('moves the node by a fixed step, mirroring a drag’s node-moved emit', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: false })
+    await keydown(wrapper, 'a', 'ArrowRight', { ctrlKey: true })
+
+    expect(wrapper.emitted('node-moved')).toEqual([['a', { x: 20, y: 0 }]])
+  })
+
+  it('never moves the node when readonly — dragging is a mutation the read-only canvas must not offer', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true })
+    await keydown(wrapper, 'a', 'ArrowRight', { ctrlKey: true })
+
+    expect(wrapper.emitted('node-moved')).toBeUndefined()
+  })
+
+  it('clamps to zero rather than moving off-canvas', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: false })
+    await keydown(wrapper, 'a', 'ArrowLeft', { ctrlKey: true })
+
+    expect(wrapper.emitted('node-moved')).toEqual([['a', { x: 0, y: 0 }]])
+  })
+})
+
+describe('WorkflowCanvas focus survives a canvas re-layout (#14609)', () => {
+  it('keeps the same node focused after `nodes` is replaced with new objects carrying the same ids', async () => {
+    const wrapper = mountCanvas({ nodes: grid(), readonly: true }, { attach: true })
+    nodeDiv(wrapper, 'c').element.focus()
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'c').element)
+
+    // Simulate OrgChart.vue's relayout watcher: a brand new array of new node
+    // objects, same ids, different position references.
+    const relaidOut = grid().map((n) => ({ ...n, position: { ...n.position } }))
+    await wrapper.setProps({ nodes: relaidOut })
+
+    expect(document.activeElement).toBe(nodeDiv(wrapper, 'c').element)
+    expect(nodeDiv(wrapper, 'c').attributes('tabindex')).toBe('0')
+    wrapper.unmount()
+  })
+})
+
+describe('WorkflowCanvas keyboard instructions are exposed to assistive tech (#14609)', () => {
+  it('describes every node, and only advertises the move shortcut when not readonly', () => {
+    const editable = mountCanvas({ nodes: WORKFLOW_NODES, readonly: false })
+    expect(editable.text()).toContain(en.workflow.canvas.a11yInstructions)
+    expect(editable.text()).toContain(en.workflow.canvas.a11yInstructionsMove)
+    const describedBy = nodeDiv(editable, 'n1').attributes('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(describedBy!.split(' ')).toHaveLength(2)
+
+    const readonlyWrapper = mountCanvas({ nodes: grid(), readonly: true })
+    expect(readonlyWrapper.text()).not.toContain(en.workflow.canvas.a11yInstructionsMove)
+    const readonlyDescribedBy = nodeDiv(readonlyWrapper, 'a').attributes('aria-describedby')
+    expect(readonlyDescribedBy!.split(' ')).toHaveLength(1)
+  })
+})

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}، {state}",
+      "a11yInstructions": "استخدم مفاتيح الأسهم لتحريك التركيز بين العقد. اضغط على Enter أو المسافة لتحديد العقدة التي عليها التركيز. اضغط على Escape لإلغاء التحديد.",
+      "a11yInstructionsMove": "اضغط مطولاً على Control ثم اضغط على مفتاح سهم لتحريك العقدة المحددة."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "تعذّر إرفاق سير العمل هذا.",
       "detachError": "تعذّرت إزالة سير العمل هذا.",
       "processDetach": "إزالة {workflow} من {role}",
-      "attachRolesUnavailable": "تعذّر تحميل الأدوار، لذا قد تكون هذه القائمة غير مكتملة."
+      "attachRolesUnavailable": "تعذّر تحميل الأدوار، لذا قد تكون هذه القائمة غير مكتملة.",
+      "canvasGroupKind": "مجموعة"
     },
     "executorRollup": {
       "title": "ملخص المنفذين",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Verwenden Sie die Pfeiltasten, um den Fokus zwischen den Knoten zu bewegen. Drücken Sie Eingabe oder Leertaste, um den fokussierten Knoten auszuwählen. Drücken Sie Escape, um die Auswahl aufzuheben.",
+      "a11yInstructionsMove": "Halten Sie Strg gedrückt und drücken Sie eine Pfeiltaste, um den ausgewählten Knoten zu verschieben."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "Dieser Workflow konnte nicht zugeordnet werden.",
       "detachError": "Dieser Workflow konnte nicht entfernt werden.",
       "processDetach": "{workflow} von {role} entfernen",
-      "attachRolesUnavailable": "Rollen konnten nicht geladen werden, daher ist diese Liste möglicherweise unvollständig."
+      "attachRolesUnavailable": "Rollen konnten nicht geladen werden, daher ist diese Liste möglicherweise unvollständig.",
+      "canvasGroupKind": "Gruppe"
     },
     "executorRollup": {
       "title": "Ausführungs-Übersicht",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Use the arrow keys to move focus between nodes. Press Enter or Space to select the focused node. Press Escape to deselect.",
+      "a11yInstructionsMove": "Hold Control and press an arrow key to move the selected node."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8295,7 +8299,8 @@
       "attachError": "Could not attach that workflow.",
       "detachError": "Could not detach that workflow.",
       "processDetach": "Detach {workflow} from {role}",
-      "attachRolesUnavailable": "Roles could not be loaded, so this list may be incomplete."
+      "attachRolesUnavailable": "Roles could not be loaded, so this list may be incomplete.",
+      "canvasGroupKind": "Group"
     },
     "executorRollup": {
       "title": "Executor Rollup",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Use las teclas de flecha para mover el foco entre los nodos. Presione Enter o Espacio para seleccionar el nodo enfocado. Presione Escape para anular la selección.",
+      "a11yInstructionsMove": "Mantenga presionada la tecla Control y presione una tecla de flecha para mover el nodo seleccionado."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "No se pudo adjuntar ese flujo.",
       "detachError": "No se pudo quitar ese flujo.",
       "processDetach": "Quitar {workflow} de {role}",
-      "attachRolesUnavailable": "No se pudieron cargar los roles, por lo que esta lista puede estar incompleta."
+      "attachRolesUnavailable": "No se pudieron cargar los roles, por lo que esta lista puede estar incompleta.",
+      "canvasGroupKind": "Grupo"
     },
     "executorRollup": {
       "title": "Resumen de ejecutores",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -3815,7 +3815,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "برای انتقال فوکوس بین گره‌ها از کلیدهای جهت‌نما استفاده کنید. برای انتخاب گره فوکوس‌شده، Enter یا Space را فشار دهید. برای لغو انتخاب، Escape را فشار دهید.",
+      "a11yInstructionsMove": "کلید Control را نگه دارید و یک کلید جهت‌نما را فشار دهید تا گره انتخاب‌شده جابه‌جا شود."
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8307,7 +8311,8 @@
       "attachError": "پیوست کردن این گردش‌کار ممکن نشد.",
       "detachError": "جدا کردن این گردش‌کار ممکن نشد.",
       "processDetach": "جدا کردن {workflow} از {role}",
-      "attachRolesUnavailable": "نقش‌ها بارگیری نشدند، بنابراین این فهرست ممکن است ناقص باشد."
+      "attachRolesUnavailable": "نقش‌ها بارگیری نشدند، بنابراین این فهرست ممکن است ناقص باشد.",
+      "canvasGroupKind": "گروه"
     },
     "executorRollup": {
       "title": "خلاصه مجریان",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind} : {name}",
+      "nodeAriaLabelWithState": "{kind} : {name}, {state}",
+      "a11yInstructions": "Utilisez les touches fléchées pour déplacer le focus entre les nœuds. Appuyez sur Entrée ou Espace pour sélectionner le nœud ciblé. Appuyez sur Échap pour désélectionner.",
+      "a11yInstructionsMove": "Maintenez Ctrl enfoncé et appuyez sur une touche fléchée pour déplacer le nœud sélectionné."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "Impossible d'associer ce workflow.",
       "detachError": "Impossible de détacher ce workflow.",
       "processDetach": "Détacher {workflow} de {role}",
-      "attachRolesUnavailable": "Les rôles n'ont pas pu être chargés, cette liste peut donc être incomplète."
+      "attachRolesUnavailable": "Les rôles n'ont pas pu être chargés, cette liste peut donc être incomplète.",
+      "canvasGroupKind": "Groupe"
     },
     "executorRollup": {
       "title": "Récapitulatif des exécutants",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -3815,7 +3815,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "השתמשו במקשי החצים כדי להזיז את המיקוד בין הצמתים. הקישו Enter או Space כדי לבחור בצומת הממוקד. הקישו Escape כדי לבטל את הבחירה.",
+      "a11yInstructionsMove": "החזיקו את מקש Control ולחצו על מקש חץ כדי להזיז את הצומת הנבחרת."
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8307,7 +8311,8 @@
       "attachError": "לא ניתן היה לצרף תהליך זה.",
       "detachError": "לא ניתן היה להסיר תהליך זה.",
       "processDetach": "הסר את {workflow} מ-{role}",
-      "attachRolesUnavailable": "לא ניתן היה לטעון את התפקידים, ולכן ייתכן שרשימה זו חלקית."
+      "attachRolesUnavailable": "לא ניתן היה לטעון את התפקידים, ולכן ייתכן שרשימה זו חלקית.",
+      "canvasGroupKind": "קבוצה"
     },
     "executorRollup": {
       "title": "סיכום מבצעים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Izmantojiet bulttaustiņus, lai pārvietotu fokusu starp mezgliem. Nospiediet Enter vai atstarpi, lai atlasītu fokusēto mezglu. Nospiediet Escape, lai atceltu atlasi.",
+      "a11yInstructionsMove": "Turiet nospiestu Control un nospiediet bulttaustiņu, lai pārvietotu atlasīto mezglu."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "Neizdevās pievienot šo darbplūsmu.",
       "detachError": "Neizdevās noņemt šo darbplūsmu.",
       "processDetach": "Noņemt {workflow} no {role}",
-      "attachRolesUnavailable": "Lomas neizdevās ielādēt, tāpēc šis saraksts var būt nepilnīgs."
+      "attachRolesUnavailable": "Lomas neizdevās ielādēt, tāpēc šis saraksts var būt nepilnīgs.",
+      "canvasGroupKind": "Grupa"
     },
     "executorRollup": {
       "title": "Izpildītāju kopsavilkums",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Użyj klawiszy strzałek, aby przenieść fokus między węzłami. Naciśnij Enter lub Spację, aby wybrać zaznaczony węzeł. Naciśnij Escape, aby anulować wybór.",
+      "a11yInstructionsMove": "Przytrzymaj Control i naciśnij klawisz strzałki, aby przenieść wybrany węzeł."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "Nie udało się dołączyć tego przepływu.",
       "detachError": "Nie udało się odłączyć tego przepływu.",
       "processDetach": "Odłącz {workflow} od {role}",
-      "attachRolesUnavailable": "Nie udało się wczytać ról, więc ta lista może być niekompletna."
+      "attachRolesUnavailable": "Nie udało się wczytać ról, więc ta lista może być niekompletna.",
+      "canvasGroupKind": "Grupa"
     },
     "executorRollup": {
       "title": "Zestawienie wykonawców",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -4376,7 +4376,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "Use as teclas de seta para mover o foco entre os nós. Pressione Enter ou Espaço para selecionar o nó focado. Pressione Escape para desmarcar.",
+      "a11yInstructionsMove": "Mantenha pressionado Control e pressione uma tecla de seta para mover o nó selecionado."
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8307,7 +8311,8 @@
       "attachError": "Não foi possível anexar esse fluxo.",
       "detachError": "Não foi possível remover esse fluxo.",
       "processDetach": "Remover {workflow} de {role}",
-      "attachRolesUnavailable": "Não foi possível carregar as funções, portanto esta lista pode estar incompleta."
+      "attachRolesUnavailable": "Não foi possível carregar as funções, portanto esta lista pode estar incompleta.",
+      "canvasGroupKind": "Grupo"
     },
     "executorRollup": {
       "title": "Resumo de executores",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -3815,7 +3815,11 @@
       "switchDefaultHint": "Switch default hint",
       "switchLabel": "switch",
       "loopLabel": "Loop",
-      "switchOnPlaceholder": "Enter switch on..."
+      "switchOnPlaceholder": "Enter switch on...",
+      "nodeAriaLabel": "{kind}: {name}",
+      "nodeAriaLabelWithState": "{kind}: {name}, {state}",
+      "a11yInstructions": "نوڈز کے درمیان فوکس منتقل کرنے کے لیے ایرو کیز استعمال کریں۔ فوکس شدہ نوڈ کو منتخب کرنے کے لیے Enter یا Space دبائیں۔ انتخاب ختم کرنے کے لیے Escape دبائیں۔",
+      "a11yInstructionsMove": "منتخب نوڈ کو حرکت دینے کے لیے Control دبائے رکھیں اور ایک ایرو کی دبائیں۔"
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8307,7 +8311,8 @@
       "attachError": "یہ ورک فلو منسلک نہیں ہو سکا۔",
       "detachError": "یہ ورک فلو الگ نہیں ہو سکا۔",
       "processDetach": "{workflow} کو {role} سے الگ کریں",
-      "attachRolesUnavailable": "کردار لوڈ نہیں ہو سکے، اس لیے یہ فہرست نامکمل ہو سکتی ہے۔"
+      "attachRolesUnavailable": "کردار لوڈ نہیں ہو سکے، اس لیے یہ فہرست نامکمل ہو سکتی ہے۔",
+      "canvasGroupKind": "گروپ"
     },
     "executorRollup": {
       "title": "عمل کنندہ خلاصہ",


### PR DESCRIPTION
Closes #14609 · Parent #13935

## Thinking Path

Measured before building: `WorkflowCanvas.vue` contained **0** occurrences of `@keydown`, `tabindex` and `role="button"` on a node. A node was a bare `<div>` with `@mousedown` and `@click.stop`. Nothing on the canvas could be focused, selected, opened or moved without a mouse, and the drawer could not be reached at all.

That is out of step with its own neighbourhood — #13941 replaced colour-only status with a marker and label, #13963 gave the process node an accessible description — while the node itself stayed unreachable. The Org Chart is the surface Company OS uses to show who is in a company, so this is a defect shipping today, not a missing nicety.

## What Changed

**`WorkflowCanvas.vue`**

- Roving tabindex: every node is `role="button"`, exactly one carries `tabindex=0`. A composite widget is one Tab stop, not N.
- Enter/Space select (identical effect to click); Escape deselects.
- Arrow keys move focus by **visual** nearest-neighbour over node centres, not array order — predictable on a laid-out canvas.
- Ctrl/Cmd+Arrow moves the focused node, emitting `node-moved` exactly as dragging does, and **refused when `readonly`** — dragging is a mutation the Company OS canvas deliberately does not offer.
- `e.target !== e.currentTarget` guard, so typing a space into a node's own input is not swallowed as "select".
- RTL: ArrowLeft/ArrowRight resolve against `document.documentElement.dir` **per keypress**, since that attribute is not a Vue-reactive source. Node positions stay physical; only the key→direction mapping flips.
- Accessible name states kind, name and state, built from `STATUS_RULES`/`OWNER_RULES` directly so the announcement does not depend on the sighted legend's active colour mode. Shortcuts are stated via `aria-describedby` + `sr-only` text, with the move instructions omitted when `readonly`.

**`CanvasNodeSidebar.vue`** — wired the existing `@autobot/ui` focus trio (`useFocusTrap`, `useInitialFocus`, `useFocusRestore`), already built and used by `EntityDetail.vue` but unused here, rather than writing a second focus-management path. Because `OrgChart.vue` mounts the drawer under `v-if`, "on close" is "on unmount", so focus returns to the triggering node with **no change to `OrgChart.vue`** — which also kept this branch clear of the concurrent #14596 work.

Five locale keys across all 11 locales, added one at a time.

## Verification

The agent reported 16 mutations. I re-derived two of the load-bearing ones myself rather than accept the list, each asserting the edit applied before running:

| Mutation | Test that went red |
|---|---|
| `isRtl()` forced false | **both** RTL arrow tests |
| `readonly` guard on keyboard move removed | "never moves the node when readonly" |

Its own 16 covered the rest: roving tabindex, `role`, `aria-pressed`, the state in the accessible name, Enter/Space, Escape, the input guard, move step size, focus surviving re-layout (`:key` mutated to force recreation), the focus trap, Escape-to-close, initial focus, and focus restore.

**Base moved under this branch** — #14592 (pan) merged while it was building, and both changes touch the same node element. I merged base and re-ran the two suites *together*: **24/24**, so the pan-click suppression and the keyboard handling coexist. A clean textual merge would not have shown that.

- `vitest run src/components/workflow src/components/llc src/views/llc src/composables/llc` — **46 files, 466 tests, all passed**
- `vue-tsc --noEmit` — 0 · `eslint` / `oxlint` / `stylelint` — exit 0 · `check-i18n-keys` — exit 0

One combined run failed on `OrgChart.people.test.ts`, passed alone and on re-run. That is the flake tracked in #14613 — now its **third** instance and its **second different test in that same file**, which narrows it to state shared across files rather than a slow mount. Recorded there, not papered over here.

## Found, not fixed

- Selecting an `org-group` in `OrgChart.onCanvasNodeSelected` is a pre-existing no-op (`flattenOrgNodes` never contains a synthetic `org-group:` id). Not introduced here.
- The authoring Save dialog has no focus trap. Unreachable in Company OS (`readonly` hides it), so out of scope — but a real gap if the workflow builder is audited on its own.

## Model Used

Claude Opus 5 (1M context)
