### PR TITLE
fix(provision): close node_roles_declared's setup-wizard fallback dependency (#14594)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -337,6 +337,17 @@ _role_aliases:
 # services/inventory_privileged_node_roles_test.py, which derives the
 # five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
 # repeating this list, so it fails loud on a sixth privileged fact.
+#
+# #14594: the fallback above existed because api/setup_wizard.py -- a SECOND
+# node_roles producer -- did not stamp node_roles_declared, relying on the
+# NodeRole assignment table happening to be declared-only. It now stamps
+# node_roles_declared directly from Node.roles (never the NodeRole table), so
+# the fallback is dead for every LIVE producer; it stays only for
+# hand-authored static inventories (ansible/inventory/slm-nodes.yml). Guarded
+# by services/node_roles_declared_producers_test.py (derives every node_roles
+# producer and asserts it also stamps node_roles_declared) and
+# api/setup_wizard_privileged_node_roles_test.py (end-to-end reproduction
+# through the setup-wizard path specifically).
 role_backend_active: >-
   {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
      ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -46,6 +46,17 @@
 # services/inventory_privileged_node_roles_test.py, which derives the
 # five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
 # repeating this list, so it fails loud on a sixth privileged fact.
+#
+# #14594: the fallback above existed because api/setup_wizard.py -- a SECOND
+# node_roles producer -- did not stamp node_roles_declared, relying on the
+# NodeRole assignment table happening to be declared-only. It now stamps
+# node_roles_declared directly from Node.roles (never the NodeRole table), so
+# the fallback is dead for every LIVE producer; it stays only for
+# hand-authored static inventories (ansible/inventory/slm-nodes.yml). Guarded
+# by services/node_roles_declared_producers_test.py (derives every node_roles
+# producer and asserts it also stamps node_roles_declared) and
+# api/setup_wizard_privileged_node_roles_test.py (end-to-end reproduction
+# through the setup-wizard path specifically).
 role_backend_active: >-
   {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
      ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or

--- a/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/group_vars/all.yml
@@ -53,6 +53,17 @@
 # services/inventory_privileged_node_roles_test.py, which derives the
 # five-fact set from inventory_builder._DECLARED_ONLY_GROUPS instead of
 # repeating this list, so it fails loud on a sixth privileged fact.
+#
+# #14594: the fallback above existed because api/setup_wizard.py -- a SECOND
+# node_roles producer -- did not stamp node_roles_declared, relying on the
+# NodeRole assignment table happening to be declared-only. It now stamps
+# node_roles_declared directly from Node.roles (never the NodeRole table), so
+# the fallback is dead for every LIVE producer; it stays only for
+# hand-authored static inventories (ansible/inventory/slm-nodes.yml). Guarded
+# by services/node_roles_declared_producers_test.py (derives every node_roles
+# producer and asserts it also stamps node_roles_declared) and
+# api/setup_wizard_privileged_node_roles_test.py (end-to-end reproduction
+# through the setup-wizard path specifically).
 role_backend_active: >-
   {{ ('backend' in (node_roles_declared | default(node_roles | default([])))) or
      ('autobot-backend' in (node_roles_declared | default(node_roles | default([])))) or

--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -31,7 +31,7 @@ from services.ansible_secrets import fetch_deploy_secrets
 from services.ansible_utils import _extract_failure_summary
 from services.auth import get_current_user
 from services.database import db_service
-from services.inventory_builder import groups_for_role_tokens
+from services.inventory_builder import _declared_roles, groups_for_role_tokens
 from services.playbook_executor import ANSIBLE_LOCAL_TMP, get_playbook_executor, link_group_vars
 from services.role_registry import ROLE_ANSIBLE_GROUPS
 
@@ -299,11 +299,23 @@ def _apply_role_host_vars(
     db_nodes: list,
     all_node_roles: list,
 ) -> None:
-    """Stamp node_roles, node_dependencies, and pending_dep_removals onto hosts (#2823).
+    """Stamp node_roles, node_roles_declared, node_dependencies, and
+    pending_dep_removals onto hosts (#2823).
 
     Sets node_roles so provision-fleet-roles.yml conditions work, resolves
     shared-dependency names for Phase 0 (#2747), and propagates any pending
     dependency removals recorded in node.extra_data.
+
+    #14594: node_roles_declared is stamped from ``node.roles`` directly (the
+    same source ``inventory_builder._declared_roles`` reads for the dynamic
+    inventory path), NOT from the NodeRole assignment table that node_roles
+    itself is built from. #14552's ``_declare_role_on_node`` already
+    established ``Node.roles`` as the sole record of operator intent for
+    privileged-group gating; this makes the node_roles_declared hostvar rest
+    on that same guarantee instead of on the incidental fact that every
+    current NodeRole writer happens to keep the table declared-only. If a
+    future writer ever stamps a NodeRole row the node never declared, this
+    hostvar is unaffected -- it never reads that table.
     """
     from services.role_registry import ROLE_DEPENDENCIES
 
@@ -320,6 +332,7 @@ def _apply_role_host_vars(
             continue
         if node.node_id in node_id_to_roles:
             hosts[inv_name]["node_roles"] = node_id_to_roles[node.node_id]
+        hosts[inv_name]["node_roles_declared"] = _declared_roles(node)
         roles = hosts[inv_name].get("node_roles", [])
         deps: set[str] = set()
         for role in roles:
@@ -418,6 +431,14 @@ def _inject_co_located_ai_stack(
         if _ai_stack_roles & set(roles):
             continue
         hosts[inv_name]["node_roles"] = list(roles) + ["ai-stack"]
+        # #14594: also inject into node_roles_declared. This is a deliberate
+        # system decision to run ai-stack here (#3461), equivalent to an
+        # operator declaring it -- role_ai_stack_active is one of the five
+        # PRIVILEGED facts that read node_roles_declared instead of the raw
+        # union, so without this the co-location convenience silently stops
+        # deploying ChromaDB the moment node_roles_declared exists.
+        declared = hosts[inv_name].get("node_roles_declared", [])
+        hosts[inv_name]["node_roles_declared"] = list(declared) + ["ai-stack"]
         # Note: ai-stack role now defaults to autobot:autobot (not autobot-ai)
         # per unified service account model (#4091). No override needed.
         injected.append(inv_name)

--- a/autobot-slm-backend/api/setup_wizard_privileged_node_roles_test.py
+++ b/autobot-slm-backend/api/setup_wizard_privileged_node_roles_test.py
@@ -96,9 +96,9 @@ def test_detected_only_node_does_not_activate_privileged_facts_via_wizard():
     result = _render_all(facts, context)
 
     still_active = {name for name in _PRIVILEGED_FACTS if result[name]}
-    assert not still_active, (
-        f"privileged fact(s) activated for a wizard-built detected-only node: {sorted(still_active)}"
-    )
+    assert (
+        not still_active
+    ), f"privileged fact(s) activated for a wizard-built detected-only node: {sorted(still_active)}"
     assert result["role_tts_worker_active"] is True, "deliberately-union fact must still activate off node_roles"
 
 

--- a/autobot-slm-backend/api/setup_wizard_privileged_node_roles_test.py
+++ b/autobot-slm-backend/api/setup_wizard_privileged_node_roles_test.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A detected-but-undeclared privileged role must not activate through the
+SETUP-WIZARD inventory path specifically (#14594).
+
+``services/inventory_privileged_node_roles_test.py`` (#14589) proved the
+dynamic-inventory path (``inventory_builder.build_registry_inventory``) is
+safe. It did not exercise ``api/setup_wizard.py`` at all -- that producer
+built ``node_roles`` from the ``NodeRole`` assignment table and, until this
+change, never stamped ``node_roles_declared``, so the fallback
+(``node_roles_declared | default(node_roles | default([]))``) silently kept
+gating every setup-wizard-generated inventory on the raw union. It was safe
+only because every current NodeRole writer happens to keep the table
+declared-only (see ``api/nodes.py._declare_role_on_node``, #14552) -- nothing
+asserted that, and nothing here proved the setup-wizard path itself was safe.
+
+This module drives ``api.setup_wizard``'s own hostvar-building functions
+(``_apply_role_host_vars``, ``_inject_co_located_ai_stack``) end to end and
+renders the real ``role_active_facts.yml`` against the resulting hostvars,
+exactly as ``inventory_privileged_node_roles_test.py`` does for the dynamic
+path. The two should now behave identically for a detected-only node.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+jinja2 = pytest.importorskip("jinja2")
+
+from api.setup_wizard import _apply_role_host_vars, _inject_co_located_ai_stack, _sanitize_ansible_name  # noqa: E402
+
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+_FACTS_FILE = _SLM_ROOT / "ansible" / "playbooks" / "vars" / "role_active_facts.yml"
+
+_PRIVILEGED_FACTS = frozenset(
+    {
+        "role_backend_active",
+        "role_frontend_active",
+        "role_ai_stack_active",
+        "role_npu_worker_active",
+        "role_browser_active",
+    }
+)
+
+
+def _load_facts() -> dict[str, str]:
+    data = yaml.safe_load(_FACTS_FILE.read_text(encoding="utf-8"))
+    return {k: v for k, v in data.items() if k.startswith("role_") and k.endswith("_active")}
+
+
+def _render_all(facts: dict[str, str], context: dict) -> dict[str, bool]:
+    env = jinja2.Environment()
+    rendered: dict[str, bool] = {}
+    for name, expr in facts.items():
+        rendered[name] = env.from_string(expr).render(context).strip() == "True"
+    return rendered
+
+
+def _wizard_hostvars(node_id: str, roles: list[str], node_role_names: list[str]) -> dict:
+    """Build one host's vars the way _generate_dynamic_inventory does.
+
+    ``roles`` is the node's declared ``Node.roles``. ``node_role_names`` is
+    every ``NodeRole`` row's ``role_name`` for the node -- deliberately
+    allowed to diverge from ``roles`` here, to prove node_roles_declared
+    does not follow that table.
+    """
+    host_key = _sanitize_ansible_name(node_id)
+    hosts = {host_key: {"ansible_host": "127.0.0.1"}}
+    node = SimpleNamespace(node_id=node_id, ansible_target=node_id, extra_data={}, roles=roles)
+    all_node_roles = [SimpleNamespace(node_id=node_id, role_name=r) for r in node_role_names]
+    _apply_role_host_vars(hosts, [node], all_node_roles)
+    return hosts[host_key]
+
+
+def test_detected_only_node_does_not_activate_privileged_facts_via_wizard():
+    """The #14560 reproduction, driven through api.setup_wizard specifically.
+
+    A NodeRole row exists for every privileged role (simulating a producer
+    that stamped the assignment table without the node ever declaring the
+    role), but Node.roles is empty -- nothing was declared.
+    """
+    facts = _load_facts()
+    detected = ["frontend", "backend", "ai-stack", "npu-worker", "browser-service", "tts-worker"]
+    hostvars = _wizard_hostvars("detected-only-node", roles=[], node_role_names=detected)
+
+    assert hostvars["node_roles"] == detected, "node_roles stays the NodeRole-table content, unfiltered"
+    assert hostvars["node_roles_declared"] == [], "nothing was declared, so node_roles_declared must be empty"
+
+    context = {**hostvars, "groups": {}, "inventory_hostname": "detected-only-node"}
+    result = _render_all(facts, context)
+
+    still_active = {name for name in _PRIVILEGED_FACTS if result[name]}
+    assert not still_active, (
+        f"privileged fact(s) activated for a wizard-built detected-only node: {sorted(still_active)}"
+    )
+    assert result["role_tts_worker_active"] is True, "deliberately-union fact must still activate off node_roles"
+
+
+def test_declared_node_still_activates_via_wizard():
+    facts = _load_facts()
+    hostvars = _wizard_hostvars("declared-frontend-node", roles=["frontend"], node_role_names=["frontend"])
+
+    context = {**hostvars, "groups": {}, "inventory_hostname": "declared-frontend-node"}
+    result = _render_all(facts, context)
+
+    assert result["role_frontend_active"] is True
+    assert result["role_backend_active"] is False
+
+
+def test_co_located_ai_stack_injection_activates_role_ai_stack_active_via_wizard():
+    """Non-regression for #3461 through the #14594 fix: the co-location
+    injection is a deliberate system decision and must keep activating
+    role_ai_stack_active even though node_roles_declared now gates it.
+    """
+    facts = _load_facts()
+    host_key = _sanitize_ansible_name("01-Backend")
+    hosts = {host_key: {"ansible_host": "127.0.0.1"}}
+    node = SimpleNamespace(node_id="01-Backend", ansible_target="01-Backend", extra_data={}, roles=["backend"])
+    all_node_roles = [SimpleNamespace(node_id="01-Backend", role_name="backend")]
+    _apply_role_host_vars(hosts, [node], all_node_roles)
+    _inject_co_located_ai_stack(hosts, [node], fleet_has_ai_stack=False)
+
+    context = {**hosts[host_key], "groups": {}, "inventory_hostname": host_key}
+    result = _render_all(facts, context)
+
+    assert result["role_ai_stack_active"] is True, "co-located ai-stack injection (#3461) must survive #14594's gate"

--- a/autobot-slm-backend/services/node_roles_declared_producers_test.py
+++ b/autobot-slm-backend/services/node_roles_declared_producers_test.py
@@ -1,0 +1,137 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every live producer of the ``node_roles`` hostvar must also stamp
+``node_roles_declared`` (#14594).
+
+#14589 gated role_active_facts.yml's five PRIVILEGED facts on
+``node_roles_declared | default(node_roles | default([]))``. The fallback
+means any producer that stamps ``node_roles`` without ``node_roles_declared``
+keeps the original #14560 defect alive for hosts it builds -- a
+detected-only node activating a privileged deploy fact. #14589 only fixed
+``services/inventory_builder.py``; ``api/setup_wizard.py`` was safe only by
+the coincidence that its ``node_roles`` source (the ``NodeRole`` table)
+happened to always be declared-only, which nothing enforced.
+
+Rather than hand-list "the producers are inventory_builder.py and
+setup_wizard.py" (the exact defect shape #14555 already showed for a
+hand-maintained regex derivation, see
+``inventory_privileged_node_roles_test.py``), this module DERIVES the
+producer set with an AST walk: any ``.py`` file under ``autobot-slm-backend``
+(excluding test files) that assigns the literal string key ``"node_roles"``
+as a dict key or a subscript-assignment target is a producer, and must also
+assign ``"node_roles_declared"`` somewhere in the same file. A future
+producer that forgets the declared-only stamp fails this test by name,
+without anyone updating a list here.
+
+AST parsing only -- files are never imported or executed (that would be
+"running code from the codebase", never the agent's job; CI runs the tests).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SLM_ROOT = Path(__file__).resolve().parent.parent
+
+# Static (hand-authored / operator-edited) inventories are explicitly exempt --
+# see test_static_inventory_still_needs_the_fallback below for why the
+# fallback must stay for them. Excluded here so this module only derives
+# LIVE (code) producers.
+_EXCLUDE_DIR_PARTS = frozenset({"ansible", "tests", "__pycache__", "node_modules", ".git", "migrations"})
+
+
+def _is_test_file(path: Path) -> bool:
+    stem = path.stem
+    return stem.startswith("test_") or stem.endswith("_test") or stem.endswith("_tests")
+
+
+def _files_to_scan(root: Path) -> list[Path]:
+    files = []
+    for path in root.rglob("*.py"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in _EXCLUDE_DIR_PARTS for part in rel_parts[:-1]):
+            continue
+        if _is_test_file(path):
+            continue
+        files.append(path)
+    return files
+
+
+def _assigns_string_key(tree: ast.AST, key: str) -> bool:
+    """True if *tree* assigns dict-literal key ``key`` or does ``x[key] = ...``."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for k in node.keys:
+                if isinstance(k, ast.Constant) and k.value == key:
+                    return True
+        elif isinstance(node, ast.Subscript) and isinstance(node.ctx, ast.Store):
+            sl = node.slice
+            # Python 3.9+: node.slice is the index expression directly.
+            if isinstance(sl, ast.Constant) and sl.value == key:
+                return True
+    return False
+
+
+def _node_roles_producers(root: Path) -> list[Path]:
+    producers = []
+    for path in _files_to_scan(root):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        if _assigns_string_key(tree, "node_roles"):
+            producers.append(path)
+    return producers
+
+
+def test_derivation_is_not_vacuous_and_finds_the_known_producers():
+    """Sanity check on the derivation itself, not the invariant it guards."""
+    producers = {p.relative_to(_SLM_ROOT) for p in _node_roles_producers(_SLM_ROOT)}
+
+    assert producers, "derivation found zero node_roles producers -- the guard below would be vacuous"
+    assert Path("services/inventory_builder.py") in producers
+    assert Path("api/setup_wizard.py") in producers
+
+
+def test_every_node_roles_producer_also_stamps_node_roles_declared():
+    producers = _node_roles_producers(_SLM_ROOT)
+    assert producers, "derivation found zero node_roles producers -- the guard below would be vacuous"
+
+    missing = []
+    for path in producers:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if not _assigns_string_key(tree, "node_roles_declared"):
+            missing.append(path.relative_to(_SLM_ROOT))
+
+    assert not missing, (
+        f"{sorted(str(p) for p in missing)} stamp node_roles but never node_roles_declared -- "
+        "a producer like this reopens #14560 through the node_roles_declared fallback (#14594)"
+    )
+
+
+def test_static_inventory_still_needs_the_fallback():
+    """Evidence for the fallback decision: it is NOT dead code.
+
+    ``slm-nodes.yml`` is the legacy static fallback inventory (#10110) --
+    hand-authored, not generated by either Python producer above. Its
+    05-LLM-CPU host stamps node_roles but (correctly, by the file's own
+    "Do not add new nodes here" convention) never node_roles_declared. As
+    long as a file like this is in the repo, the
+    ``node_roles_declared | default(node_roles | default([]))`` fallback in
+    role_active_facts.yml is load-bearing and must not be removed.
+    """
+    yaml = pytest.importorskip("yaml")
+    path = _SLM_ROOT / "ansible" / "inventory" / "slm-nodes.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    llm_host = data["all"]["children"]["slm_nodes"]["hosts"]["05-LLM-CPU"]
+
+    assert "node_roles" in llm_host, "fixture drifted -- this file no longer demonstrates the static case"
+    assert "node_roles_declared" not in llm_host, (
+        "slm-nodes.yml now stamps node_roles_declared -- if every static inventory does this too, "
+        "the role_active_facts.yml fallback may be removable; re-evaluate #14594's decision to keep it"
+    )

--- a/autobot-slm-backend/tests/api/test_setup_wizard_ai_stack_injection.py
+++ b/autobot-slm-backend/tests/api/test_setup_wizard_ai_stack_injection.py
@@ -1,0 +1,61 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Unit test: co-located ai-stack injection stamps node_roles_declared too (#14594).
+
+_inject_co_located_ai_stack (#3461) silently adds "ai-stack" to a co-located
+backend node's node_roles so Phase 5a deploys ChromaDB, even though the
+operator never declared ai-stack anywhere. role_ai_stack_active is one of the
+five PRIVILEGED facts #14560/#14589 repointed at node_roles_declared instead
+of the raw union -- so the injection must land in node_roles_declared too, or
+this deliberate co-location convenience silently stops deploying ChromaDB the
+moment node_roles_declared exists (a regression this test guards against).
+"""
+
+from types import SimpleNamespace
+
+from api.setup_wizard import _apply_role_host_vars, _inject_co_located_ai_stack, _sanitize_ansible_name
+
+
+def _build_hosts(role_name: str):
+    raw = "01-Backend"
+    host_key = _sanitize_ansible_name(raw)
+    hosts = {host_key: {"ansible_host": "127.0.0.1"}}
+    node = SimpleNamespace(node_id="01-Backend", ansible_target=raw, extra_data={}, roles=[role_name])
+    all_node_roles = [SimpleNamespace(node_id="01-Backend", role_name=role_name)]
+    _apply_role_host_vars(hosts, [node], all_node_roles)
+    return hosts, [node], host_key
+
+
+def test_injection_adds_ai_stack_to_both_hostvars_when_fleet_lacks_it():
+    hosts, db_nodes, host_key = _build_hosts("backend")
+
+    injected = _inject_co_located_ai_stack(hosts, db_nodes, fleet_has_ai_stack=False)
+
+    assert injected == [host_key]
+    assert "ai-stack" in hosts[host_key]["node_roles"]
+    assert "ai-stack" in hosts[host_key]["node_roles_declared"], (
+        "ai-stack co-location injection (#3461) must also land in node_roles_declared "
+        "or role_ai_stack_active silently stops firing for it (#14594)"
+    )
+
+
+def test_injection_is_noop_when_fleet_already_has_ai_stack():
+    hosts, db_nodes, host_key = _build_hosts("backend")
+
+    injected = _inject_co_located_ai_stack(hosts, db_nodes, fleet_has_ai_stack=True)
+
+    assert injected == []
+    assert "ai-stack" not in hosts[host_key]["node_roles"]
+    assert "ai-stack" not in hosts[host_key]["node_roles_declared"]
+
+
+def test_injection_skips_non_backend_nodes():
+    hosts, db_nodes, host_key = _build_hosts("frontend")
+
+    injected = _inject_co_located_ai_stack(hosts, db_nodes, fleet_has_ai_stack=False)
+
+    assert injected == []
+    assert "ai-stack" not in hosts[host_key].get("node_roles_declared", [])

--- a/autobot-slm-backend/tests/api/test_setup_wizard_node_roles.py
+++ b/autobot-slm-backend/tests/api/test_setup_wizard_node_roles.py
@@ -10,6 +10,9 @@ _fetch_inventory_data uses as the host key. Previously it used the raw
 node.ansible_target (e.g. '00-SLM-Manager') which never matched the sanitized
 key ('node_00_SLM_Manager'), so node_roles was never stamped and optional roles
 (tts-worker, browser-service) silently never deployed.
+
+Also covers #14594: node_roles_declared must be stamped from node.roles alone,
+never from the NodeRole rows node_roles itself is built from.
 """
 
 from types import SimpleNamespace
@@ -23,7 +26,7 @@ def test_apply_role_host_vars_stamps_via_sanitized_key():
     assert host_key != raw, "node id should require sanitizing for this test to be meaningful"
 
     hosts = {host_key: {"ansible_host": "127.0.0.1"}}
-    node = SimpleNamespace(node_id="00-SLM-Manager", ansible_target=raw, extra_data={})
+    node = SimpleNamespace(node_id="00-SLM-Manager", ansible_target=raw, extra_data={}, roles=["ai-stack"])
     all_node_roles = [
         SimpleNamespace(node_id="00-SLM-Manager", role_name="tts-worker"),
         SimpleNamespace(node_id="00-SLM-Manager", role_name="browser-service"),
@@ -35,3 +38,41 @@ def test_apply_role_host_vars_stamps_via_sanitized_key():
     assert "node_roles" in hosts[host_key]
     for role in ("tts-worker", "browser-service", "ai-stack"):
         assert role in hosts[host_key]["node_roles"]
+
+
+def test_apply_role_host_vars_declared_excludes_undeclared_node_role_rows():
+    """#14594: a NodeRole row does not, by itself, make a role "declared".
+
+    node_roles_declared must come from node.roles alone -- if a NodeRole row
+    ever exists for a role the node's own `roles` list does not carry (today
+    every writer keeps them in sync, see api/nodes.py._declare_role_on_node,
+    but that is a fact about the writers, not a guarantee this hostvar should
+    depend on), node_roles_declared must not pick it up.
+    """
+    raw = "00-SLM-Manager"
+    host_key = _sanitize_ansible_name(raw)
+    hosts = {host_key: {"ansible_host": "127.0.0.1"}}
+    # Declares only "backend"; a "frontend" NodeRole row exists regardless
+    # (simulating a future writer that stamps NodeRole without node.roles).
+    node = SimpleNamespace(node_id="00-SLM-Manager", ansible_target=raw, extra_data={}, roles=["backend"])
+    all_node_roles = [
+        SimpleNamespace(node_id="00-SLM-Manager", role_name="backend"),
+        SimpleNamespace(node_id="00-SLM-Manager", role_name="frontend"),
+    ]
+
+    _apply_role_host_vars(hosts, [node], all_node_roles)
+
+    assert "frontend" in hosts[host_key]["node_roles"], "node_roles stays the NodeRole-table union"
+    assert hosts[host_key]["node_roles_declared"] == ["backend"]
+    assert "frontend" not in hosts[host_key]["node_roles_declared"]
+
+
+def test_apply_role_host_vars_declared_defaults_empty_when_no_roles():
+    raw = "00-SLM-Manager"
+    host_key = _sanitize_ansible_name(raw)
+    hosts = {host_key: {"ansible_host": "127.0.0.1"}}
+    node = SimpleNamespace(node_id="00-SLM-Manager", ansible_target=raw, extra_data={}, roles=[])
+
+    _apply_role_host_vars(hosts, [node], [])
+
+    assert hosts[host_key]["node_roles_declared"] == []


### PR DESCRIPTION
Closes #14594

## Thinking Path

#14589 gated `role_active_facts.yml`'s five PRIVILEGED facts (backend,
frontend, ai_stack, npu_worker, browser) on `node_roles_declared | default(node_roles | default([]))`,
stamping `node_roles_declared` in `services/inventory_builder.py`
(the dynamic-inventory path). #14594 pointed out a second producer,
`api/setup_wizard.py`, never stamped it — it built `node_roles` from the
`NodeRole` assignment table and relied on the fallback, safe only because
that table happened to always be declared-only.

I verified what `NodeRole` rows actually represent by reading the model and
every write path (`api/nodes.py`, `services/compose_fleet.py`,
`services/node_seeder.py`, `services/sync_orchestrator.py`, `main.py`).
`NodeRole` is an *assignment* table, distinct from `Node.detected_roles`
(populated only from agent heartbeat reports, `api/nodes.py:1872`). Every
current writer keeps `NodeRole` rows for the five privileged tokens
byte-for-byte in sync with `Node.roles` — most tellingly,
`api/nodes.py._declare_role_on_node` (added by #14552) explicitly documents
that `Node.roles` is "the sole record of operator intent" for exactly this
kind of gating, and every NodeRole write path routes through it or an
equivalent seeder that mirrors `Node.roles` verbatim. So this was a **latent**
risk, not a live one: no code path today creates a privileged NodeRole row
the node never declared. The severity in #14594 stands as filed — fragile
by construction, not currently exploitable.

Given `Node.roles` is already the established SSOT for declared intent (the
same one `_strip_undeclared_privileged_groups` reads on the group side), the
root-cause fix is to stop reading the `NodeRole` table for
`node_roles_declared` at all, rather than filtering it. I found one
complication while doing this: `_inject_co_located_ai_stack` (#3461)
deliberately injects `"ai-stack"` into a co-located backend node's
`node_roles` in memory (ChromaDB auto-deploy) — a system decision equivalent
to a declaration, not a detection artifact. Left alone, my fix would have
silently broken that feature the moment `node_roles_declared` existed, since
`role_ai_stack_active` is one of the five gated facts. Fixed by injecting into
`node_roles_declared` at the same site.

## What Changed

- `autobot-slm-backend/api/setup_wizard.py`: `_apply_role_host_vars` now
  stamps `node_roles_declared` from `node.roles` directly (mirroring
  `inventory_builder._declared_roles`), not from the `NodeRole` table.
  `_inject_co_located_ai_stack` mirrors its `node_roles` injection into
  `node_roles_declared` too, so the #3461 convenience keeps activating
  `role_ai_stack_active`.
- `autobot-slm-backend/services/node_roles_declared_producers_test.py`
  (new): an AST-derived guard — walks every `.py` file under
  `autobot-slm-backend` (excluding tests) for a literal `"node_roles"`
  dict-key or subscript-assignment, and asserts each such producer also
  assigns `"node_roles_declared"`. Finds exactly the two live producers
  (`services/inventory_builder.py`, `api/setup_wizard.py`) without a
  hand-written list, so a third producer that forgets the stamp fails by
  name. Also pins that `ansible/inventory/slm-nodes.yml` (the legacy static
  fallback inventory) stamps `node_roles` without `node_roles_declared` —
  evidence the `role_active_facts.yml` fallback is still load-bearing and
  must stay.
- `autobot-slm-backend/api/setup_wizard_privileged_node_roles_test.py`
  (new): drives `_apply_role_host_vars` / `_inject_co_located_ai_stack` end
  to end and renders the real `role_active_facts.yml` facts against the
  result — #14589's equivalent test only exercised the dynamic-inventory
  path. Proves a detected-only node built through setup-wizard specifically
  does not activate any privileged fact, a declared node still does, and the
  ai-stack co-location injection still does too.
- `autobot-slm-backend/tests/api/test_setup_wizard_ai_stack_injection.py`
  (new): unit coverage for `_inject_co_located_ai_stack`'s
  `node_roles_declared` side directly.
- `autobot-slm-backend/tests/api/test_setup_wizard_node_roles.py`: existing
  test updated (nodes now need a `.roles` attribute) plus two new cases
  pinning `node_roles_declared` comes from `node.roles` alone, never from
  `NodeRole` rows.
- `ansible/inventory/group_vars/all.yml`,
  `ansible/playbooks/vars/role_active_facts.yml`,
  `ansible/tests/inventory/group_vars/all.yml`: comment-only addendum
  (kept identical across the three copies, as before) recording that the
  setup-wizard producer is now covered and pointing at the two new guards.
  The `role_*_active` fragments themselves are untouched.

### On the fallback

Kept. Every LIVE (Python) producer now stamps both hostvars, so
`node_roles_declared | default(node_roles | default([]))` is dead for any
inventory either producer builds — but `ansible/inventory/slm-nodes.yml` is
a hand-authored, "do not add new nodes here" legacy static inventory that
stamps `node_roles` without `node_roles_declared`, and nothing generates it.
`test_static_inventory_still_needs_the_fallback` pins that as evidence the
fallback stays necessary for static inventories and should not be removed.

### Discovered but out of scope

`api/setup_wizard.py`'s own inventory builder never calls
`_strip_undeclared_privileged_groups` on its GROUP branch (unlike
`services/inventory_builder.py`) — it derives ansible groups from the same
`NodeRole` table this PR stops trusting for `node_roles_declared`. Today
that's safe for the identical reason (`NodeRole` stays declared-only), but
it's the same latent shape one layer over, on a different branch of the same
OR-chain. Filed as #14638 rather than folded into this PR (different code
path, different risk to review).

## Verification

All verification ran against scratch copies under
`/tmp/.../scratchpad/` — no ansible playbook or repo-tree code was executed
directly, per the task constraints.

- `python3 -m py_compile` on every new/edited Python file: clean.
- `yaml.safe_load` on all three edited facts-comment files: valid YAML.
- Scratch reimplementation of `ansible/tests/check_role_facts_synced.py`'s
  comparison (never ran that repo file directly): 0 divergence, 12 shared
  facts compared — the comment-only edit didn't touch the compared
  fragments.
- AST-derived producer scan (the guard's own logic, run standalone against
  the worktree — pure `ast.parse`, no application code imported/executed):
  **2 producers found** (`services/inventory_builder.py`,
  `api/setup_wizard.py`), **0 missing** `node_roles_declared` on the fixed
  tree.
- **Mutation**: copied `api/setup_wizard.py` to scratch and removed both
  `node_roles_declared` stamps (the `_apply_role_host_vars` line and the
  `_inject_co_located_ai_stack` injection), reverting the file to its
  pre-fix shape. Re-ran the same scan against the tree with that file
  substituted:

  | | fixed | mutated |
  |---|---|---|
  | producers found | 2 | 2 |
  | missing `node_roles_declared` | **0** | **1** (`api/setup_wizard.py`) |

  The guard goes red on the mutation, as required.
- Jinja2-rendered `role_active_facts.yml`'s real fact expressions (extracted
  via `yaml.safe_load`, not a scalar-style-specific regex) against a
  detected-only context built through `_apply_role_host_vars` semantics:
  **pre-fix** (`node_roles_declared` absent, matching the file before this
  PR) all 5 privileged facts render `True` for a detected-only node — the
  live #14560 reproduction through the setup-wizard path specifically,
  which #14589 never exercised. **Post-fix** (`node_roles_declared=[]`
  stamped) all 5 render `False`, and the deliberately-union
  `role_tts_worker_active` still renders `True`.
- Confirmed `_inject_co_located_ai_stack`'s ai-stack injection lands in both
  hostvars and that `role_ai_stack_active` still renders `True` afterward —
  the #3461 non-regression this PR's fix required.

## Model Used

Claude Sonnet 5