### PR TITLE
fix(shared): a deployed install must resolve its own project root (#14624)

### DIFF
--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -97,12 +97,7 @@ def is_install_root(path: Path) -> bool:
     """
     if not (path / "autobot_shared").exists():
         return False
-    try:
-        return any(child.is_dir() and child.name.startswith(INSTALL_COMPONENT_PREFIX) for child in path.iterdir())
-    except OSError:
-        # An unreadable directory is not an install root; let the walk continue
-        # rather than turning a permissions problem into a resolution failure.
-        return False
+    return any(child.is_dir() and child.name.startswith(INSTALL_COMPONENT_PREFIX) for child in path.iterdir())
 
 
 def project_root() -> Path:
@@ -158,9 +153,20 @@ def resolve_project_root(start: Path) -> Path:
     if configured:
         return Path(configured).resolve()
 
+    # #14640 review: an OSError while inspecting a candidate is remembered rather
+    # than swallowed. Returning False on a permissions failure still fails loud
+    # (nothing else matches, so the raise below fires), but the message would
+    # blame an unrecognised layout when the real cause was an unreadable
+    # directory that IS the right root. This module already cost one long
+    # outage; the diagnosis should not have to be reconstructed twice.
+    inspection_errors: list[str] = []
+
     for parent in [start] + list(start.parents):
-        if (parent / ".env").exists() or is_checkout_root(parent) or is_install_root(parent):
-            return parent
+        try:
+            if (parent / ".env").exists() or is_checkout_root(parent) or is_install_root(parent):
+                return parent
+        except OSError as exc:
+            inspection_errors.append(f"{parent}: {exc.__class__.__name__}: {exc}")
 
     # ssot-config-exempt: bootstrap self-reference (carried from the
     # implementation this replaced, landed in #13646).
@@ -174,4 +180,10 @@ def resolve_project_root(start: Path) -> Path:
         "ancestor holds a .env or looks like a source checkout "
         f"({', '.join(CHECKOUT_MARKERS)}). Set one of those two environment "
         "variables — a silent guess is the defect this raise replaces (#14544)."
+        + (
+            "\n\nNote: some candidates could not be inspected, which may be the real "
+            "cause rather than an unrecognised layout: " + "; ".join(inspection_errors)
+            if inspection_errors
+            else ""
+        )
     )

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -34,15 +34,15 @@ from pathlib import Path
 #: this repository's whole workflow runs from worktrees.
 CHECKOUT_MARKERS = (".git", "autobot_shared")
 
-#: Component directories a deployed install places beside ``autobot_shared``.
-#: Used only by :func:`is_install_root`; any one of them is enough, because a
-#: node deploys only the components its roles carry (#14624).
-INSTALL_COMPONENT_MARKERS = (
-    "autobot-slm-backend",
-    "autobot-backend",
-    "autobot-frontend",
-    "autobot-slm-frontend",
-)
+#: Prefix of the component directories a deployed install places beside
+#: ``autobot_shared`` (``autobot-backend``, ``autobot-npu-worker``, ...).
+#:
+#: A PREFIX, not a list of names. The first version of this enumerated four
+#: components and would have left a node carrying only, say, ``autobot-npu-worker``
+#: unable to resolve — precisely the minimal fleet nodes most likely to hit it.
+#: This install alone has twelve such directories, and the set grows with every
+#: new component (#14624).
+INSTALL_COMPONENT_PREFIX = "autobot-"
 
 #: Environment variable naming an explicit project root. This is the same name
 #: the shell scripts honour, so exporting it once governs both languages.
@@ -97,7 +97,14 @@ def is_install_root(path: Path) -> bool:
     """
     if not (path / "autobot_shared").exists():
         return False
-    return any((path / component).is_dir() for component in INSTALL_COMPONENT_MARKERS)
+    try:
+        return any(
+            child.is_dir() and child.name.startswith(INSTALL_COMPONENT_PREFIX) for child in path.iterdir()
+        )
+    except OSError:
+        # An unreadable directory is not an install root; let the walk continue
+        # rather than turning a permissions problem into a resolution failure.
+        return False
 
 
 def project_root() -> Path:

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -34,6 +34,16 @@ from pathlib import Path
 #: this repository's whole workflow runs from worktrees.
 CHECKOUT_MARKERS = (".git", "autobot_shared")
 
+#: Component directories a deployed install places beside ``autobot_shared``.
+#: Used only by :func:`is_install_root`; any one of them is enough, because a
+#: node deploys only the components its roles carry (#14624).
+INSTALL_COMPONENT_MARKERS = (
+    "autobot-slm-backend",
+    "autobot-backend",
+    "autobot-frontend",
+    "autobot-slm-frontend",
+)
+
 #: Environment variable naming an explicit project root. This is the same name
 #: the shell scripts honour, so exporting it once governs both languages.
 PROJECT_ROOT_ENV = "AUTOBOT_PROJECT_ROOT"
@@ -61,6 +71,33 @@ class ProjectRootUndeterminable(RuntimeError):
 def is_checkout_root(path: Path) -> bool:
     """True when *path* looks like the root of a source checkout."""
     return all((path / marker).exists() for marker in CHECKOUT_MARKERS)
+
+
+def is_install_root(path: Path) -> bool:
+    """True when *path* looks like a deployed install root (#14624).
+
+    A deployed install satisfies none of the other arms, which took down a live
+    SLM backend: `/opt/autobot` has no `.git` (so `is_checkout_root` is False,
+    correctly — it is not a checkout) and no top-level `.env` either, because
+    the per-component files live one level down (`autobot-backend/.env`,
+    `autobot-ai-stack/.env`, ...). `resolve_project_root` therefore raised on
+    import and uvicorn exited 1 in a restart loop.
+
+    The deployment does normally set ``AUTOBOT_PROJECT_ROOT`` — the unit
+    template renders it — but the raise then depends on every host's systemd
+    unit being current, and the host this was found on had one from two months
+    earlier. A resolution that only works where deployed state is fresh is not
+    a resolution; this arm makes the layout recognisable on its own terms.
+
+    Deliberately narrow, and NOT a relaxation of ``CHECKOUT_MARKERS``: those
+    require both markers for reasons that still hold (see their comment). An
+    install is identified by `autobot_shared` sitting beside at least one
+    deployed component directory — a shape a package's own parent does not
+    have, and one that never appears above a checkout or worktree root.
+    """
+    if not (path / "autobot_shared").exists():
+        return False
+    return any((path / component).is_dir() for component in INSTALL_COMPONENT_MARKERS)
 
 
 def project_root() -> Path:
@@ -117,7 +154,7 @@ def resolve_project_root(start: Path) -> Path:
         return Path(configured).resolve()
 
     for parent in [start] + list(start.parents):
-        if (parent / ".env").exists() or is_checkout_root(parent):
+        if (parent / ".env").exists() or is_checkout_root(parent) or is_install_root(parent):
             return parent
 
     # ssot-config-exempt: bootstrap self-reference (carried from the

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -98,9 +98,7 @@ def is_install_root(path: Path) -> bool:
     if not (path / "autobot_shared").exists():
         return False
     try:
-        return any(
-            child.is_dir() and child.name.startswith(INSTALL_COMPONENT_PREFIX) for child in path.iterdir()
-        )
+        return any(child.is_dir() and child.name.startswith(INSTALL_COMPONENT_PREFIX) for child in path.iterdir())
     except OSError:
         # An unreadable directory is not an install root; let the walk continue
         # rather than turning a permissions problem into a resolution failure.

--- a/autobot_shared/paths_install_root_test.py
+++ b/autobot_shared/paths_install_root_test.py
@@ -154,3 +154,38 @@ def test_an_unresolvable_tree_still_raises(tmp_path):
 
     with pytest.raises(paths.ProjectRootUndeterminable):
         paths.resolve_project_root(nothing / "paths.py")
+
+
+@pytest.mark.parametrize(
+    "component",
+    ["autobot-npu-worker", "autobot-tts-worker", "autobot-ai-stack", "autobot-browser-worker", "autobot-slm-agent"],
+)
+def test_a_minimal_node_resolves_whatever_single_component_it_carries(tmp_path, component):
+    """A fleet node deploys only the components its roles carry.
+
+    The first version of this fix enumerated four component names and would
+    have left a node carrying only npu-worker (or tts-worker, or ai-stack)
+    raising exactly as before — and those minimal nodes are the ones most
+    likely to be affected, because a fleet update unpacks the shared tree and
+    restarts their services in the same pass.
+    """
+    node = tmp_path / "autobot"
+    (node / "autobot_shared").mkdir(parents=True)
+    (node / component).mkdir()
+
+    assert paths.is_install_root(node), f"a node carrying only {component} cannot resolve its root"
+    assert paths.resolve_project_root(node / "autobot_shared" / "paths.py") == node
+
+
+def test_a_non_component_sibling_is_not_enough(tmp_path):
+    """The prefix must still mean something.
+
+    `autobot_shared` next to an unrelated directory is not an install; treating
+    it as one would drift back toward the silent guess #14544 removed.
+    """
+    lone = tmp_path / "somewhere"
+    (lone / "autobot_shared").mkdir(parents=True)
+    (lone / "unrelated").mkdir()
+    (lone / "autobot_docs").mkdir()  # underscore, not the component prefix
+
+    assert not paths.is_install_root(lone)

--- a/autobot_shared/paths_install_root_test.py
+++ b/autobot_shared/paths_install_root_test.py
@@ -1,0 +1,156 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A deployed install must resolve its own project root (#14624).
+
+Live outage: the SLM backend crash-looped on a deployed host, uvicorn exiting 1
+during import, restart counter past 530, API unreachable — including the
+code-sync and self-update endpoints that would normally deploy a fix.
+
+`resolve_project_root` raises rather than guessing (#14544), which is right, but
+every arm failed on the install layout:
+
+* `/opt/autobot/.env` does not exist — per-component `.env` files live one level
+  down (`autobot-backend/.env`, `autobot-ai-stack/.env`, ...), so the docstring's
+  "an install has a .env" premise did not hold.
+* `is_checkout_root` requires BOTH `.git` and `autobot_shared`; an install has
+  only the latter.
+* neither env override was set, because the host's systemd unit was two months
+  stale and predated the template line that renders it.
+
+The deployment does normally export `AUTOBOT_PROJECT_ROOT`. Depending on that
+alone makes startup contingent on every host's unit being current, and this one
+was not — so the layout is now recognisable on its own terms.
+
+These build real directory trees and run the real resolver against them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_paths_module():
+    """Load `paths.py` directly: it is a bootstrap module that must not import config."""
+    name = "_paths_under_test_14624"
+    spec = importlib.util.spec_from_file_location(name, _REPO_ROOT / "autobot_shared" / "paths.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+paths = _load_paths_module()
+
+
+@pytest.fixture(autouse=True)
+def _no_env_overrides(monkeypatch):
+    """The overrides short-circuit everything; these tests are about the walk."""
+    monkeypatch.delenv(paths.PROJECT_ROOT_ENV, raising=False)
+    monkeypatch.delenv(paths.BASE_DIR_ENV, raising=False)
+
+
+def _deployed_install(root: Path) -> Path:
+    """The real layout: autobot_shared beside components, no .git, no root .env."""
+    (root / "autobot_shared").mkdir(parents=True)
+    (root / "autobot-slm-backend").mkdir()
+    (root / "autobot-backend").mkdir()
+    (root / "autobot-backend" / ".env").write_text("X=1\n", encoding="utf-8")
+    return root
+
+
+def test_the_module_loaded_for_real():
+    assert callable(paths.resolve_project_root)
+    assert callable(paths.is_install_root)
+
+
+def test_a_deployed_install_resolves_instead_of_raising(tmp_path):
+    """The outage, reproduced as a rule."""
+    install = _deployed_install(tmp_path / "autobot")
+
+    resolved = paths.resolve_project_root(install / "autobot_shared" / "paths.py")
+
+    assert resolved == install, "a deployed install still cannot resolve its own root (#14624)"
+
+
+def test_the_pre_fix_arms_really_did_all_fail(tmp_path):
+    """Pins WHY it raised, so a future change cannot quietly reintroduce it.
+
+    If any of these three becomes true for an install layout, the reasoning in
+    `is_install_root` needs revisiting rather than silently still working.
+    """
+    install = _deployed_install(tmp_path / "autobot")
+
+    assert not (install / ".env").exists(), "the install layout grew a root .env — revisit is_install_root"
+    assert not paths.is_checkout_root(install), "an install now looks like a checkout — markers changed"
+    assert paths.is_install_root(install), "the install arm no longer recognises the deployed layout"
+
+
+def test_a_source_checkout_still_wins_on_its_own_terms(tmp_path):
+    """The checkout arm must keep matching where it always did."""
+    checkout = tmp_path / "AutoBot-AI"
+    (checkout / "autobot_shared").mkdir(parents=True)
+    (checkout / "autobot-slm-backend").mkdir()
+    (checkout / ".git").write_text("gitdir: elsewhere\n", encoding="utf-8")
+
+    assert paths.is_checkout_root(checkout)
+    assert paths.resolve_project_root(checkout / "autobot_shared" / "paths.py") == checkout
+
+
+def test_a_worktree_does_not_escape_to_the_main_tree(tmp_path):
+    """#13149: the failure the single-pass walk exists to prevent.
+
+    A worktree has no `.env` of its own. If the walk climbed past it, every
+    worktree's paths would point at the main checkout. The new arm must not
+    reopen that: it matches at the worktree's own level, not above it.
+    """
+    main = tmp_path / "AutoBot-AI"
+    (main / "autobot_shared").mkdir(parents=True)
+    (main / "autobot-slm-backend").mkdir()
+    (main / ".git").mkdir()
+    (main / ".env").write_text("MAIN=1\n", encoding="utf-8")
+
+    worktree = main / ".worktrees" / "issue-1"
+    (worktree / "autobot_shared").mkdir(parents=True)
+    (worktree / "autobot-slm-backend").mkdir()
+    (worktree / ".git").write_text("gitdir: ../../.git/worktrees/issue-1\n", encoding="utf-8")
+
+    resolved = paths.resolve_project_root(worktree / "autobot_shared" / "paths.py")
+
+    assert resolved == worktree, f"worktree escaped to {resolved} — #13149 regression"
+
+
+def test_a_bare_package_parent_is_not_an_install_root(tmp_path):
+    """`autobot_shared` alone must not be enough.
+
+    That is why CHECKOUT_MARKERS requires both markers, and the new arm must not
+    become a backdoor around it: a directory holding only the package is not an
+    install and resolving to it would be the silent-guess behaviour #14544
+    removed.
+    """
+    lone = tmp_path / "somewhere"
+    (lone / "autobot_shared").mkdir(parents=True)
+
+    assert not paths.is_install_root(lone)
+
+    with pytest.raises(paths.ProjectRootUndeterminable):
+        paths.resolve_project_root(lone / "autobot_shared" / "paths.py")
+
+
+def test_an_unresolvable_tree_still_raises(tmp_path):
+    """The #14544 guarantee is preserved: no guessing when nothing identifies a root."""
+    nothing = tmp_path / "empty" / "deep"
+    nothing.mkdir(parents=True)
+
+    with pytest.raises(paths.ProjectRootUndeterminable):
+        paths.resolve_project_root(nothing / "paths.py")

--- a/autobot_shared/paths_install_root_test.py
+++ b/autobot_shared/paths_install_root_test.py
@@ -189,3 +189,44 @@ def test_a_non_component_sibling_is_not_enough(tmp_path):
     (lone / "autobot_docs").mkdir()  # underscore, not the component prefix
 
     assert not paths.is_install_root(lone)
+
+
+def test_an_unreadable_candidate_is_named_in_the_error(tmp_path, monkeypatch):
+    """#14640 review: a permissions failure must not read as "unknown layout".
+
+    Swallowing the OSError still failed loudly — nothing else matches, so the
+    raise fires — but it blamed an unrecognised layout while the real cause was
+    an unreadable directory that IS the correct root. This module already cost
+    one long outage; the diagnosis should not have to be reconstructed twice.
+    """
+    root = tmp_path / "autobot"
+    (root / "autobot_shared").mkdir(parents=True)
+    (root / "autobot-backend").mkdir()
+
+    real_iterdir = Path.iterdir
+
+    def _refuse(self):
+        if self == root:
+            raise PermissionError(13, "Permission denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _refuse)
+
+    with pytest.raises(paths.ProjectRootUndeterminable) as excinfo:
+        paths.resolve_project_root(root / "autobot_shared" / "paths.py")
+
+    message = str(excinfo.value)
+    assert "could not be inspected" in message, "the error does not mention that a candidate was unreadable"
+    assert "PermissionError" in message, "the underlying OSError type is not surfaced"
+    assert str(root) in message, "the unreadable directory is not named"
+
+
+def test_a_readable_tree_carries_no_inspection_note(tmp_path):
+    """The note must not appear when nothing failed — it would be noise on every raise."""
+    nothing = tmp_path / "empty" / "deep"
+    nothing.mkdir(parents=True)
+
+    with pytest.raises(paths.ProjectRootUndeterminable) as excinfo:
+        paths.resolve_project_root(nothing / "paths.py")
+
+    assert "could not be inspected" not in str(excinfo.value)


### PR DESCRIPTION
## Thinking Path

The SLM backend crash-looped on a deployed host — uvicorn exiting 1 during import, restart counter past 530, API unreachable. That included the code-sync and self-update endpoints, so the normal recovery path was inside the thing that was down.

```
ProjectRootUndeterminable: cannot determine the project root by walking up from
/opt/autobot/autobot_shared/paths.py
```

#14544 replacing a silent `/opt/autobot` guess with a raise is right. What made it fatal is that a deployed install satisfies none of the arms:

- `/opt/autobot/.env` does not exist. The per-component files live one level down (`autobot-backend/.env`, `autobot-ai-stack/.env`, ...). The resolver's docstring assumes the opposite — *"an install has a `.env` and no `.git`, so it matches on the `.env` arm"* — and that premise does not hold for this layout.
- `is_checkout_root` requires **both** `.git` and `autobot_shared`; an install has only the second. Correctly so: it is not a checkout.
- Neither env override was set, because the host's systemd unit was dated **2026-06-18**, two months before the template line that renders `AUTOBOT_PROJECT_ROOT`.

The deployment *does* normally export the override. But that makes startup contingent on every host's unit being current, with nothing checking it — and this host's was not. A resolution that only works where deployed state is fresh is not a resolution.

## What Changed

`is_install_root()` recognises a deployed install: `autobot_shared` sitting beside at least one deployed component directory.

Deliberately **not** a relaxation of `CHECKOUT_MARKERS`. Their both-markers rule exists for stated reasons that still hold — `autobot_shared` alone matches a package parent, `.git` alone matches an unrelated repo if vendored — and loosening it would be a backdoor around exactly that. The install shape is distinct: a package's own parent does not carry component directories, and neither does anything above a checkout or worktree root.

Added to the same single-pass walk, so the #13149 reasoning is untouched: a worktree still matches at its own level and never climbs to the main tree's `.env`.

## Verification

Not run from the checkout, by instruction — CI verifies correctness, the deployment verifies runtime.

The resolver executed against real directory trees mirroring each layout:

```
install resolves        -> True   (root .env: False, is_checkout_root: False — both pre-fix arms confirmed failing)
checkout resolves       -> True
worktree stays put      -> True   (#13149: did not escape to the main tree)
lone package parent     -> raises (good)
nothing identifiable    -> raises (good)
```

The last two matter as much as the first: #14544's guarantee is that nothing is guessed, and this must not become a silent fallback.

`test_the_pre_fix_arms_really_did_all_fail` pins *why* it raised, so a future change cannot quietly reintroduce the gap while the fix appears to still work.

## Not in this PR

Why the host's systemd unit was two months stale — that gap is independent of this crash and likely affects other deployed units. Tracked on #14624.

## Model Used

Claude Opus 5

Refs #14624
