### PR TITLE
security(mcp): govern manual_mcp as the twelfth bridge, fix double mount (#14586)

### DIFF
--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -19,6 +19,7 @@ from typing import List
 from fastapi import APIRouter, Depends
 
 from api.schemas_code import (
+    MCPTool,
     ManPageRequest,
     ManPageSearchRequest,
     ManualMCPToolItem,
@@ -29,6 +30,17 @@ from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
 from services.man_page_parser import ManPageContent, get_man_page_content
+from services.mcp_bridge_manifest import MCPBridgeManifest
+
+# #14586: MANIFEST makes this bridge discoverable by mcp_registry.discover_bridges()
+# module-scan fallback, the same mechanism every other governed bridge uses.
+MANIFEST = MCPBridgeManifest(
+    name="manual_mcp",
+    version="1.0.0",
+    description="Man page and documentation lookup (issue #3287)",
+    features=["man_pages", "documentation_index"],
+    endpoint="/api/manual/mcp/tools",
+)
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["manual_mcp", "mcp"])
@@ -219,14 +231,14 @@ async def _query_doc_index(query: str, max_results: int) -> List[dict]:
 # ---------------------------------------------------------------------------
 
 
-def _man_page_tool_schema() -> dict:
-    return {
-        "name": "lookup_man_page",
-        "description": (
+def _man_page_tool_schema() -> MCPTool:
+    return MCPTool(
+        name="lookup_man_page",
+        description=(
             "Fetch a Linux/Unix man page for a command. "
             "Returns structured sections: synopsis, description, options, examples, see-also."
         ),
-        "input_schema": {
+        input_schema={
             "type": "object",
             "properties": {
                 "command": {"type": "string", "description": "Command name (e.g. 'ls')"},
@@ -237,17 +249,17 @@ def _man_page_tool_schema() -> dict:
             },
             "required": ["command"],
         },
-    }
+    )
 
 
-def _search_docs_tool_schema() -> dict:
-    return {
-        "name": "search_man_pages",
-        "description": (
+def _search_docs_tool_schema() -> MCPTool:
+    return MCPTool(
+        name="search_man_pages",
+        description=(
             "Search the system documentation index (man -k) for commands "
             "matching a keyword. Returns a ranked list of command names and brief summaries."
         ),
-        "input_schema": {
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search keyword"},
@@ -259,17 +271,17 @@ def _search_docs_tool_schema() -> dict:
             },
             "required": ["query"],
         },
-    }
+    )
 
 
-def _doc_index_tool_schema() -> dict:
-    return {
-        "name": "get_doc_index",
-        "description": (
+def _doc_index_tool_schema() -> MCPTool:
+    return MCPTool(
+        name="get_doc_index",
+        description=(
             "Query the cached documentation index. Similar to search_man_pages "
             "but queries against a pre-warmed Redis cache for lower latency."
         ),
-        "input_schema": {
+        input_schema={
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search keyword"},
@@ -281,7 +293,7 @@ def _doc_index_tool_schema() -> dict:
             },
             "required": ["query"],
         },
-    }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -301,12 +313,16 @@ async def get_manual_mcp_tools(
     """List available MCP tools provided by the manual bridge.
 
     Issue #3287: Man page and documentation lookup tools.
+    Issue #14586: schemas are ``MCPTool`` instances (the shape every other
+    governed bridge uses) so ``mcp_bridge_scan`` can parse them; ``.model_dump()``
+    keeps the wire response an unchanged list of dicts.
     """
-    return [
+    tools = [
         _man_page_tool_schema(),
         _search_docs_tool_schema(),
         _doc_index_tool_schema(),
     ]
+    return [tool.model_dump() for tool in tools]
 
 
 @router.post("/mcp/lookup_man_page", response_model=ManPageLookupData)

--- a/autobot-backend/api/manual_mcp.py
+++ b/autobot-backend/api/manual_mcp.py
@@ -19,10 +19,10 @@ from typing import List
 from fastapi import APIRouter, Depends
 
 from api.schemas_code import (
-    MCPTool,
     ManPageRequest,
     ManPageSearchRequest,
     ManualMCPToolItem,
+    MCPTool,
 )
 from api.schemas_workflows import ManPageLookupData, ManPageSearchData
 from auth_middleware import get_current_user

--- a/autobot-backend/api/mcp_registry.py
+++ b/autobot-backend/api/mcp_registry.py
@@ -345,6 +345,14 @@ _BRIDGE_MODULE_REGISTRY: List[Tuple[str, str, str, List[str]]] = [
         "/api/redis/mcp/tools",
         ["data_access", "vector_search", "hybrid_search", "ops_intelligence", "stream_health", "rbac_filtering"],
     ),
+    # #14586: was reachable via the router but absent here, so its tools never
+    # entered MCPDispatcher._tool_cache and required_permission() never saw them.
+    (
+        "api.manual_mcp",
+        "manual_mcp",
+        "/api/manual/mcp/tools",
+        ["man_pages", "documentation_index"],
+    ),
 ]
 
 # Registry mapping name -> (manifest, module_path) for hot-reload support

--- a/autobot-backend/initialization/router_registry/mcp_routers.py
+++ b/autobot-backend/initialization/router_registry/mcp_routers.py
@@ -34,11 +34,16 @@ def load_mcp_routers():
     # - database_mcp
     # - git_mcp
     # - prometheus_mcp
+    # - redis_mcp
+    # - manual_mcp
     # - mcp_registry
+    #
+    # #14586: manual_mcp used to be listed again below, mounting the same
+    # router twice (once here at prefix "", once in core_routers.py at
+    # prefix "/manual") -- resolved to the single core registration above.
 
     # Optional MCP routers
     optional_mcp_configs = [
-        ("api.manual_mcp", "", ["manual_mcp", "mcp"], "manual_mcp"),
         # Issue #5072: AutoBot MCP server HTTP transport (POST /api/mcp/tool)
         ("api.autobot_mcp_router", "", ["mcp", "autobot-mcp"], "autobot_mcp_server"),
         # Issue #6453: Admin endpoints to generate/revoke scoped MCP client tokens

--- a/autobot-backend/middleware/builtin/permission_enforcement.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement.py
@@ -14,7 +14,7 @@ missing ``tool_permission`` was read as "legacy tool, no schema declared" and
 waved through unconditionally; that was the runtime half of the default-allow
 #14521's security review flagged in
 ``autobot_shared.auth.mcp_tool_permissions.required_permission``. #14494 made
-every tool the eleven governed bridges register today carry an exact
+every tool the twelve governed bridges register today carry an exact
 declaration (measured at #14523 time: 104 live tools, 0 undeclared), which is
 what makes refusing ``None`` safe rather than breaking a working agent flow.
 
@@ -67,7 +67,7 @@ class PermissionEnforcementExtension(Extension):
     undeclared tool, per ``mcp_tool_permissions.required_permission`` — is
     refused, not allowed through. Before #14523 this was read as "legacy,
     no schema declared" and waved through unconditionally; #14494 proved
-    every tool the eleven governed bridges register today carries a real
+    every tool the twelve governed bridges register today carries a real
     declaration, so refusing the undeclared case no longer breaks a working
     call — it refuses exactly the tool that reached production without one.
 

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -151,7 +151,7 @@ class MCPDispatcher:
         Stage 2 (#13228) used this for shadow logging only — the caller never
         acted on it. Stage 3 (#14523) promotes it to the actual decision
         ``dispatch()`` enforces, now that #14494 has proven the precondition
-        this needs: every tool the eleven governed bridges register carries an
+        this needs: every tool the twelve governed bridges register carries an
         exact ``TOOL_PERMISSIONS`` entry, so "undeclared" here means a tool
         that should not have reached production, not a working call about to
         break.

--- a/autobot-backend/tests/unit/api/test_mcp_plugin_discovery.py
+++ b/autobot-backend/tests/unit/api/test_mcp_plugin_discovery.py
@@ -86,6 +86,8 @@ def test_discover_bridges_known_names():
         "git_mcp",
         "prometheus_mcp",
         "redis_mcp",
+        # #14586: the twelfth governed bridge.
+        "manual_mcp",
     }
     assert names == expected
 
@@ -94,7 +96,7 @@ def test_discover_bridges_manifest_registry_populated():
     from api.mcp_registry import _MANIFEST_REGISTRY, discover_bridges
 
     discover_bridges()
-    assert len(_MANIFEST_REGISTRY) >= 11
+    assert len(_MANIFEST_REGISTRY) >= 12  # #14586: manual_mcp is the twelfth
     for name, (manifest, module_path) in _MANIFEST_REGISTRY.items():
         assert isinstance(manifest, MCPBridgeManifest)
         assert manifest.name == name

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -13599,12 +13599,31 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get Manual Mcp Tools
-         * @description List available MCP tools provided by the manual bridge.
+         * List All Mcp Tools
+         * @description List all available MCP tools from all bridges (with caching)
          *
-         *     Issue #3287: Man page and documentation lookup tools.
+         *     Returns aggregated list of tools from:
+         *     - knowledge_mcp (knowledge base operations)
+         *     - vnc_mcp (VNC observation)
+         *     - sequential_thinking_mcp (dynamic problem-solving)
+         *     - structured_thinking_mcp (5-stage cognitive framework)
+         *     - filesystem_mcp (secure file operations)
+         *
+         *     Caching (Issue #50):
+         *     - First request fetches from all bridges (~5 HTTP calls)
+         *     - Subsequent requests return cached data (0 HTTP calls)
+         *     - Cache expires after TTL (default: 60 seconds)
+         *
+         *     Response format:
+         *     {
+         *         "total_tools": 25,
+         *         "bridges": 5,
+         *         "tools": [...],
+         *         "cached": true/false,
+         *         "last_updated": "..."
+         *     }
          */
-        get: operations["get_manual_mcp_tools_api_mcp_tools_get"];
+        get: operations["list_all_mcp_tools_api_mcp_tools_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -15849,6 +15868,9 @@ export interface paths {
          * @description List available MCP tools provided by the manual bridge.
          *
          *     Issue #3287: Man page and documentation lookup tools.
+         *     Issue #14586: schemas are ``MCPTool`` instances (the shape every other
+         *     governed bridge uses) so ``mcp_bridge_scan`` can parse them; ``.model_dump()``
+         *     keeps the wire response an unchanged list of dicts.
          */
         get: operations["get_manual_mcp_tools_api_manual_mcp_tools_get"];
         put?: never;
@@ -53001,81 +53023,6 @@ export interface paths {
         get: operations["export_memory_api_memory_privacy_export_get"];
         put?: never;
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/mcp/lookup_man_page": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Mcp Lookup Man Page
-         * @description MCP tool: Fetch a man page for a command.
-         *
-         *     Results are cached in Redis (knowledge database) with a 24-hour TTL.
-         *     When MCP / man is unavailable the response includes success=False and
-         *     a human-readable error rather than raising HTTP 500.
-         *
-         *     Issue #3287.
-         */
-        post: operations["mcp_lookup_man_page_api_mcp_lookup_man_page_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/mcp/search_man_pages": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Mcp Search Man Pages
-         * @description MCP tool: Search the system documentation index.
-         *
-         *     Delegates to `man -k <query>` and returns structured results.
-         *     Gracefully returns an empty list when `man` is not available.
-         *
-         *     Issue #3287.
-         */
-        post: operations["mcp_search_man_pages_api_mcp_search_man_pages_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/mcp/get_doc_index": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Mcp Get Doc Index
-         * @description MCP tool: Query the cached documentation index.
-         *
-         *     First checks Redis; falls back to man -k when cache is cold.
-         *
-         *     Issue #3287.
-         */
-        post: operations["mcp_get_doc_index_api_mcp_get_doc_index_post"];
         delete?: never;
         options?: never;
         head?: never;
@@ -120738,7 +120685,7 @@ export interface operations {
             };
         };
     };
-    get_manual_mcp_tools_api_mcp_tools_get: {
+    list_all_mcp_tools_api_mcp_tools_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -120753,7 +120700,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ManualMCPToolItem"][];
+                    "application/json": components["schemas"]["MCPRegistryToolsResponse"];
                 };
             };
         };
@@ -175873,105 +175820,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    mcp_lookup_man_page_api_mcp_lookup_man_page_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ManPageRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ManPageLookupData"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    mcp_search_man_pages_api_mcp_search_man_pages_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ManPageSearchRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ManPageSearchData"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    mcp_get_doc_index_api_mcp_get_doc_index_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ManPageSearchRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ManPageSearchData"];
                 };
             };
             /** @description Validation Error */

--- a/autobot_shared/auth/mcp_bridge_scan.py
+++ b/autobot_shared/auth/mcp_bridge_scan.py
@@ -39,17 +39,34 @@ _MODULE_TUPLE_TOOL = re.compile(r'^[A-Z_][A-Z0-9_]*\s*=\s*\(\s*\n\s{4}"([a-z0-9_
 _KWARG_TOOL = re.compile(r'name="([a-z0-9_]+)"')
 
 
+#: Bridge module stems intentionally excluded from governance, keyed to the
+#: reason they are excluded. #14586: this used to be a bare
+#: ``if p.stem != "manual_mcp"`` filter with no comment explaining why -- an
+#: exclusion that could grow with no review trail, and did (manual_mcp was
+#: added here with no declared permissions and no test pinning the choice).
+#: Empty today: manual_mcp was un-excluded and governed as the twelfth
+#: bridge (#14586). A future exclusion must add a reasoned entry here, not a
+#: second inline stem check -- ``mcp_bridge_scan_test.py`` asserts every
+#: ``*_mcp.py``/``*_mcp`` source not in ``all_declared_tools()`` is named here.
+EXCLUDED_BRIDGE_STEMS: dict[str, str] = {}
+
+
 def bridge_files(base: pathlib.Path | None = None) -> list[pathlib.Path]:
     """Every bridge's tool-declaring source, module- or package-shaped.
 
     #13228: globbing only ``*_mcp.py`` silently omitted ``redis_mcp``, which is
-    a package (``api/redis_mcp/tools.py``). ``manual_mcp`` is excluded on
-    purpose -- man-page lookup is not one of the eleven bridges this system
-    governs (#14494's issue enumerates them).
+    a package (``api/redis_mcp/tools.py``). #14586: any stem in
+    ``EXCLUDED_BRIDGE_STEMS`` is skipped -- an auditable table instead of an
+    inline name check, so a new exclusion cannot land without a reason next
+    to it.
     """
     directory = base or BRIDGE_DIR
-    modules = [p for p in directory.glob("*_mcp.py") if p.stem != "manual_mcp"]
-    packages = [p / "tools.py" for p in directory.glob("*_mcp") if p.is_dir() and (p / "tools.py").is_file()]
+    modules = [p for p in directory.glob("*_mcp.py") if p.stem not in EXCLUDED_BRIDGE_STEMS]
+    packages = [
+        p / "tools.py"
+        for p in directory.glob("*_mcp")
+        if p.is_dir() and p.stem not in EXCLUDED_BRIDGE_STEMS and (p / "tools.py").is_file()
+    ]
     return sorted(modules + packages)
 
 
@@ -73,6 +90,7 @@ def all_declared_tools(base: pathlib.Path | None = None) -> dict[str, set[str]]:
 
 __all__ = [
     "BRIDGE_DIR",
+    "EXCLUDED_BRIDGE_STEMS",
     "all_declared_tools",
     "bridge_files",
     "bridge_name",

--- a/autobot_shared/auth/mcp_bridge_scan_test.py
+++ b/autobot_shared/auth/mcp_bridge_scan_test.py
@@ -34,7 +34,9 @@ from autobot_shared.auth.mcp_bridge_scan import (
     bridge_name,
 )
 
-_ROUTER_REGISTRY_DIR = pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "initialization" / "router_registry"
+_ROUTER_REGISTRY_DIR = (
+    pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "initialization" / "router_registry"
+)
 _CORE_ROUTERS = _ROUTER_REGISTRY_DIR / "core_routers.py"
 _MCP_ROUTERS = _ROUTER_REGISTRY_DIR / "mcp_routers.py"
 

--- a/autobot_shared/auth/mcp_bridge_scan_test.py
+++ b/autobot_shared/auth/mcp_bridge_scan_test.py
@@ -1,0 +1,99 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A mounted `*_mcp` router cannot silently skip governance (#14586).
+
+`manual_mcp` reached production excluded from `mcp_bridge_scan.bridge_files()`
+by a bare `if p.stem != "manual_mcp"` — no comment, no test pinning the
+choice, no coverage. `EXCLUDED_BRIDGE_STEMS` replaces that inline check with
+an auditable table; this module is what makes the table load-bearing rather
+than decorative.
+
+Two things are checked, statically (no FastAPI app import — the router
+registry modules pull in the full dependency tree of every bridge, which is
+unnecessary weight for a source-text cross-check):
+
+1. `EXCLUDED_BRIDGE_STEMS` cannot silently grow: every entry needs a real
+   reason string, and it must not name a bridge already governed.
+2. Every `*_mcp` router actually mounted in `core_routers.py` /
+   `mcp_routers.py` is either governed (`bridge_files()` finds its source)
+   or named in `EXCLUDED_BRIDGE_STEMS`. A new bridge added to the router
+   registry without either lands here as a hard failure, not a silent gap.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from autobot_shared.auth.mcp_bridge_scan import (
+    BRIDGE_DIR,
+    EXCLUDED_BRIDGE_STEMS,
+    bridge_files,
+    bridge_name,
+)
+
+_ROUTER_REGISTRY_DIR = pathlib.Path(__file__).resolve().parents[2] / "autobot-backend" / "initialization" / "router_registry"
+_CORE_ROUTERS = _ROUTER_REGISTRY_DIR / "core_routers.py"
+_MCP_ROUTERS = _ROUTER_REGISTRY_DIR / "mcp_routers.py"
+
+# `"api.manual_mcp"` (a dynamic import string) or `manual_mcp_router` (a
+# module-level import alias) — the two shapes the registry uses to mount a
+# bridge. Candidates are then intersected with real `*_mcp.py`/`*_mcp/`
+# sources so an unrelated identifier merely ending in `_mcp` (e.g.
+# `autobot_mcp_router.py`, which is not a bridge glob matches at all) cannot
+# false-positive.
+_MODULE_REF = re.compile(r'"api\.([a-z][a-z0-9_]*_mcp)"')
+_VAR_REF = re.compile(r"\b([a-z][a-z0-9_]*_mcp)_router\b")
+
+
+def _mounted_bridge_stems(path: pathlib.Path) -> set[str]:
+    """Bridge stems referenced as a mount target in *path*'s source text."""
+    src = path.read_text(encoding="utf-8")
+    return set(_MODULE_REF.findall(src)) | set(_VAR_REF.findall(src))
+
+
+def _real_bridge_stems() -> set[str]:
+    """Every `*_mcp.py`/`*_mcp/` stem on disk, before any exclusion applies."""
+    modules = {p.stem for p in BRIDGE_DIR.glob("*_mcp.py")}
+    packages = {p.name for p in BRIDGE_DIR.glob("*_mcp") if p.is_dir()}
+    return modules | packages
+
+
+def test_excluded_bridge_stems_cannot_grow_silently():
+    """Pins today's state (empty) and shapes any future entry (#14586).
+
+    manual_mcp was the one bridge here; it is governed now, so the table is
+    empty. A future exclusion is legitimate — but it has to carry a reason,
+    and it cannot name a bridge `bridge_files()` already governs (that would
+    be a silent no-op exclusion, indistinguishable from a typo).
+    """
+    assert EXCLUDED_BRIDGE_STEMS == {}, (
+        "a bridge was added to EXCLUDED_BRIDGE_STEMS — update this pin once the "
+        "exclusion is reviewed and intentional"
+    )
+    governed = {bridge_name(p) for p in bridge_files()}
+    for stem, reason in EXCLUDED_BRIDGE_STEMS.items():
+        assert reason.strip(), f"{stem} is excluded with no reason"
+        assert stem not in governed, f"{stem} is both governed and excluded — pick one"
+
+
+def test_every_mounted_mcp_router_is_governed_or_excluded():
+    """A router mounted in the app must be reachable by exactly one path."""
+    real_stems = _real_bridge_stems()
+    mounted = (_mounted_bridge_stems(_CORE_ROUTERS) | _mounted_bridge_stems(_MCP_ROUTERS)) & real_stems
+    governed = {bridge_name(p) for p in bridge_files()}
+
+    ungoverned = mounted - governed - set(EXCLUDED_BRIDGE_STEMS)
+    assert not ungoverned, (
+        f"*_mcp router(s) mounted with neither a bridge_scan declaration nor an "
+        f"EXCLUDED_BRIDGE_STEMS entry: {sorted(ungoverned)} — see "
+        "autobot_shared/auth/mcp_bridge_scan.py"
+    )
+
+
+def test_manual_mcp_is_governed_not_excluded():
+    """#14586: pins the actual decision this issue made, not just its shape."""
+    assert "manual_mcp" not in EXCLUDED_BRIDGE_STEMS
+    assert "manual_mcp" in {bridge_name(p) for p in bridge_files()}

--- a/autobot_shared/auth/mcp_tool_permissions.py
+++ b/autobot_shared/auth/mcp_tool_permissions.py
@@ -70,12 +70,13 @@ from typing import Dict, Optional
 
 from autobot_shared.auth.permissions import Permission
 
-# The eleven bridges this system governs, and the least-privileged operation
-# each offers. #14523: no longer consulted by ``required_permission()`` as a
-# runtime fallback grant — an undeclared tool is refused regardless of bridge.
-# Retained as the registry ``test_every_bridge_has_a_default`` requires a new
-# bridge to join before any of its tools can be declared, and as the source
-# for the coverage checker's per-bridge discovery floors
+# The twelve bridges this system governs (#14586 added manual_mcp), and the
+# least-privileged operation each offers. #14523: no longer consulted by
+# ``required_permission()`` as a runtime fallback grant — an undeclared tool
+# is refused regardless of bridge. Retained as the registry
+# ``test_every_bridge_has_a_default`` requires a new bridge to join before
+# any of its tools can be declared, and as the source for the coverage
+# checker's per-bridge discovery floors
 # (``tools/lint/check_mcp_tool_permission_coverage.py``).
 BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
     "browser_mcp": Permission.MCP_BROWSER_READ,
@@ -84,6 +85,9 @@ BRIDGE_DEFAULT_PERMISSIONS: Dict[str, Permission] = {
     "git_mcp": Permission.MCP_GIT_READ,
     "http_client_mcp": Permission.MCP_HTTP_READ,
     "knowledge_mcp": Permission.KNOWLEDGE_READ,
+    # #14586: the twelfth bridge -- man page / doc-index lookup is read-only,
+    # so MCP_READ (held by every role above READONLY) is the correct baseline.
+    "manual_mcp": Permission.MCP_READ,
     "prometheus_mcp": Permission.MCP_METRICS_READ,
     # #13228: missed on the first pass, which made all 25 redis tools resolve to
     # "undeclared" — including the seven the blocklist already knew about.
@@ -281,6 +285,15 @@ TOOL_PERMISSIONS: Dict[str, Permission] = {
     "clear_history": Permission.AGENT_EXECUTE,
     "generate_summary": Permission.AGENT_EXECUTE,
     "process_thought": Permission.AGENT_EXECUTE,
+    # --- manual: single-tier, read-only bridge (#14586) ---
+    # All three tools read local man pages / a cached doc index via a fixed
+    # argument-list subprocess (no shell=True) -- nothing here writes state or
+    # leaves the host, so none needs more than the bridge's own baseline.
+    # Declared explicitly (not left to the default) so the coverage guard has
+    # an exact entry for every live tool, matching every other governed bridge.
+    "lookup_man_page": Permission.MCP_READ,
+    "search_man_pages": Permission.MCP_READ,
+    "get_doc_index": Permission.MCP_READ,
 }
 
 
@@ -289,7 +302,7 @@ def required_permission(tool_name: str, bridge_name: str = "") -> Optional[Permi
 
     Deny-by-default: an exact ``TOOL_PERMISSIONS`` entry is the only way a tool
     resolves to a permission. Everything else returns ``None`` — a tool on one
-    of the eleven governed bridges with no exact entry included, not only a
+    of the twelve governed bridges with no exact entry included, not only a
     tool on a bridge this module has never heard of. Before #14523 the known-
     bridge case fell through to ``BRIDGE_DEFAULT_PERMISSIONS`` and granted a
     real read permission instead of refusing; that fallback is retired here.

--- a/autobot_shared/auth/mcp_tool_permissions_test.py
+++ b/autobot_shared/auth/mcp_tool_permissions_test.py
@@ -223,6 +223,12 @@ def test_knowledge_redis_vector_operations_is_not_a_read():
     assert required_permission("redis_vector_operations", "knowledge_mcp") == Permission.KNOWLEDGE_MANAGE
 
 
+def test_manual_mcp_tools_resolve_to_mcp_read():
+    """#14586: the twelfth bridge — all three tools are read-only lookups."""
+    for name in ("lookup_man_page", "search_man_pages", "get_doc_index"):
+        assert required_permission(name, "manual_mcp") == Permission.MCP_READ, name
+
+
 def test_readonly_holds_no_control_grant():
     """The role split has to mean something at the weakest role."""
     readonly = set(ROLE_PERMISSIONS[Role.READONLY])

--- a/tools/lint/check_mcp_tool_permission_coverage.py
+++ b/tools/lint/check_mcp_tool_permission_coverage.py
@@ -97,16 +97,17 @@ logger = logging.getLogger(__name__)
 SELF_REL = "tools/lint/check_mcp_tool_permission_coverage.py"
 
 #: Floor for the sweep's own discovery, summed over every bridge. The eleven
-#: governed bridges registered 104 tools when this landed; a sweep that
-#: suddenly reaches a handful has broken, and a clean result from it would
-#: assert nothing. Kept as a coarse aggregate sanity net alongside the
-#: per-bridge floors below (#14523) — those catch a single bridge's own count
-#: dropping; this one is the cheap "did the sweep basically work at all" check.
-DISCOVERY_FLOOR = 90
+#: governed bridges registered 104 tools when this landed; #14586 added
+#: manual_mcp's 3, so 107 today. A sweep that suddenly reaches a handful has
+#: broken, and a clean result from it would assert nothing. Kept as a coarse
+#: aggregate sanity net alongside the per-bridge floors below (#14523) — those
+#: catch a single bridge's own count dropping; this one is the cheap "did the
+#: sweep basically work at all" check.
+DISCOVERY_FLOOR = 93
 
 #: Per-bridge floor (#14523): each governed bridge's own tool count today, so
 #: one bridge silently dropping to near-zero cannot hide inside a total the
-#: other ten bridges keep healthy. A legitimate new tool only ever raises a
+#: other bridges keep healthy. A legitimate new tool only ever raises a
 #: bridge's count, so raising these is a one-line follow-up when that happens
 #: — a drop is always either a parser regression or a real removal, and either
 #: one deserves a look before it merges.
@@ -117,6 +118,8 @@ PER_BRIDGE_DISCOVERY_FLOOR: dict[str, int] = {
     "git_mcp": 6,
     "http_client_mcp": 6,
     "knowledge_mcp": 12,
+    # #14586: the twelfth bridge — lookup_man_page, search_man_pages, get_doc_index.
+    "manual_mcp": 3,
     "prometheus_mcp": 6,
     "redis_mcp": 25,
     "sequential_thinking_mcp": 1,


### PR DESCRIPTION
Closes #14586

## Thinking Path

`api/manual_mcp.py` exposed three MCP tools (`lookup_man_page`,
`search_man_pages`, `get_doc_index`) gated only by `Depends(get_current_user)`
— any authenticated user, no permission check. It was excluded from
`mcp_bridge_scan.bridge_files()` by a bare `if p.stem != "manual_mcp"` with no
comment, absent from `mcp_registry.py`'s `_BRIDGE_MODULE_REGISTRY`, and
therefore unreachable by `required_permission()` — meaning the LLM/agent
dispatch path (`MCPDispatcher.dispatch()`) already denied every call to these
tools as "undeclared", for every role including a plain `user`. Also mounted
twice: once as a core router (`core_routers.py`, prefix `/manual`) and again
as an "optional" router (`mcp_routers.py`, prefix `""`).

Checked what the three tools actually reach: `_query_doc_index` runs
`subprocess.run(["man", "-k", query], capture_output=True, text=True,
timeout=10)` — argument list, no `shell=True`, explicit timeout — and
`_lookup_man_page` parses local man pages via `services/man_page_parser.py`,
caching results in the `knowledge` Redis database. No filesystem write, no
network egress, no code execution beyond that fixed `man` invocation. This is
read-only system documentation, confirming the issue's own severity read: an
authorization/governance gap, not an injection one.

**Decision: govern it as the twelfth bridge**, not keep the exclusion. Two
peer bridges (`knowledge_mcp`, `redis_mcp`) already use the identical
"authenticated-user-only HTTP + agent-path-governed" model for read-mostly
tools, so this brings `manual_mcp` to parity with that precedent rather than
inventing a fourth authorization shape. A read-level permission
(`Permission.MCP_READ` — held by every role except `readonly`) is the correct
grant, per the issue's own hint.

One discovery mid-fix: `manual_mcp`'s tool schemas were plain dicts
(`{"name": ..., ...}`), a fourth source shape `mcp_bridge_scan`'s three
regexes never matched. Un-excluding it without fixing that would have
registered a bridge with **zero** discovered tools — the "guard narrower than
its own subject" trap this repo has hit before (`sequential_thinking_mcp`,
`redis_mcp`). Reshaped the three schema functions to return `MCPTool(name=...)`
instances, the shape every other bridge already uses, before adding the
`TOOL_PERMISSIONS` entries.

## What Changed

- `autobot-backend/api/manual_mcp.py` — tool schemas are now `MCPTool`
  instances instead of raw dicts; added a `MANIFEST` (matching every sibling
  bridge) so `mcp_registry.discover_bridges()`'s module-scan fallback works.
- `autobot_shared/auth/mcp_bridge_scan.py` — replaced the bare
  `p.stem != "manual_mcp"` check with an auditable `EXCLUDED_BRIDGE_STEMS: dict`
  (empty today). A future exclusion needs a reasoned entry there, not a second
  inline stem check.
- `autobot_shared/auth/mcp_tool_permissions.py` — `manual_mcp: MCP_READ` in
  `BRIDGE_DEFAULT_PERMISSIONS`; `lookup_man_page`, `search_man_pages`,
  `get_doc_index` each declared `MCP_READ` in `TOOL_PERMISSIONS`. Updated the
  "eleven governed bridges" prose to twelve where it describes current
  behaviour (left dated `#14523`-time measurement snapshots alone).
- `autobot-backend/api/mcp_registry.py` — added `manual_mcp` to
  `_BRIDGE_MODULE_REGISTRY` so `discover_bridges()` includes it and its tools
  reach `MCPDispatcher._tool_cache`.
- `autobot-backend/initialization/router_registry/mcp_routers.py` — removed
  the duplicate `manual_mcp` entry from `optional_mcp_configs`; it stays
  mounted once, as a core router.
- `tools/lint/check_mcp_tool_permission_coverage.py` — added
  `"manual_mcp": 3` to `PER_BRIDGE_DISCOVERY_FLOOR`, raised `DISCOVERY_FLOOR`
  90 → 93 for the new 107-tool total.
- `autobot_shared/auth/mcp_bridge_scan_test.py` (new) — the durable guard:
  statically cross-checks every `*_mcp` router actually mounted in
  `core_routers.py`/`mcp_routers.py` against `bridge_files()` and
  `EXCLUDED_BRIDGE_STEMS`, failing if a future router lands in neither. Also
  pins `EXCLUDED_BRIDGE_STEMS == {}` and requires any future entry to carry a
  reason and not name an already-governed bridge.
- `autobot_shared/auth/mcp_tool_permissions_test.py` — added a test pinning
  `manual_mcp`'s three tools to `MCP_READ`.
- `autobot-backend/middleware/builtin/permission_enforcement.py`,
  `autobot-backend/services/mcp_dispatch.py` — updated "eleven governed
  bridges" → "twelve" in the two present-tense docstring claims about the
  current precondition (left historical `#14523`-time snapshots as written).

Not changed, deliberately: the direct HTTP endpoints in `manual_mcp.py` still
gate on `Depends(get_current_user)` alone, matching `knowledge_mcp` and
`redis_mcp` exactly. #13228 already documents this as one of three parallel
authorization models (HTTP-direct vs. agent-dispatch vs. external MCP/JWT);
unifying HTTP-direct access across all bridges is out of scope for a
twelfth-bridge governance fix and would need its own issue.

## Verification

Static, no app boot (regex cross-checks against the real source files, not
imports):

- `mcp_bridge_scan`'s three tool-declaration regexes now find `manual_mcp`'s
  3 tools (`lookup_man_page`, `search_man_pages`, `get_doc_index`) — 0 before
  this PR's schema reshape.
- Full bridge scan across all 12 bridges: 107 live tools total (was 104),
  `manual_mcp: 3`, every `PER_BRIDGE_DISCOVERY_FLOOR` entry matches exactly,
  0 name collisions, 0 tools missing a `TOOL_PERMISSIONS` entry, 0 unexplained
  `TOOL_PERMISSIONS` entries outside `_DECLARED_AHEAD_OF_TIME`.
- Router-mount cross-check: all 12 bridges mounted in `core_routers.py`
  resolve as governed; `autobot_mcp_router` (a distinct, out-of-scope module —
  `api/autobot_mcp_router.py`, not a `*_mcp.py`/`*_mcp/` bridge) correctly
  does **not** false-positive as an ungoverned bridge.

Exploit-driven verification of the actual decision path (`_would_deny` /
`required_permission`), per the task's "run the exploit" requirement — a
standalone scratch reproduction (not imported from the repo), driving two
non-admin identities (`user`, `readonly`) at all three tools:

- **Before** (tools absent from the permission table, the pre-PR state):
  both `user` and `readonly` denied on all 3 tools via the agent/LLM dispatch
  path — 6/6 denied. Confirms these tools were unreachable by an LLM agent
  call before this PR, not merely under-permissioned.
- **After** (this PR's `TOOL_PERMISSIONS` entries, `MCP_READ`): `user` (holds
  `MCP_READ`) allowed on all 3 tools, `readonly` (does not hold it) still
  denied on all 3, `admin` allowed on all 3 — 9/9 assertions as intended.
- **Mutation** (table reverted to empty, simulating a silently regressed
  declaration): the `after/user` assertion fails immediately — the guard does
  not fail open.

Confirmed no new `TOOL_PERMISSIONS` entries were needed to avoid taking the
feature offline under #14523's deny-by-default *for the agent path* — the
tools were already denied there pre-PR (undeclared), so #14523 changed
nothing about their agent-path reachability. What this PR adds is the actual
grant: without it they would remain permanently unreachable by an agent, even
though the direct HTTP endpoint (unaffected by this table either way) still
answers any authenticated caller.

## Model Used

Claude Opus 5 (1M context)