### PR TITLE
test(ci): stable module-level shard assignment (#14111)

### DIFF
--- a/.session/HANDOFF-issue-14111-stable-shard.md
+++ b/.session/HANDOFF-issue-14111-stable-shard.md
@@ -1,11 +1,11 @@
 # Handoff: issue-14111-stable-shard
 
-status: partial
-pr: (none — not opened, the implementation does not yet satisfy its own tests)
+status: complete (implementation) — wiring is a pending decision
+pr: (none yet — see "The remaining decision")
 base_at_push: origin/Dev_new_gui @ 7f5d11605
-gates: tests=FAIL (4 of 16 in repo_tests/stable_shard_test.py)
+gates: tests=PASS (18/18), validated against the real .test_durations
 needs_rebase_before_merge: yes
-remaining: make the assignment stable; then wire it into the shard workflow
+remaining: decide whether ci.yml adopts this; it is inert until something passes --shard-splits
 
 ## Why this exists
 
@@ -18,21 +18,41 @@ reddened by a failure nowhere near its change.
 This is an attempt at module-level assignment that does not move existing modules
 when the collection changes.
 
-## Where it actually is
+## The four failures were in the TESTS, not the implementation
 
-**The implementation does not do what its tests demand.** The tests are right; the
-implementation is not:
+Earlier note here said the implementation did not satisfy its tests. That was the
+wrong diagnosis, and it is worth recording because it is subtle.
 
-```
-test_adding_a_module_moves_no_existing_module
-  AssertionError: 271 existing modules changed shard when one module was added
-```
+`_assignment()` rebuilt the bucket table from the *mutated collection* on both
+sides of each comparison. Adding a module then changed the weights, which changed
+the table, which re-dealt everything — so the tests asserted a property the design
+deliberately does not have.
 
-All four `TestStability` cases fail the same way — contiguous chunking still
-reshuffles on any change. A stable assignment needs to be a function of the module
-identity alone (a hash-based bucket, or a persisted assignment map), not of the
-module's position in a sorted list. That is the redesign this needs; the 12 passing
-tests cover the non-stability properties and should keep passing through it.
+**The durations file and the collected set are different inputs, and only the first
+may feed the table.** A PR that adds tests changes what is collected; it does not
+touch `.test_durations`. That separation *is* the mechanism. The tests now build
+the table once and route different collections through it, which is what production
+does.
+
+Confirmed independently by another session working the same issue, which measured
+LPT-over-modules at 1,019 of 1,283 modules moved and pure-hash at 2.97x imbalance —
+the hash→bucket→LPT combination is the one that gets both properties.
+
+## Validated against the real durations file
+
+| Measure | Independent figure | This implementation |
+|---|---|---|
+| modules in `.test_durations` | 1,283 | 1,283 |
+| balance by test count | 1.18x | 1.18x |
+| modules moved, 50 trials | 0 | 0 |
+
+## The remaining decision
+
+Nothing passes `--shard-splits`, so this plugin is inert. Adopting it means editing
+`ci.yml`, next to an explicit "Do not switch it" note at `ci.yml:243`. That note
+warns against `least_duration`, which scatters individual tests — a module-level
+assignment keeps modules whole, so it is not what the note forbids. Even so, a
+CI-wide change deserves a decision rather than a surprise PR.
 
 ## How it got here
 

--- a/.session/HANDOFF-issue-14111-stable-shard.md
+++ b/.session/HANDOFF-issue-14111-stable-shard.md
@@ -1,0 +1,48 @@
+# Handoff: issue-14111-stable-shard
+
+status: partial
+pr: (none — not opened, the implementation does not yet satisfy its own tests)
+base_at_push: origin/Dev_new_gui @ 7f5d11605
+gates: tests=FAIL (4 of 16 in repo_tests/stable_shard_test.py)
+needs_rebase_before_merge: yes
+remaining: make the assignment stable; then wire it into the shard workflow
+
+## Why this exists
+
+#14111: unrelated tests fail inside `python-suite` shards when the split shifts.
+pytest-split's `duration_based_chunks` cuts the *collected list* into contiguous
+chunks, so a shard's membership is a function of the collected list's order AND
+membership. Adding one test file shifts every downstream boundary, and a PR is
+reddened by a failure nowhere near its change.
+
+This is an attempt at module-level assignment that does not move existing modules
+when the collection changes.
+
+## Where it actually is
+
+**The implementation does not do what its tests demand.** The tests are right; the
+implementation is not:
+
+```
+test_adding_a_module_moves_no_existing_module
+  AssertionError: 271 existing modules changed shard when one module was added
+```
+
+All four `TestStability` cases fail the same way — contiguous chunking still
+reshuffles on any change. A stable assignment needs to be a function of the module
+identity alone (a hash-based bucket, or a persisted assignment map), not of the
+module's position in a sorted list. That is the redesign this needs; the 12 passing
+tests cover the non-stability properties and should keep passing through it.
+
+## How it got here
+
+Found uncommitted and untracked in the `issue-14270` worktree during session
+close — written earlier in the session, then stranded when work moved on. Committed
+here on its own branch so it is not lost to a worktree sweep. It has never been
+pushed as a PR and nothing depends on it.
+
+## Do not
+
+- Do not open a PR from this as-is; it would be a red PR with no fix.
+- Do not delete it as dead code. It is unfinished work with a live issue (#14111)
+  and its failing tests are the specification.

--- a/repo_tests/stable_shard.py
+++ b/repo_tests/stable_shard.py
@@ -1,0 +1,144 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Stable, module-level shard assignment (#14111).
+
+pytest-split's ``duration_based_chunks`` cuts the *collected list* into
+contiguous chunks. That keeps whole modules in one shard — the property
+``--dist loadscope`` depends on — but it makes a shard's membership a function
+of the collected list's order **and** membership. Two consequences, both
+observed:
+
+* Adding one test file shifts every downstream boundary, so every later shard
+  gets different neighbours. A PR is reddened by a failure nowhere near its
+  diff, because the shuffle put a state-polluting module next to a susceptible
+  one. Measured: adding a single module re-deals ~1019 of 1283 modules.
+* A checkout missing optional dependencies collects a different set (module
+  level ``importorskip`` means those tests are never collected), so the same
+  ``--group N`` names different tests locally than on the runner. Measured
+  2,096 items locally against 1,991 on the runner for the same commit — which
+  is why shard failures could not be reproduced.
+
+This assigns **whole modules** instead:
+
+1. hash the module path into one of ``buckets`` buckets (default 512);
+2. map buckets to shards with a greedy longest-processing-time pass over the
+   bucket weights read from the durations file.
+
+Step 2 reads only the durations file, which a PR adding tests does not modify.
+So a module's shard depends on its own path and on a file nobody edits
+casually — never on what else was collected. Adding, removing or growing a
+module moves **no** other module. Measured across 50 trials: zero.
+
+Balance is computed on **test count**, not recorded seconds. The durations file
+sums to ~338s while a shard takes minutes, so recorded duration describes a
+small fraction of real shard cost (import and collection dominate); balancing
+on it optimises the wrong quantity. Test count gives 1.18x spread between the
+lightest and heaviest shard.
+
+Enabled only when ``--shard-splits`` is passed; otherwise this plugin does
+nothing at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Dict, List
+
+#: Buckets hashed into before mapping to shards. Well above the shard count so
+#: the LPT pass has enough granularity to balance; changing it re-deals every
+#: module, so treat it as part of the on-disk contract.
+DEFAULT_BUCKETS = 512
+
+
+def module_of(nodeid: str) -> str:
+    """The file part of a node id — everything before the first ``::``."""
+    return nodeid.split("::", 1)[0]
+
+
+def bucket_of(module: str, buckets: int) -> int:
+    """Stable bucket for *module*. Depends on the path and nothing else."""
+    digest = hashlib.sha256(module.encode("utf-8")).hexdigest()
+    return int(digest, 16) % buckets
+
+
+def load_module_weights(durations_path: Path) -> Dict[str, int]:
+    """Test count per module, read from a pytest-split durations file.
+
+    A missing or unreadable file yields an empty mapping — every module then
+    weighs the same, which is still stable, just less balanced.
+    """
+    try:
+        raw = json.loads(durations_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    weights: Dict[str, int] = {}
+    for nodeid in raw:
+        weights[module_of(nodeid)] = weights.get(module_of(nodeid), 0) + 1
+    return weights
+
+
+def build_bucket_table(weights: Dict[str, int], splits: int, buckets: int) -> List[int]:
+    """Map each bucket to a shard, balancing total weight across shards.
+
+    Greedy longest-processing-time over *bucket* weights. The instability that
+    makes LPT unusable over modules directly does not apply here: the input is
+    the durations file, not the collected set, so the table only changes when
+    someone regenerates durations deliberately.
+    """
+    bucket_weight = [0] * buckets
+    for module, weight in weights.items():
+        bucket_weight[bucket_of(module, buckets)] += weight
+
+    shard_load = [0] * splits
+    table = [0] * buckets
+    for bucket in sorted(range(buckets), key=lambda b: (-bucket_weight[b], b)):
+        target = min(range(splits), key=lambda s: (shard_load[s], s))
+        table[bucket] = target
+        shard_load[target] += bucket_weight[bucket]
+    return table
+
+
+def shard_of(module: str, table: List[int], buckets: int) -> int:
+    """The 0-based shard *module* belongs to."""
+    return table[bucket_of(module, buckets)]
+
+
+# ---------------------------------------------------------------------------
+# pytest plugin
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser) -> None:
+    group = parser.getgroup("stable-shard")
+    group.addoption("--shard-splits", type=int, default=0, help="Total shards (#14111). 0 disables sharding.")
+    group.addoption("--shard-group", type=int, default=1, help="1-based shard to run.")
+    group.addoption(
+        "--shard-durations",
+        default=".test_durations",
+        help="Durations file used to balance buckets across shards.",
+    )
+
+
+def pytest_collection_modifyitems(config, items) -> None:
+    """Deselect everything outside this shard, whole modules at a time."""
+    splits = config.getoption("--shard-splits")
+    if not splits or splits < 1:
+        return
+
+    group = config.getoption("--shard-group")
+    if not 1 <= group <= splits:
+        raise ValueError(f"--shard-group must be within 1..{splits}, got {group}")
+
+    durations = Path(config.rootpath) / config.getoption("--shard-durations")
+    table = build_bucket_table(load_module_weights(durations), splits, DEFAULT_BUCKETS)
+
+    selected, deselected = [], []
+    for item in items:
+        target = shard_of(module_of(item.nodeid), table, DEFAULT_BUCKETS)
+        (selected if target == group - 1 else deselected).append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+    items[:] = selected

--- a/repo_tests/stable_shard_test.py
+++ b/repo_tests/stable_shard_test.py
@@ -12,11 +12,10 @@ and quoted.
 import json
 
 import pytest
-
 from repo_tests.stable_shard import (
     DEFAULT_BUCKETS,
-    build_bucket_table,
     bucket_of,
+    build_bucket_table,
     load_module_weights,
     module_of,
     shard_of,
@@ -29,61 +28,108 @@ def _weights(n_modules=400, tests_per_module=8):
     return {f"pkg/mod_{i:04d}_test.py": tests_per_module for i in range(n_modules)}
 
 
-def _assignment(weights, splits=SPLITS):
-    table = build_bucket_table(weights, splits, DEFAULT_BUCKETS)
-    return {m: shard_of(m, table, DEFAULT_BUCKETS) for m in weights}
+def _assignment(collected, table, splits=SPLITS):
+    """Shard per collected module, through a table that is already built.
+
+    Mirrors production: the table comes from the durations file, the modules
+    come from whatever this run collected. Keeping the two apart is the whole
+    mechanism — see `TestStability`.
+    """
+    del splits  # the table already encodes it
+    return {m: shard_of(m, table, DEFAULT_BUCKETS) for m in collected}
 
 
 class TestStability:
-    """The property the whole change exists for."""
+    """The property the whole change exists for.
+
+    **The durations file and the collected set are different inputs**, and only
+    the first may feed the table. A PR that adds tests changes what is
+    *collected*; it does not touch `.test_durations`. That is precisely why the
+    assignment survives it.
+
+    An earlier version of these tests rebuilt the table from the mutated
+    collection and failed all four assertions — correctly. Rebuilding from what
+    was just collected destroys every property below, because adding a module
+    changes the weights, which changes the table, which re-deals everything. The
+    tests were wrong, not the implementation; this comment exists so the same
+    mistake is not made a third time.
+    """
 
     def test_adding_a_module_moves_no_existing_module(self):
-        base_w = _weights()
-        base = _assignment(base_w)
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+        base = _assignment(_weights(), table)
 
-        grown = dict(base_w)
-        grown["pkg/brand_new_test.py"] = 8
-        after = _assignment(grown)
+        collected = dict(_weights())
+        collected["pkg/brand_new_test.py"] = 8
+        after = _assignment(collected, table)
 
-        moved = [m for m in base_w if after[m] != base[m]]
+        moved = [m for m in _weights() if after[m] != base[m]]
         assert moved == [], f"{len(moved)} existing modules changed shard when one module was added"
 
     def test_growing_a_module_moves_no_other_module(self):
-        base_w = _weights()
-        base = _assignment(base_w)
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+        base = _assignment(_weights(), table)
 
-        grown = dict(base_w)
+        collected = dict(_weights())
         victim = "pkg/mod_0007_test.py"
-        grown[victim] += 50
-        after = _assignment(grown)
+        collected[victim] += 50
+        after = _assignment(collected, table)
 
-        moved = [m for m in base_w if m != victim and after[m] != base[m]]
+        moved = [m for m in _weights() if m != victim and after[m] != base[m]]
         assert moved == [], f"{len(moved)} unrelated modules changed shard when one module grew"
 
     def test_removing_a_module_moves_no_other_module(self):
-        base_w = _weights()
-        base = _assignment(base_w)
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+        base = _assignment(_weights(), table)
 
-        shrunk = dict(base_w)
-        del shrunk["pkg/mod_0100_test.py"]
-        after = _assignment(shrunk)
+        collected = dict(_weights())
+        del collected["pkg/mod_0100_test.py"]
+        after = _assignment(collected, table)
 
-        moved = [m for m in shrunk if after[m] != base[m]]
+        moved = [m for m in collected if after[m] != base[m]]
         assert moved == [], f"{len(moved)} modules changed shard when one module was removed"
 
     def test_a_module_keeps_its_shard_when_collection_is_partial(self):
         """A checkout missing optional deps collects fewer modules.
 
-        Under contiguous chunking that changed which tests a group named, so
-        "passes locally" could not clear a shard failure. Here the assignment
-        does not depend on what was collected at all.
+        Module-level `importorskip` means those tests are never collected, so
+        under contiguous chunking the same `--group N` named different tests
+        locally than on the runner — measured 2,096 against 1,991 for one
+        commit. That is why "passes locally" could not clear a shard failure.
+        Here the assignment does not consult the collected set at all.
         """
-        base_w = _weights()
-        full = _assignment(base_w)
-        partial = _assignment({m: w for i, (m, w) in enumerate(base_w.items()) if i % 3})
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+        full = _assignment(_weights(), table)
+        partial = _assignment({m: w for i, (m, w) in enumerate(_weights().items()) if i % 3}, table)
 
         for module in partial:
             assert partial[module] == full[module], f"{module} moved shard when collection was partial"
+
+    def test_a_module_absent_from_durations_still_gets_a_shard(self):
+        """15% of collected tests have no recorded duration. They must still be
+        assigned, and by the same rule — the table is consulted by hash, so a
+        module the durations file has never seen is not a special case."""
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+
+        shard = shard_of("pkg/never_measured_test.py", table, DEFAULT_BUCKETS)
+
+        assert 0 <= shard < SPLITS
+
+    def test_regenerating_durations_IS_allowed_to_re_deal(self):
+        """The one operation that legitimately reshuffles.
+
+        Named here so it is a known, deliberate act rather than a surprise: if
+        this ever stops being true the table has become independent of its own
+        input, which would mean the balancing pass is not running.
+        """
+        table = build_bucket_table(_weights(), SPLITS, DEFAULT_BUCKETS)
+        regenerated = build_bucket_table(
+            {m: (w + 40 if i % 2 else w) for i, (m, w) in enumerate(_weights().items())},
+            SPLITS,
+            DEFAULT_BUCKETS,
+        )
+
+        assert table != regenerated, "a materially different durations file should re-balance the table"
 
 
 class TestWholeModulesStayTogether:
@@ -99,13 +145,13 @@ class TestWholeModulesStayTogether:
 class TestPartition:
     def test_every_module_lands_in_exactly_one_shard_and_none_is_lost(self):
         weights = _weights()
-        assignment = _assignment(weights)
+        assignment = _assignment(weights, build_bucket_table(weights, SPLITS, DEFAULT_BUCKETS))
         assert set(assignment) == set(weights)
         assert all(0 <= s < SPLITS for s in assignment.values())
 
     def test_the_union_of_all_shards_is_the_whole_set(self):
         weights = _weights()
-        assignment = _assignment(weights)
+        assignment = _assignment(weights, build_bucket_table(weights, SPLITS, DEFAULT_BUCKETS))
         union = set()
         for shard in range(SPLITS):
             union |= {m for m, s in assignment.items() if s == shard}
@@ -122,7 +168,7 @@ class TestBalance:
         gates the whole job.
         """
         weights = {f"pkg/mod_{i:04d}_test.py": (i % 37) + 1 for i in range(1200)}
-        assignment = _assignment(weights)
+        assignment = _assignment(weights, build_bucket_table(weights, SPLITS, DEFAULT_BUCKETS))
         load = [0] * SPLITS
         for module, shard in assignment.items():
             load[shard] += weights[module]

--- a/repo_tests/stable_shard_test.py
+++ b/repo_tests/stable_shard_test.py
@@ -1,0 +1,168 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Properties the shard assignment must hold (#14111).
+
+The defect being fixed is not a wrong answer, it is an *unstable* one: with
+contiguous chunking, adding one test file re-deals every later shard, so a PR
+goes red on a failure nowhere near its diff. Stability is therefore the property
+under test here, and it is asserted as an invariant rather than measured once
+and quoted.
+"""
+
+import json
+
+import pytest
+
+from repo_tests.stable_shard import (
+    DEFAULT_BUCKETS,
+    build_bucket_table,
+    bucket_of,
+    load_module_weights,
+    module_of,
+    shard_of,
+)
+
+SPLITS = 12
+
+
+def _weights(n_modules=400, tests_per_module=8):
+    return {f"pkg/mod_{i:04d}_test.py": tests_per_module for i in range(n_modules)}
+
+
+def _assignment(weights, splits=SPLITS):
+    table = build_bucket_table(weights, splits, DEFAULT_BUCKETS)
+    return {m: shard_of(m, table, DEFAULT_BUCKETS) for m in weights}
+
+
+class TestStability:
+    """The property the whole change exists for."""
+
+    def test_adding_a_module_moves_no_existing_module(self):
+        base_w = _weights()
+        base = _assignment(base_w)
+
+        grown = dict(base_w)
+        grown["pkg/brand_new_test.py"] = 8
+        after = _assignment(grown)
+
+        moved = [m for m in base_w if after[m] != base[m]]
+        assert moved == [], f"{len(moved)} existing modules changed shard when one module was added"
+
+    def test_growing_a_module_moves_no_other_module(self):
+        base_w = _weights()
+        base = _assignment(base_w)
+
+        grown = dict(base_w)
+        victim = "pkg/mod_0007_test.py"
+        grown[victim] += 50
+        after = _assignment(grown)
+
+        moved = [m for m in base_w if m != victim and after[m] != base[m]]
+        assert moved == [], f"{len(moved)} unrelated modules changed shard when one module grew"
+
+    def test_removing_a_module_moves_no_other_module(self):
+        base_w = _weights()
+        base = _assignment(base_w)
+
+        shrunk = dict(base_w)
+        del shrunk["pkg/mod_0100_test.py"]
+        after = _assignment(shrunk)
+
+        moved = [m for m in shrunk if after[m] != base[m]]
+        assert moved == [], f"{len(moved)} modules changed shard when one module was removed"
+
+    def test_a_module_keeps_its_shard_when_collection_is_partial(self):
+        """A checkout missing optional deps collects fewer modules.
+
+        Under contiguous chunking that changed which tests a group named, so
+        "passes locally" could not clear a shard failure. Here the assignment
+        does not depend on what was collected at all.
+        """
+        base_w = _weights()
+        full = _assignment(base_w)
+        partial = _assignment({m: w for i, (m, w) in enumerate(base_w.items()) if i % 3})
+
+        for module in partial:
+            assert partial[module] == full[module], f"{module} moved shard when collection was partial"
+
+
+class TestWholeModulesStayTogether:
+    def test_every_test_in_a_module_lands_in_one_shard(self):
+        weights = _weights()
+        table = build_bucket_table(weights, SPLITS, DEFAULT_BUCKETS)
+        for module in weights:
+            ids = [f"{module}::test_{i}" for i in range(5)]
+            shards = {shard_of(module_of(i), table, DEFAULT_BUCKETS) for i in ids}
+            assert len(shards) == 1, f"{module} was split across shards {shards}"
+
+
+class TestPartition:
+    def test_every_module_lands_in_exactly_one_shard_and_none_is_lost(self):
+        weights = _weights()
+        assignment = _assignment(weights)
+        assert set(assignment) == set(weights)
+        assert all(0 <= s < SPLITS for s in assignment.values())
+
+    def test_the_union_of_all_shards_is_the_whole_set(self):
+        weights = _weights()
+        assignment = _assignment(weights)
+        union = set()
+        for shard in range(SPLITS):
+            union |= {m for m, s in assignment.items() if s == shard}
+        assert union == set(weights)
+
+
+class TestBalance:
+    def test_the_heaviest_shard_is_within_a_bounded_factor_of_the_lightest(self):
+        """Guards the reason a stable-but-useless assignment is not acceptable.
+
+        A pure hash is perfectly stable and gave 2.97x on real data; the bucket
+        table exists to get balance back. The bound is asserted so a future
+        change to bucketing cannot quietly unbalance CI — the slowest shard
+        gates the whole job.
+        """
+        weights = {f"pkg/mod_{i:04d}_test.py": (i % 37) + 1 for i in range(1200)}
+        assignment = _assignment(weights)
+        load = [0] * SPLITS
+        for module, shard in assignment.items():
+            load[shard] += weights[module]
+        assert max(load) / max(min(load), 1) < 1.5, f"shard load spread too wide: {sorted(load)}"
+
+
+class TestDurationsFileHandling:
+    def test_a_missing_durations_file_still_assigns(self, tmp_path):
+        assert load_module_weights(tmp_path / "nope.json") == {}
+        table = build_bucket_table({}, SPLITS, DEFAULT_BUCKETS)
+        assert len(table) == DEFAULT_BUCKETS
+        assert set(table) <= set(range(SPLITS))
+
+    def test_a_corrupt_durations_file_does_not_raise(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        assert load_module_weights(bad) == {}
+
+    def test_weights_count_tests_per_module(self, tmp_path):
+        path = tmp_path / "d.json"
+        path.write_text(
+            json.dumps({"a_test.py::test_x": 0.1, "a_test.py::test_y": 0.2, "b_test.py::test_z": 0.3}),
+            encoding="utf-8",
+        )
+        assert load_module_weights(path) == {"a_test.py": 2, "b_test.py": 1}
+
+
+class TestNodeIdParsing:
+    @pytest.mark.parametrize(
+        "nodeid,expected",
+        [
+            ("pkg/x_test.py::test_a", "pkg/x_test.py"),
+            ("pkg/x_test.py::TestC::test_a", "pkg/x_test.py"),
+            ("pkg/x_test.py::test_a[param::with::colons]", "pkg/x_test.py"),
+            ("pkg/x_test.py", "pkg/x_test.py"),
+        ],
+    )
+    def test_the_module_is_everything_before_the_first_separator(self, nodeid, expected):
+        assert module_of(nodeid) == expected
+
+    def test_bucketing_depends_only_on_the_path(self):
+        assert bucket_of("a/b_test.py", DEFAULT_BUCKETS) == bucket_of("a/b_test.py", DEFAULT_BUCKETS)
+        assert bucket_of("a/b_test.py", DEFAULT_BUCKETS) < DEFAULT_BUCKETS


### PR DESCRIPTION
## Thinking Path

#14111: unrelated tests fail inside `python-suite` shards when the split shifts, and a shard failure cannot be reproduced locally. Both symptoms come from one mechanism.

pytest-split's `duration_based_chunks` cuts the **collected list** into contiguous chunks. That keeps whole modules in one shard — the property `--dist loadscope` depends on — but it makes a shard's membership a function of that list's *order and membership*. So:

- Adding one test file shifts every downstream boundary. Not just the shard the file lands in — every later shard gets different neighbours, and a PR goes red on a failure nowhere near its diff. Measured on the real durations file: **1019 of 1283 modules** move when one module is added.
- A checkout missing optional dependencies collects a different set (module-level `importorskip` means those tests are never collected), so the same `--group N` names different tests locally than on the runner — measured **2096 locally against 1991** for one commit. That is why "passes locally" could never clear a shard failure.

## What Changed

`repo_tests/stable_shard.py`: hash each module path into one of 512 buckets, then map buckets to shards with a greedy longest-processing-time pass over **the durations file**.

The two-stage shape is the whole point, and the obvious one-stage alternatives both fail:

| Algorithm | Balance | Modules moved when one is added |
|---|---|---|
| contiguous (pytest-split) | — | re-deals every downstream shard |
| LPT directly over modules | 1.15x | **1019 of 1283** |
| pure hash → shard | 2.97x | 0 |
| **hash → 512 buckets → LPT** | **1.18x** | **0** |

LPT looks best on balance and is as unstable as what it replaces. Pure hash is perfectly stable and leaves one shard carrying ~3x another, which matters because the slowest shard gates the job.

**The table is built from `.test_durations`, never from the collected set.** A PR that adds tests changes what is collected; it does not touch that file. That separation *is* the stability. Balance is computed on **test count**, not recorded seconds — the durations file sums to ~338s while a shard takes minutes, so recorded duration describes a small fraction of real cost (import and collection dominate); balancing on it optimises the wrong quantity, and gives a 23.9x spread on the same data.

This PR adds the plugin and its tests only. It does nothing until something passes `--shard-splits`, which is the stacked **#14570**.

## Verification

```
repo_tests/stable_shard_test.py     18 passed
```

Against the real `.test_durations` (1282 modules, 22087 tests): **1.18x** spread, and **zero** modules move across 50 trials each of adding, growing and removing a module.

Properties asserted, not just measured once: adding/growing/removing moves nothing; a partial checkout assigns identically to a full one; whole modules never split; the heaviest shard stays within a bounded factor of the lightest; and regenerating durations **is** allowed to re-deal — named in a test so it is a known operation rather than a surprise.

**The tests were wrong before they were right**, and that is recorded in the file: an earlier version rebuilt the table from the mutated collection on both sides of each comparison, so it asserted a property the design deliberately does not have and failed all four stability cases. Another session independently hit the same mistake. The comment exists so it is not made a third time.

## Model Used

Opus 5

Refs #14111
