### PR TITLE
fix(egress): mask email and reduce the Teams webhook URL before the governor (#14573)

### DIFF
--- a/autobot-backend/api/integration_communication.py
+++ b/autobot-backend/api/integration_communication.py
@@ -11,6 +11,7 @@ listing channels/guilds.
 """
 
 from typing import Any, Dict, List
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -196,6 +197,11 @@ async def send_message(
     # `message.channel_id` (see `SendMessageRequest`) — read whichever the
     # request populated, or the audit record silently records an empty
     # identifier for every Slack send.
+    # Teams has no channel target in this schema at all — `SendMessageRequest`
+    # carries no webhook field, so `raw_channel_id` is "" for it by
+    # construction, not a bug (#14573). The Teams identifier that IS
+    # reachable lives in `send_webhook_message` below, which reduces the
+    # webhook URL to its host.
     # The HTTPException below carries a fixed message, never verdict.reason —
     # that field is audit-facing only and can carry raw approver-exception text
     # once #14068 registers real approvers (#14539).
@@ -300,9 +306,19 @@ async def send_webhook_message(
     # says nothing about this one, which reaches the same Teams webhook by its
     # own route — so governing that function left this bypass wide open, reading
     # as covered because the governor appears elsewhere in the module.
-    verdict = await egress_governor.evaluate(platform="teams", channel_id="", message_id="")
+    #
+    # channel_id used to be passed as "" unconditionally (#14573). A Teams
+    # webhook URL embeds a bearer token in its path
+    # (https://.../webhook/<token>/IncomingWebhook/<token>/...) — directly
+    # usable outside this system, the same shape notification_service's
+    # webhook seam already reduces to hostname. Applied here to the audit
+    # record and the denial log line alike (channel-identity rule, #14540).
+    host = urlparse(webhook.webhook_url).hostname or "unknown"
+    verdict = await egress_governor.evaluate(platform="teams", channel_id=host, message_id="")
     if not verdict.allowed:
-        logger.warning("teams webhook send blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+        logger.warning(
+            "teams webhook send to %s blocked by egress governance (%s): %s", host, verdict.rule, verdict.reason
+        )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Outbound send denied by egress policy")
 
     try:

--- a/autobot-backend/services/gateway/egress_governor.py
+++ b/autobot-backend/services/gateway/egress_governor.py
@@ -45,12 +45,18 @@ answer "how much of it" from what the raw value IS, not which platform sends
 it:
 
 * A value that is directly usable **outside** this system on its own — a
-  dialable phone number, a URL whose path embeds a bearer token — is reduced
-  before it reaches :meth:`EgressGovernor.evaluate`
+  dialable phone number, a URL whose path embeds a bearer token, an email
+  address — is reduced before it reaches :meth:`EgressGovernor.evaluate`
   (``whatsapp_integration._mask_phone``,
-  ``notification_service._send_webhook``'s ``urlparse(url).hostname``).
-  Recording it whole would hand PII or a credential to anyone who can read
-  the audit trail or the logs.
+  ``notification_service._send_webhook``'s ``urlparse(url).hostname``,
+  ``notification_service._mask_email``,
+  ``integration_communication.send_webhook_message``'s
+  ``urlparse(webhook_url).hostname`` for Teams). Recording it whole would
+  hand PII or a credential to anyone who can read the audit trail or the
+  logs. #14573: an *absent* identifier is the same failure in miniature — a
+  caller must never pass ``""`` as a stand-in for "no reduction needed"; if a
+  call site genuinely has no channel identifier available, that is a
+  documented decision at the call site, not a silent default.
 * A value that is an **opaque identifier scoped to this system's own
   platform credential** — a Telegram ``chat_id``, a Slack/Discord
   ``channel_id`` — is recorded as-is. It resolves to a person only through

--- a/autobot-backend/services/gateway/live_egress_seams_test.py
+++ b/autobot-backend/services/gateway/live_egress_seams_test.py
@@ -495,3 +495,78 @@ class TestChannelIdentityRule:
 
         assert "hooks.example.invalid" in caplog.text
         assert "secret-token-path" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_email_is_masked_before_reaching_the_governor(self):
+        """#14573: channel_id used to be "" unconditionally. An email address
+        is directly usable outside this system — reduce it, per the rule."""
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        spy = AsyncMock(side_effect=_allow)
+        with patch("services.notification_service.egress_governor.evaluate", new=spy):
+            with patch("smtplib.SMTP"), patch("smtplib.SMTP_SSL"):
+                try:
+                    await svc._send_email("jane.doe@example.invalid", "subj", "body")
+                except Exception:
+                    pass  # transport is stubbed; the governance call is what matters
+
+        channel_id = spy.await_args.kwargs["channel_id"]
+        assert channel_id != ""
+        assert "jane.doe" not in channel_id
+        assert channel_id.endswith("@example.invalid")
+
+    @pytest.mark.asyncio
+    async def test_email_denial_log_line_masks_the_local_part(self, caplog):
+        from services.notification_service import NotificationService
+
+        svc = NotificationService()
+        with caplog.at_level(logging.WARNING):
+            with patch("services.notification_service.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+                with patch("smtplib.SMTP"), patch("smtplib.SMTP_SSL"):
+                    await svc._send_email("jane.doe@example.invalid", "subj", "body")
+
+        assert "jane.doe" not in caplog.text
+        assert "example.invalid" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_teams_webhook_host_is_passed_to_the_governor(self):
+        """#14573: channel_id used to be "" unconditionally. A Teams webhook
+        URL embeds a bearer token in its path — reduce it to the host, the
+        same precedent notification_service's webhook seam already sets."""
+        from api.integration_communication import send_webhook_message
+
+        integration = MagicMock()
+        integration.execute_action = AsyncMock(return_value={"success": True})
+        spy = AsyncMock(side_effect=_allow)
+        with patch("api.integration_communication.egress_governor.evaluate", new=spy):
+            with patch("api.integration_communication.TeamsIntegration", return_value=integration):
+                await send_webhook_message(
+                    provider="teams",
+                    webhook=MagicMock(
+                        text="hi", title=None, webhook_url="https://example.invalid/webhook/secret-token"
+                    ),
+                )
+
+        channel_id = spy.await_args.kwargs["channel_id"]
+        assert channel_id == "example.invalid"
+        assert "secret-token" not in channel_id
+
+    @pytest.mark.asyncio
+    async def test_teams_denial_log_line_names_the_host_not_the_full_url(self, caplog):
+        from fastapi import HTTPException
+
+        from api.integration_communication import send_webhook_message
+
+        with caplog.at_level(logging.WARNING):
+            with patch("api.integration_communication.egress_governor.evaluate", new=AsyncMock(side_effect=_deny)):
+                with pytest.raises(HTTPException):
+                    await send_webhook_message(
+                        provider="teams",
+                        webhook=MagicMock(
+                            text="hi", title=None, webhook_url="https://example.invalid/webhook/secret-token"
+                        ),
+                    )
+
+        assert "example.invalid" in caplog.text
+        assert "secret-token" not in caplog.text

--- a/autobot-backend/services/notification_service.py
+++ b/autobot-backend/services/notification_service.py
@@ -58,6 +58,25 @@ _NOTIFICATIONS_REDIS_DB = "main"
 _NOTIFICATION_TTL_SECONDS = TTL_7_DAYS
 
 
+def _mask_email(email: str) -> str:
+    """Mask a recipient address for the egress audit record and log line.
+
+    An email address is directly usable outside this system on its own — more
+    identifying than the phone number the WhatsApp seam already masks via
+    ``whatsapp_integration._mask_phone`` (channel-identity rule, #14540, see
+    ``services.gateway.egress_governor``). The local part is redacted; the
+    domain is kept, since "which mailbox" plus "which domain" is enough for
+    an operator to locate the blocked send without a plaintext address
+    sitting in every audit row (#14573).
+    """
+    if not email or "@" not in email:
+        return "<none>"
+    local, _, domain = email.rpartition("@")
+    if not local:
+        return f"***@{domain}"
+    return f"{local[0]}***@{domain}"
+
+
 class NotificationChannel(str, Enum):
     """Supported delivery channels for notifications."""
 
@@ -451,14 +470,25 @@ class NotificationService:
         # for a reason other than approval (a blocklist, a kill switch) would
         # otherwise be silently ignored here, and nothing in this file would say
         # so. Two reviews flagged the discarded verdict as a fail-open gate.
+        #
+        # channel_id used to be passed as "" unconditionally, so a blocked send
+        # left an audit row that identified nothing (#14573). An email address
+        # is directly usable outside this system — reduce it (channel-identity
+        # rule, #14540) before it reaches evaluate() and the denial log line.
+        masked_to = _mask_email(to)
         verdict = await egress_governor.evaluate(
             platform="email",
-            channel_id="",
+            channel_id=masked_to,
             message_id="",
             require_approval=False,
         )
         if not verdict.allowed:
-            logger.warning("email notification blocked by egress governance (%s): %s", verdict.rule, verdict.reason)
+            logger.warning(
+                "email notification to %s blocked by egress governance (%s): %s",
+                masked_to,
+                verdict.rule,
+                verdict.reason,
+            )
             return
 
         try:


### PR DESCRIPTION
Closes #14573

## Thinking Path

The rule is already stated in `services/gateway/egress_governor.py`'s module docstring (#14540): reduce a channel identifier that is directly usable outside this system on its own before it reaches `evaluate()`; record an opaque, platform-credential-scoped identifier as-is. Applied it to the two call sites the issue names, then swept every remaining `evaluate()` call site for the same empty-identifier shape:

- **Email** (`notification_service._send_email`): an address is squarely "directly usable outside this system" — more identifying than a phone number, which the WhatsApp seam already masks. Chose local-part-redacted, domain-kept (`j***@example.com`), matching the WhatsApp precedent of "partial, still enough to correlate" rather than dropping the value entirely or keeping only the domain — an operator needs "which mailbox" as well as "which domain" to locate a specific blocked send among several to the same organization.
- **Teams** (`api/integration_communication.send_webhook_message`): established that Teams *does* have an identifier here — `webhook.webhook_url`, present in the request body. A Teams webhook URL embeds a bearer token in its path, the same shape as the webhook seam's `notification_service._send_webhook`, which already reduces to `urlparse(url).hostname`. Applied the identical reduction rather than inventing a new rule.
- **The other Teams call site** (`api/integration_communication.send_message`, the general `/messages` endpoint): here `raw_channel_id` is genuinely `""` for Teams — `SendMessageRequest` carries no webhook field for that provider, and this endpoint's Teams branch has no channel target to read at all. Documented that as a deliberate, not-a-bug empty value rather than forcing a masked/host value where none exists, per the issue's explicit instruction not to force a value where no value is available.

## What Changed

- `services/notification_service.py`: added `_mask_email()` (local-part redacted, domain kept). `_send_email` now passes the masked address to `egress_governor.evaluate()` and names it in the denial log line, instead of `channel_id=""`.
- `api/integration_communication.py`: `send_webhook_message` (the Teams webhook route) now reduces `webhook.webhook_url` to its host with `urlparse(...).hostname`, passed to `evaluate()` and the denial log line, instead of `channel_id=""`. Added a comment on the sibling `send_message` endpoint explaining why Teams is empty-by-construction there and pointing at the route that does carry an identifier.
- `services/gateway/egress_governor.py`: extended the channel-identity rule's docstring with the email and Teams webhook-host examples, and an explicit note that an *absent* identifier is the same failure as an unreduced one — `""` must never stand in for "no reduction needed."
- `services/gateway/live_egress_seams_test.py`: four new cases in `TestChannelIdentityRule` — email masked (evaluate() argument + denial log line) and Teams webhook host (evaluate() argument + denial log line).

### `evaluate()` call site sweep (7 total, counted directly, not taken from #14569)

| Call site | Verdict |
|---|---|
| `integrations/whatsapp_integration.py` (`_egress_denied`) | Conforms — phone masked (#14569) |
| `services/telegram_bot_service.py` (`send_message`) | Conforms — chat_id unmasked, deliberately (#14569) |
| `services/gateway/gateway.py` (`Gateway.send_message`) | Conforms — `session.session_id`, an internal opaque identifier, never empty |
| `api/integration_communication.py` `send_message` (Slack/Discord/Teams) | Conforms for Slack/Discord (#14569); Teams is documented empty-by-construction (no identifier in that request shape) — this PR |
| `api/integration_communication.py` `send_webhook_message` (Teams) | **Fixed this PR** — was `channel_id=""` unconditionally, now the webhook host |
| `services/notification_service.py` `_send_email` | **Fixed this PR** — was `channel_id=""` unconditionally, now the masked address |
| `services/notification_service.py` `_send_webhook` | Conforms — host-only (pre-#14569 precedent) |

## Verification

Never run from the codebase — copied the touched package tree (`autobot-backend/` + `autobot_shared/`) into a scratch directory and ran the repo's existing `pytest` + `pytest-asyncio` there:

- `services/gateway/egress_governor_test.py` + `services/gateway/live_egress_seams_test.py`: **41 passed** (37 pre-existing + 4 new).
- Wider regression sweep (`integrations/whatsapp_integration_test.py`, `api/whatsapp_test.py`, `api/telegram_bot_test.py`, `tests/services/notification_service_test.py`, `services/gateway/gateway_test.py`): **90 passed**, 0 failed.

Mutation-checked all four new guards in the scratch copy, reverted after each:
- Reverted email `channel_id` to `""`: 4 selected → **1 failed** (`test_email_is_masked_before_reaching_the_governor`). Reverted → 4 passed.
- Reverted the email denial log line to drop the masked address: 4 selected → **1 failed** (`test_email_denial_log_line_masks_the_local_part`). Reverted → 4 passed.
- Reverted Teams `channel_id` to `""`: 3 selected → **1 failed** (`test_teams_webhook_host_is_passed_to_the_governor`). Reverted → 3 passed.
- Reverted the Teams denial log line to drop the host: 3 selected → **1 failed** (`test_teams_denial_log_line_names_the_host_not_the_full_url`). Reverted → 3 passed.

Full suite re-run after all reverts, clean: **131 passed**.

## Model Used

Claude Opus 5 (1M context)