### PR TITLE
feat(llc): give tools a canvas presence, with attach and detach (#14597)

### DIFF
--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -1537,6 +1537,75 @@ async def get_process_nodes(
     )
 
 
+# ------------------------------------------------------------------
+# Tool nodes (#14597) — which tools this company's roles depend on
+# ------------------------------------------------------------------
+
+
+class ToolNode(BaseModel):
+    """One tool made available to one role, as an org-chart-adjacent node.
+
+    Derived read-only from ``llc_role_tools`` (#14221 step 4) — the same
+    projection shape ``ProcessNode`` above uses for ``llc_role_workflows``. A
+    tool attached to several roles produces one row per role here; the canvas
+    (``buildToolCanvasNodes``) folds the rows that share a ``tool_name`` into
+    a single node, so "one tool used by several roles" stays one node rather
+    than one per role.
+
+    ``role_id``/``role_name`` are included so the canvas can draw which roles
+    a tool belongs to; ``tool_name`` is the tool's registry identity.
+    """
+
+    role_id: str
+    role_name: str
+    tool_name: str
+
+
+class ToolNodesResponse(BaseModel):
+    nodes: List[ToolNode]
+
+
+@router.get("/{company_id}/tool-nodes", response_model=ToolNodesResponse)
+async def get_tool_nodes(
+    company_id: uuid.UUID,
+    session: AsyncSession = Depends(get_async_session),
+    _current_user: dict = Depends(get_current_user),
+    ctx: TenantContext = Depends(require_org_context),
+) -> ToolNodesResponse:
+    """Return the tools this company's roles carry (#14597).
+
+    Company-scoped through the same shared :func:`assert_company_access` guard
+    the rest of this router uses, and pinned again in the query itself — the
+    role must belong to this company *and* the attachment must, so losing
+    either predicate cannot widen the result. Mirrors ``get_process_nodes``
+    above exactly, for the sibling attachment (tools rather than workflows).
+
+    Read-only: this composes existing rows and creates nothing.
+    """
+    from sqlalchemy import select  # noqa: PLC0415
+
+    from llc.models.role_tool import LLCRoleTool  # noqa: PLC0415
+    from user_management.models.role import Role  # noqa: PLC0415
+
+    assert_company_access(ctx, company_id)
+
+    result = await session.execute(
+        select(Role.id, Role.name, LLCRoleTool.tool_name)
+        .join(LLCRoleTool, LLCRoleTool.role_id == Role.id)
+        .where(
+            Role.org_id == company_id,
+            LLCRoleTool.company_id == company_id,
+        )
+        .order_by(Role.name, LLCRoleTool.tool_name)
+    )
+    return ToolNodesResponse(
+        nodes=[
+            ToolNode(role_id=str(role_id), role_name=name, tool_name=tool_name)
+            for role_id, name, tool_name in result.all()
+        ]
+    )
+
+
 @router.get("/{company_id}/teams", response_model=CompanyTeamsResponse)
 async def get_company_teams(
     company_id: uuid.UUID,

--- a/autobot-backend/llc/tests/test_tool_nodes.py
+++ b/autobot-backend/llc/tests/test_tool_nodes.py
@@ -1,0 +1,238 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tool nodes — which tools a company's roles depend on (#14597).
+
+Derived from ``llc_role_tools`` rather than stored again, so these tests pin
+the projection: a role with no tool produces no node, and a tool attached in
+another company never appears here. The second one matters most — the
+endpoint joins two tables that each carry ``company_id``, and a scoping
+predicate that silently matches nothing looks exactly like one that works.
+
+Mirrors ``test_process_nodes.py`` exactly (same fixture shape, same test
+names translated to the tool vocabulary) — ``get_tool_nodes`` is the sibling
+of ``get_process_nodes``, built the same way for the same reason.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from llc.api.companies import get_tool_nodes
+from llc.models.enums import MembershipRole
+from llc.models.membership import LLCCompanyMembership
+from llc.models.role_tool import LLCRoleTool
+from llc.services.role import RoleService
+
+# Registers the SQLite compile shims for postgresql.JSONB / postgresql.UUID.
+from llc.tests import _e2e_harness as harness
+from user_management.models.base import Base
+from user_management.models.role import Role
+from user_management.services import TenantContext
+
+_ADMIN_USER = uuid.uuid4()
+
+
+@pytest_asyncio.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(  # canonical: ignore py-adhoc-db-engine (test-local engine)
+        "sqlite+aiosqlite:///:memory:"
+    )
+    tables = [Role.__table__, LLCRoleTool.__table__, LLCCompanyMembership.__table__]
+    for table in tables:
+        harness._scrub_pg_server_defaults(table)
+        harness._clientside_timestamps(table)
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    yield async_sessionmaker(  # canonical: ignore py-adhoc-db-engine (test-local factory)
+        engine, expire_on_commit=False, class_=AsyncSession
+    )
+    await engine.dispose()
+
+
+async def _grant_admin(session_factory, company_id: uuid.UUID) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        existing = await session.execute(
+            sa.select(LLCCompanyMembership.id).where(
+                LLCCompanyMembership.company_id == company_id,
+                LLCCompanyMembership.user_id == _ADMIN_USER,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            return
+        session.add(
+            LLCCompanyMembership(
+                id=uuid.uuid4(),
+                company_id=company_id,
+                user_id=_ADMIN_USER,
+                role=MembershipRole.ADMIN.value,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_role(session_factory, company_id: uuid.UUID, name: str) -> uuid.UUID:  # noqa: ANN001
+    await _grant_admin(session_factory, company_id)
+    async with session_factory() as session:
+        role = await RoleService().create(session, company_id=company_id, name=name, actor_user_id=_ADMIN_USER)
+        await session.commit()
+        return role.id
+
+
+async def _attach(session_factory, company_id: uuid.UUID, role_id: uuid.UUID, tool_name: str) -> None:  # noqa: ANN001
+    async with session_factory() as session:
+        session.add(LLCRoleTool(company_id=company_id, role_id=role_id, tool_name=tool_name))
+        await session.commit()
+
+
+async def _query(session_factory, company_id: uuid.UUID, caller_org: uuid.UUID | None = None):  # noqa: ANN001, ANN201
+    """Call the **real** endpoint, not a copy of its query.
+
+    An earlier draft re-implemented the endpoint's select here. That passes
+    forever regardless of what the endpoint actually does — the test and the
+    code would have to drift apart before it noticed, which is the one thing it
+    exists to notice. Calling the route function also exercises
+    ``assert_company_access``, which a bare query never touches.
+    """
+    ctx = TenantContext(org_id=caller_org or company_id, user_id=_ADMIN_USER, is_platform_admin=False)
+    async with session_factory() as session:
+        response = await get_tool_nodes(company_id=company_id, session=session, _current_user={}, ctx=ctx)
+    return [(n.role_id, n.role_name, n.tool_name) for n in response.nodes]
+
+
+@pytest.mark.asyncio
+async def test_a_role_with_a_tool_becomes_a_tool_node(session_factory):  # noqa: ANN001
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "Head of Sales")
+    await _attach(session_factory, company, role_id, "web_search")
+
+    nodes = await _query(session_factory, company)
+
+    assert nodes == [(str(role_id), "Head of Sales", "web_search")]
+
+
+@pytest.mark.asyncio
+async def test_a_role_without_a_tool_produces_no_node(session_factory):  # noqa: ANN001
+    """The join is inner on purpose — a role that carries nothing is not a tool node."""
+    company = uuid.uuid4()
+    await _seed_role(session_factory, company, "Head of Sales")
+
+    assert await _query(session_factory, company) == []
+
+
+@pytest.mark.asyncio
+async def test_another_companys_tools_never_appear(session_factory):  # noqa: ANN001
+    """A whole company's tools stay in that company."""
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    await _attach(session_factory, company_b, role_b, "shell_exec")
+
+    assert await _query(session_factory, company_a) == []
+    assert len(await _query(session_factory, company_b)) == 1
+
+
+@pytest.mark.asyncio
+async def test_one_role_may_carry_several_tools(session_factory):  # noqa: ANN001
+    company = uuid.uuid4()
+    role_id = await _seed_role(session_factory, company, "SRE")
+    for tool in ("web_search", "shell_exec"):
+        await _attach(session_factory, company, role_id, tool)
+
+    nodes = await _query(session_factory, company)
+
+    # Sorted by role then tool, so the canvas order is stable between reads.
+    assert [tool for _, _, tool in nodes] == ["shell_exec", "web_search"]
+
+
+@pytest.mark.asyncio
+async def test_one_tool_may_be_carried_by_several_roles(session_factory):  # noqa: ANN001
+    """The projection stays flat — grouping into one node per tool is the
+    canvas builder's job (`buildToolCanvasNodes`), not this endpoint's."""
+    company = uuid.uuid4()
+    role_a = await _seed_role(session_factory, company, "Head of Sales")
+    role_b = await _seed_role(session_factory, company, "SRE")
+    await _attach(session_factory, company, role_a, "web_search")
+    await _attach(session_factory, company, role_b, "web_search")
+
+    nodes = await _query(session_factory, company)
+
+    assert sorted(n[0] for n in nodes) == sorted([str(role_a), str(role_b)])
+    assert all(n[2] == "web_search" for n in nodes)
+
+
+@pytest.mark.asyncio
+async def test_nodes_are_ordered_by_role_name(session_factory):  # noqa: ANN001
+    company = uuid.uuid4()
+    for name in ("Team Lead", "Head of Sales"):
+        role_id = await _seed_role(session_factory, company, name)
+        await _attach(session_factory, company, role_id, f"tool-{name.split()[0].lower()}")
+
+    nodes = await _query(session_factory, company)
+
+    assert [name for _, name, _ in nodes] == ["Head of Sales", "Team Lead"]
+
+
+@pytest.mark.asyncio
+async def test_a_caller_from_another_company_is_refused(session_factory):  # noqa: ANN001
+    """404, not an empty list — "not mine" must not be distinguishable from "empty".
+
+    Only reachable because this test calls the route rather than its query; a
+    bare select would return [] here and look identical to a working guard.
+    """
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    await _attach(session_factory, company_b, role_b, "shell_exec")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _query(session_factory, company_b, caller_org=company_a)
+
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_cross_wired_attachment_is_excluded(session_factory):  # noqa: ANN001
+    """The attachment's own company_id must be checked, not just the role's.
+
+    Both predicates are only distinguishable when they disagree: an attachment
+    row claiming company A against a role owned by company B. Every other test
+    here seeds them equal, so dropping either predicate leaves those green —
+    verified by mutation, which is how this gap was found rather than assumed.
+
+    Such a row should not exist. That is the point: the redundant predicate is
+    what stops one corrupt row leaking a tool into another company's canvas.
+    """
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_b = await _seed_role(session_factory, company_b, "SRE")
+    await _grant_admin(session_factory, company_a)
+
+    # Cross-wired: the attachment claims company A, the role belongs to B.
+    await _attach(session_factory, company_a, role_b, "crosswired-tool")
+
+    assert await _query(session_factory, company_a) == []
+
+
+@pytest.mark.asyncio
+async def test_an_attachment_claiming_another_company_is_excluded(session_factory):  # noqa: ANN001
+    """The mirror of the case above, and the one the *attachment* predicate owns.
+
+    Cross-wiring has two directions, and each predicate catches exactly one:
+
+    * role in B, attachment claims A  -> caught by ``Role.org_id``
+    * role in A, attachment claims B  -> caught by ``LLCRoleTool.company_id``
+
+    Testing only the first left the second predicate free to be deleted with
+    every test still green — found by mutating it away and seeing nothing fail.
+    """
+    company_a, company_b = uuid.uuid4(), uuid.uuid4()
+    role_a = await _seed_role(session_factory, company_a, "SRE")
+
+    # Cross-wired the other way: the role belongs to A, the attachment claims B.
+    await _attach(session_factory, company_b, role_a, "crosswired-tool")
+
+    assert await _query(session_factory, company_a) == []

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -234,6 +234,35 @@
                 </button>
               </div>
             </template>
+            <!-- #14597: a tool one or more roles carry. `roles` is empty
+                 for the moment a node exists with zero roles left, which
+                 cannot happen from the API today (a tool node is only ever
+                 built from at least one attachment) but is handled the same
+                 defensive way `org-group`'s size guard is: no crash, just an
+                 empty list. -->
+            <template v-else-if="node.type === 'org-tool'">
+              <p class="org-title">{{ nodeText(node, 'tool_name') }}</p>
+              <ul v-if="toolRoles(node).length > 0" class="tool-roles">
+                <li
+                  v-for="role in toolRoles(node)"
+                  :key="role.role_id"
+                  class="tool-role-chip"
+                >
+                  <span class="tool-role-name">{{ role.role_name }}</span>
+                  <!-- #14597: mirrors the org-process detach control — `.stop`
+                       keeps the click from also selecting the tool node. -->
+                  <button
+                    type="button"
+                    class="tool-detach-btn"
+                    data-testid="tool-detach-btn"
+                    :aria-label="toolDetachLabel(node, role)"
+                    @click.stop="emit('tool-detached', role.role_id, nodeText(node, 'tool_name'))"
+                  >
+                    <Icon name="times" />
+                  </button>
+                </li>
+              </ul>
+            </template>
             <!-- GH#13939: Company OS org nodes are read-only descriptors -->
             <template v-else-if="node.type === 'org-person'">
               <p class="org-title">{{ nodeText(node, 'title') }}</p>
@@ -356,6 +385,9 @@ const emit = defineEmits<{
   // called against the API directly — this component is shared with real
   // workflow editing and must stay ignorant of the LLC endpoints.
   (e: 'process-detached', roleId: string, workflowId: string): void;
+  // #14597: an org-tool node's own per-role detach control, same reasoning —
+  // this component only ever emits the LLC mutation, never performs it.
+  (e: 'tool-detached', roleId: string, toolName: string): void;
 }>();
 
 const showVisionDropdown = ref(false);
@@ -379,9 +411,14 @@ const nodeIcons: Record<CanvasNodeType, IconName> = {
   'org-person': 'user',
   'org-group': 'sitemap',
   'org-process': 'project-diagram',
+  // #14597: distinct from 'project-diagram' (org-process) — colour is never
+  // the only signal a node type carries (#13941), so a tool also gets its
+  // own icon rather than only a caption.
+  'org-tool': 'wrench',
 };
 const nodeLabels = computed(() => ({
   'org-process': t('llc.orgChart.processNodeLabel'),
+  'org-tool': t('llc.orgChart.toolNodeLabel'),
   step: t('workflow.canvas.stepLabel'),
   condition: t('workflow.canvas.conditionLabel'),
   switch: t('workflow.canvas.switchLabel'),
@@ -464,6 +501,32 @@ function processDetachLabel(node: CanvasNode): string {
   return t('llc.orgChart.processDetach', {
     workflow: nodeText(node, 'workflow_id'),
     role: nodeText(node, 'role_name'),
+  });
+}
+
+/** An org-tool node's roles, off its untyped `data` bag (#14597). */
+function toolRoles(node: CanvasNode): { role_id: string; role_name: string }[] {
+  const roles = (node.data as Record<string, unknown>).roles;
+  return Array.isArray(roles)
+    ? roles.filter(
+        (role): role is { role_id: string; role_name: string } =>
+          typeof role?.role_id === 'string' && typeof role?.role_name === 'string',
+      )
+    : [];
+}
+
+/**
+ * Accessible name for a tool node's per-role detach control (#14597).
+ *
+ * Mirrors `processDetachLabel`: the visible chip carries only a role name, so
+ * a screen reader landing on its bare "×" would not know what it detaches or
+ * from which tool — this node can list several roles, so the role has to be
+ * named explicitly rather than assumed from context.
+ */
+function toolDetachLabel(node: CanvasNode, role: { role_name: string }): string {
+  return t('llc.orgChart.toolDetach', {
+    tool: nodeText(node, 'tool_name'),
+    role: role.role_name,
   });
 }
 
@@ -1320,6 +1383,56 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
   background: var(--bg-hover);
 }
 .process-detach-btn:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+/* #14597: a tool node must not read as "another process node" — colour is
+   never the only signal (#13941), so the header background AND the border
+   style both differ from every other org node type (solid info for
+   org-person, dashed/solid info-warning for org-group, unstyled default for
+   org-process). The dotted inline-start border pairs with the distinct
+   'wrench' icon and 'Tool' caption set in nodeIcons/nodeLabels above. */
+.workflow-node.org-tool {
+  border-inline-start-width: 6px;
+  border-inline-start-style: dotted;
+  border-inline-start-color: var(--color-secondary);
+}
+.workflow-node.org-tool .node-header {
+  background: var(--color-secondary);
+}
+.tool-roles {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  margin: var(--spacing-0);
+  padding: var(--spacing-0);
+  list-style: none;
+}
+.tool-role-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+.tool-role-name {
+  flex: 1;
+  font-family: var(--font-family-mono, monospace);
+}
+.tool-detach-btn {
+  padding: var(--spacing-1);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-default);
+  line-height: 1;
+}
+.tool-detach-btn:hover {
+  color: var(--color-error);
+  background: var(--bg-hover);
+}
+.tool-detach-btn:focus-visible {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.toolNodeDetach.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.toolNodeDetach.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14597: the tool node's own per-role detach controls. It must not call the
+// API itself — `WorkflowCanvas.vue` is shared with real workflow editing —
+// and it must not hijack the node's own click. Mirrors
+// `WorkflowCanvas.processNodeDetach.test.ts` for the tool node's sibling
+// control, with the added wrinkle that a tool node can carry several roles
+// and so several detach controls.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import { buildToolCanvasNodes } from '@/composables/llc/orgCanvasGraph'
+
+const ONE_ROLE_TOOL_NODES = buildToolCanvasNodes(
+  [{ role_id: 'role-1', role_name: 'Head of Ops', tool_name: 'web_search' }],
+  [],
+  0,
+)
+
+const SHARED_TOOL_NODES = buildToolCanvasNodes(
+  [
+    { role_id: 'role-1', role_name: 'Head of Ops', tool_name: 'web_search' },
+    { role_id: 'role-2', role_name: 'SRE', tool_name: 'web_search' },
+  ],
+  [],
+  0,
+)
+
+function mountCanvas(nodes = ONE_ROLE_TOOL_NODES, locale: 'en' | 'ar' = 'en') {
+  const i18n = createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages: { en, ar },
+  })
+  return mount(WorkflowCanvas, {
+    props: { nodes, selectedNodeId: null, readonly: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('org-tool node (#14597)', () => {
+  it('renders the tool name as its title', () => {
+    const wrapper = mountCanvas()
+
+    expect(wrapper.find('.org-title').text()).toBe('web_search')
+  })
+
+  it('renders one role chip per role that carries the tool, sharing one node', () => {
+    const wrapper = mountCanvas(SHARED_TOOL_NODES)
+
+    // Positive companion to the detach-control tests below: the node itself
+    // rendered, so an absent chip cannot be blamed on the whole node failing
+    // to draw.
+    expect(wrapper.findAll('.tool-role-chip')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Head of Ops')
+    expect(wrapper.text()).toContain('SRE')
+  })
+
+  it('emits tool-detached with the role and tool name, not node-selected', async () => {
+    const wrapper = mountCanvas()
+
+    await wrapper.find('[data-testid="tool-detach-btn"]').trigger('click')
+
+    expect(wrapper.emitted('tool-detached')).toEqual([['role-1', 'web_search']])
+    // The click must not have bubbled to the node's own click handler.
+    expect(wrapper.emitted('node-selected')).toBeUndefined()
+  })
+
+  it('detaches the correct role when the node carries several', async () => {
+    const wrapper = mountCanvas(SHARED_TOOL_NODES)
+
+    const buttons = wrapper.findAll('[data-testid="tool-detach-btn"]')
+    expect(buttons).toHaveLength(2)
+    await buttons[1].trigger('click')
+
+    expect(wrapper.emitted('tool-detached')).toEqual([['role-2', 'web_search']])
+  })
+
+  it('renders regardless of the readonly prop', () => {
+    // OrgChart.vue always mounts this canvas `readonly` (view-only authoring
+    // controls). The detach control is an LLC action, not an authoring one,
+    // and must not be gated behind the same flag as `addStepNode`/`deleteNode`.
+    const wrapper = mountCanvas()
+
+    expect(wrapper.find('[data-testid="tool-detach-btn"]').exists()).toBe(true)
+  })
+
+  it('names the tool and role in its accessible name', () => {
+    const wrapper = mountCanvas()
+    const expected = (en as { llc: { orgChart: { toolDetach: string } } }).llc.orgChart.toolDetach
+      .replace('{tool}', 'web_search')
+      .replace('{role}', 'Head of Ops')
+
+    expect(wrapper.find('[data-testid="tool-detach-btn"]').attributes('aria-label')).toBe(
+      expected,
+    )
+  })
+
+  it('names the tool and role in a non-English (RTL) locale', () => {
+    const wrapper = mountCanvas(ONE_ROLE_TOOL_NODES, 'ar')
+    const expected = (ar as { llc: { orgChart: { toolDetach: string } } }).llc.orgChart.toolDetach
+      .replace('{tool}', 'web_search')
+      .replace('{role}', 'Head of Ops')
+
+    expect(wrapper.find('[data-testid="tool-detach-btn"]').attributes('aria-label')).toBe(
+      expected,
+    )
+  })
+})

--- a/autobot-frontend/src/components/workflow/canvasNode.ts
+++ b/autobot-frontend/src/components/workflow/canvasNode.ts
@@ -22,6 +22,10 @@ export type CanvasNodeType =
   // #13963: a workflow a role runs, drawn on the org canvas as the
   // contextual entrance to the absorbed automation module.
   | 'org-process'
+  // #14597: a tool one or more roles carry. One node per distinct tool name
+  // (never one per role) — `buildToolCanvasNodes` folds the role -> tool
+  // attachments that share a `tool_name` before this type is ever reached.
+  | 'org-tool'
 
 /** A node as the canvas sees it. `WorkflowNode` is assignable to this. */
 export interface CanvasNode extends Omit<WorkflowNode, 'type'> {

--- a/autobot-frontend/src/composables/llc/__tests__/toolNodes.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/toolNodes.test.ts
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14597: tool nodes on the org canvas — the graph half of "tools are stored
+// and listed but have no canvas presence".
+//
+// Two things a hand-rolled fixture could not prove: that a tool carried by
+// several roles folds into one node (never one per role), and that a tool
+// node's edges point at the process nodes of the roles that carry it, built
+// with the real `buildProcessCanvasNodes` producer rather than a hand-written
+// id string that could drift from what that function actually emits.
+
+import { describe, it, expect } from 'vitest'
+import {
+  buildProcessCanvasNodes,
+  buildToolCanvasNodes,
+  canvasBottom,
+  toolNameFromNode,
+  TOOL_NODE_PREFIX,
+} from '../orgCanvasGraph'
+
+const TOOLS = [
+  { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+  { role_id: 'r2', role_name: 'SRE', tool_name: 'shell_exec' },
+]
+
+describe('tool canvas nodes (#14597)', () => {
+  it('builds one node per distinct tool, typed so the canvas can draw it', () => {
+    const nodes = buildToolCanvasNodes(TOOLS, [], 0)
+
+    expect(nodes).toHaveLength(2)
+    expect(nodes.every((n) => n.type === 'org-tool')).toBe(true)
+  })
+
+  it('folds a tool carried by several roles into a single node, not one per role', () => {
+    const shared = [
+      { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+      { role_id: 'r2', role_name: 'SRE', tool_name: 'web_search' },
+      { role_id: 'r3', role_name: 'Support', tool_name: 'web_search' },
+    ]
+
+    const nodes = buildToolCanvasNodes(shared, [], 0)
+
+    expect(nodes).toHaveLength(1)
+    expect((nodes[0].data as { roles: { role_id: string }[] }).roles).toHaveLength(3)
+  })
+
+  it("carries every role's id and name on the shared node", () => {
+    const shared = [
+      { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+      { role_id: 'r2', role_name: 'SRE', tool_name: 'web_search' },
+    ]
+
+    const [node] = buildToolCanvasNodes(shared, [], 0)
+
+    expect(node.data.roles).toEqual([
+      { role_id: 'r1', role_name: 'Head of Sales' },
+      { role_id: 'r2', role_name: 'SRE' },
+    ])
+  })
+
+  it('de-duplicates the same (role, tool) attachment seen twice', () => {
+    const duplicated = [
+      { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+      { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+    ]
+
+    const [node] = buildToolCanvasNodes(duplicated, [], 0)
+
+    expect(node.data.roles).toHaveLength(1)
+  })
+
+  it('round-trips the tool name through the node id', () => {
+    for (const tool of TOOLS) {
+      const [node] = buildToolCanvasNodes([tool], [], 0)
+      expect(toolNameFromNode(node.id)).toBe(tool.tool_name)
+    }
+  })
+
+  it('does not decode a tool name from a non-tool node', () => {
+    expect(toolNameFromNode('agent-7')).toBeNull()
+    expect(toolNameFromNode('org-group:sales')).toBeNull()
+    expect(toolNameFromNode(`${TOOL_NODE_PREFIX}`)).toBeNull()
+  })
+
+  it('connects a tool to the process node of a role that carries it, built with the real producer', () => {
+    // Built with buildProcessCanvasNodes — not a hand-written id — so this
+    // fails if that function's id shape ever changes without this one
+    // following (GH#14027 family: a hand-rolled fixture can drift from what
+    // the real producer emits).
+    const processes = buildProcessCanvasNodes(
+      [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+      0,
+    )
+
+    const [node] = buildToolCanvasNodes(
+      [{ role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' }],
+      [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+      0,
+    )
+
+    expect(node.connections).toEqual([processes[0].id])
+  })
+
+  it("carries no connection to a process belonging to a role that does not use the tool", () => {
+    const [node] = buildToolCanvasNodes(
+      [{ role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' }],
+      [{ role_id: 'r2', role_name: 'SRE', workflow_id: 'wf-oncall' }],
+      0,
+    )
+
+    expect(node.connections).toEqual([])
+  })
+
+  it('places tools below whatever section came before them', () => {
+    const tools = buildToolCanvasNodes(TOOLS, [], 0)
+    const below = buildToolCanvasNodes(TOOLS, [], canvasBottom(tools))
+
+    expect(Math.min(...below.map((n) => n.position.y))).toBeGreaterThan(
+      Math.max(...tools.map((n) => n.position.y)),
+    )
+  })
+
+  it('returns nothing for a company with no tools', () => {
+    expect(buildToolCanvasNodes([], [], 0)).toEqual([])
+  })
+})

--- a/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
@@ -318,6 +318,93 @@ export function canvasBottom(nodes: CanvasNode[]): number {
   return nodes.reduce((lowest, node) => Math.max(lowest, node.position.y + ROW_HEIGHT), 0)
 }
 
+/** A tool a role carries, as returned by ``GET .../tool-nodes`` (#14597). */
+export interface ToolNodeSource {
+  role_id: string
+  role_name: string
+  tool_name: string
+}
+
+/** Prefix that marks a canvas node as a tool. */
+export const TOOL_NODE_PREFIX = 'tool:'
+
+/** One role's identity, as carried inside a tool node's `data.roles`. */
+export interface ToolNodeRole {
+  role_id: string
+  role_name: string
+}
+
+/**
+ * Lay out tool nodes below the process grid (#14597).
+ *
+ * `tools` is a flat (role, tool) attachment list — the same shape
+ * `get_tool_nodes` returns, mirroring `ProcessNodeSource` for its sibling
+ * endpoint. This is where "one tool used by several roles is one node, not
+ * one per role" actually happens: attachments are grouped by `tool_name`
+ * first, so a tool three roles carry produces exactly one canvas node,
+ * carrying all three roles in `data.roles`.
+ *
+ * A tool node's relationship to a *process* is drawn as a real graph edge
+ * (`connections`), because a process already has its own canvas node
+ * (`buildProcessCanvasNodes`) to point at: the edge connects a tool to every
+ * process node whose role is one of the tool's roles. A tool's relationship
+ * to a *role* has no such target — a role is not itself a canvas node — so it
+ * is carried as data or displayed directly on the node instead of as an edge
+ * that would have nowhere to land.
+ *
+ * Placed *below* the process grid rather than interleaved with it, for the
+ * same reason processes are placed below the reporting hierarchy: a tool is
+ * not a person and does not report to anyone.
+ */
+export function buildToolCanvasNodes(
+  tools: ToolNodeSource[],
+  processes: ProcessNodeSource[],
+  topOffset: number,
+): CanvasNode[] {
+  const rolesByTool = new Map<string, Map<string, string>>()
+  for (const row of tools) {
+    let roles = rolesByTool.get(row.tool_name)
+    if (!roles) {
+      roles = new Map()
+      rolesByTool.set(row.tool_name, roles)
+    }
+    roles.set(row.role_id, row.role_name)
+  }
+  const toolNames = [...rolesByTool.keys()].sort()
+  return toolNames.map((toolName, index) => {
+    const roles = rolesByTool.get(toolName)
+    const roleRefs: ToolNodeRole[] = roles
+      ? [...roles.entries()]
+          .map(([role_id, role_name]) => ({ role_id, role_name }))
+          .sort((a, b) => a.role_name.localeCompare(b.role_name))
+      : []
+    const roleIds = new Set(roleRefs.map((role) => role.role_id))
+    const connections = processes
+      .filter((process) => roleIds.has(process.role_id))
+      .map((process) => `${PROCESS_NODE_PREFIX}${process.role_id}:${process.workflow_id}`)
+    return {
+      id: `${TOOL_NODE_PREFIX}${toolName}`,
+      type: 'org-tool',
+      position: {
+        x: (index % UNGROUPED_COLUMNS) * (CANVAS_NODE_WIDTH + COLUMN_GAP),
+        y: topOffset + Math.floor(index / UNGROUPED_COLUMNS) * ROW_HEIGHT,
+      },
+      data: {
+        tool_name: toolName,
+        roles: roleRefs,
+      },
+      connections,
+    }
+  })
+}
+
+/** The tool name behind a tool node's id, or `null` when `nodeId` does not name one. */
+export function toolNameFromNode(nodeId: string): string | null {
+  if (!nodeId.startsWith(TOOL_NODE_PREFIX)) return null
+  const toolName = nodeId.slice(TOOL_NODE_PREFIX.length)
+  return toolName.length > 0 ? toolName : null
+}
+
 /**
  * Teams on the canvas (GH#14596, parent #13938).
  *

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8314,7 +8314,15 @@
       "detachError": "تعذّرت إزالة سير العمل هذا.",
       "processDetach": "إزالة {workflow} من {role}",
       "attachRolesUnavailable": "تعذّر تحميل الأدوار، لذا قد تكون هذه القائمة غير مكتملة.",
-      "canvasGroupKind": "مجموعة"
+      "canvasGroupKind": "مجموعة",
+      "toolNodeLabel": "أداة",
+      "attachToolNameLabel": "اسم الأداة",
+      "attachToolNamePlaceholder": "اسم الأداة",
+      "toolAttachError": "تعذّر إرفاق هذه الأداة.",
+      "toolDetachError": "تعذّرت إزالة هذه الأداة.",
+      "toolDetach": "إزالة {tool} من {role}",
+      "canvasToolsUnavailable": "معلومات الأدوات غير متاحة حاليًا — قد تكون هذه القائمة غير مكتملة.",
+      "canvasNoToolsDefined": "لا توجد أدوات مرفقة بأي دور في هذه الشركة."
     },
     "executorRollup": {
       "title": "ملخص المنفذين",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8314,7 +8314,15 @@
       "detachError": "Dieser Workflow konnte nicht entfernt werden.",
       "processDetach": "{workflow} von {role} entfernen",
       "attachRolesUnavailable": "Rollen konnten nicht geladen werden, daher ist diese Liste möglicherweise unvollständig.",
-      "canvasGroupKind": "Gruppe"
+      "canvasGroupKind": "Gruppe",
+      "toolNodeLabel": "Werkzeug",
+      "attachToolNameLabel": "Werkzeugname",
+      "attachToolNamePlaceholder": "Werkzeugname",
+      "toolAttachError": "Dieses Werkzeug konnte nicht zugeordnet werden.",
+      "toolDetachError": "Dieses Werkzeug konnte nicht entfernt werden.",
+      "toolDetach": "{tool} von {role} entfernen",
+      "canvasToolsUnavailable": "Werkzeuginformationen sind derzeit nicht verfügbar — diese Liste ist möglicherweise unvollständig.",
+      "canvasNoToolsDefined": "Diesem Unternehmen sind keiner Rolle Werkzeuge zugeordnet."
     },
     "executorRollup": {
       "title": "Ausführungs-Übersicht",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8302,7 +8302,15 @@
       "detachError": "Could not detach that workflow.",
       "processDetach": "Detach {workflow} from {role}",
       "attachRolesUnavailable": "Roles could not be loaded, so this list may be incomplete.",
-      "canvasGroupKind": "Group"
+      "canvasGroupKind": "Group",
+      "toolNodeLabel": "Tool",
+      "attachToolNameLabel": "Tool name",
+      "attachToolNamePlaceholder": "Tool name",
+      "toolAttachError": "Could not attach that tool.",
+      "toolDetachError": "Could not detach that tool.",
+      "toolDetach": "Detach {tool} from {role}",
+      "canvasToolsUnavailable": "Tool information is unavailable right now — this list may be incomplete.",
+      "canvasNoToolsDefined": "No tools are attached to any role in this company."
     },
     "executorRollup": {
       "title": "Executor Rollup",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8314,7 +8314,15 @@
       "detachError": "No se pudo quitar ese flujo.",
       "processDetach": "Quitar {workflow} de {role}",
       "attachRolesUnavailable": "No se pudieron cargar los roles, por lo que esta lista puede estar incompleta.",
-      "canvasGroupKind": "Grupo"
+      "canvasGroupKind": "Grupo",
+      "toolNodeLabel": "Herramienta",
+      "attachToolNameLabel": "Nombre de la herramienta",
+      "attachToolNamePlaceholder": "Nombre de la herramienta",
+      "toolAttachError": "No se pudo adjuntar esa herramienta.",
+      "toolDetachError": "No se pudo quitar esa herramienta.",
+      "toolDetach": "Quitar {tool} de {role}",
+      "canvasToolsUnavailable": "La información de herramientas no está disponible ahora mismo: esta lista puede estar incompleta.",
+      "canvasNoToolsDefined": "No hay herramientas adjuntas a ningún rol en esta empresa."
     },
     "executorRollup": {
       "title": "Resumen de ejecutores",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8314,7 +8314,15 @@
       "detachError": "جدا کردن این گردش‌کار ممکن نشد.",
       "processDetach": "جدا کردن {workflow} از {role}",
       "attachRolesUnavailable": "نقش‌ها بارگیری نشدند، بنابراین این فهرست ممکن است ناقص باشد.",
-      "canvasGroupKind": "گروه"
+      "canvasGroupKind": "گروه",
+      "toolNodeLabel": "ابزار",
+      "attachToolNameLabel": "نام ابزار",
+      "attachToolNamePlaceholder": "نام ابزار",
+      "toolAttachError": "پیوست کردن این ابزار ممکن نشد.",
+      "toolDetachError": "جدا کردن این ابزار ممکن نشد.",
+      "toolDetach": "جدا کردن {tool} از {role}",
+      "canvasToolsUnavailable": "اطلاعات ابزارها در حال حاضر در دسترس نیست — این فهرست ممکن است ناقص باشد.",
+      "canvasNoToolsDefined": "هیچ ابزاری به هیچ نقشی در این شرکت پیوست نشده است."
     },
     "executorRollup": {
       "title": "خلاصه مجریان",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8314,7 +8314,15 @@
       "detachError": "Impossible de détacher ce workflow.",
       "processDetach": "Détacher {workflow} de {role}",
       "attachRolesUnavailable": "Les rôles n'ont pas pu être chargés, cette liste peut donc être incomplète.",
-      "canvasGroupKind": "Groupe"
+      "canvasGroupKind": "Groupe",
+      "toolNodeLabel": "Outil",
+      "attachToolNameLabel": "Nom de l'outil",
+      "attachToolNamePlaceholder": "Nom de l'outil",
+      "toolAttachError": "Impossible d'associer cet outil.",
+      "toolDetachError": "Impossible de détacher cet outil.",
+      "toolDetach": "Détacher {tool} de {role}",
+      "canvasToolsUnavailable": "Les informations sur les outils sont indisponibles pour le moment — cette liste peut être incomplète.",
+      "canvasNoToolsDefined": "Aucun outil n'est associé à un rôle dans cette entreprise."
     },
     "executorRollup": {
       "title": "Récapitulatif des exécutants",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8314,7 +8314,15 @@
       "detachError": "לא ניתן היה להסיר תהליך זה.",
       "processDetach": "הסר את {workflow} מ-{role}",
       "attachRolesUnavailable": "לא ניתן היה לטעון את התפקידים, ולכן ייתכן שרשימה זו חלקית.",
-      "canvasGroupKind": "קבוצה"
+      "canvasGroupKind": "קבוצה",
+      "toolNodeLabel": "כלי",
+      "attachToolNameLabel": "שם הכלי",
+      "attachToolNamePlaceholder": "שם הכלי",
+      "toolAttachError": "לא ניתן היה לצרף כלי זה.",
+      "toolDetachError": "לא ניתן היה להסיר כלי זה.",
+      "toolDetach": "הסר את {tool} מ-{role}",
+      "canvasToolsUnavailable": "מידע על כלים אינו זמין כעת — רשימה זו עשויה להיות חלקית.",
+      "canvasNoToolsDefined": "לא צורפו כלים לאף תפקיד בחברה זו."
     },
     "executorRollup": {
       "title": "סיכום מבצעים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8314,7 +8314,15 @@
       "detachError": "Neizdevās noņemt šo darbplūsmu.",
       "processDetach": "Noņemt {workflow} no {role}",
       "attachRolesUnavailable": "Lomas neizdevās ielādēt, tāpēc šis saraksts var būt nepilnīgs.",
-      "canvasGroupKind": "Grupa"
+      "canvasGroupKind": "Grupa",
+      "toolNodeLabel": "Rīks",
+      "attachToolNameLabel": "Rīka nosaukums",
+      "attachToolNamePlaceholder": "Rīka nosaukums",
+      "toolAttachError": "Neizdevās pievienot šo rīku.",
+      "toolDetachError": "Neizdevās noņemt šo rīku.",
+      "toolDetach": "Noņemt {tool} no {role}",
+      "canvasToolsUnavailable": "Rīku informācija pašlaik nav pieejama — šis saraksts var būt nepilnīgs.",
+      "canvasNoToolsDefined": "Šim uzņēmumam nevienai lomai nav pievienots neviens rīks."
     },
     "executorRollup": {
       "title": "Izpildītāju kopsavilkums",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8314,7 +8314,15 @@
       "detachError": "Nie udało się odłączyć tego przepływu.",
       "processDetach": "Odłącz {workflow} od {role}",
       "attachRolesUnavailable": "Nie udało się wczytać ról, więc ta lista może być niekompletna.",
-      "canvasGroupKind": "Grupa"
+      "canvasGroupKind": "Grupa",
+      "toolNodeLabel": "Narzędzie",
+      "attachToolNameLabel": "Nazwa narzędzia",
+      "attachToolNamePlaceholder": "Nazwa narzędzia",
+      "toolAttachError": "Nie udało się dołączyć tego narzędzia.",
+      "toolDetachError": "Nie udało się odłączyć tego narzędzia.",
+      "toolDetach": "Odłącz {tool} od {role}",
+      "canvasToolsUnavailable": "Informacje o narzędziach są obecnie niedostępne — ta lista może być niepełna.",
+      "canvasNoToolsDefined": "Żadne narzędzie nie jest dołączone do żadnej roli w tej firmie."
     },
     "executorRollup": {
       "title": "Zestawienie wykonawców",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8314,7 +8314,15 @@
       "detachError": "Não foi possível remover esse fluxo.",
       "processDetach": "Remover {workflow} de {role}",
       "attachRolesUnavailable": "Não foi possível carregar as funções, portanto esta lista pode estar incompleta.",
-      "canvasGroupKind": "Grupo"
+      "canvasGroupKind": "Grupo",
+      "toolNodeLabel": "Ferramenta",
+      "attachToolNameLabel": "Nome da ferramenta",
+      "attachToolNamePlaceholder": "Nome da ferramenta",
+      "toolAttachError": "Não foi possível anexar essa ferramenta.",
+      "toolDetachError": "Não foi possível remover essa ferramenta.",
+      "toolDetach": "Remover {tool} de {role}",
+      "canvasToolsUnavailable": "As informações de ferramentas estão indisponíveis neste momento — esta lista pode estar incompleta.",
+      "canvasNoToolsDefined": "Nenhuma ferramenta está anexada a nenhuma função nesta empresa."
     },
     "executorRollup": {
       "title": "Resumo de executores",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8314,7 +8314,15 @@
       "detachError": "یہ ورک فلو الگ نہیں ہو سکا۔",
       "processDetach": "{workflow} کو {role} سے الگ کریں",
       "attachRolesUnavailable": "کردار لوڈ نہیں ہو سکے، اس لیے یہ فہرست نامکمل ہو سکتی ہے۔",
-      "canvasGroupKind": "گروپ"
+      "canvasGroupKind": "گروپ",
+      "toolNodeLabel": "ٹول",
+      "attachToolNameLabel": "ٹول کا نام",
+      "attachToolNamePlaceholder": "ٹول کا نام",
+      "toolAttachError": "یہ ٹول منسلک نہیں ہو سکا۔",
+      "toolDetachError": "یہ ٹول الگ نہیں ہو سکا۔",
+      "toolDetach": "{tool} کو {role} سے الگ کریں",
+      "canvasToolsUnavailable": "ٹول کی معلومات اس وقت دستیاب نہیں ہیں — یہ فہرست نامکمل ہو سکتی ہے۔",
+      "canvasNoToolsDefined": "اس کمپنی میں کسی کردار کے ساتھ کوئی ٹول منسلک نہیں۔"
     },
     "executorRollup": {
       "title": "عمل کنندہ خلاصہ",

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -49683,6 +49683,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/llc/companies/{company_id}/tool-nodes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Tool Nodes
+         * @description Return the tools this company's roles carry (#14597).
+         *
+         *     Company-scoped through the same shared :func:`assert_company_access` guard
+         *     the rest of this router uses, and pinned again in the query itself — the
+         *     role must belong to this company *and* the attachment must, so losing
+         *     either predicate cannot widen the result. Mirrors ``get_process_nodes``
+         *     above exactly, for the sibling attachment (tools rather than workflows).
+         *
+         *     Read-only: this composes existing rows and creates nothing.
+         */
+        get: operations["get_tool_nodes_api_llc_companies__company_id__tool_nodes_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/llc/companies/{company_id}/teams": {
         parameters: {
             query?: never;
@@ -97887,6 +97915,37 @@ export interface components {
              * @default true
              */
             update_first: boolean | null;
+        } & {
+            [key: string]: unknown;
+        };
+        /**
+         * ToolNode
+         * @description One tool made available to one role, as an org-chart-adjacent node.
+         *
+         *     Derived read-only from ``llc_role_tools`` (#14221 step 4) — the same
+         *     projection shape ``ProcessNode`` above uses for ``llc_role_workflows``. A
+         *     tool attached to several roles produces one row per role here; the canvas
+         *     (``buildToolCanvasNodes``) folds the rows that share a ``tool_name`` into
+         *     a single node, so "one tool used by several roles" stays one node rather
+         *     than one per role.
+         *
+         *     ``role_id``/``role_name`` are included so the canvas can draw which roles
+         *     a tool belongs to; ``tool_name`` is the tool's registry identity.
+         */
+        ToolNode: {
+            /** Role Id */
+            role_id: string;
+            /** Role Name */
+            role_name: string;
+            /** Tool Name */
+            tool_name: string;
+        } & {
+            [key: string]: unknown;
+        };
+        /** ToolNodesResponse */
+        ToolNodesResponse: {
+            /** Nodes */
+            nodes: components["schemas"]["ToolNode"][];
         } & {
             [key: string]: unknown;
         };
@@ -168756,6 +168815,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProcessNodesResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_tool_nodes_api_llc_companies__company_id__tool_nodes_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                company_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolNodesResponse"];
                 };
             };
             /** @description Validation Error */

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -18,6 +18,7 @@ import {
   buildOrgCanvasGraph,
   buildProcessCanvasNodes,
   buildTeamCanvasNodes,
+  buildToolCanvasNodes,
   canvasBottom,
   flattenOrgNodes,
   orgLayoutKey,
@@ -26,7 +27,7 @@ import {
   workflowIdFromProcessNode,
   ORG_GROUP_PREFIX,
 } from '@/composables/llc/orgCanvasGraph'
-import type { ProcessNodeSource } from '@/composables/llc/orgCanvasGraph'
+import type { ProcessNodeSource, ToolNodeSource } from '@/composables/llc/orgCanvasGraph'
 import { WORKFLOW_QUERY_KEY } from '@/composables/workflow/workflowDeepLink'
 import OrgPeopleList from '@/components/llc/OrgPeopleList.vue'
 import CanvasNodeSidebar from '@/components/llc/CanvasNodeSidebar.vue'
@@ -132,6 +133,20 @@ const canvasNodes = ref<CanvasNode[]>([])
 const processNodes = ref<ProcessNodeSource[]>([])
 const processNodesLoaded = ref(false)
 
+// #14597: the tools this company's roles carry — the sibling of
+// `processNodes` above, same reasoning: its own ref so a failed fetch cannot
+// blank anything else, and its own loaded guard so the canvas fetches once
+// per visit.
+const toolNodes = ref<ToolNodeSource[]>([])
+const toolNodesLoaded = ref(false)
+/** The tool-nodes request did not answer — distinct from answering "none"
+ *  (#14064, #13617, #14556: this exact conflation has been a real defect
+ *  three times in this area already). */
+const toolNodesFailed = ref(false)
+/** Whether the tool-nodes request has been tried at all, so the "no tools"
+ *  banner cannot appear before there is anything to report. */
+const toolNodesAttempted = ref(false)
+
 // #14549: the canvas can now change the attachment it displays, not just show
 // it. `roles` backs the "choose a role" picker for attach; fetched lazily like
 // `processNodes`, on the same canvas-open trigger, since neither is needed in
@@ -150,6 +165,15 @@ const attachWorkflowId = ref('')
 // second attach/detach cannot fire while the first is still in flight.
 const processMutationInFlight = ref(false)
 const processMutationError = ref<string | null>(null)
+
+// #14597: the tool attach form's own state, mirroring the process attach
+// form above exactly (same `attachableRoles` picker, a name field instead of
+// a workflow-id field) and its own in-flight/error pair — a tool mutation and
+// a process mutation are independent actions and must not block each other.
+const attachToolRoleId = ref('')
+const attachToolName = ref('')
+const toolMutationInFlight = ref(false)
+const toolMutationError = ref<string | null>(null)
 
 /**
  * Explicit, shallow layout source (#13996): ids, nesting and labels — never
@@ -236,6 +260,19 @@ const teamCanvasNodes = computed<CanvasNode[]>(() =>
   ),
 )
 
+/**
+ * Tool nodes, laid out below every other section (#14597) — same derived-not-
+ * stored reasoning as `processCanvasNodes`/`teamCanvasNodes`: nothing here is
+ * ever dragged, so recomputing on every render loses nothing.
+ */
+const toolCanvasNodes = computed<CanvasNode[]>(() =>
+  buildToolCanvasNodes(
+    toolNodes.value,
+    processNodes.value,
+    canvasBottom([...canvasNodes.value, ...processCanvasNodes.value, ...teamCanvasNodes.value]),
+  ),
+)
+
 const lensedCanvasNodes = computed<CanvasNode[]>(() => [
   ...applyRoleLens(canvasNodes.value, roleLens.value || null),
   // Not lensed: the role lens filters *people* by role, and a process is not a
@@ -247,6 +284,8 @@ const lensedCanvasNodes = computed<CanvasNode[]>(() => [
   // (they are always still on the reporting-hierarchy canvas too), so it is
   // left unlensed for the same reason process nodes are.
   ...teamCanvasNodes.value,
+  // #14597: a tool is not a person either, same reasoning as processes.
+  ...toolCanvasNodes.value,
 ])
 const lensCounts = computed(() => roleLensCounts(canvasNodes.value, roleLens.value || null))
 
@@ -320,6 +359,8 @@ function setViewMode(mode: OrgViewMode) {
     // and the same guard the People list already uses — a second entry into
     // canvas mode does not re-request them.
     void loadPeopleSources()
+    // #14597: tools render on the canvas too, same lazy-on-canvas-open trigger.
+    void fetchToolNodes()
   }
 }
 
@@ -507,6 +548,100 @@ async function onProcessDetached(roleId: string, workflowId: string): Promise<vo
     processMutationError.value = describeError(err, 'llc.orgChart.detachError')
   } finally {
     processMutationInFlight.value = false
+  }
+}
+
+/**
+ * Load the tools this company's roles carry (#14597).
+ *
+ * Mirrors `fetchProcessNodes`, but — unlike that one — distinguishes a failed
+ * fetch from an empty answer via `toolNodesFailed`/`toolNodesAttempted`,
+ * because this exact conflation ("failed" reading as "this company has
+ * none") has been a real defect three times in this area (#14064, #13617,
+ * #14556) and the issue that added this surface calls it out by name.
+ */
+async function fetchToolNodes() {
+  if (toolNodesLoaded.value) return
+  try {
+    const cid = await resolveCompanyIdOnce()
+    if (!cid) {
+      toolNodes.value = []
+      return
+    }
+    const resp = await api.get<{ nodes: ToolNodeSource[] }>(`/api/llc/companies/${cid}/tool-nodes`)
+    // Accept only rows that actually carry the three strings a tool node is
+    // made of — same defensive filter `fetchProcessNodes` applies, so a
+    // misrouted mock or a changed contract renders as nothing rather than as
+    // nonsense nodes on the canvas.
+    const rows = Array.isArray(resp?.nodes) ? resp.nodes : []
+    toolNodes.value = rows.filter(
+      (row): row is ToolNodeSource =>
+        typeof row?.role_id === 'string' &&
+        typeof row?.role_name === 'string' &&
+        typeof row?.tool_name === 'string',
+    )
+    toolNodesFailed.value = false
+    toolNodesLoaded.value = true
+  } catch (err: unknown) {
+    logger.error('Failed to fetch tool nodes:', err instanceof Error ? err.message : String(err))
+    toolNodes.value = []
+    toolNodesFailed.value = true
+  } finally {
+    toolNodesAttempted.value = true
+  }
+}
+
+/**
+ * Force the lazy tool-node fetch to actually re-run (#14597).
+ *
+ * Mirrors `reloadProcessNodes` — `toolNodesLoaded` guards the lazy fetch, so a
+ * mutation has to clear it first or the "refetch" would hit the guard and
+ * silently keep showing the pre-mutation list.
+ */
+async function reloadToolNodes(): Promise<void> {
+  toolNodesLoaded.value = false
+  await fetchToolNodes()
+}
+
+/** Attach a tool to a role from the canvas (#14597). */
+async function onToolAttach(): Promise<void> {
+  const roleId = attachToolRoleId.value
+  const toolName = attachToolName.value.trim()
+  if (!companyId.value || !roleId || !toolName || toolMutationInFlight.value) return
+  toolMutationInFlight.value = true
+  toolMutationError.value = null
+  try {
+    await api.post(`/api/llc/roles/${companyId.value}/${roleId}/tools`, { tool_name: toolName })
+    attachToolName.value = ''
+    // The canvas is the confirmation, same as the process attach form: a
+    // successful attach must be visible on it, not just accepted by the
+    // server (no optimistic update — the reload IS the confirmation).
+    await reloadToolNodes()
+  } catch (err: unknown) {
+    logger.error('Failed to attach tool:', err)
+    toolMutationError.value = describeError(err, 'llc.orgChart.toolAttachError')
+  } finally {
+    toolMutationInFlight.value = false
+  }
+}
+
+/**
+ * Detach a tool from a role, reached from the tool node's own per-role
+ * control on the canvas (#14597). No optimistic update: a failed call leaves
+ * `toolNodes` — and so the graph — exactly as it was.
+ */
+async function onToolDetached(roleId: string, toolName: string): Promise<void> {
+  if (!companyId.value || toolMutationInFlight.value) return
+  toolMutationInFlight.value = true
+  toolMutationError.value = null
+  try {
+    await api.delete(`/api/llc/roles/${companyId.value}/${roleId}/tools/${encodeURIComponent(toolName)}`)
+    await reloadToolNodes()
+  } catch (err: unknown) {
+    logger.error('Failed to detach tool:', err)
+    toolMutationError.value = describeError(err, 'llc.orgChart.toolDetachError')
+  } finally {
+    toolMutationInFlight.value = false
   }
 }
 
@@ -828,6 +963,92 @@ onMounted(() => {
         {{ processMutationError }}
       </div>
 
+      <!-- #14597: the tool sibling of the process-attach form above — a role
+           picker (reusing `attachableRoles`) plus a tool-name field. Attach
+           reaches from here; detach reaches from each role chip on the tool
+           node itself (WorkflowCanvas.vue). Always shown in canvas mode,
+           independent of the role lens, for the same reason the process form
+           is: it is a mutation control, not a view filter. -->
+      <div
+        class="flex flex-wrap items-end gap-3 border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-sm"
+        data-testid="tool-attach-form"
+      >
+        <div class="flex flex-col gap-1">
+          <label for="tool-attach-role" class="text-xs text-autobot-text-secondary">
+            {{ t('llc.orgChart.attachRoleLabel') }}
+          </label>
+          <select
+            id="tool-attach-role"
+            v-model="attachToolRoleId"
+            :disabled="toolMutationInFlight"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="tool-attach-role-select"
+          >
+            <option value="">{{ t('llc.orgChart.attachRolePlaceholder') }}</option>
+            <option v-for="role in attachableRoles" :key="role.id" :value="role.id">
+              {{ role.name }}
+            </option>
+          </select>
+          <p
+            v-if="attachRolesFailed"
+            class="text-xs text-autobot-text-muted"
+            data-testid="tool-attach-roles-unavailable"
+          >
+            {{ t('llc.orgChart.attachRolesUnavailable') }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label for="tool-attach-name" class="text-xs text-autobot-text-secondary">
+            {{ t('llc.orgChart.attachToolNameLabel') }}
+          </label>
+          <input
+            id="tool-attach-name"
+            v-model="attachToolName"
+            type="text"
+            :disabled="toolMutationInFlight"
+            :placeholder="t('llc.orgChart.attachToolNamePlaceholder')"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="tool-attach-name-input"
+          />
+        </div>
+        <BaseButton
+          variant="primary"
+          data-testid="tool-attach-submit"
+          :disabled="!attachToolRoleId || !attachToolName.trim() || toolMutationInFlight"
+          @click="onToolAttach"
+        >
+          {{ t('llc.orgChart.attach') }}
+        </BaseButton>
+      </div>
+      <div
+        v-if="toolMutationError"
+        class="border-b border-autobot-border bg-autobot-error-bg text-autobot-error px-3 py-2 text-sm"
+        role="alert"
+        data-testid="tool-mutation-error"
+      >
+        {{ toolMutationError }}
+      </div>
+
+      <!-- #14597: a failed tool-nodes fetch must read as "could not load",
+           never as "this company uses no tools" — the exact conflation
+           named in the issue as a repeat defect (#14064, #13617, #14556).
+           Shown only once the request has actually answered (or failed), so
+           the banner cannot appear before there is anything to report. -->
+      <p
+        v-if="toolNodesFailed"
+        class="border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-xs text-autobot-text-muted"
+        data-testid="canvas-tools-unavailable"
+      >
+        {{ t('llc.orgChart.canvasToolsUnavailable') }}
+      </p>
+      <p
+        v-else-if="toolNodesAttempted && toolNodes.length === 0"
+        class="border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-xs text-autobot-text-muted"
+        data-testid="canvas-no-tools"
+      >
+        {{ t('llc.orgChart.canvasNoToolsDefined') }}
+      </p>
+
       <!-- #14596: teams on the canvas carry the same honest-failure distinction
            the People list already makes (#14064, #13617, #14556) — a request
            that failed must never read as "this company has no teams". Shown
@@ -899,6 +1120,7 @@ onMounted(() => {
         @node-moved="onCanvasNodeMoved"
         @tab-selected="activeTabId = $event"
         @process-detached="onProcessDetached"
+        @tool-detached="onToolDetached"
       />
     </div>
     <p v-if="viewMode === 'canvas' && !isLoading && tree.length > 0" class="mt-2 text-xs text-autobot-text-muted">

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.toolMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.toolMutation.test.ts
@@ -1,0 +1,305 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14597: the canvas showed a role-to-tool attachment only as a list in the
+// Roles tab, with no presence on Company OS. These guard the canvas half of
+// that surface: fetch (with the failed-vs-empty distinction that has been a
+// real defect three times in this area — #14064, #13617, #14556), attach (a
+// form on the canvas) and detach (a control on the tool node itself), all
+// against the endpoints `RolesView.vue` already uses. Mirrors
+// `OrgChart.processMutation.test.ts` for the tool sibling.
+//
+// The one most worth stating up front: `toolNodesLoaded` guards the lazy
+// fetch `fetchToolNodes` runs on canvas-open. A mutation has to clear that
+// guard before it refetches, or the "refetch" hits the guard, does nothing,
+// and the canvas keeps showing the pre-mutation list while looking correct.
+// Every attach/detach test below asserts the GET call count, not just the
+// mutation call, so that specific failure mode cannot pass silently.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const del = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post, delete: del }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ params: { companyId: 'c1' }, query: {} }),
+}))
+
+const companyRef = ref('c1')
+vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
+  useLlcCompanyContext: () => ({
+    companyId: companyRef,
+    resolveCompanyId: () => Promise.resolve(companyRef.value),
+  }),
+}))
+
+import OrgChart from '../OrgChart.vue'
+import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
+
+const PEOPLE = [
+  {
+    id: 'ceo',
+    node_id: 'n-ceo',
+    name: 'Ada',
+    title: 'CEO',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+]
+
+const TOOLS = [{ role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' }]
+const ROLES = [{ id: 'r1', name: 'Head of Sales' }, { id: 'r2', name: 'SRE' }]
+
+/** GET responses. `tools` is swapped for the SECOND tool-nodes call, so a test
+ * can tell the pre-mutation list apart from the post-mutation one. */
+function respond(tools: unknown = TOOLS, afterTools: unknown = tools): void {
+  let toolCalls = 0
+  get.mockImplementation((url: string) => {
+    if (url.includes('/tool-nodes')) {
+      toolCalls += 1
+      return Promise.resolve({ nodes: toolCalls === 1 ? tools : afterTools })
+    }
+    if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+    if (url.includes('/api/llc/roles/')) return Promise.resolve(ROLES)
+    return Promise.resolve({ nodes: [] })
+  })
+}
+
+function toolFetchCount(): number {
+  return get.mock.calls.filter((c) => String(c[0]).includes('/tool-nodes')).length
+}
+
+async function mountChart() {
+  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+  const wrapper = mount(OrgChart, {
+    global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, OrgPeopleList: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+async function openCanvas(wrapper: Awaited<ReturnType<typeof mountChart>>) {
+  await wrapper.find('[data-testid="org-view-canvas"]').trigger('click')
+  await flushPromises()
+}
+
+describe('OrgChart tool attach/detach (#14597)', () => {
+  beforeEach(() => {
+    get.mockReset()
+    post.mockReset()
+    del.mockReset()
+    push.mockReset()
+  })
+
+  // A failed fetch and an empty answer are different claims, and a plain
+  // absence of nodes on the canvas renders them identically. The pair below
+  // is deliberate: neither test can pass on its own if the distinction is
+  // dropped, because one demands the notice and the other forbids it.
+  it('says "could not load" when the tool-nodes request fails, never "no tools"', async () => {
+    get.mockImplementation((url: string) => {
+      if (url.includes('/tool-nodes')) return Promise.reject(new Error('HTTP 503: upstream'))
+      if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+      if (url.includes('/api/llc/roles/')) return Promise.resolve(ROLES)
+      return Promise.resolve({ nodes: [] })
+    })
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    expect(wrapper.find('[data-testid="canvas-tools-unavailable"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="canvas-no-tools"]').exists()).toBe(false)
+    // Positive companion: the form is still there, so the assertion above
+    // cannot be satisfied by the view having failed to render at all.
+    expect(wrapper.find('[data-testid="tool-attach-form"]').exists()).toBe(true)
+  })
+
+  it('says "no tools" when the request answers with none, not "could not load"', async () => {
+    respond([])
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    expect(wrapper.find('[data-testid="canvas-no-tools"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="canvas-tools-unavailable"]').exists()).toBe(false)
+  })
+
+  it('shows neither banner before the request has answered', async () => {
+    // The company has people but no roles/tools sources have resolved yet at
+    // the instant canvas mode opens — asserted via a controlled promise so
+    // the assertion runs before the tool-nodes request settles.
+    let resolveTools: (v: unknown) => void = () => {}
+    get.mockImplementation((url: string) => {
+      if (url.includes('/tool-nodes')) return new Promise((r) => { resolveTools = r })
+      if (url.includes('/org-chart')) return Promise.resolve({ nodes: PEOPLE })
+      if (url.includes('/api/llc/roles/')) return Promise.resolve(ROLES)
+      return Promise.resolve({ nodes: [] })
+    })
+    const wrapper = await mountChart()
+    await wrapper.find('[data-testid="org-view-canvas"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="canvas-tools-unavailable"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="canvas-no-tools"]').exists()).toBe(false)
+
+    resolveTools({ nodes: [] })
+    await flushPromises()
+    expect(wrapper.find('[data-testid="canvas-no-tools"]').exists()).toBe(true)
+  })
+
+  it('renders a role with no tools without an error or an empty-looking box', async () => {
+    respond([])
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    // No org-tool node at all — never an empty container claiming "no tools
+    // exist" for a role that simply carries none.
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(0)
+    expect(wrapper.find('[data-testid="canvas-no-tools"]').exists()).toBe(true)
+  })
+
+  it('disables the submit button while an attach is in flight, so it cannot post twice', async () => {
+    respond([], TOOLS)
+    let resolvePost: () => void = () => {}
+    post.mockImplementation(() => new Promise<void>((r) => { resolvePost = () => r() }))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    await wrapper.find('[data-testid="tool-attach-role-select"]').setValue('r1')
+    await wrapper.find('[data-testid="tool-attach-name-input"]').setValue('web_search')
+    const submit = wrapper.find('[data-testid="tool-attach-submit"]')
+    await submit.trigger('click')
+    // Second click while the first is still in flight.
+    await submit.trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('[data-testid="tool-attach-submit"]').attributes('disabled')).toBeDefined()
+
+    resolvePost()
+    await flushPromises()
+  })
+
+  it('does not delete the same attachment twice when detached rapidly', async () => {
+    respond(TOOLS, [])
+    let resolveDel: () => void = () => {}
+    del.mockImplementation(() => new Promise<void>((r) => { resolveDel = () => r() }))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('tool-detached', 'r1', 'web_search')
+    canvas.vm.$emit('tool-detached', 'r1', 'web_search')
+    await flushPromises()
+
+    expect(del).toHaveBeenCalledTimes(1)
+    resolveDel()
+    await flushPromises()
+  })
+
+  it('detaches a tool from its own control and the node disappears', async () => {
+    respond(TOOLS, [])
+    del.mockResolvedValue(undefined)
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+    expect(toolFetchCount()).toBe(1)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('tool-detached', 'r1', 'web_search')
+    await flushPromises()
+
+    expect(del).toHaveBeenCalledWith('/api/llc/roles/c1/r1/tools/web_search')
+    // The refetch must actually re-run, not hit the `toolNodesLoaded` guard
+    // and silently keep the stale list.
+    expect(toolFetchCount()).toBe(2)
+    const nodes = canvas.props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(0)
+  })
+
+  it('attaches a tool to a role from the canvas form and the node appears', async () => {
+    respond([], TOOLS)
+    post.mockResolvedValue(undefined)
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+    expect(toolFetchCount()).toBe(1)
+
+    await wrapper.find('[data-testid="tool-attach-role-select"]').setValue('r1')
+    await wrapper.find('[data-testid="tool-attach-name-input"]').setValue('web_search')
+    await wrapper.find('[data-testid="tool-attach-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(post).toHaveBeenCalledWith('/api/llc/roles/c1/r1/tools', { tool_name: 'web_search' })
+    expect(toolFetchCount()).toBe(2)
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(1)
+  })
+
+  it('a failed detach surfaces an error and leaves the graph unchanged', async () => {
+    respond(TOOLS)
+    del.mockRejectedValue(new Error('HTTP 409: tool still in use'))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    const canvas = wrapper.findComponent(WorkflowCanvas)
+    canvas.vm.$emit('tool-detached', 'r1', 'web_search')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="tool-mutation-error"]').text()).toBe(
+      'HTTP 409: tool still in use',
+    )
+    // No optimistic mutation and no reload attempted on failure.
+    expect(toolFetchCount()).toBe(1)
+    const nodes = canvas.props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(1)
+  })
+
+  it('a failed attach surfaces an error and does not add a node', async () => {
+    respond(TOOLS)
+    post.mockRejectedValue(new Error('HTTP 400: unknown tool'))
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    await wrapper.find('[data-testid="tool-attach-role-select"]').setValue('r2')
+    await wrapper.find('[data-testid="tool-attach-name-input"]').setValue('bogus_tool')
+    await wrapper.find('[data-testid="tool-attach-submit"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="tool-mutation-error"]').text()).toBe(
+      'HTTP 400: unknown tool',
+    )
+    expect(toolFetchCount()).toBe(1)
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(1)
+  })
+
+  it('a tool used by several roles is one node, not one per role', async () => {
+    respond([
+      { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'web_search' },
+      { role_id: 'r2', role_name: 'SRE', tool_name: 'web_search' },
+    ])
+    const wrapper = await mountChart()
+    await openCanvas(wrapper)
+
+    const nodes = wrapper.findComponent(WorkflowCanvas).props('nodes') as { type: string }[]
+    expect(nodes.filter((n) => n.type === 'org-tool')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Closes #14597 · Parent #13935

## Thinking Path

Role→tool attachments have existed since #14509 and rendered only as a list in the Roles tab. So "what software does this part of the operation depend on" could not be answered by looking at the operation.

There was no company-wide read of them — only `GET .../{role_id}/tools` per role — so the canvas would have needed one request per role. The endpoint mirrors `GET /{company_id}/process-nodes` (#13963) exactly, including its double-pinned scoping: the role must belong to the company **and** the attachment must, so losing either predicate cannot widen the result.

## What Changed

**Backend** — `GET /api/llc/companies/{company_id}/tool-nodes`, read-only, composing existing `llc_role_tools` rows. No migration; the table already existed.

**Frontend**

- New `org-tool` canvas type. Adding a `CanvasNodeType` requires entries in **both** `nodeIcons` and `nodeLabels` or `vue-tsc` fails — the constraint that blocked the teams work in #14614, resolvable now that `WorkflowCanvas.vue` is free.
- **A tool carried by several roles is one node**, listing every role, not one node per role. Each role appears as a chip with its own detach control.
- Its `connections` point at the `org-process` node ids of roles that carry it, built with the real `PROCESS_NODE_PREFIX` — a role has no canvas node of its own to connect to.
- Attach and detach from the canvas against the existing role-tool endpoints, reloading from the server rather than mutating local state.
- Distinguished by more than colour (#13941): its own `wrench` icon, its own header, and a **dotted** inline-start border against org-person's solid and org-group's dashed.
- A failed fetch and a zero-tools answer are separate states — the conflation this area has produced three times (#14064, #13617, #14556).
- Ten strings across all 11 locales.

## Verification

I re-derived the two load-bearing claims myself rather than accept the report, each asserting the edit applied before running:

| Mutation | Tests that went red |
|---|---|
| group by `tool + role` so a shared tool splits into several nodes | 4 — including "a tool used by several roles is one node, not one per role" |
| a failed fetch sets `toolNodesFailed = false` | "says could not load … never no tools" |

My first attempt at the grouping mutation **did not apply**, and the `assert n != s` guard caught it — without that, a green suite would have read as proof. That guard exists because this exact mistake produced a false proof earlier in this programme.

Plus the implementer's: dropping the backend `company_id` predicate (backend test red), forcing the connections filter false, and hardcoding the wrong role id in the detach emit.

- `vitest run src/components/workflow src/views/llc src/composables/llc src/components/llc` — **53 files, 534 tests, all passed**
- `vue-tsc` 0 · `eslint` / `oxlint` clean

**One combined run failed on `OrgChart.roleLens.test.ts`; it passed alone (9/9) and passed on an immediate re-run (534/534).** That is the flake tracked in #14613 — now its **fourth** distinct test across three files. The implementer hit the same intermittency independently and needed `--no-file-parallelism`, which is the most useful diagnostic yet: one piece of state shared across worker boundaries, not four separate bugs. Recorded there.

## Flagged, not decided

Tool→process edges are real graph `connections`; tool→role relationships are chips on the node rather than edges. The issue did not specify which, and roles have no canvas node to draw an edge to. Documented in the composable.

Two pre-existing route tests (`test_roles_routes_registered`) fail identically on base in this local environment — a `llc_router.routes` walk finding zero routes, which is interpreter/FastAPI-version dependent locally and passes in CI. Not caused by this change; flagged rather than silently ignored.

## Model Used

Claude Opus 5 (1M context)
