### PR TITLE
fix(provision): gate the setup-wizard ansible-group builder on declared roles (#14638)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -31,7 +31,7 @@ from services.ansible_secrets import fetch_deploy_secrets
 from services.ansible_utils import _extract_failure_summary
 from services.auth import get_current_user
 from services.database import db_service
-from services.inventory_builder import _declared_roles, groups_for_role_tokens
+from services.inventory_builder import _DECLARED_ONLY_GROUPS, _declared_roles, groups_for_role_tokens
 from services.playbook_executor import ANSIBLE_LOCAL_TMP, get_playbook_executor, link_group_vars
 from services.role_registry import ROLE_ANSIBLE_GROUPS
 
@@ -110,34 +110,92 @@ async def _set_setting(key: str, value: str) -> None:
         await session.commit()
 
 
-def _ansible_groups_for_nodes(node_roles, node_id_to_inv_name: dict[str, str]) -> dict[str, set[str]]:
+def _groups_for_role_tokens_both_vocabularies(role_tokens: list[str]) -> set[str]:
+    """Union of the canonical map AND the legacy ``ROLE_ANSIBLE_GROUPS`` one.
+
+    Split out so both the raw (all NodeRole rows) and declared (Node.roles
+    alone) group sets in ``_ansible_groups_for_nodes`` are computed the same
+    way -- a role like ``vnc`` reaches ``backend`` ONLY through the legacy
+    map (it has no entry in ``inventory_builder._ROLE_TO_GROUPS`` at all), so
+    computing "declared" through the canonical map alone would strip a role
+    the node genuinely declared (#14638).
+    """
+    groups = set(groups_for_role_tokens(role_tokens))
+    for token in role_tokens:
+        legacy = ROLE_ANSIBLE_GROUPS.get(token)
+        if legacy:
+            groups.add(legacy)
+    return groups
+
+
+def _ansible_groups_for_nodes(
+    node_roles,
+    node_id_to_inv_name: dict[str, str],
+    db_nodes: list,
+) -> dict[str, set[str]]:
     """Group name -> inventory names, unioning both vocabularies (#14286).
 
     Split out of ``_build_inventory_children`` to keep it under the length
     rule. The union is the point: neither map is a superset of the other, so
     dropping either would trade one set of silent no-ops for another.
 
+    #14638: the result is gated the same way the dynamic-inventory builder
+    gates its own groups (``_strip_undeclared_privileged_groups``,
+    #14513/#14552) -- a node whose only route into a privileged group
+    (``slm_server``, ``backend``, ``main``, ``frontend``, ``aiml``, ``npu``,
+    ``browser``) is a ``NodeRole`` row it never declared must not join it.
+    The check reads ``Node.roles`` directly through ``db_nodes`` -- the same
+    source #14637 uses for ``node_roles_declared`` -- rather than trusting the
+    ``NodeRole`` assignment table ``node_roles`` itself is built from, so the
+    gate survives a future writer that stops keeping that table declared-only
+    instead of depending on it staying that way (#14594).
+
+    ``_strip_undeclared_privileged_groups`` itself is not reused here: it
+    computes "declared" through ``groups_for_role_tokens`` alone, and this
+    path's raw side unions in ``ROLE_ANSIBLE_GROUPS`` too -- reusing it as-is
+    would strip a role (``vnc`` -> ``backend``) that is declared but only
+    reachable through the second vocabulary. Both sides go through
+    ``_groups_for_role_tokens_both_vocabularies`` instead, so "declared" and
+    "raw" agree on what a role token means.
+
     Args:
         node_roles: NodeRole rows, each carrying ``node_id`` and ``role_name``.
         node_id_to_inv_name: node id -> the name the inventory uses.
+        db_nodes: Node ORM rows -- the source of declared intent (Node.roles)
+            used to strip groups a node only reached via detection.
 
     Returns:
-        Every group each host belongs to, from both mappings.
+        Every group each host belongs to, from both mappings, privileged
+        groups stripped for any node that did not declare its way in.
     """
     roles_by_node: dict[str, list[str]] = {}
-    groups: dict[str, set[str]] = {}
+    raw_node_groups: dict[str, set[str]] = {}
 
     for nr in node_roles:
         inv_name = node_id_to_inv_name.get(nr.node_id)
         if not inv_name:
             continue
         roles_by_node.setdefault(inv_name, []).append(nr.role_name)
-        legacy = ROLE_ANSIBLE_GROUPS.get(nr.role_name)
-        if legacy:
-            groups.setdefault(legacy, set()).add(inv_name)
 
     for inv_name, role_tokens in roles_by_node.items():
-        for group in groups_for_role_tokens(role_tokens):
+        raw_node_groups[inv_name] = _groups_for_role_tokens_both_vocabularies(role_tokens)
+
+    declared_roles_by_inv: dict[str, list[str]] = {}
+    for node in db_nodes:
+        inv_name = node_id_to_inv_name.get(node.node_id)
+        if inv_name:
+            declared_roles_by_inv[inv_name] = _declared_roles(node)
+
+    groups: dict[str, set[str]] = {}
+    for inv_name, node_group_set in raw_node_groups.items():
+        undeclared = node_group_set & _DECLARED_ONLY_GROUPS
+        if undeclared:
+            # A node this path cannot resolve back to a Node row has no
+            # declared intent to stand on -- absent means [], which fails
+            # closed rather than skipping the gate.
+            declared_groups = _groups_for_role_tokens_both_vocabularies(declared_roles_by_inv.get(inv_name, []))
+            node_group_set = node_group_set - (undeclared - declared_groups)
+        for group in node_group_set:
             groups.setdefault(group, set()).add(inv_name)
 
     return groups
@@ -147,6 +205,7 @@ def _build_inventory_children(
     hosts: dict[str, dict],
     node_roles: list,
     node_id_to_inv_name: dict[str, str],
+    db_nodes: list,
 ) -> tuple[dict[str, dict], dict[str, set[str]]]:
     """Build Ansible inventory ``children`` with role-based groups (#1346).
 
@@ -173,7 +232,7 @@ def _build_inventory_children(
     # and read back by nothing, so they contributed no activation at all;
     # ROLE_ANSIBLE_GROUPS now names the consulted spellings (`database`,
     # `browser`), which the canonical map emits too.
-    ansible_groups = _ansible_groups_for_nodes(node_roles, node_id_to_inv_name)
+    ansible_groups = _ansible_groups_for_nodes(node_roles, node_id_to_inv_name, db_nodes)
 
     children: dict[str, dict] = {
         "slm_nodes": {"hosts": {h: None for h in hosts}},
@@ -601,7 +660,7 @@ async def _generate_dynamic_inventory(
         return None
 
     (
-        _db_nodes,
+        db_nodes,
         hosts,
         node_id_to_hostname,
         _node_id_to_ip,
@@ -616,8 +675,10 @@ async def _generate_dynamic_inventory(
     # carries group membership, and roles whose mapped group isn't the one
     # role_*_active checks (tts-worker, browser-service) silently never deploy —
     # the provision reports failed=0 while optional roles stay inactive.
-    _apply_role_host_vars(hosts, _db_nodes, all_node_roles)
-    children, ansible_groups = _build_inventory_children(hosts, all_node_roles, node_id_to_hostname)
+    _apply_role_host_vars(hosts, db_nodes, all_node_roles)
+    # #14638: db_nodes carries Node.roles, the declared-intent source
+    # _ansible_groups_for_nodes gates privileged group membership on.
+    children, ansible_groups = _build_inventory_children(hosts, all_node_roles, node_id_to_hostname, db_nodes)
     infra_vars = _build_infra_vars(all_active, all_ip_map, local_ips)
     # For co-located ai-stack (injected, no dedicated AI stack VM), _build_infra_vars
     # never sees the injected role because it reads from DB node_roles, not the

--- a/autobot-slm-backend/tests/services/test_wizard_inventory_parity_14286.py
+++ b/autobot-slm-backend/tests/services/test_wizard_inventory_parity_14286.py
@@ -127,12 +127,19 @@ _build_inventory_children = _wiz._build_inventory_children
 
 
 def _children_for(roles_by_node: dict[str, list[str]]) -> dict[str, dict]:
-    """Run the wizard's real children builder over a fleet."""
+    """Run the wizard's real children builder over a fleet.
+
+    #14638: every role here is treated as DECLARED (db_nodes.roles mirrors
+    roles_by_node) -- this module tests vocabulary parity between the two
+    group builders, not the declared/detected distinction, which has its own
+    coverage in ``setup_wizard_group_privileged_test.py``.
+    """
     hosts = {n: {} for n in roles_by_node}
     node_roles = [
         SimpleNamespace(node_id=node, role_name=role) for node, roles in roles_by_node.items() for role in roles
     ]
-    children, _groups = _build_inventory_children(hosts, node_roles, {n: n for n in roles_by_node})
+    db_nodes = [SimpleNamespace(node_id=node, roles=list(roles)) for node, roles in roles_by_node.items()]
+    children, _groups = _build_inventory_children(hosts, node_roles, {n: n for n in roles_by_node}, db_nodes)
     return children
 
 
@@ -372,3 +379,101 @@ def test_the_wizard_path_links_group_vars():
         if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
     }
     assert "link_group_vars" in called, "the wizard inventory still has no group_vars sibling"
+
+
+# --------------------------------------------------------------------------
+# 5. #14638 -- a detected-but-undeclared role must not join a privileged GROUP
+#    through this path either. Mirrors services/inventory_detected_roles_test.py
+#    (#14513, the dynamic-inventory builder's own group gate) for the wizard's
+#    independent group builder, and setup_wizard_privileged_node_roles_test.py
+#    (#14594, the node_roles/node_roles_declared hostvar branch) for the
+#    sibling activation path this issue closes on the GROUP side.
+# --------------------------------------------------------------------------
+
+_ansible_groups_for_nodes = _wiz._ansible_groups_for_nodes
+_DECLARED_ONLY_GROUPS = _ib._DECLARED_ONLY_GROUPS
+
+
+def _groups_for(node_id: str, node_role_names: list, declared_roles: list) -> dict:
+    """Run the wizard's real GROUP builder for one node.
+
+    ``node_role_names`` is every ``NodeRole`` row's ``role_name`` (the
+    assignment table) for the node; ``declared_roles`` is ``Node.roles`` --
+    deliberately allowed to diverge, to prove group membership follows
+    Node.roles and not the NodeRole table (#14638).
+    """
+    node_roles = [SimpleNamespace(node_id=node_id, role_name=r) for r in node_role_names]
+    db_nodes = [SimpleNamespace(node_id=node_id, roles=list(declared_roles))]
+    return _ansible_groups_for_nodes(node_roles, {node_id: node_id}, db_nodes)
+
+
+def test_detected_only_node_does_not_join_any_privileged_group():
+    """The #14638 reproduction: a NodeRole row exists for every privileged
+    role, but Node.roles is empty -- nothing was declared."""
+    detected = ["frontend", "backend", "ai-stack", "npu-worker", "browser-service", "vnc"]
+    groups = _groups_for("detected-only-node", detected, declared_roles=[])
+
+    joined = {g for g in _DECLARED_ONLY_GROUPS if "detected-only-node" in groups.get(g, set())}
+    assert not joined, f"detected-only node joined privileged group(s) via the wizard path: {sorted(joined)}"
+
+
+def test_declared_node_still_joins_its_privileged_group():
+    """Over-tight check, mirrors #14552's test_ordinary_groups_are_not_swept_in."""
+    groups = _groups_for("declared-frontend-node", ["frontend"], declared_roles=["frontend"])
+    assert "declared-frontend-node" in groups.get("frontend", set())
+
+    backend_groups = _groups_for("declared-backend-node", ["backend"], declared_roles=["backend"])
+    assert "declared-backend-node" in backend_groups.get("main", set())
+
+
+def test_a_role_reached_only_through_the_legacy_vocabulary_still_gates_correctly():
+    """``vnc`` maps to ``backend`` ONLY through ``ROLE_ANSIBLE_GROUPS`` --
+    absent from ``inventory_builder._ROLE_TO_GROUPS`` entirely. Proves the
+    declared-side check uses the same union of vocabularies as the raw side,
+    not the canonical map alone (a bug this PR's own first draft had)."""
+    detected_only = _groups_for("vnc-detected", ["vnc"], declared_roles=[])
+    assert "vnc-detected" not in detected_only.get("backend", set())
+
+    declared = _groups_for("vnc-declared", ["vnc"], declared_roles=["vnc"])
+    assert "vnc-declared" in declared.get("backend", set())
+
+
+def test_detection_still_grants_ordinary_groups_through_the_wizard_path():
+    """Non-regression: the #14513 carve-out holds here too -- an undeclared
+    but detected redis role still joins redis/database."""
+    groups = _groups_for("redis-detected", ["redis"], declared_roles=[])
+    assert "redis-detected" in groups.get("redis", set())
+    assert "redis-detected" in groups.get("database", set())
+
+
+def test_deliberately_union_role_keeps_its_non_privileged_group():
+    """tts-worker's ``npu_worker`` membership (legacy-vocabulary only) is not
+    privileged and must survive detection alone -- mirrors
+    ``role_tts_worker_active``'s deliberate node_roles-only activation
+    (#9965), on the group side."""
+    groups = _groups_for("tts-detected", ["tts-worker"], declared_roles=[])
+    assert "tts-detected" in groups.get("npu_worker", set())
+    assert "tts-detected" not in groups.get("aiml", set())
+
+
+def test_an_unresolved_node_fails_closed():
+    """A NodeRole row whose node_id has no matching db_nodes entry must not
+    default to open -- its privileged groups strip to nothing rather than
+    passing through unfiltered."""
+    node_roles = [SimpleNamespace(node_id="ghost-node", role_name="backend")]
+    groups = _ansible_groups_for_nodes(node_roles, {"ghost-node": "ghost-node"}, db_nodes=[])
+    assert "ghost-node" not in groups.get("backend", set())
+
+
+def test_the_wizard_inventory_path_end_to_end_via_build_inventory_children():
+    """Drives the real caller, not just the inner helper -- proves the
+    wiring, not only the function in isolation."""
+    hosts = {"detected-only-node": {}}
+    node_roles = [SimpleNamespace(node_id="detected-only-node", role_name="frontend")]
+    db_nodes = [SimpleNamespace(node_id="detected-only-node", roles=[])]
+    children, groups = _build_inventory_children(
+        hosts, node_roles, {"detected-only-node": "detected-only-node"}, db_nodes
+    )
+
+    assert "detected-only-node" not in groups.get("frontend", set())
+    assert "frontend" not in children or "detected-only-node" not in children["frontend"]["hosts"]


### PR DESCRIPTION
Closes #14638

## Thinking Path

Read `_ansible_groups_for_nodes` (the setup-wizard's own ansible-group
builder, `api/setup_wizard.py`) and traced everything that feeds it, per
#14638's ask. It builds group membership from the `NodeRole` assignment
table with no gate at all — unlike `services/inventory_builder.py`'s
`build_registry_inventory`, which has called
`_strip_undeclared_privileged_groups` on the group branch since #14513/#14552.
This is the second half of the shape #14594/#14637 fixed for the *hostvar*
branch (`node_roles_declared`): same defect class, different code path
(`_ansible_groups_for_nodes` vs `_apply_role_host_vars`), which is why it was
filed and fixed separately.

Root cause: `_ansible_groups_for_nodes(node_roles, node_id_to_inv_name)` in
`api/setup_wizard.py:113` (pre-fix) unions two group vocabularies
(`services/inventory_builder.groups_for_role_tokens` and the legacy
`services/role_registry.ROLE_ANSIBLE_GROUPS`) for every `NodeRole` row it is
given, with nothing filtering the privileged groups
(`slm_server`/`backend`/`main`/`frontend`/`aiml`/`npu`/`browser`,
`inventory_builder._DECLARED_ONLY_GROUPS`) the way the dynamic-inventory
builder's own group branch already does.

## What Changed

- `api/setup_wizard.py::_ansible_groups_for_nodes` now takes `db_nodes` (Node
  ORM rows) and strips privileged groups a node's `Node.roles` does not
  justify — reading declared intent straight off `Node.roles`
  (`inventory_builder._declared_roles`), the same source #14637 uses for
  `node_roles_declared`, rather than trusting the `NodeRole` table to stay
  declared-only. `_build_inventory_children` and `_generate_dynamic_inventory`
  thread `db_nodes` through.
- Added `_groups_for_role_tokens_both_vocabularies`: both the "raw" and
  "declared" group sets are computed through the same union of the canonical
  map and the legacy `ROLE_ANSIBLE_GROUPS` map. `_strip_undeclared_privileged_groups`
  itself is deliberately NOT reused as-is — it only consults the canonical map,
  and the wizard's raw side also unions in `ROLE_ANSIBLE_GROUPS` (e.g. `vnc`
  reaches `backend` *only* through that legacy map). Reusing it unmodified
  would have stripped a genuinely declared `vnc` node's `backend` membership —
  caught by mutation-testing my own first draft against the existing
  `test_no_group_this_path_already_emitted_disappears` parity test.
- An unresolved node (a `NodeRole` row whose `node_id` has no matching
  `db_nodes` entry) fails closed: its privileged groups strip to nothing
  rather than passing through unfiltered.
- Extended `tests/services/test_wizard_inventory_parity_14286.py` (already the
  colocated, correctly-real-loaded home for this builder's tests) with 8 new
  tests covering the detected-only, declared, legacy-vocabulary, unresolved-node
  and end-to-end-via-`_build_inventory_children` cases.
- Updated the existing `_children_for` test helper to mark every role as
  declared (matching the file's existing "vocabulary parity" scope), and
  `_build_inventory_children`'s only other test call site.

## Verification

Full enumeration of every path from a *detected* role to a privileged group
or privileged activation fact, across both the dynamic-inventory builder and
the setup wizard (the deliverable #14638 asked for):

| # | Path | Gate | Verdict |
|---|---|---|---|
| 1 | `services/inventory_builder.py:438` `build_registry_inventory` GROUP branch | `_strip_undeclared_privileged_groups` (#14513/#14552) | SAFE |
| 2 | `services/inventory_builder.py:327` `node_roles` hostvar (raw union) | privileged facts don't read this branch any more (#14560/#14589 repointed them) | SAFE — non-privileged facts (tts-worker/redis/vnc/xrdp/llm) deliberately still do (#9965) |
| 3 | `services/inventory_builder.py:334` `node_roles_declared` hostvar | `_declared_roles(node)` = `Node.roles` only | SAFE (#14560/#14589) |
| 4 | `api/setup_wizard.py` `_ansible_groups_for_nodes` GROUP branch | **was ungated** | **FIXED by this PR (#14638)** |
| 5 | `api/setup_wizard.py:394` `node_roles` hostvar (raw union from `NodeRole` table) | same reasoning as #2 | SAFE |
| 6 | `api/setup_wizard.py` `node_roles_declared` hostvar | `_declared_roles(node)` = `Node.roles` directly | SAFE (#14594/#14637, `e8517c3e6`) |
| 7 | `api/setup_wizard.py` `_inject_co_located_ai_stack` (#3461) | stamps both `node_roles` and `node_roles_declared`; never reaches the GROUP builder at all (only the in-memory hostvar dict) | SAFE / deliberate, unaffected by this PR — confirmed by regression test |
| 8 | `ansible/playbooks/vars/role_active_facts.yml` five privileged facts | both branches (group + `node_roles_declared`) now gated on both builders | SAFE |
| 9 | Static inventories (`ansible/inventory/slm-nodes.yml`, CI fixtures) | operator-authored, definitionally declared; `node_roles_declared` fallback intentionally preserved | SAFE by design |
| 10 | Every other caller of `groups_for_role_tokens` / `ROLE_ANSIBLE_GROUPS` | grepped — none exist outside the two builders above | N/A, no third path |

Also audited every `NodeRole(...)` / `Node.roles =` write site in
`api/`, `services/`, `main.py` (the thing both builders' "declared" side
ultimately trusts): SLM-manager bootstrap and `node_seeder.sync_slm_node_roles`
are bounded by a hardcoded/existing declared set; `compose_fleet.py`'s
`_ensure_compose_nodes` derives from a hardcoded topology table (declared by
construction, not agent-probed — a producer not previously named in #14594's
provenance table, documented here for completeness); `sync_orchestrator.py`'s
role-sync only touches an operator-selected role already on the node;
`api/nodes.py`, `api/npu.py` are authenticated admin endpoints;
`deployment.py`/`reconciler.py`/`blue_green.py` only ever *subtract* roles or
move already-declared roles between paired nodes. The one place
`Node.detected_roles` (the untrusted agent heartbeat probe) is written
(`api/nodes.py:1872`) never reaches `Node.roles` or the `NodeRole` table —
detection stays correctly firewalled from declared intent everywhere.

**Test run** (local design-aid only — CI is authoritative):
`pytest tests/services/test_wizard_inventory_parity_14286.py` — 16/16 passed
after the fix.

**Mutation**: reverted the gate in `_ansible_groups_for_nodes` (dropped the
`_DECLARED_ONLY_GROUPS` stripping) → 11 passed / 5 failed, all 5 failures the
new detected-only/legacy-vocabulary/unresolved-node/end-to-end tests, exactly
as expected. Restored the fix → back to 16/16.

Also ran the full existing coverage for this area unmodified —
`setup_wizard_privileged_node_roles_test.py`,
`inventory_privileged_node_roles_test.py`, `inventory_detected_roles_test.py`,
`node_roles_declared_producers_test.py`, `inventory_deploy_groups_test.py`:
43/43 passed. A broader `autobot-slm-backend/api autobot-slm-backend/services
autobot-slm-backend/tests` run: 2189 passed, 3 skipped, 5 failed — the 5
failures are `services/hf_token_validator_test.py`, pre-existing and
unrelated (fail identically in complete isolation, before touching any file
this PR changes — a local `httpx`-import gap in this environment).

## Model Used

Claude Opus 5 (1M context)