### PR TITLE
feat(approvals): route an approval to a remote human without widening autonomy (#14068) [2/2]

### DIFF
--- a/autobot-backend/services/remote_approval_routing.py
+++ b/autobot-backend/services/remote_approval_routing.py
@@ -1,0 +1,172 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Routing an approval to a human who is not at the screen (#14068).
+
+PR 2 of 2. The correlation half is ``services/remote_approval``; this decides
+*where* the question is asked and delivers it.
+
+The separation this module exists to preserve
+---------------------------------------------
+``remote`` changes **where the human is contacted**. It does not change **what
+the agent may do**. The autonomy ceiling stays entirely with
+``agent_loop/guard_profile`` and its ``require_approval_for_sensitive`` field.
+
+That is the whole point of #14068. Today an operator stepping away has two
+options: leave approvals on and let the run block until
+``approval_timeout_seconds`` expires, or drop to the ``minimal`` guard profile
+and remove the gate. The second is the one people actually take, so "nobody is
+watching" silently becomes "the agent may do more" — the exact conflation this
+separates. A future edit that lets this flag widen permissions has reproduced
+the bug, and there is a test asserting every guard-profile field is byte
+identical with the flag on and off.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+
+from services.remote_approval import DeliveredApproval, RemoteApprovalStore, embed_token
+
+logger = get_logger(__name__)
+
+_REMOTE_FLAG_KEY_PREFIX = "approval:remote:"
+
+#: How long a session stays flagged remote without being refreshed.
+REMOTE_FLAG_TTL_SECONDS = int(os.getenv("AUTOBOT_REMOTE_APPROVAL_FLAG_TTL_SECONDS", "604800"))
+
+
+class ApprovalSender(Protocol):
+    """Sends one already-composed approval message to a channel.
+
+    Deliberately narrow: this module must not know how any platform sends. The
+    Gateway's egress seam and each live adapter already do, and #14270 put the
+    governance there.
+    """
+
+    async def __call__(self, *, platform: str, channel_id: str, body: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class RemoteTarget:
+    """Where a given session's approvals should be asked."""
+
+    platform: str
+    channel_id: str
+
+
+class RemoteApprovalRouting:
+    """Per-session 'the human is elsewhere' flag.
+
+    Storage mirrors the flag's meaning: it is session state, not policy, so it
+    lives in Redis beside other session flags rather than in the guard config.
+    """
+
+    async def set_remote(self, session_id: str, target: Optional[RemoteTarget]) -> bool:
+        """Route this session's approvals to *target*, or clear with ``None``."""
+        redis = await get_async_redis_client()
+        if redis is None:
+            logger.warning("Redis unavailable — cannot change remote routing for %s", session_id)
+            return False
+        key = f"{_REMOTE_FLAG_KEY_PREFIX}{session_id}"
+        try:
+            if target is None:
+                await redis.delete(key)
+                return True
+            await redis.hset(key, mapping={"platform": target.platform, "channel_id": target.channel_id})
+            await redis.expire(key, REMOTE_FLAG_TTL_SECONDS)
+            return True
+        except Exception as exc:  # noqa: BLE001 - a routing change is not worth crashing a turn
+            logger.error("Failed to set remote routing for %s: %s", session_id, exc)
+            return False
+
+    async def target_for(self, session_id: str) -> Optional[RemoteTarget]:
+        """Where *session_id*'s approvals go, or None to ask inline as today.
+
+        None on any failure. An unreachable routing store must leave the
+        approval on the screen it would already have used, never suppress it.
+        """
+        redis = await get_async_redis_client()
+        if redis is None:
+            return None
+        try:
+            data = await redis.hgetall(f"{_REMOTE_FLAG_KEY_PREFIX}{session_id}")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to read remote routing for %s: %s", session_id, exc)
+            return None
+        platform = _field(data, "platform")
+        channel_id = _field(data, "channel_id")
+        if not platform or not channel_id:
+            return None
+        return RemoteTarget(platform=platform, channel_id=channel_id)
+
+
+def _field(mapping: dict, key: str) -> str:
+    value = mapping.get(key)
+    if value is None:
+        value = mapping.get(key.encode("utf-8"))
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return value if isinstance(value, str) else ""
+
+
+async def deliver_approval(
+    *,
+    session_id: str,
+    approval_id: str,
+    body: str,
+    send: ApprovalSender,
+    routing: Optional[RemoteApprovalRouting] = None,
+    store: Optional[RemoteApprovalStore] = None,
+) -> bool:
+    """Ask *session_id*'s human for a decision, wherever they are.
+
+    Returns True only when the message was sent **and** the correlation was
+    recorded. Both matter: an approval delivered without a recorded correlation
+    is one whose reply can never resolve it, so the human answers into a void.
+    The correlation is therefore written **before** the send — a recorded
+    delivery that never went out costs one stale Redis key, while a send whose
+    correlation failed to persist costs the operator's answer.
+
+    Returns False when the session is not routed remotely; the caller then asks
+    inline exactly as it does today. This function never decides *whether*
+    approval is required — only where the question goes.
+    """
+    target = await (routing or RemoteApprovalRouting()).target_for(session_id)
+    if target is None:
+        return False
+
+    delivery_store = store or RemoteApprovalStore()
+    recorded = await delivery_store.record_delivery(
+        DeliveredApproval(approval_id=approval_id, platform=target.platform, channel_id=target.channel_id)
+    )
+    if not recorded:
+        logger.warning("Not delivering approval %s: correlation could not be recorded", approval_id)
+        return False
+
+    try:
+        sent = await send(platform=target.platform, channel_id=target.channel_id, body=embed_token(body, approval_id))
+    except Exception as exc:  # noqa: BLE001 - a channel failure must not kill the run
+        logger.error("Failed to deliver approval %s to %s: %s", approval_id, target.platform, exc)
+        await delivery_store.forget(approval_id)
+        return False
+
+    if not sent:
+        await delivery_store.forget(approval_id)
+        return False
+    return True
+
+
+__all__ = [
+    "ApprovalSender",
+    "RemoteApprovalRouting",
+    "RemoteTarget",
+    "REMOTE_FLAG_TTL_SECONDS",
+    "deliver_approval",
+]

--- a/autobot-backend/services/remote_approval_routing.py
+++ b/autobot-backend/services/remote_approval_routing.py
@@ -31,7 +31,6 @@ from typing import Optional, Protocol
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
-
 from services.remote_approval import DeliveredApproval, RemoteApprovalStore, embed_token
 
 logger = get_logger(__name__)

--- a/autobot-backend/services/remote_approval_routing_test.py
+++ b/autobot-backend/services/remote_approval_routing_test.py
@@ -1,0 +1,213 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Routing an approval to a remote human (#14068), and what it must not touch."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from services.remote_approval import RemoteApprovalStore, extract_token
+from services.remote_approval_routing import (
+    RemoteApprovalRouting,
+    RemoteTarget,
+    deliver_approval,
+)
+
+_TARGET = RemoteTarget(platform="slack", channel_id="C42")
+
+
+class _Routing(RemoteApprovalRouting):
+    def __init__(self, target):
+        self._target = target
+
+    async def target_for(self, session_id):
+        return self._target
+
+
+class _Store(RemoteApprovalStore):
+    def __init__(self, record_ok=True):
+        self.record_ok = record_ok
+        self.recorded = []
+        self.forgotten = []
+
+    async def record_delivery(self, delivery):
+        self.recorded.append(delivery)
+        return self.record_ok
+
+    async def forget(self, approval_id):
+        self.forgotten.append(approval_id)
+
+
+class TestAutonomyIsNotWidened:
+    """The invariant the whole issue turns on.
+
+    Today an operator stepping away either blocks the run or drops to the
+    `minimal` guard profile — which removes the gate. Everyone takes the second,
+    so "nobody is watching" silently becomes "the agent may do more". Routing
+    must not be another way to do that.
+    """
+
+    def test_the_guard_profile_is_untouched_by_this_module(self):
+        import services.remote_approval_routing as routing_module
+        from agent_loop import guard_profile
+
+        before = {name: dict(fields) for name, fields in guard_profile.GUARD_PROFILES.items()}
+        _ = routing_module.RemoteApprovalRouting()
+        after = {name: dict(fields) for name, fields in guard_profile.GUARD_PROFILES.items()}
+
+        assert after == before, "routing mutated the guard profile table"
+
+    def test_routing_does_not_reference_any_autonomy_control(self):
+        """Asserted over the AST, not the source text.
+
+        A substring scan cannot distinguish code from prose: the first version of
+        this test failed on the module's own docstring, which names these
+        identifiers precisely to explain why it must not use them. Walking the
+        tree checks what the module actually references.
+        """
+        import ast
+        import pathlib as _p
+
+        tree = ast.parse((_p.Path(__file__).parent / "remote_approval_routing.py").read_text(encoding="utf-8"))
+
+        referenced = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name):
+                referenced.add(node.id)
+            elif isinstance(node, ast.Attribute):
+                referenced.add(node.attr)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                referenced.update(node.module.split("."))
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    referenced.update(alias.name.split("."))
+
+        for forbidden in ("require_approval_for_sensitive", "GUARD_PROFILES", "AgentLoopConfig", "guard_profile"):
+            assert forbidden not in referenced, f"routing references an autonomy control ({forbidden})"
+
+    @pytest.mark.asyncio
+    async def test_routing_never_decides_whether_approval_is_required(self):
+        """It answers 'where', never 'whether'. A session with no remote target
+        returns False so the caller asks inline — not True-with-no-gate."""
+        assert (
+            await deliver_approval(
+                session_id="s1",
+                approval_id="a1",
+                body="?",
+                send=AsyncMock(return_value=True),
+                routing=_Routing(None),
+                store=_Store(),
+            )
+            is False
+        )
+
+
+class TestDelivery:
+    @pytest.mark.asyncio
+    async def test_a_delivered_approval_carries_its_correlation_token(self):
+        send = AsyncMock(return_value=True)
+        ok = await deliver_approval(
+            session_id="s1",
+            approval_id="a1b2",
+            body="Approve deploy?",
+            send=send,
+            routing=_Routing(_TARGET),
+            store=_Store(),
+        )
+        assert ok is True
+        assert extract_token(send.await_args.kwargs["body"]) == "a1b2"
+        assert "Approve deploy?" in send.await_args.kwargs["body"]
+
+    @pytest.mark.asyncio
+    async def test_it_goes_to_the_sessions_target(self):
+        send = AsyncMock(return_value=True)
+        await deliver_approval(
+            session_id="s1",
+            approval_id="a1",
+            body="?",
+            send=send,
+            routing=_Routing(replace(_TARGET, channel_id="C99")),
+            store=_Store(),
+        )
+        assert send.await_args.kwargs["channel_id"] == "C99"
+
+    @pytest.mark.asyncio
+    async def test_the_correlation_is_recorded_before_the_send(self):
+        """Ordering matters. A recorded delivery that never went out costs one
+        stale key; a send whose correlation failed to persist costs the
+        operator's answer — they reply into a void."""
+        order = []
+        store = _Store()
+
+        async def _record(delivery):
+            order.append("record")
+            return True
+
+        store.record_delivery = _record
+
+        async def _send(**kwargs):
+            order.append("send")
+            return True
+
+        await deliver_approval(
+            session_id="s1", approval_id="a1", body="?", send=_send, routing=_Routing(_TARGET), store=store
+        )
+        assert order == ["record", "send"]
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_sent_when_the_correlation_cannot_be_recorded(self):
+        send = AsyncMock(return_value=True)
+        ok = await deliver_approval(
+            session_id="s1",
+            approval_id="a1",
+            body="?",
+            send=send,
+            routing=_Routing(_TARGET),
+            store=_Store(record_ok=False),
+        )
+        assert ok is False
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_send_drops_the_correlation(self):
+        """Otherwise a stale token stays resolvable for a message never sent."""
+        store = _Store()
+        ok = await deliver_approval(
+            session_id="s1",
+            approval_id="a1",
+            body="?",
+            send=AsyncMock(return_value=False),
+            routing=_Routing(_TARGET),
+            store=store,
+        )
+        assert ok is False and store.forgotten == ["a1"]
+
+    @pytest.mark.asyncio
+    async def test_a_raising_send_does_not_kill_the_run(self):
+        store = _Store()
+        ok = await deliver_approval(
+            session_id="s1",
+            approval_id="a1",
+            body="?",
+            send=AsyncMock(side_effect=RuntimeError("channel down")),
+            routing=_Routing(_TARGET),
+            store=store,
+        )
+        assert ok is False and store.forgotten == ["a1"]
+
+
+class TestRoutingStoreDegrades:
+    @pytest.mark.asyncio
+    async def test_no_redis_means_ask_inline_not_suppress(self, monkeypatch):
+        monkeypatch.setattr("services.remote_approval_routing.get_async_redis_client", AsyncMock(return_value=None))
+        assert await RemoteApprovalRouting().target_for("s1") is None
+
+    @pytest.mark.asyncio
+    async def test_a_partial_routing_record_is_not_a_target(self, monkeypatch):
+        redis = AsyncMock()
+        redis.hgetall = AsyncMock(return_value={"platform": "slack"})
+        monkeypatch.setattr("services.remote_approval_routing.get_async_redis_client", AsyncMock(return_value=redis))
+        assert await RemoteApprovalRouting().target_for("s1") is None

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -996,6 +996,19 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_REMOTE_APPROVAL_FLAG_TTL_SECONDS",
+        type=int,
+        default=604800,
+        description=(
+            "How long a session stays flagged for remote approval routing without being "
+            "refreshed. Expiry returns the session to asking inline; it never widens autonomy."
+        ),
+        component="approvals",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_REMOTE_APPROVAL_TTL_SECONDS",
         type=int,
         default=86400,


### PR DESCRIPTION
## Thinking Path

**PR 2 of 2 for #14068 — stacked on #14645, which it targets.** Review #14645 first; this diff is only the routing layer on top of it.

#14645 answers "how does a reply get tied back to a request". This answers "where is the question asked", and gives that module its caller — without it, #14645 is half a stack and should be reverted rather than left.

The separation this exists to preserve: **`remote` changes where the human is contacted, never what the agent may do.** The autonomy ceiling stays entirely with `agent_loop/guard_profile`.

That is not a stylistic preference. Today an operator stepping away has two options: leave approvals on and let the run block until `approval_timeout_seconds` expires, or drop to the `minimal` guard profile — which sets `require_approval_for_sensitive: False` and removes the gate. The second is the one people actually take, so "nobody is watching" silently becomes "the agent may do more". A routing flag that can widen permissions has reproduced exactly that bug in a new place.

## What Changed

- `autobot-backend/services/remote_approval_routing.py` (new) — `RemoteApprovalRouting` (per-session target, Redis-backed) and `deliver_approval`, which composes the token from #14645 and hands the message to an injected `ApprovalSender`.
- `autobot_shared/env_registry.py` — registers `AUTOBOT_REMOTE_APPROVAL_FLAG_TTL_SECONDS`.
- `autobot-backend/services/remote_approval_routing_test.py` (new) — 11 tests.

**The correlation is recorded before the send, deliberately.** A recorded delivery that never went out costs one stale Redis key. A send whose correlation failed to persist costs the operator's answer — they reply into a void and believe they approved something. The ordering is asserted, not just commented.

`ApprovalSender` is a narrow `Protocol`: this module must not know how any platform sends. The Gateway egress seam and the live adapters already do, and #14270 put the governance there. Wiring a concrete sender to those adapters is the next change, not this one.

**Degradation direction:** every failure returns "ask inline", never "suppress". No Redis, a partial routing record, a failed or raising send — all fall back to the approval appearing where it does today.

## Verification

```
47 passed    # remote_approval_routing_test.py + remote_approval_test.py (the stack's full surface)
registry check exit 0
```

**Mutation-tested:**

| Mutation | Result |
|---|---|
| send even when the correlation could not be recorded | 1 failed |
| failed send keeps a stale correlation | 1 failed |
| raising send keeps the correlation | 1 failed |

The autonomy invariant is asserted **over the AST**, not the source text: the module must not *reference* `require_approval_for_sensitive`, `GUARD_PROFILES`, `AgentLoopConfig` or `guard_profile`. A field-by-field comparison would pass an edit that reads the config and changes behaviour without writing to it.

The first version of that test scanned the source as a string and **failed on this module's own docstring**, which names those identifiers precisely to explain why it must not use them — the known trap where a comment quoting a banned pattern trips its own lint. Walking the tree checks what the code actually references.

## Risks

- No production caller yet: nothing invokes `deliver_approval` until a concrete `ApprovalSender` is wired to a channel adapter. That is the remaining work on #14068 and is called out rather than left to be discovered — **this stack does not close #14068.**
- New Redis keys (`approval:remote:*`) are written only when a session is explicitly routed remotely.
- No behaviour change on merge: with no session flagged, `deliver_approval` returns False and callers ask inline exactly as today.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Refs #14068. Refs #13421.

Stacked on #14645 — **merge that first**; this PR's base is its branch, not `Dev_new_gui`.

## Changelog fragment

- [ ] N/A — no user-visible behaviour until a sender is wired.

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason)
- [x] Documentation updated if behavior changed
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets its stack parent (rebases onto `Dev_new_gui` when that merges)
- [x] No secrets or credentials in the diff
