### PR TITLE
fix(infra): honest codebase_metrics and a construction NameError in the code-analysis suite (#14635, #14634)

### DIFF
--- a/autobot-backend/code_analysis/src/code_analyzer.py
+++ b/autobot-backend/code_analysis/src/code_analyzer.py
@@ -63,7 +63,11 @@ class CodeAnalyzer:
     def __init__(self, redis_client=None, use_npu: bool = True):
         self.redis_client = redis_client  # Lazy init if None (#2725)
         self.use_npu = use_npu
-        self.config = config
+        # #14634: this used to read `self.config = config`, referencing a name
+        # never imported or defined anywhere in this module -- a guaranteed
+        # NameError on every construction. Grepped for `self.config` call
+        # sites (in this module and across the repo): none. Dead assignment,
+        # removed rather than importing an unused symbol.
 
         # Caching keys
         self.FUNCTION_KEY = "code_analysis:function:{}"

--- a/autobot-backend/code_analysis/src/code_analyzer_config_14634_test.py
+++ b/autobot-backend/code_analysis/src/code_analyzer_config_14634_test.py
@@ -1,0 +1,47 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Regression test for CodeAnalyzer.__init__'s undefined-name bug (#14634).
+
+``self.config = config`` referenced a name never imported or defined anywhere
+in ``code_analyzer.py``, so every ``CodeAnalyzer()`` construction raised
+``NameError`` -- and ``analyze_duplicates.py`` constructs one unconditionally,
+so the "duplicates" analysis category could never complete a single run.
+
+Same root pattern, same day (2026-02-06), as ``anti_pattern_detector.py``'s
+own ``self.config = config`` (#6733, already removed there) -- the fix here
+follows that precedent: the assignment is dead (no call site reads
+``self.config`` anywhere in this module or the rest of the repo), so it is
+removed rather than importing an unused symbol.
+"""
+
+import importlib.util
+
+import pytest
+
+_MODULE_PATH = "autobot-backend/code_analysis/src/code_analyzer.py"
+
+
+def _load_code_analyzer_module():
+    """Import code_analyzer.py by path; skip if its real dep chain (sklearn,
+    numpy) isn't installed in this environment rather than failing the suite
+    on an unrelated missing package."""
+    spec = importlib.util.spec_from_file_location("code_analyzer_under_test", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as exc:
+        pytest.skip(f"code_analyzer.py's dependency chain unavailable: {exc}")
+    return module
+
+
+def test_construction_does_not_raise_nameerror():
+    """#14634: constructing CodeAnalyzer() must not raise NameError on 'config'."""
+    module = _load_code_analyzer_module()
+
+    analyzer = module.CodeAnalyzer(redis_client=None, use_npu=False)
+
+    assert analyzer.use_npu is False
+    assert analyzer.similarity_threshold == 0.85
+    assert not hasattr(analyzer, "config")

--- a/autobot-infrastructure/shared/scripts/run_code_analysis.py
+++ b/autobot-infrastructure/shared/scripts/run_code_analysis.py
@@ -209,17 +209,49 @@ def _run_requested_analyses(results: Dict[str, Any], target_path: str, analysis_
             results["communication_patterns"] = architecture["communication_patterns"]
 
 
+# #14635: the real producer (code_quality_dashboard.py's
+# generate_comprehensive_report, written verbatim to comprehensive_quality_
+# report.json by analyze_code_quality.py) nests its scores under a
+# "quality_metrics" object, not at the report's top level, and has no
+# "complexity" or "doc_coverage" field anywhere. Reading top-level
+# "complexity"/"maintainability"/"test_coverage"/"doc_coverage" keys used to
+# always miss and fall back to these four hardcoded numbers -- fabricated
+# telemetry on every run, including a genuinely successful one. Maps only the
+# fields the real "quality_metrics" object actually carries.
+_QUALITY_METRICS_FIELD_MAP = {
+    "maintainability": "maintainability_index",
+    "test_coverage": "test_coverage_score",
+}
+
+
 def _extract_codebase_metrics(results: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Roll up headline metrics from the quality analysis, when it succeeded."""
+    """Roll up headline metrics the quality analysis actually computed.
+
+    Returns ``None`` when the quality analysis itself didn't run or failed --
+    same as before. A quality analysis that *succeeded* but is missing the
+    "quality_metrics" block it always writes is a producer/consumer shape
+    mismatch, not something to paper over with a default, so that raises
+    instead of returning fabricated numbers.
+
+    "complexity" and "doc_coverage" have no equivalent in the real report
+    (#14635) -- they are simply not included, rather than invented.
+    """
     quality = results.get("code_quality")
     if not isinstance(quality, dict) or quality.get("error"):
         return None
-    return {
-        "complexity": quality.get("complexity", 5),
-        "maintainability": quality.get("maintainability", "good"),
-        "test_coverage": quality.get("test_coverage", 70),
-        "doc_coverage": quality.get("doc_coverage", 65),
-    }
+
+    metrics = quality.get("quality_metrics")
+    if not isinstance(metrics, dict):
+        raise ValueError(
+            "code_quality analysis succeeded but its report has no "
+            "'quality_metrics' object -- producer/consumer shape mismatch"
+        )
+
+    missing = [src for src in _QUALITY_METRICS_FIELD_MAP.values() if src not in metrics]
+    if missing:
+        raise ValueError(f"code_quality report's 'quality_metrics' is missing expected keys: {missing}")
+
+    return {dest: metrics[src] for dest, src in _QUALITY_METRICS_FIELD_MAP.items()}
 
 
 def run_full_analysis(target_path: str, analysis_type: str = "full") -> Dict[str, Any]:

--- a/repo_tests/run_code_analysis_channel_14587_test.py
+++ b/repo_tests/run_code_analysis_channel_14587_test.py
@@ -261,8 +261,11 @@ def test_main_exits_nonzero_when_every_analysis_fails(scripts_dir, target_dir, c
 
 
 def test_main_exits_zero_when_analysis_succeeds(scripts_dir, target_dir, capsys, monkeypatch):
+    # #14635: shaped like the real code_quality_dashboard.py report -- scores
+    # nest under "quality_metrics", not at the top level.
+    payload = {"status": "success", "quality_metrics": {"maintainability_index": 82.5, "test_coverage_score": 91.0}}
     _write_report_writing_script(
-        scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", {"complexity": 1}
+        scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", payload
     )
     argv = ["run_code_analysis.py", "--target", str(target_dir), "--analysis-type", "quality"]
     monkeypatch.setattr(sys, "argv", argv)
@@ -271,6 +274,7 @@ def test_main_exits_zero_when_analysis_succeeds(scripts_dir, target_dir, capsys,
 
     printed = json.loads(capsys.readouterr().out)
     assert printed["status"] == "success"
+    assert printed["codebase_metrics"] == {"maintainability": 82.5, "test_coverage": 91.0}
 
 
 def test_output_file_map_matches_what_each_real_script_writes():

--- a/repo_tests/run_code_analysis_metrics_14635_test.py
+++ b/repo_tests/run_code_analysis_metrics_14635_test.py
@@ -1,0 +1,151 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for run_code_analysis's codebase_metrics rollup (#14635).
+
+``_extract_codebase_metrics`` used to read ``complexity`` / ``maintainability``
+/ ``test_coverage`` / ``doc_coverage`` off the *top level* of the parsed
+``comprehensive_quality_report.json``. The real producer -- ``code_quality_
+dashboard.py``'s ``generate_comprehensive_report``, written verbatim to that
+file by ``analyze_code_quality.py`` -- nests its scores under a
+``quality_metrics`` object instead, as ``maintainability_index`` and
+``test_coverage_score``, and has no ``complexity`` or ``doc_coverage`` field
+anywhere. Every one of the four numbers this function returned was therefore
+its own hardcoded ``.get(key, default)`` fallback, even on a genuinely
+successful run.
+
+Derives the producer's real ``quality_metrics`` key set from
+``code_quality_dashboard.py``'s own source (the dict literal in
+``_build_report_dict``) rather than restating it by hand, then drives that
+shape through ``_extract_codebase_metrics`` and asserts the real numbers come
+through -- not fallback constants.
+"""
+
+import importlib.util
+import pathlib
+import re
+import sys
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_MODULE_PATH = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts" / "run_code_analysis.py"
+_DASHBOARD_PATH = _REPO_ROOT / "autobot-backend" / "code_analysis" / "src" / "code_quality_dashboard.py"
+
+# Matches each ``"key": qm.attr,`` line inside the ``quality_metrics`` dict
+# literal in ``CodeQualityDashboard._build_report_dict``.
+_QUALITY_METRICS_KEY_RE = re.compile(r'"([a-z_]+)":\s*qm\.\w+,')
+
+
+def _load_module():
+    """Import run_code_analysis by path -- its directory is not a package."""
+    spec = importlib.util.spec_from_file_location("run_code_analysis_14635", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["run_code_analysis_14635"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _real_quality_metrics_keys() -> set:
+    """The key set the real dashboard's ``quality_metrics`` object carries."""
+    source = _DASHBOARD_PATH.read_text(encoding="utf-8")
+    block = source.split('"quality_metrics": {', 1)[1].split("},", 1)[0]
+    return set(_QUALITY_METRICS_KEY_RE.findall(block))
+
+
+rca = _load_module()
+
+# A payload shaped exactly like the real ``generate_comprehensive_report``
+# output: scores nested under "quality_metrics", no top-level "complexity" /
+# "maintainability" / "test_coverage" / "doc_coverage" keys at all.
+_REAL_SHAPED_REPORT = {
+    "status": "success",
+    "timestamp": "2026-08-16T00:00:00+00:00",
+    "overall_quality_score": 91.2,
+    "quality_metrics": {
+        "overall_score": 91.2,
+        "code_duplication_score": 95.0,
+        "environment_config_score": 88.0,
+        "performance_score": 90.5,
+        "security_score": 97.0,
+        "api_consistency_score": 84.0,
+        "test_coverage_score": 88.0,
+        "architecture_score": 92.0,
+        "maintainability_index": 77.5,
+        "technical_debt_ratio": 3.1,
+    },
+    "files_analyzed": 42,
+}
+
+
+def test_real_dashboard_key_set_has_no_complexity_or_doc_coverage():
+    """Ground truth: the producer's real key set, read from its own source."""
+    keys = _real_quality_metrics_keys()
+    assert "maintainability_index" in keys
+    assert "test_coverage_score" in keys
+    assert "complexity" not in keys
+    assert "doc_coverage" not in keys
+
+
+def test_field_map_targets_keys_the_real_producer_actually_writes():
+    """The orchestrator's mapping must draw only from keys the dashboard emits."""
+    real_keys = _real_quality_metrics_keys()
+    assert set(rca._QUALITY_METRICS_FIELD_MAP.values()) <= real_keys
+
+
+def test_extract_returns_real_numbers_not_fabricated_defaults():
+    metrics = rca._extract_codebase_metrics({"code_quality": _REAL_SHAPED_REPORT})
+
+    assert metrics == {"maintainability": 77.5, "test_coverage": 88.0}
+    # The historical fabricated defaults must never appear.
+    assert metrics.get("complexity") is None
+    assert metrics.get("doc_coverage") is None
+    assert "complexity" not in metrics
+    assert "doc_coverage" not in metrics
+
+
+def test_extract_returns_none_when_quality_analysis_failed():
+    results = {"code_quality": {"error": "boom"}}
+    assert rca._extract_codebase_metrics(results) is None
+
+
+def test_extract_returns_none_when_no_quality_analysis_ran():
+    assert rca._extract_codebase_metrics({}) is None
+
+
+def test_extract_raises_on_shape_mismatch_missing_quality_metrics():
+    """A successful report missing 'quality_metrics' is a producer/consumer
+    disagreement -- it must surface, not silently degrade to defaults."""
+    results = {"code_quality": {"status": "success", "complexity": 3, "maintainability": "excellent"}}
+
+    with pytest.raises(ValueError, match="quality_metrics"):
+        rca._extract_codebase_metrics(results)
+
+
+def test_extract_raises_on_shape_mismatch_incomplete_quality_metrics():
+    results = {"code_quality": {"status": "success", "quality_metrics": {"overall_score": 91.2}}}
+
+    with pytest.raises(ValueError, match="missing expected keys"):
+        rca._extract_codebase_metrics(results)
+
+
+def test_run_full_analysis_reports_the_real_metrics(tmp_path, monkeypatch):
+    """End-to-end through run_full_analysis with a real-shaped report file."""
+    import json
+
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    monkeypatch.setattr(rca, "_ANALYSIS_SCRIPTS_DIR", scripts_dir)
+
+    body = (
+        "import json\n"
+        f"json.dump({_REAL_SHAPED_REPORT!r}, open('comprehensive_quality_report.json', 'w', encoding='utf-8'))\n"
+    )
+    (scripts_dir / "analyze_code_quality.py").write_text(body, encoding="utf-8")
+
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+
+    results = rca.run_full_analysis(str(target_dir), "quality")
+
+    assert results["status"] == "success"
+    assert results["codebase_metrics"] == {"maintainability": 77.5, "test_coverage": 88.0}


### PR DESCRIPTION
## Thinking Path

`_extract_codebase_metrics` in `run_code_analysis.py` read `complexity` /
`maintainability` / `test_coverage` / `doc_coverage` off the top level of the
parsed quality report, always missed, and silently fell back to four
hardcoded numbers -- on a genuinely successful analysis, not just a failed
one (the same "fabricated success" shape #14543 fixed for the status field,
one layer in for the numbers).

Traced the real producer: `analyze_code_quality.py` writes
`code_quality_dashboard.py`'s `generate_comprehensive_report` output verbatim
to the file the orchestrator reads. That report nests its scores under a
`quality_metrics` object and has no `complexity` or `doc_coverage` field
anywhere:

| Consumer read (before) | Real producer field | Exists? |
|---|---|---|
| `complexity` (top level) | -- | No -- no equivalent anywhere in the report |
| `maintainability` (top level) | `quality_metrics.maintainability_index` | Yes, nested |
| `test_coverage` (top level) | `quality_metrics.test_coverage_score` | Yes, nested |
| `doc_coverage` (top level) | -- | No -- no equivalent anywhere in the report |

Fixed by mapping only the fields that exist, omitting the two that don't
(rather than inventing them or emitting a disguised zero), and raising loudly
on a shape mismatch (a successful report missing `quality_metrics`, or
missing one of its expected keys) instead of degrading to defaults.

While reading `code_analyzer.py` for the mapping's call chain,
`CodeAnalyzer.__init__` referenced `self.config = config` -- `config` is
never imported or defined anywhere in the module, so every construction
raised `NameError`, which is exactly issue #14634. Grepped for `self.config`
call sites (none, anywhere), and found the same pattern already fixed the
same way in `anti_pattern_detector.py` (#6733) -- removed the dead
assignment rather than importing an unused symbol, same precedent.

That same grep turned up a third instance of the identical bug in
`CodeQualityDashboard.__init__` (`code_quality_dashboard.py:79`) -- out of
scope for either issue here, filed separately as #14642 rather than
scope-creeping this PR.

## What Changed

- `autobot-infrastructure/shared/scripts/run_code_analysis.py`:
  `_extract_codebase_metrics` now maps `maintainability` /
  `test_coverage` from the real `quality_metrics.maintainability_index` /
  `quality_metrics.test_coverage_score` fields, drops the nonexistent
  `complexity` / `doc_coverage` keys entirely (no fabricated value, no
  disguised zero), and raises `ValueError` if a successful report is missing
  `quality_metrics` or any of its expected keys.
- `autobot-backend/code_analysis/src/code_analyzer.py`: removed the dead,
  undefined-name `self.config = config` assignment from `CodeAnalyzer.__init__`
  (#14634) -- nothing read `self.config`.
- `repo_tests/run_code_analysis_channel_14587_test.py`: updated
  `test_main_exits_zero_when_analysis_succeeds`'s fixture payload from an
  unrealistic top-level shape to the real nested `quality_metrics` shape, and
  asserts the resulting `codebase_metrics` carries the real numbers.
- `repo_tests/run_code_analysis_metrics_14635_test.py` (new): derives the
  producer's real `quality_metrics` key set from `code_quality_dashboard.py`'s
  own source, drives that shape through `_extract_codebase_metrics`, and
  covers the failure/shape-mismatch paths.
- `autobot-backend/code_analysis/src/code_analyzer_config_14634_test.py`
  (new): constructs a real `CodeAnalyzer()` and asserts no `NameError`.

## Verification

New test file (8 tests) plus one updated case in the existing #14587 suite,
run against a scratch copy with `AUTOBOT_PROJECT_ROOT` pointed at it (never
executed in the working tree):

```
23 passed in 1.24s
```

Mutated `_extract_codebase_metrics` back to the original top-level reads in a
second scratch copy (`assert mutated != original` before running):

```
17 passed, 6 failed in 2.48s
```

The 6 failures are exactly the tests this PR added/touched for the fix; the
17 unaffected failure-mode tests (missing script, non-zero exit, malformed
JSON, etc.) stayed green, confirming the mutation is scoped correctly.

For #14634, stubbed only the two third-party deps unavailable in this sandbox
(`sklearn`, `numpy` -- both real dependencies per
`autobot-backend/requirements.txt`, installed in CI) and constructed a real
`CodeAnalyzer()`:

- Before the fix: `NameError: name 'config' is not defined` (reproduced against the original code).
- After the fix: construction succeeds, `similarity_threshold == 0.85`, no `config` attribute.

`git blame` confirms both defects predate this stacked chain:
`_extract_codebase_metrics` was introduced by `d3dd8eee93` (#14543, 2026-08-18);
`code_analyzer.py:66` traces to `970daa16a4` (2026-02-06).

Base verified against `origin/Dev_new_gui`: `cc9b78cd4` (#14587's merge) is an
ancestor, `_ANALYSIS_OUTPUT_FILES` and
`repo_tests/run_code_analysis_channel_14587_test.py` are both present.

## Model Used

Claude Opus 5 (1M context)

Closes #14635, #14634