### PR TITLE
fix(monitoring): verify prometheus loaded the rules, not just that they exist (#14531)

### DIFF
--- a/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/defaults/main.yml
@@ -43,6 +43,11 @@ prometheus_config_dir: "/etc/prometheus"
 # #12460: fail the play when no alerts-*.yml is found rather than installing
 # zero rules silently. Set false only for a node that intentionally ships none.
 prometheus_alert_rules_required: true
+# How long to wait for Prometheus to serve /api/v1/rules after a restart
+# (#14531). Var-backed rather than literal, matching backend_health_check_*:
+# a large WAL replay can outlast a fixed minute and false-fail the play.
+prometheus_rules_check_retries: 12
+prometheus_rules_check_delay: 5
 prometheus_data_dir: "/var/lib/prometheus"
 grafana_data_dir: "/var/lib/grafana"
 

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -139,8 +139,8 @@
     url: "http://127.0.0.1:{{ prometheus_port }}/api/v1/rules"
     return_content: true
   register: _prometheus_loaded_rules
-  retries: 12
-  delay: 5
+  retries: "{{ prometheus_rules_check_retries | default(12) }}"
+  delay: "{{ prometheus_rules_check_delay | default(5) }}"
   until: _prometheus_loaded_rules.status | default(0) == 200
   changed_when: false
 
@@ -152,7 +152,7 @@
     that:
       - >-
         (_prometheus_loaded_rules.json.data.groups | default([])
-         | map(attribute='rules') | map('length') | sum) > 0
+         | map(attribute='rules', default=[]) | map('length') | sum) > 0
     fail_msg: >-
       Prometheus is running but has loaded 0 alert rules. The files under
       {{ prometheus_config_dir }}/rules were installed and rule_files points at
@@ -163,6 +163,6 @@
     success_msg: >-
       Prometheus loaded
       {{ _prometheus_loaded_rules.json.data.groups | default([])
-         | map(attribute='rules') | map('length') | sum }} alert rule(s)
+         | map(attribute='rules', default=[]) | map('length') | sum }} alert rule(s)
       in {{ _prometheus_loaded_rules.json.data.groups | default([]) | length }} group(s).
   when: prometheus_alert_rules_required | bool

--- a/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
+++ b/autobot-slm-backend/ansible/roles/monitoring/tasks/prometheus.yml
@@ -122,3 +122,47 @@
     state: started
     enabled: true
     daemon_reload: true
+
+# #14531: everything above proves the rule FILES were found, copied and pointed
+# at by the config. None of it proves the running Prometheus read any of them.
+# The deployed host carried `rule_files: []` and 0 loaded rules for four months
+# while every task here reported changed/ok — so no alert could fire, and an
+# alerting stack with no rules is indistinguishable from a fleet in perfect
+# health. Both produce silence.
+#
+# Ask the server what it actually loaded, after the restart it needed.
+- name: "Prometheus | Apply the pending restart before verifying what loaded (#14531)"
+  ansible.builtin.meta: flush_handlers
+
+- name: "Prometheus | Ask the running server which rules it loaded (#14531)"
+  ansible.builtin.uri:
+    url: "http://127.0.0.1:{{ prometheus_port }}/api/v1/rules"
+    return_content: true
+  register: _prometheus_loaded_rules
+  retries: 12
+  delay: 5
+  until: _prometheus_loaded_rules.status | default(0) == 200
+  changed_when: false
+
+- name: "Prometheus | Assert the rules reached the server, not just the disk (#14531)"
+  # Counts RULES, not groups. A group that parsed but contained nothing would
+  # satisfy a groups-only check while alerting on nothing — the same shape as
+  # the rule files existing on disk and never being read.
+  ansible.builtin.assert:
+    that:
+      - >-
+        (_prometheus_loaded_rules.json.data.groups | default([])
+         | map(attribute='rules') | map('length') | sum) > 0
+    fail_msg: >-
+      Prometheus is running but has loaded 0 alert rules. The files under
+      {{ prometheus_config_dir }}/rules were installed and rule_files points at
+      them, so the gap is between the config and the server — check that
+      rule_files is not [] in the rendered prometheus.yml, and that the server
+      restarted after the config changed. Until this passes, no alert on this
+      host can fire and nothing else reports that (#14531).
+    success_msg: >-
+      Prometheus loaded
+      {{ _prometheus_loaded_rules.json.data.groups | default([])
+         | map(attribute='rules') | map('length') | sum }} alert rule(s)
+      in {{ _prometheus_loaded_rules.json.data.groups | default([]) | length }} group(s).
+  when: prometheus_alert_rules_required | bool

--- a/autobot-slm-backend/tests/services/test_prometheus_rules_are_verified_loaded_14531_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_rules_are_verified_loaded_14531_test.py
@@ -1,0 +1,111 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The monitoring role verifies rules REACHED the server (#14531).
+
+The deployed host ran for four months with `rule_files: []` and 0 loaded rules.
+Every task in the role reported changed/ok throughout: the rule files were found
+in the repo, an assert confirmed they were found, they were copied to disk, and
+the config template pointed at them. None of that is evidence that the running
+Prometheus read any of it, and nothing asked.
+
+So no alert could fire — not the cgroup memory alerts (#13765), not the
+chat-SSOT rules (#7590), not the TTS ones (#13767). An alerting stack with zero
+rules and a fleet in perfect health produce exactly the same observable output:
+silence.
+
+These tests assert the role asks the server what it loaded, and that the check
+counts rules rather than groups — a group that parsed but held nothing would
+satisfy a groups-only check while alerting on nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_TASKS = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "monitoring" / "tasks" / "prometheus.yml"
+
+
+def _tasks() -> list[dict]:
+    return yaml.safe_load(_TASKS.read_text(encoding="utf-8"))
+
+
+def _module(task: dict, name: str) -> dict:
+    for key in (name, f"ansible.builtin.{name}"):
+        if isinstance(task.get(key), dict):
+            return task[key]
+    return {}
+
+
+def _rules_query() -> tuple[int, dict]:
+    """Index and arguments of the task that queries the running server."""
+    for index, task in enumerate(_tasks()):
+        uri = _module(task, "uri")
+        if uri and "/api/v1/rules" in str(uri.get("url", "")):
+            return index, uri
+    raise AssertionError("no task asks the running Prometheus which rules it loaded")
+
+
+def test_the_role_asks_the_server_what_it_loaded():
+    """The regression: the role proved the files existed and stopped there."""
+    _, uri = _rules_query()
+    assert uri.get("url", "").endswith("/api/v1/rules")
+
+
+def test_the_query_runs_after_the_restart_is_applied():
+    """Asking before the restart reports the OLD server's rules.
+
+    The config change notifies a handler, and handlers run at the end of the
+    play unless flushed — so without the flush this would read the state the
+    change was meant to fix and pass.
+    """
+    tasks = _tasks()
+    query_index, _ = _rules_query()
+    flushes = [
+        i for i, t in enumerate(tasks) if str(t.get("ansible.builtin.meta") or t.get("meta") or "") == "flush_handlers"
+    ]
+    assert flushes, "handlers are never flushed, so the query reads the pre-restart server"
+    assert min(flushes) < query_index, "the restart is flushed after the verification that depends on it"
+
+
+def test_the_assertion_counts_rules_not_groups():
+    """A group that parsed but contains nothing alerts on nothing.
+
+    Counting groups would accept that, which is the same shape as counting the
+    files on disk and calling it loaded.
+    """
+    tasks = _tasks()
+    query_index, _ = _rules_query()
+    asserts = [_module(t, "assert") for t in tasks[query_index:] if _module(t, "assert")]
+    assert asserts, "nothing asserts on the query result"
+    conditions = " ".join(str(c) for a in asserts for c in a.get("that", []))
+    assert "rules" in conditions, "the assertion does not look at the rules within each group"
+    assert "sum" in conditions, "the assertion does not total the rules, so an empty group would pass"
+
+
+def test_the_verification_is_gated_by_the_same_flag_as_the_source_check():
+    """A node that legitimately ships no rules already has a way to say so.
+
+    Introducing a second, differently-named escape hatch is how two checks come
+    to disagree about whether this host is supposed to have alerts.
+    """
+    tasks = _tasks()
+    query_index, _ = _rules_query()
+    guarded = [
+        t
+        for t in tasks[query_index:]
+        if _module(t, "assert") and "prometheus_alert_rules_required" in str(t.get("when", ""))
+    ]
+    assert guarded, "the loaded-rules assertion is not gated by prometheus_alert_rules_required"
+
+
+def test_the_query_retries_rather_than_racing_the_restart():
+    """Prometheus takes a moment to serve after a restart; a single attempt
+    would fail for timing rather than for the condition under test."""
+    _, uri = _rules_query()
+    task = next(t for t in _tasks() if _module(t, "uri") is uri or _module(t, "uri") == uri)
+    assert int(task.get("retries", 0)) > 1, "the query does not retry"
+    assert task.get("until"), "the query has retries but no success condition"

--- a/autobot-slm-backend/tests/services/test_prometheus_rules_are_verified_loaded_14531_test.py
+++ b/autobot-slm-backend/tests/services/test_prometheus_rules_are_verified_loaded_14531_test.py
@@ -104,8 +104,31 @@ def test_the_verification_is_gated_by_the_same_flag_as_the_source_check():
 
 def test_the_query_retries_rather_than_racing_the_restart():
     """Prometheus takes a moment to serve after a restart; a single attempt
-    would fail for timing rather than for the condition under test."""
+    would fail for timing rather than for the condition under test.
+
+    The count is var-backed (`prometheus_rules_check_retries`) rather than a
+    literal, matching `backend_health_check_retries` — a large WAL replay can
+    outlast a fixed minute. So this asserts a retry budget exists and is
+    tunable, not that it equals a particular number.
+    """
     _, uri = _rules_query()
-    task = next(t for t in _tasks() if _module(t, "uri") is uri or _module(t, "uri") == uri)
-    assert int(task.get("retries", 0)) > 1, "the query does not retry"
+    task = next(t for t in _tasks() if _module(t, "uri") == uri)
+
+    retries = str(task.get("retries", ""))
+    assert retries, "the query does not retry"
+    if retries.isdigit():
+        assert int(retries) > 1
+    else:
+        assert "prometheus_rules_check_retries" in retries, f"unrecognised retry budget: {retries!r}"
     assert task.get("until"), "the query has retries but no success condition"
+
+
+def test_the_retry_budget_has_a_default_so_an_unset_var_cannot_disable_it():
+    """A bare `{{ prometheus_rules_check_retries }}` would render empty on a
+    host that never set it, turning the poll into a single attempt."""
+    _, uri = _rules_query()
+    task = next(t for t in _tasks() if _module(t, "uri") == uri)
+    for field in ("retries", "delay"):
+        value = str(task.get(field, ""))
+        if not value.isdigit():
+            assert "default(" in value, f"{field} is templated without a default: {value!r}"


### PR DESCRIPTION
Closes #14531.

## Thinking Path

Found while gathering host evidence for #13765. Prometheus on the deployed host reports **0 rule groups and 0 rules**, and its config carries `rule_files: []` — the pre-fix state, mtime 2026-04-02.

So no alert has ever been able to fire there: not the cgroup memory alerts (#13765), not the chat-SSOT rules (#7590), not the TTS ones (#13767). Every alert in the repository is inert on that host, and has been for four months.

What makes it this umbrella's shape rather than just a stale deploy is that **every task in the monitoring role reported changed/ok throughout**. The role finds the rule files in the repo, asserts they were found, copies them to disk, and templates a config that points at them. All true, all green, and none of it evidence that the running Prometheus read any of it. Nothing asked.

Zero rules loaded and a fleet in perfect health produce exactly the same observable output: silence. That is the failure mode #13852 exists to remove, sitting in the alerting layer itself.

## What Changed

`roles/monitoring/tasks/prometheus.yml` gains three tasks after the service is started:

1. **Flush the pending restart.** The config and rule copies notify a handler, and handlers run at the end of the play — asking first would read the server the change was meant to fix.
2. **Ask the running server** `/api/v1/rules`, with retries, since Prometheus takes a moment to serve after a restart.
3. **Assert it loaded something**, counting **rules rather than groups**. A group that parsed but held nothing would satisfy a groups-only check while alerting on nothing — the same shape as counting the files on disk and calling them loaded.

Gated by the existing `prometheus_alert_rules_required` rather than a new flag, so the source-side assert and this one cannot disagree about whether a host is meant to have alerts.

## Verification

Mutation-tested — each guard bites:

| Mutation | Result |
|---|---|
| Remove the handler flush (query reads the pre-restart server) | 1 fail |
| Count groups instead of rules | 1 fail |
| Drop the query entirely | 5 fail |
| Single attempt, no retries | 1 fail |

`autobot-slm-backend/tests/services/` — 505 passed, 2 skipped. black, isort, flake8 clean.

## Risk worth naming

This turns a silent no-op into a play failure. A host where Prometheus is genuinely unreachable on `prometheus_port`, or is deliberately not serving, will now fail the play where it previously completed green. That is the intended direction — the whole point is that "no alerts loaded" stops being indistinguishable from success — but it is a behaviour change for anyone relying on the role completing regardless. `prometheus_alert_rules_required=false` is the existing, documented way to opt a node out.

**This fixes new runs. The already-deployed host stays at 0 rules until the monitoring role runs again** — the same redeploy #13765 and the stale-config half of #14337 are waiting on.

## Model Used

Opus 5 (1M context).


---

## Round 2 — both review findings applied

Review said land it with two low-severity findings. Both taken rather than filed, since each is a few characters and one is squarely the failure class this PR is about.

**`map(attribute='rules')` had no default.** A group lacking a `rules` key raised `AnsibleUndefinedVariable` instead of failing the assertion with its own message. Review confirmed it is unreachable against a real Prometheus — every group in a genuine `/api/v1/rules` response carries a `rules` array, even an empty one — so this is defensive only. Taken anyway: a template error where the operator should see "Prometheus loaded 0 alert rules" is exactly the confusing-failure shape this change exists to remove.

**The retry budget was a literal.** This repo already polls a local health endpoint after a restart with `backend_health_check_retries | default(60)`. Now var-backed the same way, because a large WAL replay can outlast a fixed minute and false-fail the play.

That change broke my own test, which cast `retries` to `int` — caught immediately, and the fix is better than the original: the test now accepts a templated budget, and a **second** test pins that the template carries a `default(...)`. A bare `{{ prometheus_rules_check_retries }}` would render empty on a host that never set the var and silently collapse the poll to a single attempt. Stripping the default fails that test.

6 tests; `autobot-slm-backend/tests/services/` — 506 passed, 2 skipped.

Review also independently cleared the thing I was least sure of: `meta: flush_handlers` cannot leak other roles' handlers here, because `prometheus.yml` runs before `grafana.yml`/`node_exporter.yml` in this role, and the one multi-role play has both earlier roles self-flushing already. It follows an existing repo-wide convention rather than introducing one.
