### PR TITLE
feat(approvals): correlate a remotely delivered approval with its reply (#14068) [1/2]

### DIFF
--- a/autobot-backend/services/remote_approval.py
+++ b/autobot-backend/services/remote_approval.py
@@ -1,0 +1,237 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Correlating an approval delivered to a chat channel with the reply (#14068).
+
+An approval can only be answered by a human looking at the app. For a platform
+that runs unattended loops that makes an approval nobody can answer a stall, and
+the only workaround — lowering the guard profile — grants the agent *more*
+autonomy when what was needed was a different way to reach the person.
+
+This module is the correlation half: embed a token in the delivered message,
+recognise it in a reply, and map it back to the pending approval. Delivery
+itself and the per-session routing flag are the next change in the stack; this
+one has no side effects beyond its own Redis keys.
+
+Fail-closed throughout. An unparseable reply, an unknown token, or a reply with
+no clear decision resolves **nothing** — silence is not consent, and neither is
+a thumbs-up on a message we cannot tie to a request.
+
+Not built on ``services/slack_approval_integration.py``: that store is keyed by
+workflow node and named for one platform, and bending a node-shaped, Slack-named
+record into a channel-agnostic approval correlation would consolidate by
+contortion. Its Slack thread tracking is still the right thing for the Slack
+adapter's ``thread_ts`` and is wired in the delivery change, not here.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+logger = get_logger(__name__)
+
+#: Redis key prefix for a pending approval's delivery record.
+_DELIVERY_KEY_PREFIX = "approval:delivery:"
+
+#: How long a delivered approval stays correlatable. Beyond this the reply can
+#: no longer be tied to a request, and fail-closed means it resolves nothing.
+REMOTE_APPROVAL_TTL_SECONDS = int(os.getenv("AUTOBOT_REMOTE_APPROVAL_TTL_SECONDS", "86400"))
+
+#: The correlation token, embedded in the delivered message.
+#: Deliberately narrow: the id charset is bounded so a token cannot be forged by
+#: pasting arbitrary text, and the pattern cannot span lines.
+_TOKEN_RE = re.compile(r"\[ab:([A-Za-z0-9][A-Za-z0-9._-]{0,63})\]")
+
+_APPROVE_WORDS = frozenset({"approve", "approved", "yes", "ok", "okay", "lgtm", "go", "allow"})
+_DENY_WORDS = frozenset({"deny", "denied", "no", "reject", "rejected", "stop", "block"})
+_APPROVE_EMOJI = ("👍", "✅", "☑️", "✔️")
+_DENY_EMOJI = ("👎", "❌", "🛑", "✖️")
+
+
+def embed_token(body: str, approval_id: str) -> str:
+    """Append the correlation token to *body*.
+
+    The token is what makes a reply resolvable. A delivered message without one
+    is undeliverable rather than best-effort: a human answering a message we
+    cannot correlate would believe they had approved something.
+    """
+    if not approval_id or not _TOKEN_RE.fullmatch(f"[ab:{approval_id}]"):
+        raise ValueError(f"approval id is not token-safe: {approval_id!r}")
+    return f"{body}\n\n[ab:{approval_id}]"
+
+
+def extract_token(text: str) -> Optional[str]:
+    """The approval id referenced by *text*, or None.
+
+    Returns None when the text carries more than one token: a reply quoting two
+    approvals names no single decision, and guessing which one would resolve the
+    wrong request.
+    """
+    if not isinstance(text, str):
+        return None
+    found = _TOKEN_RE.findall(text)
+    if len(found) != 1:
+        return None
+    return found[0]
+
+
+def parse_decision(text: str) -> Optional[bool]:
+    """True to approve, False to deny, None when the reply says neither.
+
+    A reply containing both an approve and a deny signal returns None rather
+    than picking one — "no, don't approve" must not read as approval because it
+    contains the word.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    lowered = text.lower()
+    approve = any(e in text for e in _APPROVE_EMOJI) or bool(_APPROVE_WORDS & set(re.findall(r"[a-z]+", lowered)))
+    deny = any(e in text for e in _DENY_EMOJI) or bool(_DENY_WORDS & set(re.findall(r"[a-z]+", lowered)))
+
+    if approve == deny:  # neither, or contradictory
+        return None
+    return approve
+
+
+@dataclass(frozen=True)
+class DeliveredApproval:
+    """Where a pending approval was sent, so a reply can be tied back to it."""
+
+    approval_id: str
+    platform: str
+    channel_id: str
+
+
+@dataclass(frozen=True)
+class ResolvedReply:
+    """A reply that named exactly one known approval and one clear decision."""
+
+    approval_id: str
+    approved: bool
+    platform: str
+    channel_id: str
+
+
+class RemoteApprovalStore:
+    """Redis-backed record of which approvals were delivered where."""
+
+    async def record_delivery(self, delivery: DeliveredApproval) -> bool:
+        """Remember that *delivery* went out. False when Redis is unavailable."""
+        redis = await get_async_redis_client()
+        if redis is None:
+            logger.warning("Redis unavailable — approval %s delivered uncorrelated", delivery.approval_id)
+            return False
+        try:
+            await redis.hset(
+                f"{_DELIVERY_KEY_PREFIX}{delivery.approval_id}",
+                mapping={"platform": delivery.platform, "channel_id": delivery.channel_id},
+            )
+            await redis.expire(f"{_DELIVERY_KEY_PREFIX}{delivery.approval_id}", REMOTE_APPROVAL_TTL_SECONDS)
+            return True
+        except Exception as exc:  # noqa: BLE001 - a correlation we cannot store is not a crash
+            logger.error("Failed to record approval delivery %s: %s", delivery.approval_id, exc)
+            return False
+
+    async def get_delivery(self, approval_id: str) -> Optional[DeliveredApproval]:
+        """The recorded delivery for *approval_id*, or None if unknown/expired."""
+        redis = await get_async_redis_client()
+        if redis is None:
+            return None
+        try:
+            data = await redis.hgetall(f"{_DELIVERY_KEY_PREFIX}{approval_id}")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to read approval delivery %s: %s", approval_id, exc)
+            return None
+        if not data:
+            return None
+        platform = _decoded(data, "platform")
+        channel_id = _decoded(data, "channel_id")
+        if not platform or not channel_id:
+            return None
+        return DeliveredApproval(approval_id=approval_id, platform=platform, channel_id=channel_id)
+
+    async def forget(self, approval_id: str) -> None:
+        """Drop the correlation once the approval is resolved."""
+        redis = await get_async_redis_client()
+        if redis is None:
+            return
+        try:
+            await redis.delete(f"{_DELIVERY_KEY_PREFIX}{approval_id}")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to clear approval delivery %s: %s", approval_id, exc)
+
+
+def _decoded(mapping: dict, key: str) -> str:
+    """Field from a Redis hash, tolerating bytes or str keys and values."""
+    value = mapping.get(key)
+    if value is None:
+        value = mapping.get(key.encode("utf-8"))
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else ""
+
+
+async def resolve_from_reply(
+    text: str,
+    *,
+    platform: str,
+    channel_id: str,
+    store: Optional[RemoteApprovalStore] = None,
+) -> Optional[ResolvedReply]:
+    """Tie a channel reply back to a pending approval, or return None.
+
+    Every rejection path is deliberate and silent-by-design at the caller:
+
+    * no token, or more than one — nothing to resolve;
+    * no clear decision, or a contradictory one — the human has not answered;
+    * a token we never delivered, or one that expired — not ours to act on;
+    * a reply arriving on a different platform or channel than the delivery —
+      the reply must come back where the question was asked, or anyone able to
+      post the token anywhere could answer for the operator.
+    """
+    approval_id = extract_token(text)
+    if approval_id is None:
+        return None
+
+    decision = parse_decision(text)
+    if decision is None:
+        logger.info("Approval reply for %s carried no clear decision", approval_id)
+        return None
+
+    delivery = await (store or RemoteApprovalStore()).get_delivery(approval_id)
+    if delivery is None:
+        logger.info("Approval reply names unknown or expired approval %s", approval_id)
+        return None
+
+    if delivery.platform != platform or delivery.channel_id != channel_id:
+        logger.warning(
+            "Approval reply for %s arrived on %s:%s but was delivered to %s:%s — ignored",
+            approval_id,
+            platform,
+            channel_id,
+            delivery.platform,
+            delivery.channel_id,
+        )
+        return None
+
+    return ResolvedReply(approval_id=approval_id, approved=decision, platform=platform, channel_id=channel_id)
+
+
+__all__ = [
+    "DeliveredApproval",
+    "RemoteApprovalStore",
+    "ResolvedReply",
+    "REMOTE_APPROVAL_TTL_SECONDS",
+    "embed_token",
+    "extract_token",
+    "parse_decision",
+    "resolve_from_reply",
+]

--- a/autobot-backend/services/remote_approval_test.py
+++ b/autobot-backend/services/remote_approval_test.py
@@ -1,0 +1,164 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Correlating a delivered approval with its reply (#14068).
+
+Every test here is about a *rejection* path as much as an acceptance one. The
+failure that matters is not "a valid reply was missed" — it is "something was
+approved that the operator did not approve", so the fail-closed direction is
+asserted case by case rather than assumed from the happy path.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.remote_approval import (
+    DeliveredApproval,
+    RemoteApprovalStore,
+    embed_token,
+    extract_token,
+    parse_decision,
+    resolve_from_reply,
+)
+
+
+class _Store(RemoteApprovalStore):
+    """A store with a known content, so tests never touch Redis."""
+
+    def __init__(self, delivery=None):
+        self._delivery = delivery
+
+    async def get_delivery(self, approval_id):
+        if self._delivery and self._delivery.approval_id == approval_id:
+            return self._delivery
+        return None
+
+
+_DELIVERY = DeliveredApproval(approval_id="a1b2c3", platform="slack", channel_id="C42")
+
+
+class TestToken:
+    def test_a_token_round_trips(self):
+        assert extract_token(embed_token("Approve deploy?", "a1b2c3")) == "a1b2c3"
+
+    def test_the_body_survives_embedding(self):
+        assert "Approve deploy?" in embed_token("Approve deploy?", "a1b2c3")
+
+    def test_an_id_that_cannot_be_tokenised_is_refused_loudly(self):
+        """Silently emitting an uncorrelatable message is the worse failure:
+        a human would answer a question whose answer goes nowhere."""
+        for bad in ("", "has space", "has]bracket", "x" * 100, "[ab:nested]"):
+            with pytest.raises(ValueError):
+                embed_token("body", bad)
+
+    def test_text_without_a_token_yields_none(self):
+        assert extract_token("looks fine to me") is None
+
+    def test_two_tokens_yield_none(self):
+        """A reply quoting two approvals names no single decision."""
+        two = embed_token(embed_token("body", "aaa"), "bbb")
+        assert extract_token(two) is None
+
+    def test_a_non_string_yields_none(self):
+        assert extract_token(None) is None
+        assert extract_token(12345) is None
+
+
+class TestDecision:
+    @pytest.mark.parametrize("text", ["approve", "Approved", "yes", "LGTM", "👍", "✅ go ahead"])
+    def test_approval_signals(self, text):
+        assert parse_decision(text) is True
+
+    @pytest.mark.parametrize("text", ["deny", "No", "reject", "stop", "👎", "❌ not this one"])
+    def test_denial_signals(self, text):
+        assert parse_decision(text) is False
+
+    @pytest.mark.parametrize("text", ["", "   ", "what does this do?", "maybe later", None])
+    def test_no_decision_is_none_not_false(self, text):
+        """None and False are different outcomes: False *denies*, None leaves the
+        approval pending. Collapsing them would let a question deny a request."""
+        assert parse_decision(text) is None
+
+    def test_a_contradictory_reply_resolves_nothing(self):
+        """'no, do not approve' contains the approve word."""
+        assert parse_decision("no, do not approve this") is None
+        assert parse_decision("👍👎") is None
+
+    def test_a_word_inside_another_word_does_not_count(self):
+        """'okay' is a decision; 'okaying' should not be matched by substring."""
+        assert parse_decision("I am not okaying anything without review") is None
+
+
+class TestResolveFromReply:
+    @pytest.mark.asyncio
+    async def test_a_well_formed_reply_resolves(self):
+        reply = embed_token("👍", "a1b2c3")
+        got = await resolve_from_reply(reply, platform="slack", channel_id="C42", store=_Store(_DELIVERY))
+        assert got is not None and got.approval_id == "a1b2c3" and got.approved is True
+
+    @pytest.mark.asyncio
+    async def test_a_denial_resolves_as_a_denial(self):
+        reply = embed_token("👎", "a1b2c3")
+        got = await resolve_from_reply(reply, platform="slack", channel_id="C42", store=_Store(_DELIVERY))
+        assert got is not None and got.approved is False
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_token_resolves_nothing(self):
+        reply = embed_token("👍", "neversent")
+        assert await resolve_from_reply(reply, platform="slack", channel_id="C42", store=_Store(_DELIVERY)) is None
+
+    @pytest.mark.asyncio
+    async def test_a_reply_with_no_decision_resolves_nothing(self):
+        reply = embed_token("what would this do?", "a1b2c3")
+        assert await resolve_from_reply(reply, platform="slack", channel_id="C42", store=_Store(_DELIVERY)) is None
+
+    @pytest.mark.asyncio
+    async def test_a_reply_on_the_wrong_channel_resolves_nothing(self):
+        """The reply must return where the question was asked.
+
+        Without this, anyone able to post the token in any channel the bot reads
+        could answer on the operator's behalf.
+        """
+        reply = embed_token("👍", "a1b2c3")
+        assert await resolve_from_reply(reply, platform="slack", channel_id="OTHER", store=_Store(_DELIVERY)) is None
+
+    @pytest.mark.asyncio
+    async def test_a_reply_on_the_wrong_platform_resolves_nothing(self):
+        reply = embed_token("👍", "a1b2c3")
+        assert await resolve_from_reply(reply, platform="discord", channel_id="C42", store=_Store(_DELIVERY)) is None
+
+    @pytest.mark.asyncio
+    async def test_an_unavailable_store_resolves_nothing(self):
+        """Redis down must not approve by default."""
+        reply = embed_token("👍", "a1b2c3")
+        assert await resolve_from_reply(reply, platform="slack", channel_id="C42", store=_Store(None)) is None
+
+
+class TestStoreDegradesWithoutRedis:
+    @pytest.mark.asyncio
+    async def test_recording_without_redis_reports_failure_rather_than_raising(self, monkeypatch):
+        monkeypatch.setattr("services.remote_approval.get_async_redis_client", AsyncMock(return_value=None))
+        assert await RemoteApprovalStore().record_delivery(_DELIVERY) is False
+
+    @pytest.mark.asyncio
+    async def test_reading_without_redis_returns_none(self, monkeypatch):
+        monkeypatch.setattr("services.remote_approval.get_async_redis_client", AsyncMock(return_value=None))
+        assert await RemoteApprovalStore().get_delivery("a1b2c3") is None
+
+    @pytest.mark.asyncio
+    async def test_a_partial_record_is_not_a_delivery(self, monkeypatch):
+        """A hash missing a field must not resolve to a half-known delivery."""
+        redis = AsyncMock()
+        redis.hgetall = AsyncMock(return_value={"platform": "slack"})
+        monkeypatch.setattr("services.remote_approval.get_async_redis_client", AsyncMock(return_value=redis))
+        assert await RemoteApprovalStore().get_delivery("a1b2c3") is None
+
+    @pytest.mark.asyncio
+    async def test_byte_encoded_fields_are_read(self, monkeypatch):
+        redis = AsyncMock()
+        redis.hgetall = AsyncMock(return_value={b"platform": b"slack", b"channel_id": b"C42"})
+        monkeypatch.setattr("services.remote_approval.get_async_redis_client", AsyncMock(return_value=redis))
+        got = await RemoteApprovalStore().get_delivery("a1b2c3")
+        assert got is not None and got.platform == "slack"

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -996,6 +996,19 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_REMOTE_APPROVAL_TTL_SECONDS",
+        type=int,
+        default=86400,
+        description=(
+            "How long a remotely delivered approval stays correlatable with its reply. "
+            "After this the reply can no longer be tied to a request and resolves nothing."
+        ),
+        component="approvals",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_LLC_H2A_BRIEF_CACHE_TTL",
         type=int,
         default=86400,


### PR DESCRIPTION
## Thinking Path

**PR 1 of a stack of 2 for #14068.** This one is the correlation half; PR 2 (stacked on this branch) does the routing and gives it its caller.

An approval can only be answered by a human looking at the app. For a platform that runs unattended loops that makes an approval nobody can answer a stall — and the only available workaround, lowering the guard profile, grants the agent *more* autonomy when what was needed was a different way to reach the person. That conflation is the defect #14068 describes.

Delivering an approval outward is easy; **tying the reply back to it safely is the part with the failure modes**, so it lands first, alone, where it can be reviewed on its own terms.

Every rejection path here is deliberate, because the failure that matters is not "a valid reply was missed" — it is *"something was approved that the operator did not approve."* Fail-closed cases, each asserted:

- no token, or more than one — a reply quoting two approvals names no single decision;
- no clear decision, or a contradictory one — `"no, do not approve this"` contains the approve word;
- a token never delivered, or expired;
- **a reply arriving on a different platform or channel than the delivery** — without this, anyone able to post the token in any channel the bot reads could answer on the operator's behalf;
- Redis unavailable — a store we cannot read approves nothing.

`None` and `False` are kept distinct throughout: `False` *denies*, `None` leaves the approval pending. Collapsing them would let a clarifying question deny a request.

## What Changed

- `autobot-backend/services/remote_approval.py` (new) — `embed_token` / `extract_token` / `parse_decision` / `resolve_from_reply`, plus a Redis-backed `RemoteApprovalStore` recording which approval went to which platform and channel.
- `autobot_shared/env_registry.py` — registers `AUTOBOT_REMOTE_APPROVAL_TTL_SECONDS`.
- `autobot-backend/services/remote_approval_test.py` (new) — 36 tests.

`embed_token` **raises** on an id that cannot be tokenised rather than emitting a best-effort message. Silently sending an uncorrelatable approval is the worse failure: a human answers a question whose answer goes nowhere.

### On `services/slack_approval_integration.py`

I flagged that module on #14068 as an unwired component to adopt rather than duplicate. Having read it: it is keyed by **workflow node** and named for one platform, and bending a node-shaped, Slack-named record into a channel-agnostic approval correlation would be consolidating by contortion. Its Slack thread tracking is genuinely the right thing for the Slack adapter's `thread_ts`, and PR 2 wires it there. Recording the reasoning here because my own earlier comment pointed the other way.

## Verification

```
36 passed    # services/remote_approval_test.py
registry check exit 0
```

**Mutation-tested** — the fail-closed guards are the whole point, so each was reverted and confirmed to fail:

| Mutation | Result |
|---|---|
| accept a reply from any channel | 2 failed |
| let a contradictory reply decide | 5 failed |
| two tokens → pick the first | 1 failed |
| accept a partial delivery record | 1 failed |

## Risks

No caller yet — nothing imports this module until PR 2. That is deliberate for reviewability, and it is the one thing to watch: **if PR 2 does not land, this is dead code and should be reverted rather than left.** It is not a config surface waiting for someone to notice it; it is half of a stack.

No behaviour change on merge. New Redis keys are written only once PR 2 calls it.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Refs #14068.

## Changelog fragment

- [ ] N/A — no user-visible behaviour until PR 2 in this stack.

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff
