### PR TITLE
fix(llc/frontend): make the Company OS canvas operable by touch (#14610)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -914,7 +914,10 @@ function onNodeKeydown(node: CanvasNode, e: KeyboardEvent): void {
   e.preventDefault();
 
   if (e.ctrlKey || e.metaKey) {
-    if (props.readonly) return;
+    // Not gated on `readonly`, for the same reason the pointer drag is not:
+    // moving a node rearranges the *view* and persists nothing. Gating it here
+    // while a mouse could drag freely left keyboard users able to do strictly
+    // less on the same canvas — the inequity #14609 existed to remove.
     moveNodeByKeyboard(node, direction);
     return;
   }
@@ -993,14 +996,22 @@ function onNodePointerDown(node: CanvasNode, e: PointerEvent) {
   // this, every node — and every org-group container, the exact shape
   // #13996 already fixed for mouse — would be a dead zone for touch pan,
   // leaving only the canvas's bare gutters pannable on a tablet.
-  if (e.pointerType === 'touch' && props.readonly) return;
-
   e.stopPropagation();
-  // #14610: readonly (Company OS) must not let a press reposition a node —
-  // the same rule `onNodeKeydown` already applies to the keyboard move
-  // shortcut. A mouse press here is simply absorbed (unchanged pre-#14610
-  // behaviour); the plain `click` that follows still reaches `selectNode`.
-  if (props.readonly) return;
+  // Dragging a node is NOT gated on `readonly`, and that is deliberate.
+  //
+  // `readonly` means "cannot author the workflow" — no add, delete, connect or
+  // save. Rearranging where a node sits is a *view* gesture, not a change to
+  // anything stored: `OrgChart.onCanvasNodeMoved` writes the new position into
+  // its in-memory node list and nothing is persisted.
+  //
+  // It is also a feature the org chart deliberately supports. `OrgChart.vue`
+  // holds `canvasNodes` as a ref rather than a computed specifically so that
+  // "node drags stay put", and re-layout is avoided so "a drag survives
+  // pause/resume". Gating this on `readonly` would delete that, and would make
+  // `onCanvasNodeMoved` dead code on the only canvas that mounts read-only.
+  //
+  // Touch therefore behaves exactly as the mouse does: a press that starts on
+  // a node drags it, and a pan starts on empty canvas or a container.
   startDrag(node, e);
 }
 

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -83,8 +83,8 @@
     </div>
 
     <!-- Canvas -->
-    <div ref="canvasRef" class="canvas-area" @mousedown="startPan" @mousemove="onMouseMove"
-         @mouseup="endInteraction" @wheel.prevent="handleWheel">
+    <div ref="canvasRef" class="canvas-area" @pointerdown="startPan" @pointermove="onPointerMove"
+         @pointerup="endInteraction" @pointercancel="endInteraction" @wheel.prevent="handleWheel">
       <div class="canvas-content" :style="canvasTransform">
         <!-- #14609: keyboard instructions for the canvas's own composite-widget
              navigation (roving tabindex + arrow keys) — not discoverable from
@@ -123,7 +123,7 @@
              :aria-label="nodeAriaLabel(node)"
              :aria-pressed="selectedNodeId === node.id"
              :aria-describedby="instructionsId"
-             @mousedown="onNodeMouseDown(node, $event)"
+             @pointerdown="onNodePointerDown(node, $event)"
              @click.stop="selectNode(node.id)"
              @focus="focusedNodeId = node.id"
              @keydown="onNodeKeydown(node, $event)">
@@ -255,8 +255,8 @@
               </div>
             </template>
           </div>
-          <div v-if="!readonly" class="port port-in" @mousedown.stop="startConnect(node.id, 'in', $event)"></div>
-          <div v-if="!readonly" class="port port-out" @mousedown.stop="startConnect(node.id, 'out', $event)"></div>
+          <div v-if="!readonly" class="port port-in" @pointerdown.stop="startConnect(node.id, 'in', $event)"></div>
+          <div v-if="!readonly" class="port port-out" @pointerdown.stop="startConnect(node.id, 'out', $event)"></div>
         </div>
 
         <!-- Empty State -->
@@ -547,19 +547,29 @@ const zoom = ref(1);
 const pan = reactive({ x: 50, y: 50 });
 const isPanning = ref(false);
 /**
- * Whether the gesture that is ending actually panned the canvas (#14079).
+ * Whether the gesture that is ending actually moved something — panned the
+ * canvas, or (#14610) dragged a node — rather than merely pressed and
+ * released in place.
  *
- * A pan translates the canvas by the pointer delta, so the node the gesture
- * started on stays under the cursor. `mouseup` therefore lands on that node,
- * the browser fires `click`, and the node's drawer opens over the canvas the
+ * Originated as `pannedThisGesture` (#14079): a pan translates the canvas by
+ * the pointer delta, so the node the gesture started on stays under the
+ * cursor/finger. The `mouseup`/`pointerup` therefore lands on that node, the
+ * browser fires `click`, and the node's drawer opens over the canvas the
  * user was navigating.
  *
- * Cleared on the next `mousedown` rather than by the click it suppresses: a
- * pan that ends over empty canvas is followed by no node click at all, so a
- * flag cleared only on click would stay set and swallow the user's next
- * genuine click on a node.
+ * #14610 generalised it from "panned" to "moved something": a touch drag has
+ * the identical hazard for a node — the finger lifts over the node it just
+ * dragged, `click` fires, and without this the drawer would open right after
+ * the user repositioned it. One flag covers both cases (and both input
+ * types) rather than a second, parallel one — `selectNode` only ever needs
+ * to know "did this gesture move", not which kind of move it was.
+ *
+ * Cleared on the next `pointerdown` rather than by the click it suppresses: a
+ * gesture that ends over empty canvas is followed by no node click at all, so
+ * a flag cleared only on click would stay set and swallow the user's next
+ * genuine click/tap on a node.
  */
-const pannedThisGesture = ref(false);
+const movedThisGesture = ref(false);
 const panStart = reactive({ x: 0, y: 0 });
 const dragNode = ref<CanvasNode | null>(null);
 const dragOffset = reactive({ x: 0, y: 0 });
@@ -569,6 +579,63 @@ const mousePos = reactive({ x: 0, y: 0 });
 const showSaveDialog = ref(false);
 const saveName = ref('');
 const saveDesc = ref('');
+
+/* ------------------------------------------------------------------ *
+ * GH#14610: touch support.
+ *
+ * The canvas unifies mouse and touch on Pointer Events (`pointerdown` /
+ * `pointermove` / `pointerup` / `pointercancel`) rather than adding a
+ * parallel `touchstart`/`touchmove`/`touchend` path — one input path per
+ * gesture, per the repo's "reuse, never fork" rule. `PointerEvent` carries
+ * `clientX`/`clientY`/`shiftKey`/`button` exactly like `MouseEvent`, so the
+ * existing pan/drag/connect math is untouched; only the event names and the
+ * "what starts a pan" decision below changed.
+ *
+ * How a one-finger touch is disambiguated between pan and drag: there is no
+ * modifier key on touch (no shift, no middle button), so the decision moves
+ * from "which key is held" to "where the finger landed" — a press starting
+ * on empty canvas (or an org-group container, matching the existing
+ * shift-drag-from-anywhere behaviour, #13996) pans; a press starting on a
+ * node drags it (`onNodePointerDown`), exactly as a plain mouse press
+ * already did. `pointerType === 'touch'` is the only new branch in
+ * `startPan`; everything downstream (movement math, drag math, the
+ * `movedThisGesture` suppression) is shared with mouse.
+ *
+ * Two-finger touch is reserved for pinch-to-zoom (`activePointers`,
+ * `beginPinch`, `applyPinchZoom`) rather than a two-finger pan — pinch takes
+ * over as soon as a second pointer is detected, cancelling any in-flight
+ * one-finger pan/drag from the first finger.
+ */
+const activePointers = new Map<number, { x: number; y: number }>();
+const pinchStartDistance = ref(0);
+const pinchStartZoom = ref(1);
+
+/** Distance between the two active pointers, in client px; 0 with fewer than two. */
+function pinchDistance(): number {
+  const points = [...activePointers.values()];
+  if (points.length < 2) return 0;
+  return Math.hypot(points[0].x - points[1].x, points[0].y - points[1].y);
+}
+
+/** A second pointer just went down: hand off from pan/drag to pinch-zoom. */
+function beginPinch(): void {
+  isPanning.value = false;
+  dragNode.value = null;
+  pinchStartDistance.value = pinchDistance();
+  pinchStartZoom.value = zoom.value;
+}
+
+/**
+ * Widens capture past the element the gesture started on — without it, a
+ * touch that drifts off `canvasRef` (or off whichever node it started on)
+ * during a pan/drag stops delivering `pointermove` there. Feature-detected:
+ * unsupported in jsdom (and on very old engines), where the gesture still
+ * works because tests dispatch events directly on the target element.
+ */
+function capturePointer(e: PointerEvent): void {
+  const el = canvasRef.value;
+  if (el && typeof el.setPointerCapture === 'function') el.setPointerCapture(e.pointerId);
+}
 
 /* ------------------------------------------------------------------ *
  * GH#14609: keyboard operation — a roving-tabindex node graph.
@@ -720,8 +787,9 @@ function deleteNode(id: string) {
 }
 
 function selectNode(id: string) {
-  // The click that closes a pan is not a selection (#14079).
-  if (pannedThisGesture.value) return;
+  // The click/tap that closes a pan or a node drag is not a selection
+  // (#14079, generalised for touch drag by #14610).
+  if (movedThisGesture.value) return;
   emit('node-selected', id);
 }
 
@@ -802,7 +870,7 @@ function focusNodeInDirection(from: CanvasNode, direction: SpatialDirection): vo
 }
 
 /** Move the node itself (drag's keyboard equivalent, #14609) — only ever
- *  called when `!readonly`, mirroring `onMouseMove`'s own drag emit. */
+ *  called when `!readonly`, mirroring `onPointerMove`'s own drag emit. */
 function moveNodeByKeyboard(node: CanvasNode, direction: SpatialDirection): void {
   const delta: Record<SpatialDirection, { x: number; y: number }> = {
     up: { x: 0, y: -NODE_KEYBOARD_MOVE_STEP },
@@ -866,14 +934,35 @@ function autoLayout() {
   });
 }
 
-function zoomIn() { zoom.value = Math.min(2, zoom.value + 0.1); }
-function zoomOut() { zoom.value = Math.max(0.3, zoom.value - 0.1); }
-function resetZoom() { zoom.value = 1; pan.x = 50; pan.y = 50; }
-function handleWheel(e: WheelEvent) { zoom.value = Math.max(0.3, Math.min(2, zoom.value + (e.deltaY > 0 ? -0.05 : 0.05))); }
+/** Zoom clamp shared by every way of changing it — buttons, wheel, pinch. */
+const ZOOM_MIN = 0.3;
+const ZOOM_MAX = 2;
+function clampZoom(value: number): number { return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, value)); }
 
-function startPan(e: MouseEvent) {
-  pannedThisGesture.value = false;
-  if (e.button === 1 || e.shiftKey) { isPanning.value = true; panStart.x = e.clientX - pan.x; panStart.y = e.clientY - pan.y; }
+function zoomIn() { zoom.value = clampZoom(zoom.value + 0.1); }
+function zoomOut() { zoom.value = clampZoom(zoom.value - 0.1); }
+function resetZoom() { zoom.value = 1; pan.x = 50; pan.y = 50; }
+function handleWheel(e: WheelEvent) { zoom.value = clampZoom(zoom.value + (e.deltaY > 0 ? -0.05 : 0.05)); }
+
+/** Rescale from the pinch's starting distance/zoom — proportional, like `handleWheel`
+ *  and the zoom buttons, none of which anchor around a point either (#14610). */
+function applyPinchZoom(): void {
+  const distance = pinchDistance();
+  if (pinchStartDistance.value <= 0 || distance <= 0) return;
+  zoom.value = clampZoom(pinchStartZoom.value * (distance / pinchStartDistance.value));
+}
+
+function startPan(e: PointerEvent) {
+  movedThisGesture.value = false;
+  activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  capturePointer(e);
+  if (activePointers.size >= 2) { beginPinch(); return; }
+
+  // #14610: touch carries no shift key and no middle button, so a one-finger
+  // press starting on empty canvas (or an org container, handed on below) is
+  // always a pan — mirrors the mouse's shift/middle-click modifier.
+  const isTouchPan = e.pointerType === 'touch';
+  if (isTouchPan || e.button === 1 || e.shiftKey) { isPanning.value = true; panStart.x = e.clientX - pan.x; panStart.y = e.clientY - pan.y; }
 }
 
 /**
@@ -882,23 +971,46 @@ function startPan(e: MouseEvent) {
  * sized to its whole subtree and covers the drawing area, which left the
  * shift-drag pan the UI advertises working only in the canvas gutters. A pan
  * gesture is handed on; everything else still starts a node drag.
+ *
+ * #14610: a second finger landing on a node (rather than empty canvas) is
+ * still a pinch — `activePointers` is tracked here too, before any of the
+ * single-pointer branches below run.
  */
-function onNodeMouseDown(node: CanvasNode, e: MouseEvent) {
+function onNodePointerDown(node: CanvasNode, e: PointerEvent) {
   // Reset here too: a plain press on a node stops propagation below, so
   // `startPan` never runs and would never clear the flag.
-  pannedThisGesture.value = false;
+  movedThisGesture.value = false;
+  activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  capturePointer(e);
+  if (activePointers.size >= 2) { beginPinch(); e.stopPropagation(); return; }
+
   if (e.shiftKey || e.button === 1) return;
+
+  // #14610: `readonly` (Company OS) never drags a node — see below — so on
+  // touch a one-finger press starting on a node has nothing else useful to
+  // do there. Handing it on to `startPan` (by not stopping propagation) is
+  // the touch equivalent of the shift/middle-click bubble above: without
+  // this, every node — and every org-group container, the exact shape
+  // #13996 already fixed for mouse — would be a dead zone for touch pan,
+  // leaving only the canvas's bare gutters pannable on a tablet.
+  if (e.pointerType === 'touch' && props.readonly) return;
+
   e.stopPropagation();
+  // #14610: readonly (Company OS) must not let a press reposition a node —
+  // the same rule `onNodeKeydown` already applies to the keyboard move
+  // shortcut. A mouse press here is simply absorbed (unchanged pre-#14610
+  // behaviour); the plain `click` that follows still reaches `selectNode`.
+  if (props.readonly) return;
   startDrag(node, e);
 }
 
-function startDrag(node: CanvasNode, e: MouseEvent) {
+function startDrag(node: CanvasNode, e: PointerEvent) {
   dragNode.value = node;
   dragOffset.x = e.clientX - node.position.x * zoom.value - pan.x;
   dragOffset.y = e.clientY - node.position.y * zoom.value - pan.y;
 }
 
-function startConnect(nodeId: string, port: string, e: MouseEvent) {
+function startConnect(nodeId: string, port: string, e: PointerEvent) {
   drawingLine.value = true;
   const node = props.nodes.find(n => n.id === nodeId);
   if (node) {
@@ -907,24 +1019,32 @@ function startConnect(nodeId: string, port: string, e: MouseEvent) {
     lineStart.y = node.position.y + 50;
   }
   mousePos.x = e.clientX; mousePos.y = e.clientY;
+  capturePointer(e);
 }
 
-function onMouseMove(e: MouseEvent) {
+function onPointerMove(e: PointerEvent) {
+  if (activePointers.has(e.pointerId)) activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+  if (activePointers.size >= 2) { applyPinchZoom(); return; }
+
   mousePos.x = e.clientX; mousePos.y = e.clientY;
   if (isPanning.value) {
     pan.x = e.clientX - panStart.x; pan.y = e.clientY - panStart.y;
-    // Set on movement, not on press: a shift-click that never moves is still
-    // a selection, and suppressing it would break selecting with shift held.
-    pannedThisGesture.value = true;
+    // Set on movement, not on press: a shift-click/tap that never moves is
+    // still a selection, and suppressing it would break selecting with shift
+    // held (mouse) or a plain tap (touch).
+    movedThisGesture.value = true;
   }
   else if (dragNode.value) {
     const x = (e.clientX - dragOffset.x - pan.x) / zoom.value;
     const y = (e.clientY - dragOffset.y - pan.y) / zoom.value;
     emit('node-moved', dragNode.value.id, { x: Math.max(0, x), y: Math.max(0, y) });
+    // #14610: a drag that actually moved the node must not also select it
+    // when the gesture ends — the drag counterpart of the pan case above.
+    movedThisGesture.value = true;
   }
 }
 
-function endInteraction(e: MouseEvent) {
+function endInteraction(e: PointerEvent) {
   if (drawingLine.value) {
     const rect = canvasRef.value?.getBoundingClientRect();
     if (rect) {
@@ -934,6 +1054,10 @@ function endInteraction(e: MouseEvent) {
       if (target && target.id !== lineStart.nodeId) emit('nodes-connected', lineStart.nodeId, target.id);
     }
   }
+  // #14610: lifting one finger of a pinch leaves the other still down; it
+  // does not resume as a one-finger pan — the user has to lift fully and
+  // start a fresh gesture, same as releasing mid-drag does for a mouse.
+  activePointers.delete(e.pointerId);
   isPanning.value = false; dragNode.value = null; drawingLine.value = false;
 }
 
@@ -954,7 +1078,10 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .badge-experimental { font-size: 9px; padding: var(--spacing-px) var(--spacing-1); background: var(--color-warning); color: var(--wfcanvas-on-warning); border-radius: var(--radius-default); font-weight: 700; text-transform: uppercase; line-height: 1; }
 .toolbar-divider { width: 1px; height: var(--spacing-6); background: var(--border-default); margin: var(--spacing-0) var(--spacing-1); }
 
-.canvas-area { flex: 1; position: relative; overflow: hidden; background: linear-gradient(var(--border-subtle) 1px, transparent 1px), linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px); background-size: 20px 20px; cursor: grab; }
+/* #14610: `touch-action: none` on every custom-gesture surface — without it, the
+   browser's own touch scroll/pinch-zoom competes with our own pan/pinch/drag
+   handling for the same one- and two-finger gestures. */
+.canvas-area { flex: 1; position: relative; overflow: hidden; background: linear-gradient(var(--border-subtle) 1px, transparent 1px), linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px); background-size: 20px 20px; cursor: grab; touch-action: none; }
 .canvas-area:active { cursor: grabbing; }
 .canvas-content { position: absolute; min-width: 100%; min-height: 100%; transform-origin: 0 0; }
 
@@ -962,7 +1089,7 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .connection-line { fill: none; stroke: var(--color-primary); stroke-width: 2; }
 .drawing-line { fill: none; stroke: var(--color-primary); stroke-width: 2; stroke-dasharray: 5; opacity: 0.6; }
 
-.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: var(--radius-xl); box-shadow: var(--shadow-sm); cursor: move; user-select: none; }
+.workflow-node { position: absolute; width: 240px; background: var(--bg-secondary); border: 2px solid var(--border-default); border-radius: var(--radius-xl); box-shadow: var(--shadow-sm); cursor: move; user-select: none; touch-action: none; }
 .workflow-node:hover { box-shadow: var(--shadow-md); }
 .workflow-node.selected { border-color: var(--color-primary); box-shadow: 0 0 0 3px var(--color-primary-bg); }
 /* #14609: keyboard focus indicator — nodes carry no native focus styling of
@@ -1072,8 +1199,20 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 
 .node-header { display: flex; align-items: center; gap: var(--spacing-2); padding: var(--spacing-2) var(--spacing-3); color: var(--text-on-primary); border-radius: var(--radius-lg) var(--radius-lg) 0 0; font-size: var(--text-sm); font-weight: 600; }
 .node-header span { flex: 1; }
-.delete-btn { padding: var(--spacing-1); background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
+.delete-btn { position: relative; padding: var(--spacing-1); background: transparent; border: none; color: inherit; cursor: pointer; opacity: 0.7; border-radius: var(--radius-default); }
 .delete-btn:hover { opacity: 1; background: rgba(255,255,255,0.2); }
+/* #14610: same WCAG 2.5.5 touch-target widening as `.port`, for the same reason
+   — the visible icon stays compact inside the node header on a mouse. */
+@media (pointer: coarse) {
+  .delete-btn::before {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: var(--spacing-12);
+    height: var(--spacing-12);
+    transform: translate(-50%, -50%);
+  }
+}
 
 .node-body { padding: var(--spacing-3); display: flex; flex-direction: column; gap: var(--spacing-2); }
 .node-body input, .node-body select { width: 100%; padding: var(--spacing-1-5) var(--spacing-2); background: var(--bg-primary); border: 1px solid var(--border-default); border-radius: var(--radius-default); color: var(--text-primary); font-size: var(--text-xs); }
@@ -1085,10 +1224,29 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .checkbox { display: flex; align-items: center; gap: var(--spacing-1); font-size: var(--text-xs); color: var(--text-secondary); white-space: nowrap; }
 .checkbox input { width: 14px; height: 14px; }
 
-.port { position: absolute; width: var(--spacing-3); height: var(--spacing-3); background: var(--bg-secondary); border: 2px solid var(--color-primary); border-radius: 50%; cursor: crosshair; top: 50%; transform: translateY(-50%); }
+.port { position: absolute; width: var(--spacing-3); height: var(--spacing-3); background: var(--bg-secondary); border: 2px solid var(--color-primary); border-radius: 50%; cursor: crosshair; top: 50%; transform: translateY(-50%); touch-action: none; }
 .port:hover { transform: translateY(-50%) scale(1.3); background: var(--color-primary); }
 .port-in { left: -6px; }
 .port-out { right: -6px; }
+
+/* #14610: the visible port stays its usual small size (it sits right on the
+   node's edge — growing it would overlap the body), but a coarse (touch)
+   pointer gets an invisible `::before` overlay sized to the WCAG 2.5.5
+   44x44px minimum, centred on the same point, so the port is still reliably
+   tappable without changing how it looks to a mouse user. */
+@media (pointer: coarse) {
+  .port::before {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    /* #14610: no --spacing token lands on the WCAG 2.5.5 44px minimum exactly
+       (--spacing-10 is 40px, --spacing-12 is 48px) — round up to the token
+       that clears it rather than a bare literal. */
+    width: var(--spacing-12);
+    height: var(--spacing-12);
+    transform: translate(-50%, -50%);
+  }
+}
 
 .empty-state { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; padding: var(--spacing-10); }
 .empty-state i { font-size: var(--text-5xl); color: var(--text-muted); margin-bottom: var(--spacing-4); }

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
@@ -8,7 +8,8 @@
  *   - roving tabindex (one Tab stop; the rest -1) and its `@focus` sync
  *   - Enter/Space selects (same effect as `@click`), Escape deselects
  *   - arrow keys move focus in visual order, RTL-aware for left/right
- *   - a Ctrl/Cmd+arrow moves the focused node (readonly disables this)
+ *   - a Ctrl/Cmd+arrow moves the focused node (allowed on readonly too: it
+ *     rearranges the view and persists nothing — see #14610)
  *   - a keypress bubbling from a node's own input/select/button is left
  *     alone, never hijacked as a node-level shortcut
  *   - the accessible name states kind, name and (for org-person) state
@@ -237,11 +238,17 @@ describe('WorkflowCanvas Ctrl+Arrow moves the focused node (#14609)', () => {
     expect(wrapper.emitted('node-moved')).toEqual([['a', { x: 20, y: 0 }]])
   })
 
-  it('never moves the node when readonly — dragging is a mutation the read-only canvas must not offer', async () => {
+  it('moves the node on a readonly canvas too — rearranging the view is not a mutation', async () => {
+    // #14610 corrected the premise this test was written under. `readonly`
+    // means "cannot author the workflow"; moving a node persists nothing
+    // (`OrgChart.onCanvasNodeMoved` writes an in-memory position), and a mouse
+    // has always been able to drag on this canvas. Refusing the keyboard here
+    // left keyboard users able to do strictly less than mouse users on the
+    // same surface.
     const wrapper = mountCanvas({ nodes: grid(), readonly: true })
     await keydown(wrapper, 'a', 'ArrowRight', { ctrlKey: true })
 
-    expect(wrapper.emitted('node-moved')).toBeUndefined()
+    expect(wrapper.emitted('node-moved')).toEqual([['a', { x: 20, y: 0 }]])
   })
 
   it('clamps to zero rather than moving off-canvas', async () => {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
@@ -20,6 +20,7 @@ import WorkflowCanvas from '../WorkflowCanvas.vue'
 import type { CanvasNode } from '../canvasNode'
 import { buildOrgCanvasGraph } from '@/composables/llc/orgCanvasGraph'
 import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+import { firePointer } from './pointerTestUtils'
 
 const ORG_NODES: CanvasNode[] = [
   {
@@ -65,6 +66,10 @@ function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en')
  * an `org-group` container covers the whole drawing area, so a gesture that
  * only ever starts in the gutter cannot see the pan being swallowed.
  */
+// #14610: the component now listens for Pointer Events, not
+// `mousedown`/`mousemove`/`mouseup` — one input path for mouse and touch.
+// `PointerEvent` carries the same `clientX`/`clientY`/`shiftKey`/`button`
+// used below, so only the triggered event names changed.
 async function panFrom(
   wrapper: ReturnType<typeof mountCanvas>,
   selector: string,
@@ -73,9 +78,9 @@ async function panFrom(
   modifiers: Record<string, unknown> = { shiftKey: true, button: 0 },
 ) {
   const area = wrapper.get('.canvas-area')
-  await wrapper.get(selector).trigger('mousedown', { clientX: 100, clientY: 100, ...modifiers })
-  await area.trigger('mousemove', { clientX: 100 + dx, clientY: 100 + dy })
-  await area.trigger('mouseup', { clientX: 100 + dx, clientY: 100 + dy })
+  await firePointer(wrapper.get(selector).element, 'pointerdown', { clientX: 100, clientY: 100, ...modifiers })
+  await firePointer(area.element, 'pointermove', { clientX: 100 + dx, clientY: 100 + dy })
+  await firePointer(area.element, 'pointerup', { clientX: 100 + dx, clientY: 100 + dy })
   return wrapper.get('.canvas-content').attributes('style')
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
@@ -10,6 +10,12 @@
 // The suppression has to be narrow in two directions, and both are asserted
 // here: a shift-click that never moves is still a selection, and a pan that
 // ends over empty canvas must not swallow the user's NEXT click on a node.
+//
+// #14610: the component now listens for Pointer Events (`pointerdown` /
+// `pointermove` / `pointerup`), not `mousedown`/`mousemove`/`mouseup` — one
+// input path for mouse and touch. The gestures below are triggered with the
+// pointer event names; the flag they exercise (`movedThisGesture`, renamed
+// from `pannedThisGesture`) and the assertions are otherwise unchanged.
 
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
@@ -18,6 +24,7 @@ import en from '@/i18n/locales/en.json'
 
 import WorkflowCanvas from '../WorkflowCanvas.vue'
 import type { CanvasNode } from '../canvasNode'
+import { firePointer } from './pointerTestUtils'
 
 const NODES: CanvasNode[] = [
   {
@@ -45,9 +52,9 @@ const selections = (w: Wrapper) => w.emitted('node-selected') ?? []
 
 /** Shift-drag from `from` to `to`, starting on whichever element is given. */
 async function panFrom(w: Wrapper, start: ReturnType<typeof node>, dx: number): Promise<void> {
-  await start.trigger('mousedown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
-  await area(w).trigger('mousemove', { clientX: 100 + dx, clientY: 100 + dx })
-  await area(w).trigger('mouseup', { clientX: 100 + dx, clientY: 100 + dx })
+  await firePointer(start.element, 'pointerdown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
+  await firePointer(area(w).element, 'pointermove', { clientX: 100 + dx, clientY: 100 + dx })
+  await firePointer(area(w).element, 'pointerup', { clientX: 100 + dx, clientY: 100 + dx })
 }
 
 describe('a pan gesture is not a selection (#14079)', () => {
@@ -62,8 +69,8 @@ describe('a pan gesture is not a selection (#14079)', () => {
 
   it('still selects on a plain click', async () => {
     const w = mountCanvas()
-    await node(w).trigger('mousedown', { clientX: 100, clientY: 100, button: 0 })
-    await node(w).trigger('mouseup', { clientX: 100, clientY: 100 })
+    await firePointer(node(w).element, 'pointerdown', { clientX: 100, clientY: 100, button: 0 })
+    await firePointer(node(w).element, 'pointerup', { clientX: 100, clientY: 100 })
     await node(w).trigger('click')
 
     expect(selections(w)).toEqual([['ceo']])
@@ -74,8 +81,8 @@ describe('a pan gesture is not a selection (#14079)', () => {
     // Keying the suppression on the modifier instead of on movement would
     // silently make shift-click stop working.
     const w = mountCanvas()
-    await node(w).trigger('mousedown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
-    await node(w).trigger('mouseup', { clientX: 100, clientY: 100 })
+    await firePointer(node(w).element, 'pointerdown', { shiftKey: true, clientX: 100, clientY: 100, button: 0 })
+    await firePointer(node(w).element, 'pointerup', { clientX: 100, clientY: 100 })
     await node(w).trigger('click')
 
     expect(selections(w)).toEqual([['ceo']])
@@ -86,11 +93,11 @@ describe('a pan gesture is not a selection (#14079)', () => {
     // pan is followed by no node click at all, so the flag would still be set
     // when the user next clicks a node.
     const w = mountCanvas()
-    await area(w).trigger('mousedown', { shiftKey: true, clientX: 10, clientY: 10, button: 0 })
-    await area(w).trigger('mousemove', { clientX: 90, clientY: 90 })
-    await area(w).trigger('mouseup', { clientX: 90, clientY: 90 })
+    await firePointer(area(w).element, 'pointerdown', { shiftKey: true, clientX: 10, clientY: 10, button: 0 })
+    await firePointer(area(w).element, 'pointermove', { clientX: 90, clientY: 90 })
+    await firePointer(area(w).element, 'pointerup', { clientX: 90, clientY: 90 })
 
-    await node(w).trigger('mousedown', { clientX: 100, clientY: 100, button: 0 })
+    await firePointer(node(w).element, 'pointerdown', { clientX: 100, clientY: 100, button: 0 })
     await node(w).trigger('click')
 
     expect(selections(w)).toEqual([['ceo']])

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
@@ -144,7 +144,18 @@ describe('WorkflowCanvas one-finger touch drag (#14610)', () => {
     expect(transform(w)).toContain('translate(50px, 50px)')
   })
 
-  it('never drags the node, on a readonly canvas, no matter how far the finger moves', async () => {
+  it('drags the node on a readonly canvas, exactly as the mouse always has', async () => {
+    // The premise these tests were first written under was wrong, and #14610
+    // corrected it. `readonly` means "cannot author the workflow" — no add,
+    // delete, connect or save. Moving a node rearranges the *view* and
+    // persists nothing: `OrgChart.onCanvasNodeMoved` writes an in-memory
+    // position.
+    //
+    // It is also a feature the org chart deliberately supports. `OrgChart.vue`
+    // holds `canvasNodes` as a ref rather than a computed specifically so
+    // "node drags stay put", and avoids re-layout so "a drag survives
+    // pause/resume". Refusing the drag here would have made that engineering
+    // dead code on the only canvas that mounts read-only.
     const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
 
     await firePointer(node(w).element, 'pointerdown', {
@@ -154,10 +165,15 @@ describe('WorkflowCanvas one-finger touch drag (#14610)', () => {
       pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 140,
     })
 
-    expect(w.emitted('node-moved')).toBeUndefined()
+    expect(w.emitted('node-moved')).toBeTruthy()
+    // A drag, not a pan: the canvas transform is untouched.
+    expect(transform(w)).toContain('translate(50px, 50px)')
   })
 
-  it('pans instead when the press starts on a node — a readonly node can never be dragged, so it is not a touch pan dead zone (#13996 for touch)', async () => {
+  it('drags rather than pans when a touch press starts on a node, matching the mouse', async () => {
+    // Parity is the point. A press on a node drags it and a pan starts on
+    // empty canvas or a container, for touch and mouse alike — one rule, not
+    // one rule per input device.
     const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
 
     await firePointer(node(w).element, 'pointerdown', {
@@ -167,18 +183,10 @@ describe('WorkflowCanvas one-finger touch drag (#14610)', () => {
       pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 140,
     })
 
-    expect(w.emitted('node-moved')).toBeUndefined()
-    expect(transform(w)).toContain('translate(80px, 90px)')
+    expect(transform(w)).toContain('translate(50px, 50px)')
   })
 
-  it('never drags the node on a readonly canvas via mouse either — the pointer unification must not reopen this for touch only', async () => {
-    // #14610 found this while unifying mouse and touch onto one handler: a
-    // plain (unmodified) MOUSE press on a readonly node used to reach
-    // `startDrag` unconditionally — nothing gated it on `readonly` before
-    // this change, so a Company OS user could reposition an org node with a
-    // mouse even though the canvas is meant to be view-only. Fixed as part
-    // of the same `onNodePointerDown` readonly gate touch needs; guarded
-    // here so it cannot regress back to mouse-only special-casing.
+  it('drags on a readonly canvas by mouse too, so neither device is special-cased', async () => {
     const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
 
     await firePointer(node(w).element, 'pointerdown', {
@@ -188,7 +196,7 @@ describe('WorkflowCanvas one-finger touch drag (#14610)', () => {
       pointerType: 'mouse', pointerId: 1, clientX: 130, clientY: 140,
     })
 
-    expect(w.emitted('node-moved')).toBeUndefined()
+    expect(w.emitted('node-moved')).toBeTruthy()
   })
 
   it('readonly still selects the node on a genuine tap', async () => {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
@@ -1,0 +1,305 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * GH#14610: the canvas was mouse-only — `touchstart`/`@touch`/pointer events:
+ * zero occurrences. Pan needed a modifier key that does not exist on touch
+ * (shift or middle-click); zoom was wheel-only; node drag and connection
+ * drawing were equally unreachable.
+ *
+ * Covers:
+ *   - a one-finger touch press on empty canvas pans (no modifier key needed)
+ *   - a one-finger touch press on a node drags it, exactly like a plain
+ *     mouse press already did — readonly (Company OS) disables this, same
+ *     rule the keyboard move shortcut already follows (#14609)
+ *   - a plain (unmodified) mouse press on empty canvas still does NOT pan —
+ *     the touch branch must not swallow the existing mouse gating
+ *   - two-finger pinch zooms, clamped to the existing 0.3–2 range
+ *   - a touch gesture that moved something does not also select — the touch
+ *     analogue of #14079, sharing the one `movedThisGesture` flag
+ *   - horizontal pan reads identically in an RTL document (canvas pans with
+ *     a CSS transform, never mirrored)
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+import { firePointer } from './pointerTestUtils'
+
+const ORG_NODE: CanvasNode[] = [
+  {
+    id: 'ceo',
+    type: 'org-person',
+    position: { x: 40, y: 40 },
+    data: { title: 'Ada', status: 'idle' },
+    connections: [],
+  },
+]
+
+const STEP_NODE: CanvasNode[] = [
+  {
+    id: 'n1',
+    type: 'step',
+    position: { x: 100, y: 40 },
+    data: { command: '', description: '', risk_level: 'low', requires_confirmation: true },
+    connections: [],
+  },
+]
+
+function makeI18n(locale: 'en' | 'ar') {
+  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
+}
+
+function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
+  return mount(WorkflowCanvas, {
+    props: { selectedNodeId: null, ...props },
+    global: { plugins: [makeI18n(locale)] },
+  })
+}
+
+type Wrapper = ReturnType<typeof mountCanvas>
+
+const area = (w: Wrapper) => w.get('.canvas-area')
+const node = (w: Wrapper) => w.get('.workflow-node')
+const transform = (w: Wrapper) => w.get('.canvas-content').attributes('style')
+
+afterEach(() => {
+  document.documentElement.removeAttribute('dir')
+})
+
+describe('WorkflowCanvas one-finger touch pan (#14610)', () => {
+  it('pans from a press on empty canvas — no modifier key needed', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', {
+      pointerType: 'touch', pointerId: 1, clientX: 10, clientY: 10,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'touch', pointerId: 1, clientX: 90, clientY: 60,
+    })
+    await firePointer(area(w).element, 'pointerup', {
+      pointerType: 'touch', pointerId: 1, clientX: 90, clientY: 60,
+    })
+
+    // Default pan starts at (50, 50); an 80/50 finger delta lands at (130, 100).
+    expect(transform(w)).toContain('translate(130px, 100px)')
+  })
+
+  it('a plain unmodified mouse press on empty canvas still does not pan', async () => {
+    // The touch branch (`pointerType === 'touch'`) must not swallow the
+    // mouse's own shift/middle-click gating — a mouse press with neither
+    // stays a no-op on empty canvas, exactly as before #14610.
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', {
+      pointerType: 'mouse', pointerId: 1, clientX: 10, clientY: 10,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'mouse', pointerId: 1, clientX: 90, clientY: 60,
+    })
+
+    expect(transform(w)).toContain('translate(50px, 50px)')
+  })
+
+  it('pans by the same transform in an RTL locale as in an LTR one', async () => {
+    const ltr = mountCanvas({ nodes: ORG_NODE, readonly: true }, 'en')
+    await firePointer(area(ltr).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 10, clientY: 10 })
+    await firePointer(area(ltr).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 40 })
+    const ltrStyle = transform(ltr)
+
+    document.documentElement.setAttribute('dir', 'rtl')
+    const rtl = mountCanvas({ nodes: ORG_NODE, readonly: true }, 'ar')
+    await firePointer(area(rtl).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 10, clientY: 10 })
+    await firePointer(area(rtl).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 40 })
+    const rtlStyle = transform(rtl)
+
+    expect(ltrStyle).toContain('translate(170px, 80px)')
+    expect(rtlStyle).toBe(ltrStyle)
+  })
+})
+
+describe('WorkflowCanvas one-finger touch drag (#14610)', () => {
+  it('drags a node exactly like a plain mouse press already did', async () => {
+    const w = mountCanvas({ nodes: STEP_NODE, readonly: false })
+
+    await firePointer(node(w).element, 'pointerdown', {
+      pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 140,
+    })
+
+    expect(w.emitted('node-moved')).toEqual([['n1', { x: 130, y: 80 }]])
+    // The pan transform must not have moved — this was a drag, not a pan.
+    expect(transform(w)).toContain('translate(50px, 50px)')
+  })
+
+  it('never drags the node, on a readonly canvas, no matter how far the finger moves', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(node(w).element, 'pointerdown', {
+      pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 140,
+    })
+
+    expect(w.emitted('node-moved')).toBeUndefined()
+  })
+
+  it('pans instead when the press starts on a node — a readonly node can never be dragged, so it is not a touch pan dead zone (#13996 for touch)', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(node(w).element, 'pointerdown', {
+      pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'touch', pointerId: 1, clientX: 130, clientY: 140,
+    })
+
+    expect(w.emitted('node-moved')).toBeUndefined()
+    expect(transform(w)).toContain('translate(80px, 90px)')
+  })
+
+  it('never drags the node on a readonly canvas via mouse either — the pointer unification must not reopen this for touch only', async () => {
+    // #14610 found this while unifying mouse and touch onto one handler: a
+    // plain (unmodified) MOUSE press on a readonly node used to reach
+    // `startDrag` unconditionally — nothing gated it on `readonly` before
+    // this change, so a Company OS user could reposition an org node with a
+    // mouse even though the canvas is meant to be view-only. Fixed as part
+    // of the same `onNodePointerDown` readonly gate touch needs; guarded
+    // here so it cannot regress back to mouse-only special-casing.
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(node(w).element, 'pointerdown', {
+      pointerType: 'mouse', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await firePointer(area(w).element, 'pointermove', {
+      pointerType: 'mouse', pointerId: 1, clientX: 130, clientY: 140,
+    })
+
+    expect(w.emitted('node-moved')).toBeUndefined()
+  })
+
+  it('readonly still selects the node on a genuine tap', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(node(w).element, 'pointerdown', {
+      pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await firePointer(node(w).element, 'pointerup', {
+      pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100,
+    })
+    await node(w).trigger('click')
+
+    expect(w.emitted('node-selected')).toEqual([['ceo']])
+  })
+})
+
+describe('WorkflowCanvas a touch gesture that moved does not also select (#14610)', () => {
+  it('does not select the node a one-finger drag just moved', async () => {
+    const w = mountCanvas({ nodes: STEP_NODE, readonly: false })
+
+    await firePointer(node(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 170, clientY: 100 })
+    await firePointer(area(w).element, 'pointerup', { pointerType: 'touch', pointerId: 1, clientX: 170, clientY: 100 })
+    // The `click` a real touchscreen fires when the finger lifts over the node.
+    await node(w).trigger('click')
+
+    expect(w.emitted('node-selected')).toBeUndefined()
+  })
+
+  it('does not select the node a one-finger pan started on', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(node(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 170, clientY: 100 })
+    await firePointer(area(w).element, 'pointerup', { pointerType: 'touch', pointerId: 1, clientX: 170, clientY: 100 })
+    await node(w).trigger('click')
+
+    expect(w.emitted('node-selected')).toBeUndefined()
+  })
+
+  it('still selects on a tap that never moved', async () => {
+    // The negative-only trap: pair every "does not select" assertion above
+    // with a case that must stay selectable.
+    const w = mountCanvas({ nodes: STEP_NODE, readonly: false })
+
+    await firePointer(node(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await firePointer(node(w).element, 'pointerup', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await node(w).trigger('click')
+
+    expect(w.emitted('node-selected')).toEqual([['n1']])
+  })
+})
+
+describe('WorkflowCanvas pinch-to-zoom (#14610)', () => {
+  it('zooms in as two fingers spread apart', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 200, clientY: 100 })
+    // Distance 100 -> 150: 1.5x.
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 50, clientY: 100 })
+
+    expect(transform(w)).toContain('scale(1.5)')
+  })
+
+  it('zooms out as two fingers pinch together', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 0, clientY: 100 })
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 200, clientY: 100 })
+    // Distance 200 -> 100: 0.5x.
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+
+    expect(transform(w)).toContain('scale(0.5)')
+  })
+
+  it('clamps pinch-out at the existing zoom-in ceiling (2)', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 100, clientY: 100 })
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 110, clientY: 100 })
+    // Distance 10 -> 1000: wildly past the ceiling.
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: -890, clientY: 100 })
+
+    expect(transform(w)).toContain('scale(2)')
+  })
+
+  it('clamps pinch-in at the existing zoom-out floor (0.3)', async () => {
+    const w = mountCanvas({ nodes: ORG_NODE, readonly: true })
+
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 0, clientY: 100 })
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 200, clientY: 100 })
+    // Distance 200 -> 2: wildly past the floor.
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 198, clientY: 100 })
+
+    expect(transform(w)).toContain('scale(0.3)')
+  })
+
+  it('a second finger landing on a node still starts a pinch, not a drag', async () => {
+    // #14610: pinch is tracked at both `startPan` (empty canvas) and
+    // `onNodePointerDown` (a node) — a real two-finger pinch rarely lands
+    // both fingers on empty canvas.
+    const w = mountCanvas({ nodes: STEP_NODE, readonly: false })
+
+    await firePointer(area(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 1, clientX: 200, clientY: 100 })
+    await firePointer(node(w).element, 'pointerdown', { pointerType: 'touch', pointerId: 2, clientX: 100, clientY: 100 })
+    // Distance 100 -> 150: 1.5x.
+    await firePointer(area(w).element, 'pointermove', { pointerType: 'touch', pointerId: 1, clientX: 250, clientY: 100 })
+
+    expect(w.emitted('node-moved')).toBeUndefined()
+    expect(transform(w)).toContain('scale(1.5)')
+  })
+})

--- a/autobot-frontend/src/components/workflow/__tests__/pointerTestUtils.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/pointerTestUtils.ts
@@ -1,0 +1,55 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * GH#14610: shared helper for dispatching real `PointerEvent`s in tests.
+ *
+ * `@vue/test-utils`'s `wrapper.trigger('pointerdown', {...})` cannot be used
+ * here: after constructing the event (which correctly applies `clientX`,
+ * `clientY`, `shiftKey`, `button`, ...), it reassigns every option onto the
+ * event a *second* time via `event[key] = options[key]`. That second
+ * assignment walks `Object.getPrototypeOf(event)` — `PointerEvent.prototype`
+ * — and in this jsdom version `PointerEvent.prototype` does not *own*
+ * `clientX`/`clientY`/`shiftKey`/`button`; they are inherited, getter-only,
+ * from `MouseEvent.prototype`. The reassignment throws
+ * "Cannot set property clientX of #<MouseEvent> which has only a getter".
+ * This is exactly the "jsdom does not implement touch/pointer gestures
+ * natively" gap: constructing and dispatching the event directly sidesteps
+ * `trigger()`'s buggy second pass entirely, and is the same native
+ * `PointerEvent` our `@pointerdown`/`@pointermove`/`@pointerup`/
+ * `@pointercancel` template bindings listen for.
+ */
+
+import { nextTick } from 'vue'
+
+export type PointerEventType = 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel'
+
+/**
+ * Dispatch a `PointerEvent` on `el` and wait a tick for Vue to react.
+ *
+ * `pointerId` defaults to `1` — a single simulated pointer is enough for
+ * every one-finger/mouse gesture; multi-touch (pinch) tests pass distinct
+ * ids explicitly. `pointerType` defaults to `'mouse'`, matching a real
+ * browser; touch gestures pass `pointerType: 'touch'` explicitly.
+ */
+export async function firePointer(
+  el: Element,
+  type: PointerEventType,
+  init: PointerEventInit = {},
+): Promise<void> {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    pointerId: 1,
+    pointerType: 'mouse',
+    ...init,
+  })
+  // Mirrors @vue/test-utils' own workaround (vuejs/test-utils#1854): Vue
+  // ignores a dispatched event whose timestamp is not after the time its
+  // listener was attached, which a manually constructed event does not
+  // otherwise carry.
+  ;(event as PointerEvent & { _vts?: number })._vts = Date.now() + 1
+  el.dispatchEvent(event)
+  await nextTick()
+}

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.viewMode.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.viewMode.test.ts
@@ -7,6 +7,7 @@
 // resume / terminate and the detail drawer working exactly as before.
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { firePointer } from '@/components/workflow/__tests__/pointerTestUtils'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { ref } from 'vue'
@@ -123,11 +124,14 @@ async function dragPerson(
   dx: number,
   dy: number,
 ) {
+  // #14610: the canvas listens for Pointer Events now — one path for mouse and
+  // touch — so a gesture driven with `mousedown`/`mousemove` reaches nothing.
+  // The gesture and every assertion around it are otherwise unchanged.
   const person = personNode(wrapper, name)
   const area = wrapper.get('.canvas-area')
-  await person.trigger('mousedown', { clientX: 300, clientY: 300, button: 0 })
-  await area.trigger('mousemove', { clientX: 300 + dx, clientY: 300 + dy })
-  await area.trigger('mouseup', { clientX: 300 + dx, clientY: 300 + dy })
+  await firePointer(person.element, 'pointerdown', { clientX: 300, clientY: 300, button: 0 })
+  await firePointer(area.element, 'pointermove', { clientX: 300 + dx, clientY: 300 + dy })
+  await firePointer(area.element, 'pointerup', { clientX: 300 + dx, clientY: 300 + dy })
   await flushPromises()
 }
 
@@ -258,6 +262,19 @@ describe('OrgChart view-mode toggle (#13939)', () => {
     expect(dragged).not.toEqual(before)
 
     // Resume the agent from the drawer — the primary canvas-mode action.
+    //
+    // The press is fired before the click on purpose. #14610 extended the
+    // "a gesture that moved is not a selection" rule from pans to node drags
+    // (the half #14079 deferred), and the flag clears on the next pointerdown
+    // — which a real browser always delivers before a click. A bare `click`
+    // here would be a sequence no user can produce, and would now read as the
+    // click that ended the drag above.
+    await firePointer(personNode(wrapper, 'Grace').element, 'pointerdown', {
+      clientX: 420, clientY: 360, button: 0,
+    })
+    await firePointer(personNode(wrapper, 'Grace').element, 'pointerup', {
+      clientX: 420, clientY: 360,
+    })
     await personNode(wrapper, 'Grace').trigger('click')
     await flushPromises()
     await wrapper.get('[data-testid="org-drawer-pause"]').trigger('click')


### PR DESCRIPTION
Closes #14610 · Parent #13935

## Thinking Path

Measured before building: `WorkflowCanvas.vue` had **zero** touch or pointer handlers. Pan required `e.shiftKey || e.button === 1` — neither exists on touch — and zoom was bound to `wheel`. The canvas rendered on a tablet and could not be operated on one.

Unified on **Pointer Events** rather than adding a parallel touch path. `PointerEvent` carries the same `clientX`/`clientY`/`shiftKey`/`button` as `MouseEvent`, so every existing pan/drag/connect calculation is untouched, and there is one input path instead of two that drift.

## What Changed

- `pointerdown`/`pointermove`/`pointerup`/`pointercancel` replace the mouse handlers; two-finger pinch zoom shares the existing 0.3–2 clamp, now centralised in `clampZoom`.
- `pannedThisGesture` generalised to `movedThisGesture` — **one** flag, as #14079 requires — and extended to node drags. That closes the half #14079 deferred: dragging a node no longer opens its drawer when the gesture ends.
- Touch hit targets sized via `@media (pointer: coarse)` to 48px, above the WCAG 2.5.5 minimum.

## The correction, which is most of the value here

The first implementation gated node dragging on `readonly`, reporting it as a bug fix — a Company OS user could "reposition an org node with a mouse". **That was wrong, and it deleted a working feature.**

Dragging persists nothing: `OrgChart.onCanvasNodeMoved` writes an in-memory position. `readonly` means *cannot author the workflow* — no add, delete, connect, save. And the org chart deliberately supports dragging: `OrgChart.vue` holds `canvasNodes` as a ref rather than a computed specifically so "node drags stay put", and avoids re-layout so "a drag survives pause/resume". There is a test named exactly that, and it failed.

The same wrong premise had already reached the keyboard. **#14609 refused Ctrl/Cmd+arrow under `readonly` because my brief for it told the implementer that dragging is a mutation.** That left keyboard users able to do strictly less than mouse users on the same canvas — the inequity #14609 existed to remove. Both are corrected here: mouse, touch and keyboard all move a node on a read-only canvas, and none of them author anything.

Touch now matches the mouse exactly — press on a node drags, pan starts on empty canvas or a container. One rule, not one per input device.

## Verification

| Mutation | Test that went red |
|---|---|
| re-introduce the `readonly` drag gate | drags on readonly (touch) · drags on readonly (mouse) · "does not select the node a one-finger pan started on" |
| re-gate the keyboard move on `readonly` | "moves the node on a readonly canvas too" |

Plus the implementer's 10 mutations across pan/touch detection, pinch threshold and ratio, both `movedThisGesture` sites, the zoom clamp bounds, and pinch pointer registration.

**No assertion in the two protected suites was changed** — `git diff` on `panClick` and `orgMode` shows event-name substitutions only, and `keyboardA11y` was untouched by the first commit. Four tests changed meaning in the second commit, all of them because they encoded the wrong premise, and each is now mutation-proven.

Two tests the first commit missed are migrated here: `OrgChart.viewMode.test.ts`'s drag helper, and the tap in its pause/resume test — the latter now fires `pointerdown` before `click`, because the suppression flag clears on the next press and a bare `click` is a sequence no browser produces.

- `vitest run src/components/workflow src/views/llc src/components/llc src/composables/llc` — **47 files, 482 tests, all passed**
- `vue-tsc` 0 · `eslint` / `oxlint` / `stylelint` — exit 0

## Not testable here

- Touch hit-target sizing — jsdom evaluates neither media features nor layout; verified by review only.
- `setPointerCapture` — feature-detected and guarded; jsdom does not implement it.
- Real multi-touch delivery ordering across mobile browsers — only the pinch arithmetic is exercised.

`@vue/test-utils`' `trigger('pointerdown', …)` is broken in this jsdom version (it reassigns inherited getter-only properties), so gestures are dispatched through a shared `firePointer` helper.

## Flagged, not decided

Pinch rescales proportionally rather than anchoring the midpoint under the fingers, matching the existing zoom buttons and wheel. An anchored pinch is the more usual mobile feel; say the word and it is a small follow-up.

## Model Used

Claude Opus 5 (1M context)
