### PR TITLE
feat(llc/frontend): draw a team container differently from a reporting unit (#14596)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -116,6 +116,7 @@
              :ref="(el) => registerNodeEl(node.id, el as Element | null)"
              :class="[node.type, { selected: selectedNodeId === node.id }, ...ruleClasses(node)]"
              :data-rule-id="nodeRuleId(node)"
+             :data-group-kind="groupKind(node)"
              :data-node-id="node.id"
              :style="nodeStyle(node)"
              role="button"
@@ -530,6 +531,19 @@ function ruleLabel(rule: CanvasNodeRule): string {
 function nodeRuleLabel(node: CanvasNode): string {
   const rule = ruleForNode(node);
   return rule ? ruleLabel(rule) : '';
+}
+
+/**
+ * Which kind of container an `org-group` node is — team or reporting unit (#14596).
+ *
+ * `undefined` for every other node type, so the attribute is absent rather
+ * than empty: an empty attribute still matches `[data-group-kind]` in CSS and
+ * would style nodes that are not containers at all.
+ */
+function groupKind(node: CanvasNode): string | undefined {
+  if (node.type !== 'org-group') return undefined;
+  const kind = (node.data as { kind?: unknown } | undefined)?.kind;
+  return typeof kind === 'string' ? kind : undefined;
 }
 
 function nodeRuleId(node: CanvasNode): string | undefined {
@@ -991,6 +1005,14 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .workflow-node.org-person .node-header { background: var(--color-info); }
 .workflow-node.org-group { background: var(--color-info-bg); border-style: dashed; cursor: default; }
 .workflow-node.org-group .node-header { background: transparent; color: var(--text-secondary); border-bottom: 1px dashed var(--border-default); }
+/* #14596: a team is not a reporting unit. The dashed info-coloured box above
+   stands for a reporting line; a team roster is drawn solid in the warning
+   accent so the two are told apart at a glance rather than only by reading
+   their captions. Colour is not the only signal — the border STYLE differs
+   too (solid vs dashed), so the distinction survives for a reader who cannot
+   separate the hues, which is the rule #13941 established on this canvas. */
+.workflow-node.org-group[data-group-kind='team'] { background: var(--color-warning-bg); border-style: solid; }
+.workflow-node.org-group[data-group-kind='team'] .node-header { border-bottom: 1px solid var(--color-warning); }
 .org-title { margin: var(--spacing-0); font-size: var(--text-xs); color: var(--text-secondary); }
 .org-meta { display: flex; align-items: center; gap: var(--spacing-2); font-size: var(--text-xs); color: var(--text-tertiary); }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.groupKind.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.groupKind.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14596, second half: a team box and a reporting-unit box looked identical.
+//
+// #14614 gave teams their own id namespace, caption and section, but both
+// reused `org-group`'s CSS — so the only visual difference was the words
+// inside. The renderer now reads a `kind` off the container and styles the two
+// differently.
+//
+// Colour is not the only signal: the border style differs too, which is the
+// rule #13941 established on this canvas after a coloured dot was found to be
+// the sole carrier of node status.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import {
+  buildOrgCanvasGraph,
+  buildTeamCanvasNodes,
+  GROUP_KIND_TEAM,
+  GROUP_KIND_UNIT,
+} from '@/composables/llc/orgCanvasGraph'
+import { buildOrgPeople } from '@/composables/llc/orgPeople'
+
+const TREE = [
+  {
+    id: 'lead',
+    node_id: 'n-lead',
+    name: 'Ada',
+    title: 'Lead',
+    is_human: true,
+    children: [
+      { id: 'rep', node_id: 'n-rep', name: 'Grace', title: 'Rep', is_human: true, children: [] },
+    ],
+  },
+]
+
+const TEAMS = [{ id: 't1', name: 'Sales', member_user_ids: ['lead'] }]
+
+function mountCanvas(nodes: unknown[]) {
+  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+  return mount(WorkflowCanvas, {
+    props: { nodes, selectedNodeId: null, readonly: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+/** Both container kinds on one canvas — the case where confusing them matters. */
+function bothKinds() {
+  // Built by the real producers, never hand-rolled: a hand-written node can
+  // drift into a shape nothing emits, and then the test passes against data
+  // the canvas never receives.
+  const unitNodes = buildOrgCanvasGraph(TREE as never, (name: string) => `${name} unit`)
+  const people = buildOrgPeople(TREE as never, [])
+  const teamNodes = buildTeamCanvasNodes(
+    new Map(),
+    people,
+    TEAMS as never,
+    0,
+    (name: string) => `${name} team`,
+  )
+  return [...unitNodes, ...teamNodes]
+}
+
+describe('a team container is drawn differently from a reporting unit (#14596)', () => {
+  it('marks each container with its kind', () => {
+    const wrapper = mountCanvas(bothKinds())
+    const kinds = wrapper
+      .findAll('.workflow-node.org-group')
+      .map((n) => n.attributes('data-group-kind'))
+      .filter(Boolean)
+
+    // Both kinds present, and they differ — the whole point.
+    expect(kinds).toContain(GROUP_KIND_UNIT)
+    expect(kinds).toContain(GROUP_KIND_TEAM)
+  })
+
+  it('refuses the attribute on a non-container even if its data carries a kind', () => {
+    // The guard is on the node TYPE, not on the presence of the field. Without
+    // this case the guard is untestable: no producer puts `kind` on a person
+    // today, so removing the type check changes nothing observable — and a
+    // test that cannot fail is not evidence. This pins the rule against a
+    // future producer that adds the field for its own reasons.
+    const wrapper = mountCanvas([
+      {
+        id: 'user:ada',
+        type: 'org-person',
+        position: { x: 0, y: 0 },
+        data: { title: 'Ada', kind: GROUP_KIND_TEAM },
+        connections: [],
+      },
+    ])
+    const person = wrapper.find('.workflow-node.org-person')
+
+    expect(person.exists()).toBe(true)
+    expect(person.attributes('data-group-kind')).toBeUndefined()
+  })
+
+  it('does not put the attribute on nodes that are not containers', () => {
+    // An empty attribute still matches [data-group-kind] in CSS, so a person
+    // node carrying one would pick up container styling.
+    const wrapper = mountCanvas(bothKinds())
+    const people = wrapper.findAll('.workflow-node.org-person')
+
+    expect(people.length).toBeGreaterThan(0)
+    for (const person of people) {
+      expect(person.attributes('data-group-kind')).toBeUndefined()
+    }
+  })
+})

--- a/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
@@ -47,6 +47,18 @@ const GROUP_GAP = 60
  */
 const UNGROUPED_COLUMNS = 4
 /** Id prefix that keeps container ids from colliding with agent ids. */
+/**
+ * What a container node stands for (#14596).
+ *
+ * Carried in `data` rather than as a new `CanvasNodeType`: the renderer's
+ * `nodeIcons` / `nodeLabels` are `Record<CanvasNodeType, ...>` literals, so a
+ * new member is a compile error until both gain entries — and neither an icon
+ * nor a type label is what distinguishes these. What differs is how the box is
+ * drawn, which is a styling concern.
+ */
+export const GROUP_KIND_UNIT = 'unit'
+export const GROUP_KIND_TEAM = 'team'
+
 export const ORG_GROUP_PREFIX = 'org-group:'
 
 interface PlacedNode {
@@ -113,6 +125,11 @@ function toGroupNode(
     position: { x: 0, y: topOffset },
     data: {
       label: unitLabel(root.name),
+      // #14596: which kind of container this is, so the renderer can draw them
+      // differently. A team and a reporting unit answer different questions —
+      // "who works together" and "who reports to whom" — and until this
+      // existed they were the same box with different words in it.
+      kind: GROUP_KIND_UNIT,
       width: 2 * GROUP_PADDING + (depth + 1) * CANVAS_NODE_WIDTH + depth * COLUMN_GAP,
       height: GROUP_HEADER + 2 * GROUP_PADDING + rows * ROW_HEIGHT,
     },
@@ -405,6 +422,7 @@ function layoutTeamGroup(
     position: { x: 0, y: topOffset },
     data: {
       label,
+      kind: GROUP_KIND_TEAM,
       width: 2 * GROUP_PADDING + columns * CANVAS_NODE_WIDTH + (columns - 1) * COLUMN_GAP,
       height: GROUP_HEADER + 2 * GROUP_PADDING + rows * ROW_HEIGHT,
     },


### PR DESCRIPTION
Closes #14596 · Parent #13935

Finishes the half #14614 could not deliver.

## Thinking Path

#14614 gave teams their own id namespace, their own section and their own captions — but both container kinds reused `org-group`'s CSS, so a team box and a reporting-unit box **looked identical**. The scope of #14596 asked for visually distinct, so the issue stayed open rather than being closed on a partial.

It could not be finished then for a concrete reason: `WorkflowCanvas.vue` was held by #14609, and `nodeIcons` / `nodeLabels` there are `Record<CanvasNodeType, ...>` literals — a new `CanvasNodeType` member is a compile error until both gain entries, which would have broken the zero-error `vue-tsc` baseline the moment the composable used it.

That constraint turned out to point at the better design anyway. Neither an icon nor a type label is what distinguishes these two; what differs is **how the box is drawn**. So the kind travels in the node's `data` and the renderer reads it into an attribute — a styling concern solved with styling.

## What Changed

- `GROUP_KIND_UNIT` / `GROUP_KIND_TEAM` in `orgCanvasGraph.ts`, set on each container as it is built.
- `groupKind(node)` in `WorkflowCanvas.vue` → `:data-group-kind`, **omitted entirely** for non-containers. An empty attribute still matches `[data-group-kind]` in CSS and would give person nodes container styling.
- One scoped rule: a team draws in the warning accent with a **solid** border against the reporting unit's dashed info-coloured box.

**Colour is not the only signal.** The border style differs too, so the distinction survives for a reader who cannot separate the hues — the rule #13941 established on this canvas after a coloured dot was found to be the sole carrier of node status.

## Verification

| Mutation | Test that went red |
|---|---|
| team container reports `unit` (boxes identical again) | "marks each container with its kind" |
| node-type guard removed | "refuses the attribute on a non-container even if its data carries a kind" |

The second test exists because **my first version of it could not fail.** Removing the guard changed nothing observable — no producer puts `kind` on a person node today, so the test was proving the current data shape rather than the guard. It now mounts a person node that deliberately carries a `kind`, which pins the rule against a future producer that adds the field for its own reasons.

Fixtures are built by the real producers (`buildOrgCanvasGraph`, `buildTeamCanvasNodes`, `buildOrgPeople`) rather than hand-rolled, so the test cannot pass against a node shape nothing emits.

- `vitest run src/components/workflow src/composables/llc src/views/llc src/components/llc` — **48 files, 484 tests, all passed**
- `vue-tsc --noEmit` — 0 · `eslint` / `oxlint` / `stylelint` — exit 0

## Model Used

Claude Opus 5 (1M context)
