### PR TITLE
feat(llc/frontend): make the canvas findable — search, minimap, zoom-to-node, deep link (#14611)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -3,6 +3,69 @@
     <!-- Toolbar -->
     <div class="canvas-toolbar">
       <div class="toolbar-left">
+        <!-- #14611: canvas search — reachable by keyboard, screen-reader
+             announced via the live region below, never gated on `readonly`:
+             finding a node is a view concern on every canvas this component
+             draws, not an authoring one. -->
+        <div v-if="nodes.length > 0" class="canvas-search" role="search">
+          <div class="canvas-search-field">
+            <Icon name="search" class="canvas-search-icon" />
+            <input
+              ref="searchInputEl"
+              v-model="searchQuery"
+              type="text"
+              class="canvas-search-input"
+              role="combobox"
+              aria-autocomplete="list"
+              :aria-expanded="searchHasQuery"
+              aria-controls="canvas-search-listbox"
+              :aria-activedescendant="searchActiveOptionId"
+              :aria-label="$t('workflow.canvas.searchLabel')"
+              :placeholder="$t('workflow.canvas.searchPlaceholder')"
+              data-testid="canvas-search-input"
+              @keydown="onSearchKeydown"
+            />
+            <button
+              v-if="searchHasQuery"
+              type="button"
+              class="canvas-search-clear"
+              :aria-label="$t('workflow.canvas.searchClear')"
+              data-testid="canvas-search-clear"
+              @click="clearSearch"
+            >
+              <Icon name="times" />
+            </button>
+          </div>
+          <!-- #14611: absence must be stated, never left to read as an empty
+               canvas (#14064/#13617/#14556's repeat conflation) — the live
+               region carries it to a screen reader, `canvas-search-no-results`
+               carries it to a sighted one. -->
+          <p aria-live="polite" class="sr-only" data-testid="canvas-search-status">{{ searchStatusText }}</p>
+          <ul
+            v-if="searchHasQuery"
+            id="canvas-search-listbox"
+            class="canvas-search-results"
+            role="listbox"
+            :aria-label="$t('workflow.canvas.searchLabel')"
+          >
+            <li
+              v-for="(result, index) in searchResults"
+              :id="searchOptionId(index)"
+              :key="result.id"
+              role="option"
+              class="canvas-search-result"
+              :class="{ active: index === searchActiveIndex }"
+              :aria-selected="index === searchActiveIndex"
+              data-testid="canvas-search-result"
+              @click="selectSearchResult(result)"
+            >
+              {{ nodeSearchLabel(result) }}
+            </li>
+            <li v-if="searchResults.length === 0" class="canvas-search-empty" data-testid="canvas-search-no-results">
+              {{ $t('workflow.canvas.searchNoResults', { query: searchQuery.trim() }) }}
+            </li>
+          </ul>
+        </div>
         <!-- GH#13939: tab strip — rendered only when the consumer supplies tabs -->
         <div v-if="tabs.length > 0" class="canvas-tabs" role="tablist">
           <button
@@ -73,6 +136,9 @@
         <button class="tool-btn" @click="zoomIn" :aria-label="$t('common.zoomIn')"><Icon name="search-plus" /></button>
         <button class="tool-btn" @click="zoomOut" :aria-label="$t('common.zoomOut')"><Icon name="search-minus" /></button>
         <button class="tool-btn" @click="resetZoom" :aria-label="$t('common.fitToView')"><Icon name="compress-arrows-alt" /></button>
+        <!-- #14611: "fit to selection or filter" — a *second* control, the
+             fixed-reset button above stays exactly as it was. -->
+        <button class="tool-btn" @click="fitToSelectionOrView" :aria-label="$t('workflow.canvas.fitToSelection')" data-testid="canvas-fit-view"><Icon name="expand-arrows-alt" /></button>
         <template v-if="!readonly">
         <div class="toolbar-divider"></div>
         <button class="tool-btn primary" @click="saveWorkflow" :disabled="nodes.length === 0">
@@ -316,6 +382,37 @@
           </li>
         </ul>
       </div>
+
+      <!-- #14611: overview of a canvas larger than the viewport — sits
+           outside `.canvas-content` like the legend, so panning/zooming the
+           main view never moves it. Decorative (not itself an authoring
+           surface): it never gates on `readonly`, a click pans the main view
+           to the point clicked, and the dots/viewport rect are `aria-hidden`
+           since search + keyboard navigation are the actual way in for a
+           screen-reader user, not this overview. -->
+      <div
+        v-if="minimapGeometry"
+        class="canvas-minimap"
+        role="img"
+        :aria-label="$t('workflow.canvas.minimapLabel')"
+        data-testid="canvas-minimap"
+        @pointerdown="onMinimapPointerDown"
+      >
+        <div
+          v-for="node in nodes"
+          :key="`minimap-${node.id}`"
+          class="canvas-minimap-node"
+          :style="minimapNodeStyle(node)"
+          aria-hidden="true"
+        ></div>
+        <div
+          v-if="minimapViewportStyle"
+          class="canvas-minimap-viewport"
+          :style="minimapViewportStyle"
+          data-testid="canvas-minimap-viewport"
+          aria-hidden="true"
+        ></div>
+      </div>
     </div>
 
     <!-- Save Dialog -->
@@ -335,7 +432,7 @@
 
 <script setup lang="ts">
 import Icon, { type IconName } from '@/components/ui/Icon.vue'
-import { ref, reactive, computed, nextTick, useId } from 'vue';
+import { ref, reactive, computed, nextTick, useId, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
@@ -370,8 +467,13 @@ const props = withDefaults(
     readonly?: boolean;
     tabs?: CanvasTab[];
     activeTabId?: string | null;
+    // #14611: the inbound deep link's target — `OrgChart.vue` sets this once
+    // it has resolved `?node=<id>` (`canvasNodeDeepLink.ts`) to a node that
+    // actually exists in `nodes`. Optional and defaulted to null so every
+    // existing mount (WorkflowBuilderView included) is unaffected.
+    focusNodeId?: string | null;
   }>(),
-  { readonly: false, tabs: () => [], activeTabId: null },
+  { readonly: false, tabs: () => [], activeTabId: null, focusNodeId: null },
 );
 const emit = defineEmits<{
   (e: 'node-added', node: WorkflowNode): void;
@@ -1066,6 +1168,348 @@ function zoomOut() { zoom.value = clampZoom(zoom.value - 0.1); }
 function resetZoom() { zoom.value = 1; pan.x = 50; pan.y = 50; }
 function handleWheel(e: WheelEvent) { zoom.value = clampZoom(zoom.value + (e.deltaY > 0 ? -0.05 : 0.05)); }
 
+/* ------------------------------------------------------------------ *
+ * GH#14611: canvas search — a large Company OS canvas has no other way to
+ * find a node than panning until it scrolls into view.
+ *
+ * Never gated on `readonly`: searching persists nothing, the same reasoning
+ * #14610's own doc comment already gives for dragging a node — and gating a
+ * view gesture on it would make the *read-only* canvas, the one this issue is
+ * actually about, the one canvas that cannot use it.
+ * ------------------------------------------------------------------ */
+
+const searchQuery = ref('');
+const searchActiveIndex = ref(-1);
+const searchInputEl = ref<HTMLInputElement | null>(null);
+
+/** A stale highlight from a previous search must not survive into a new one. */
+watch(searchQuery, () => { searchActiveIndex.value = -1; });
+
+/**
+ * A node's own name, independent of its type's generic caption.
+ *
+ * `nodeTitle` returns the *type* label ("Process", "Tool") for an org-process
+ * or org-tool node — correct for the node's header, wrong for search, which
+ * needs the workflow's role or the tool's name to find anything.
+ */
+function nodeDisplayName(node: CanvasNode): string {
+  const label = nodeText(node, 'label');
+  if (label) return label;
+  if (node.type === 'org-process') return nodeText(node, 'role_name');
+  if (node.type === 'org-tool') return nodeText(node, 'tool_name');
+  return nodeTitle(node);
+}
+
+/** Every string a search for `node` should match against. */
+function nodeSearchText(node: CanvasNode): string {
+  const parts = [nodeDisplayName(node), nodeText(node, 'workflow_id')];
+  if (node.type === 'org-tool') {
+    for (const role of toolRoles(node)) parts.push(role.role_name);
+  }
+  return parts.filter(Boolean).join(' ');
+}
+
+/** The result list's visible (and screen-reader-read) label for `node`. */
+function nodeSearchLabel(node: CanvasNode): string {
+  const kind = nodeKindLabel(node);
+  const name = nodeDisplayName(node);
+  return kind ? `${kind}: ${name}` : name;
+}
+
+const searchHasQuery = computed(() => searchQuery.value.trim().length > 0);
+
+/** Nodes matching the current query, across every node kind (#14611
+ *  acceptance: person, group/team, process, tool). Never itself filters what
+ *  the canvas draws, only what the dropdown lists — a search must not be
+ *  confusable with the role lens. */
+const searchResults = computed<CanvasNode[]>(() => {
+  const q = searchQuery.value.trim().toLowerCase();
+  if (!q) return [];
+  return props.nodes.filter((node) => nodeSearchText(node).toLowerCase().includes(q));
+});
+
+function searchOptionId(index: number): string {
+  return `${_uid}-search-option-${index}`;
+}
+const searchActiveOptionId = computed<string | undefined>(() =>
+  searchActiveIndex.value >= 0 && searchActiveIndex.value < searchResults.value.length
+    ? searchOptionId(searchActiveIndex.value)
+    : undefined,
+);
+
+/** Announced to a screen reader via the live region, and shown to a sighted
+ *  reader in the dropdown (#14611: absence must read as "no match", never as
+ *  an empty canvas — #14064/#13617/#14556's repeat conflation). */
+const searchStatusText = computed(() => {
+  if (!searchHasQuery.value) return '';
+  const query = searchQuery.value.trim();
+  return searchResults.value.length > 0
+    ? t('workflow.canvas.searchResultsStatus', { count: searchResults.value.length, query })
+    : t('workflow.canvas.searchNoResults', { query });
+});
+
+function clearSearch(): void {
+  searchQuery.value = '';
+  searchActiveIndex.value = -1;
+}
+
+/** Move the viewport to a search hit (#14611 acceptance: "search finds nodes
+ *  and moves the viewport to a hit"). Keeps the query so Up/Down/Enter can
+ *  keep stepping through the remaining hits without retyping. */
+function selectSearchResult(node: CanvasNode): void {
+  zoomToNode(node.id);
+  searchActiveIndex.value = searchResults.value.findIndex((n) => n.id === node.id);
+}
+
+/** Keyboard operation of the results list from the search input itself —
+ *  ArrowUp/ArrowDown cycle the highlight, Enter jumps to it (or to the first
+ *  result when nothing is highlighted yet), Escape clears the search. */
+function onSearchKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    clearSearch();
+    return;
+  }
+  const results = searchResults.value;
+  if (results.length === 0) return;
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    searchActiveIndex.value = (searchActiveIndex.value + 1) % results.length;
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    searchActiveIndex.value = searchActiveIndex.value <= 0 ? results.length - 1 : searchActiveIndex.value - 1;
+  } else if (e.key === 'Enter') {
+    e.preventDefault();
+    const index = searchActiveIndex.value >= 0 ? searchActiveIndex.value : 0;
+    selectSearchResult(results[index]);
+  }
+}
+
+/* ------------------------------------------------------------------ *
+ * GH#14611: zoom-to-node, fit-to-selection/filter, and the inbound deep
+ * link's own viewport jump — all three share the same centring/fitting math.
+ * ------------------------------------------------------------------ */
+
+/** Node footprint the layout builders assume, for a node type that carries no
+ *  size of its own — the same 100px row `endInteraction` below already uses
+ *  for its connection-drop hit test, and `org-group`'s own `data.width`/
+ *  `data.height` (`nodeStyle` above) when the node IS sized. */
+const NODE_APPROX_HEIGHT = 100;
+
+/** A zoom level comfortable for looking at one node up close — fixed, rather
+ *  than a maximal fit, so repeatedly jumping between search hits or deep
+ *  links only recentres the view and never also snaps the zoom level around
+ *  (#14611: "zoom to a node"). */
+const FOCUS_ZOOM = 1;
+
+/** Padding, in canvas px, kept around a fitted bounding box so a fitted node
+ *  or selection is never drawn flush against the canvas edge. */
+const FIT_PADDING = 60;
+
+/** The width/height a node occupies for bounding-box math (fit, minimap) —
+ *  `org-group` carries its own from `data`, every other type is the fixed
+ *  240x100 footprint every layout builder in `orgCanvasGraph.ts` assumes. */
+function nodeExtent(node: CanvasNode): { width: number; height: number } {
+  if (node.type === 'org-group') {
+    const data = node.data as Record<string, unknown>;
+    const width = typeof data.width === 'number' ? data.width : CANVAS_NODE_WIDTH;
+    const height = typeof data.height === 'number' ? data.height : NODE_APPROX_HEIGHT;
+    return { width, height };
+  }
+  return { width: CANVAS_NODE_WIDTH, height: NODE_APPROX_HEIGHT };
+}
+
+/** Move the viewport so `node`'s centre lands in the middle of the visible
+ *  canvas area, without changing zoom. */
+function centerOnNode(node: CanvasNode): void {
+  const rect = canvasRef.value?.getBoundingClientRect();
+  const viewWidth = rect?.width ?? 0;
+  const viewHeight = rect?.height ?? 0;
+  const center = nodeCenter(node);
+  pan.x = viewWidth / 2 - center.x * zoom.value;
+  pan.y = viewHeight / 2 - center.y * zoom.value;
+}
+
+/**
+ * Zoom to a comfortable level and centre on `nodeId` (#14611 "zoom to a
+ * node") — the jump a search hit or the inbound deep link performs. A no-op
+ * when the id names nothing currently drawn, so a stale search result or a
+ * link to a node the active filter hides cannot move the viewport to
+ * nowhere; `zoom`/`pan` are left exactly as they were.
+ */
+function zoomToNode(nodeId: string): void {
+  const node = props.nodes.find((n) => n.id === nodeId);
+  if (!node) return;
+  zoom.value = clampZoom(FOCUS_ZOOM);
+  centerOnNode(node);
+  // Same roving-tabindex move `focusNodeInDirection` (#14609) already
+  // performs — a jump should leave keyboard focus (and the next Tab stop)
+  // where the viewport now is, not wherever it happened to be before.
+  focusedNodeId.value = nodeId;
+  void nextTick(() => nodeEls.get(nodeId)?.focus());
+}
+
+/**
+ * Zoom + pan so every node in `nodesToFit` is visible (#14611 "fit to the
+ * current selection or filter"). Respects `clampZoom`'s bounds like every
+ * other way of changing zoom on this canvas (buttons, wheel, pinch) — a
+ * selection or filter spanning more of the canvas than `ZOOM_MIN` can show at
+ * once is shown as small as the clamp allows, not zoomed out further. A no-op
+ * on an empty list, leaving the caller's fallback (if any) as the last word.
+ */
+function fitToNodes(nodesToFit: CanvasNode[]): void {
+  if (nodesToFit.length === 0) return;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const node of nodesToFit) {
+    const { width, height } = nodeExtent(node);
+    minX = Math.min(minX, node.position.x);
+    minY = Math.min(minY, node.position.y);
+    maxX = Math.max(maxX, node.position.x + width);
+    maxY = Math.max(maxY, node.position.y + height);
+  }
+  const rect = canvasRef.value?.getBoundingClientRect();
+  const viewWidth = rect?.width ?? 0;
+  const viewHeight = rect?.height ?? 0;
+  const boxWidth = Math.max(1, maxX - minX);
+  const boxHeight = Math.max(1, maxY - minY);
+  zoom.value = clampZoom(
+    Math.min((viewWidth - FIT_PADDING * 2) / boxWidth, (viewHeight - FIT_PADDING * 2) / boxHeight),
+  );
+  pan.x = viewWidth / 2 - ((minX + maxX) / 2) * zoom.value;
+  pan.y = viewHeight / 2 - ((minY + maxY) / 2) * zoom.value;
+}
+
+/**
+ * The reset button's sibling for "fit to selection or filter" (#14611) —
+ * deliberately a *second* control, not a change to `resetZoom`: that button's
+ * fixed pan(50,50)/zoom(1) stays exactly as it was.
+ *
+ * Fits the selected node when there is one; otherwise fits every node
+ * `props.nodes` currently carries. That second case IS "fit to the active
+ * filter" for free — a role lens or a unit tab narrows `props.nodes` itself
+ * (`OrgChart.vue`'s `lensedCanvasNodes`/`visibleRoots`), so fitting to
+ * whatever is actually drawn can never disagree with what the filter shows.
+ */
+function fitToSelectionOrView(): void {
+  const selected = props.nodes.filter((n) => n.id === props.selectedNodeId);
+  fitToNodes(selected.length > 0 ? selected : props.nodes);
+}
+
+/**
+ * The inbound counterpart to a search jump: `focusNodeId` names a node to
+ * open the canvas already centred on (#14611's deep link). `OrgChart.vue`
+ * only ever sets it once it has confirmed the id names a node already present
+ * in `nodes` (`lensedCanvasNodes`, the exact array this prop receives), so a
+ * single `zoomToNode` attempt per id — no retry loop watching `nodes` too —
+ * is enough; watching `nodes` as well would re-centre the view every time an
+ * unrelated node moves, fighting whatever the user panned to since.
+ *
+ * `nextTick` defers past the initial mount: an `immediate` watcher runs
+ * during `setup()`, before `canvasRef` is attached to anything, so a
+ * synchronous `zoomToNode` here would measure a null canvas area.
+ */
+watch(
+  () => props.focusNodeId,
+  (nodeId) => {
+    if (!nodeId) return;
+    void nextTick(() => zoomToNode(nodeId));
+  },
+  { immediate: true },
+);
+
+/* ------------------------------------------------------------------ *
+ * GH#14611: minimap — an overview of a canvas larger than the viewport.
+ * ------------------------------------------------------------------ */
+
+/** Minimap panel size, in CSS px — fixed, unlike the canvas itself, since the
+ *  whole point is a stable overview regardless of how far the user has
+ *  zoomed or panned the main view. */
+const MINIMAP_WIDTH = 160;
+const MINIMAP_HEIGHT = 120;
+/** Inner padding so a node at the very edge of the graph is not drawn flush
+ *  against the minimap's own border. */
+const MINIMAP_PADDING = 8;
+
+interface MinimapGeometry {
+  scale: number;
+  minX: number;
+  minY: number;
+}
+
+/** Bounding box of every node currently drawn, scaled to fit the minimap
+ *  panel — `null` when there is nothing to show an overview of. */
+const minimapGeometry = computed<MinimapGeometry | null>(() => {
+  if (props.nodes.length === 0) return null;
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  for (const node of props.nodes) {
+    const { width, height } = nodeExtent(node);
+    minX = Math.min(minX, node.position.x);
+    minY = Math.min(minY, node.position.y);
+    maxX = Math.max(maxX, node.position.x + width);
+    maxY = Math.max(maxY, node.position.y + height);
+  }
+  const boxWidth = Math.max(1, maxX - minX);
+  const boxHeight = Math.max(1, maxY - minY);
+  const scale = Math.min(
+    (MINIMAP_WIDTH - MINIMAP_PADDING * 2) / boxWidth,
+    (MINIMAP_HEIGHT - MINIMAP_PADDING * 2) / boxHeight,
+  );
+  return { scale, minX, minY };
+});
+
+/** A canvas-space point, mapped into the minimap panel's own coordinates. */
+function minimapPoint(x: number, y: number): { left: string; top: string } {
+  const geo = minimapGeometry.value;
+  if (!geo) return { left: '0px', top: '0px' };
+  return {
+    left: `${MINIMAP_PADDING + (x - geo.minX) * geo.scale}px`,
+    top: `${MINIMAP_PADDING + (y - geo.minY) * geo.scale}px`,
+  };
+}
+
+function minimapNodeStyle(node: CanvasNode): Record<string, string> {
+  const { width, height } = nodeExtent(node);
+  return minimapPoint(node.position.x + width / 2, node.position.y + height / 2);
+}
+
+/** The "you are here" rectangle: the visible canvas area's current bounds, in
+ *  canvas-content space, mapped the same way the node dots are. `null` when
+ *  there is no overview to draw it on. */
+const minimapViewportStyle = computed<Record<string, string> | null>(() => {
+  const geo = minimapGeometry.value;
+  if (!geo) return null;
+  const rect = canvasRef.value?.getBoundingClientRect();
+  const viewWidth = rect?.width ?? 0;
+  const viewHeight = rect?.height ?? 0;
+  const point = minimapPoint(-pan.x / zoom.value, -pan.y / zoom.value);
+  return {
+    left: point.left,
+    top: point.top,
+    width: `${Math.max(0, (viewWidth / zoom.value) * geo.scale)}px`,
+    height: `${Math.max(0, (viewHeight / zoom.value) * geo.scale)}px`,
+  };
+});
+
+/**
+ * A click/tap on the minimap pans the main view to that point (#14611) — a
+ * view gesture like the pan/drag/zoom above it, so it is never gated on
+ * `readonly` either. Zoom is left untouched: the minimap only ever answers
+ * "where", never "how close".
+ */
+function onMinimapPointerDown(e: PointerEvent): void {
+  const geo = minimapGeometry.value;
+  const panel = e.currentTarget as HTMLElement | null;
+  if (!geo || !panel) return;
+  const panelRect = panel.getBoundingClientRect();
+  const canvasX = geo.minX + (e.clientX - panelRect.left - MINIMAP_PADDING) / geo.scale;
+  const canvasY = geo.minY + (e.clientY - panelRect.top - MINIMAP_PADDING) / geo.scale;
+  const rect = canvasRef.value?.getBoundingClientRect();
+  const viewWidth = rect?.width ?? 0;
+  const viewHeight = rect?.height ?? 0;
+  pan.x = viewWidth / 2 - canvasX * zoom.value;
+  pan.y = viewHeight / 2 - canvasY * zoom.value;
+}
+
 /** Rescale from the pinch's starting distance/zoom — proportional, like `handleWheel`
  *  and the zoom buttons, none of which anchor around a point either (#14610). */
 function applyPinchZoom(): void {
@@ -1336,6 +1780,29 @@ function confirmSave() { emit('save-workflow', saveName.value, saveDesc.value); 
 .delete-case-btn:hover { color: var(--color-error); }
 .add-case-btn { padding: var(--spacing-1) var(--spacing-2); background: transparent; border: 1px dashed var(--border-default); border-radius: var(--radius-default); color: var(--text-secondary); cursor: pointer; font-size: var(--text-xs); text-align: left; }
 .add-case-btn:hover { border-color: var(--color-primary); color: var(--color-primary); }
+
+/* #14611: canvas search — a text field plus a listbox dropdown, following
+   the same combobox pattern the rest of the toolbar's dropdown already uses
+   (`.dropdown-container`/`.dropdown-menu` below), styled to match. */
+.canvas-search { position: relative; }
+.canvas-search-field { display: flex; align-items: center; gap: var(--spacing-1-5); padding: var(--spacing-1-5) var(--spacing-2); background: var(--bg-tertiary); border: 1px solid var(--border-default); border-radius: var(--radius-md); }
+.canvas-search-field:focus-within { border-color: var(--color-primary); }
+.canvas-search-icon { color: var(--text-tertiary); flex: none; }
+.canvas-search-input { border: none; background: transparent; color: var(--text-primary); font-size: var(--text-sm); width: 160px; }
+.canvas-search-input:focus { outline: none; }
+.canvas-search-clear { display: flex; align-items: center; padding: var(--spacing-0); background: transparent; border: none; color: var(--text-tertiary); cursor: pointer; }
+.canvas-search-clear:hover { color: var(--text-primary); }
+.canvas-search-clear:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
+.canvas-search-results { position: absolute; top: 100%; inset-inline-start: 0; z-index: 10; margin-top: var(--spacing-1); width: 260px; max-height: 260px; overflow-y: auto; list-style: none; padding: var(--spacing-1) var(--spacing-0); background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+.canvas-search-result { padding: var(--spacing-2) var(--spacing-3); font-size: var(--text-sm); color: var(--text-primary); cursor: pointer; }
+.canvas-search-result:hover, .canvas-search-result.active { background: var(--bg-tertiary); }
+.canvas-search-empty { padding: var(--spacing-2) var(--spacing-3); font-size: var(--text-sm); color: var(--text-tertiary); font-style: italic; }
+
+/* #14611: overview panel — fixed size regardless of canvas zoom/pan, opposite
+   corner from `.canvas-legend` so the two never overlap. */
+.canvas-minimap { position: absolute; top: var(--spacing-3); inset-inline-end: var(--spacing-3); width: 160px; height: 120px; background: var(--bg-secondary); border: 1px solid var(--border-default); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); overflow: hidden; cursor: pointer; touch-action: none; }
+.canvas-minimap-node { position: absolute; width: 4px; height: 4px; border-radius: 50%; background: var(--text-muted); transform: translate(-50%, -50%); pointer-events: none; }
+.canvas-minimap-viewport { position: absolute; border: 1px solid var(--color-primary); background: var(--color-primary-bg); pointer-events: none; }
 
 .dropdown-container { position: relative; display: inline-block; }
 .dropdown-menu { position: absolute; top: 100%; left: 0; z-index: 10; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: var(--radius-md); padding: var(--spacing-1) var(--spacing-0); min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.minimap.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.minimap.test.ts
@@ -1,0 +1,131 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * #14611: the minimap — an overview of a canvas larger than the viewport.
+ *
+ * As with `WorkflowCanvas.zoomFit.test.ts`, `getBoundingClientRect` is mocked
+ * to a fixed size so the "you are here" viewport rectangle's own geometry is
+ * deterministic rather than collapsing to zero.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+import { firePointer } from './pointerTestUtils'
+
+const VIEW_WIDTH = 1000
+const VIEW_HEIGHT = 700
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: VIEW_WIDTH,
+    height: VIEW_HEIGHT,
+    top: 0,
+    left: 0,
+    right: VIEW_WIDTH,
+    bottom: VIEW_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return this
+    },
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function node(id: string, x: number, y: number): CanvasNode {
+  return {
+    id,
+    type: 'org-person',
+    position: { x, y },
+    data: { label: id, title: 'role' },
+    connections: [],
+  }
+}
+
+const NODES = [node('a', 0, 0), node('b', 2000, 1000)]
+
+function mountCanvas(props: Record<string, unknown> = {}) {
+  return mount(WorkflowCanvas, {
+    props: { nodes: NODES, selectedNodeId: null, readonly: true, ...props },
+    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+  })
+}
+
+describe('minimap (#14611)', () => {
+  it('is present with an accessible label when the canvas has nodes', () => {
+    const wrapper = mountCanvas()
+    const minimap = wrapper.get('[data-testid="canvas-minimap"]')
+
+    expect(minimap.attributes('role')).toBe('img')
+    expect(minimap.attributes('aria-label')).toBe(en.workflow.canvas.minimapLabel)
+  })
+
+  it('is absent from an empty canvas — nothing to show an overview of', () => {
+    const wrapper = mountCanvas({ nodes: [] })
+
+    expect(wrapper.find('[data-testid="canvas-minimap"]').exists()).toBe(false)
+  })
+
+  it('draws one dot per node currently on the canvas', () => {
+    const wrapper = mountCanvas()
+
+    expect(wrapper.findAll('.canvas-minimap-node')).toHaveLength(NODES.length)
+  })
+
+  it('draws the "you are here" viewport rectangle', () => {
+    const wrapper = mountCanvas()
+
+    expect(wrapper.find('[data-testid="canvas-minimap-viewport"]').exists()).toBe(true)
+  })
+
+  it('moves the viewport rectangle when the main view pans', async () => {
+    const wrapper = mountCanvas()
+    const before = wrapper.get('[data-testid="canvas-minimap-viewport"]').attributes('style')
+
+    await wrapper.get('[data-testid="canvas-fit-view"]').trigger('click')
+
+    const after = wrapper.get('[data-testid="canvas-minimap-viewport"]').attributes('style')
+    expect(after).not.toBe(before)
+  })
+
+  it('is never gated on readonly — an overview is a view concern', () => {
+    const authoringWrapper = mountCanvas({ readonly: false })
+
+    expect(authoringWrapper.find('[data-testid="canvas-minimap"]').exists()).toBe(true)
+  })
+
+  it('a click on the minimap pans the main view to the clicked point', async () => {
+    const wrapper = mountCanvas()
+    const before = wrapper.get('.canvas-content').attributes('style')
+
+    const minimap = wrapper.get('[data-testid="canvas-minimap"]')
+    await firePointer(minimap.element, 'pointerdown', { clientX: 40, clientY: 30 })
+
+    const after = wrapper.get('.canvas-content').attributes('style')
+    expect(after).not.toBe(before)
+  })
+
+  it('the minimap click never changes zoom — it only answers "where"', async () => {
+    const wrapper = mountCanvas()
+
+    const minimap = wrapper.get('[data-testid="canvas-minimap"]')
+    await firePointer(minimap.element, 'pointerdown', { clientX: 40, clientY: 30 })
+
+    const style = wrapper.get('.canvas-content').attributes('style') ?? ''
+    expect(style).toContain('scale(1)')
+  })
+})

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
@@ -125,11 +125,13 @@ describe('WorkflowCanvas read-only org mode (#13939)', () => {
     expect(wrapper.find('.delete-btn').exists()).toBe(false)
   })
 
-  it('keeps pan/zoom controls available', () => {
+  it('keeps pan/zoom/fit controls available', () => {
     const wrapper = mountCanvas({ nodes: ORG_NODES, readonly: true })
 
     expect(wrapper.find('.canvas-area').exists()).toBe(true)
-    expect(wrapper.findAll('.toolbar-right .tool-btn')).toHaveLength(3)
+    // #14611 added a fourth button (fit to selection/filter) alongside the
+    // three #13939 originally pinned.
+    expect(wrapper.findAll('.toolbar-right .tool-btn')).toHaveLength(4)
   })
 
   it('labels org nodes from their data and sizes the container', () => {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
@@ -270,11 +270,12 @@ describe('workflow authoring is untouched by the rule layer (#13941)', () => {
     expect(step.classes().some((cls) => cls.startsWith('rule-'))).toBe(false)
   })
 
-  it('keeps the three pan/zoom buttons the org canvas relies on', () => {
+  it('keeps the four pan/zoom/fit buttons the org canvas relies on', () => {
     // The colour-by control lives in the left half deliberately: #13939 pins
-    // the right half at exactly three buttons in read-only mode.
+    // the right half at exactly three buttons in read-only mode — #14611
+    // added a fourth (fit to selection/filter), still gated the same way.
     const wrapper = mountCanvas({ nodes: ORG_NODES })
 
-    expect(wrapper.findAll('.toolbar-right .tool-btn')).toHaveLength(3)
+    expect(wrapper.findAll('.toolbar-right .tool-btn')).toHaveLength(4)
   })
 })

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.search.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.search.test.ts
@@ -1,0 +1,296 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * #14611: canvas search — a large Company OS canvas has no other way to find
+ * a node than panning until it scrolls into view.
+ *
+ * Every fixture node here comes from the real layout builders
+ * (`buildOrgCanvasGraph`, `buildProcessCanvasNodes`, `buildToolCanvasNodes`,
+ * `buildTeamCanvasNodes`) rather than a hand-rolled node object, so the search
+ * text these tests exercise is exactly what the canvas actually receives from
+ * `OrgChart.vue` — a hand-written fixture could drift from the real producers'
+ * shape and pass against data the canvas never sees.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import {
+  buildOrgCanvasGraph,
+  buildProcessCanvasNodes,
+  buildToolCanvasNodes,
+  buildTeamCanvasNodes,
+  canvasBottom,
+  flattenOrgNodes,
+} from '@/composables/llc/orgCanvasGraph'
+import { buildOrgPeople } from '@/composables/llc/orgPeople'
+import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+import type { CompanyTeam } from '@/composables/llc/orgPeople'
+
+function orgNode(id: string, name: string, children: OrgNode[] = []): OrgNode {
+  return {
+    id,
+    name,
+    title: 'Engineer',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children,
+  }
+}
+
+// One reporting unit (person + group), one process, one tool, one team — the
+// four node kinds #14611 requires search to reach.
+const FOREST: OrgNode[] = [orgNode('ceo', 'Ada Lovelace', [orgNode('dev', 'Bo Diddley')])]
+const PEOPLE_NODES = buildOrgCanvasGraph(FOREST, (name) => `${name} unit`)
+const PROCESS_NODES = buildProcessCanvasNodes(
+  [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+  canvasBottom(PEOPLE_NODES),
+)
+const TOOL_NODES = buildToolCanvasNodes(
+  [{ role_id: 'r1', role_name: 'Head of Sales', tool_name: 'Salesforce' }],
+  [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+  canvasBottom([...PEOPLE_NODES, ...PROCESS_NODES]),
+)
+const TEAMS: CompanyTeam[] = [{ id: 't1', name: 'Platform', member_user_ids: [] }]
+const TEAM_NODES = buildTeamCanvasNodes(
+  flattenOrgNodes(FOREST),
+  buildOrgPeople(FOREST, []),
+  TEAMS,
+  canvasBottom([...PEOPLE_NODES, ...PROCESS_NODES, ...TOOL_NODES]),
+  (name) => `${name} team`,
+  'Not on a team',
+)
+
+const ALL_NODES = [...PEOPLE_NODES, ...PROCESS_NODES, ...TOOL_NODES, ...TEAM_NODES]
+
+function mountCanvas(locale: 'en' | 'ar' = 'en', nodes = ALL_NODES) {
+  return mount(WorkflowCanvas, {
+    props: { nodes, selectedNodeId: null, readonly: true },
+    global: {
+      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
+    },
+    attachTo: document.body,
+  })
+}
+
+async function search(wrapper: ReturnType<typeof mountCanvas>, query: string) {
+  await wrapper.get('[data-testid="canvas-search-input"]').setValue(query)
+}
+
+describe('canvas search box (#14611)', () => {
+  it('is present when the canvas has nodes, and never gated on readonly', () => {
+    const readonlyWrapper = mount(WorkflowCanvas, {
+      props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    })
+    const authoringWrapper = mount(WorkflowCanvas, {
+      props: { nodes: ALL_NODES, selectedNodeId: null, readonly: false },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    })
+
+    expect(readonlyWrapper.find('[data-testid="canvas-search-input"]').exists()).toBe(true)
+    expect(authoringWrapper.find('[data-testid="canvas-search-input"]').exists()).toBe(true)
+  })
+
+  it('is absent from an empty canvas — nothing to search', () => {
+    const wrapper = mount(WorkflowCanvas, {
+      props: { nodes: [], selectedNodeId: null, readonly: true },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    })
+
+    expect(wrapper.find('[data-testid="canvas-search-input"]').exists()).toBe(false)
+  })
+
+  it('finds a person node by name, and Enter jumps focus to the real reporting-hierarchy node', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Ada Lovelace')
+
+    // Not asserted as exactly one: the fixture's "Platform" team has no
+    // members assigned, so the real producer (`buildTeamCanvasNodes`) also
+    // draws Ada as a person-less-team roster duplicate, and the unit
+    // container's own label ("Ada Lovelace unit") is itself a substring
+    // match — all legitimate hits on the actual data the canvas draws.
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results.length).toBeGreaterThanOrEqual(1)
+    expect(wrapper.find('[data-testid="canvas-search-no-results"]').exists()).toBe(false)
+
+    // Enter with nothing highlighted jumps to the FIRST result — assert on
+    // that, rather than the label text, since the exact ordering already
+    // belongs to `buildOrgCanvasGraph`/`buildTeamCanvasNodes`, not to search.
+    await wrapper.get('[data-testid="canvas-search-input"]').trigger('keydown', { key: 'Enter' })
+    expect(document.activeElement).not.toBeNull()
+    expect(document.activeElement?.getAttribute('data-node-id')).not.toBeNull()
+  })
+
+  it('finds a group/unit container by its label', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'unit')
+
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results.map((r) => r.text())).toEqual(
+      expect.arrayContaining([expect.stringContaining('Ada Lovelace unit')]),
+    )
+  })
+
+  it('finds a team container by its label', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Platform')
+
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.some((r) => r.text().includes('Platform team'))).toBe(true)
+  })
+
+  it('finds a process node by its role name', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Head of Sales')
+
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results.some((r) => r.text().includes('Head of Sales'))).toBe(true)
+  })
+
+  it('finds a tool node by its tool name', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Salesforce')
+
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results).toHaveLength(1)
+    expect(results[0].text()).toContain('Salesforce')
+  })
+
+  it('matches case-insensitively and on a partial name', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'ada love')
+
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results.length).toBeGreaterThanOrEqual(1)
+    expect(results.every((r) => r.text().toLowerCase().includes('ada love'))).toBe(true)
+  })
+
+  it('reads "no match", never an empty canvas, for a query nothing satisfies', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'zzz-nobody-here')
+
+    const noResults = wrapper.get('[data-testid="canvas-search-no-results"]')
+    expect(noResults.text()).toBe(
+      en.workflow.canvas.searchNoResults.replace('{query}', 'zzz-nobody-here'),
+    )
+    expect(wrapper.find('[data-testid="canvas-search-result"]').exists()).toBe(false)
+    // Paired positive: the canvas itself is unaffected by an unmatched search
+    // — every node is still drawn, so this is a fact about the query, not a
+    // canvas that failed to render (#14064/#13617/#14556's repeat defect).
+    expect(wrapper.findAll('.workflow-node')).toHaveLength(ALL_NODES.length)
+  })
+
+  it('announces the match count to a screen reader via the live region', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Salesforce')
+
+    expect(wrapper.get('[data-testid="canvas-search-status"]').text()).toBe(
+      en.workflow.canvas.searchResultsStatus.replace('{count}', '1').replace('{query}', 'Salesforce'),
+    )
+  })
+
+  it('announces zero matches to a screen reader too', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'zzz-nobody-here')
+
+    expect(wrapper.get('[data-testid="canvas-search-status"]').text()).toBe(
+      en.workflow.canvas.searchNoResults.replace('{query}', 'zzz-nobody-here'),
+    )
+  })
+
+  it('Enter jumps the viewport to the matched node', async () => {
+    const wrapper = mountCanvas()
+    const before = wrapper.get('.canvas-content').attributes('style')
+    await search(wrapper, 'Salesforce')
+
+    await wrapper.get('[data-testid="canvas-search-input"]').trigger('keydown', { key: 'Enter' })
+
+    const after = wrapper.get('.canvas-content').attributes('style')
+    expect(after).not.toBe(before)
+    // "Zoom to a node" (#14611) is a fixed, comfortable level — scale(1) — not
+    // a maximal fit; the reset button's own scale(1) default makes this the
+    // one part of the transform that does NOT change on a jump.
+    expect(after).toContain('scale(1)')
+  })
+
+  it('moves keyboard focus to the jumped-to node, for a screen-reader user', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Salesforce')
+    await wrapper.get('[data-testid="canvas-search-input"]').trigger('keydown', { key: 'Enter' })
+
+    const toolNode = wrapper.get('.workflow-node.org-tool')
+    expect(toolNode.element).toBe(document.activeElement)
+  })
+
+  it('ArrowDown/ArrowUp cycle which result Enter would jump to', async () => {
+    const wrapper = mountCanvas()
+    // "e" matches several of the fixture's labels/roles across kinds.
+    await search(wrapper, 'e')
+    const input = wrapper.get('[data-testid="canvas-search-input"]')
+    const resultCount = wrapper.findAll('[data-testid="canvas-search-result"]').length
+    expect(resultCount).toBeGreaterThan(1)
+
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    const activeAfterOne = wrapper.findAll('.canvas-search-result.active')
+    expect(activeAfterOne).toHaveLength(1)
+
+    await input.trigger('keydown', { key: 'ArrowDown' })
+    const activeAfterTwo = wrapper.find('.canvas-search-result.active')
+    // The highlight actually moved to a different result, not the same one.
+    expect(activeAfterTwo.text()).not.toBe(activeAfterOne[0].text())
+  })
+
+  it('Escape clears the query and closes the results', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Salesforce')
+    expect(wrapper.find('[data-testid="canvas-search-result"]').exists()).toBe(true)
+
+    await wrapper.get('[data-testid="canvas-search-input"]').trigger('keydown', { key: 'Escape' })
+
+    expect((wrapper.get('[data-testid="canvas-search-input"]').element as HTMLInputElement).value).toBe('')
+    expect(wrapper.find('[data-testid="canvas-search-result"]').exists()).toBe(false)
+  })
+
+  it('the clear button empties the query', async () => {
+    const wrapper = mountCanvas()
+    await search(wrapper, 'Salesforce')
+
+    await wrapper.get('[data-testid="canvas-search-clear"]').trigger('click')
+
+    expect((wrapper.get('[data-testid="canvas-search-input"]').element as HTMLInputElement).value).toBe('')
+    expect(wrapper.find('[data-testid="canvas-search-clear"]').exists()).toBe(false)
+  })
+
+  it('reads and operates in an RTL locale', async () => {
+    const wrapper = mountCanvas('ar')
+
+    expect(wrapper.get('[data-testid="canvas-search-input"]').attributes('placeholder')).toBe(
+      ar.workflow.canvas.searchPlaceholder,
+    )
+
+    await search(wrapper, 'Salesforce')
+    const results = wrapper.findAll('[data-testid="canvas-search-result"]')
+    expect(results).toHaveLength(1)
+
+    await wrapper.get('[data-testid="canvas-search-input"]').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.get('.workflow-node.org-tool').element).toBe(document.activeElement)
+  })
+})

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.zoomFit.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.zoomFit.test.ts
@@ -1,0 +1,180 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * #14611: zoom-to-node, fit-to-selection/filter, and the inbound deep link's
+ * own viewport jump.
+ *
+ * jsdom's `getBoundingClientRect` returns an all-zero rect unless mocked, so
+ * every test here fixes the canvas area's on-screen size explicitly — without
+ * it the pan/zoom math would be deterministic but meaningless (dividing by a
+ * zero-sized viewport).
+ *
+ * `.canvas-content`'s own inline `transform` style is the one place pan/zoom
+ * become observable from outside the component (there is no `defineExpose`),
+ * so every assertion reads it rather than the internal `pan`/`zoom` refs.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+
+const VIEW_WIDTH = 1000
+const VIEW_HEIGHT = 700
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    width: VIEW_WIDTH,
+    height: VIEW_HEIGHT,
+    top: 0,
+    left: 0,
+    right: VIEW_WIDTH,
+    bottom: VIEW_HEIGHT,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return this
+    },
+  } as DOMRect)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function node(id: string, x: number, y: number): CanvasNode {
+  return {
+    id,
+    type: 'org-person',
+    position: { x, y },
+    data: { label: id, title: 'role' },
+    connections: [],
+  }
+}
+
+function mountCanvas(props: Record<string, unknown> = {}) {
+  return mount(WorkflowCanvas, {
+    props: { nodes: [node('a', 0, 0), node('b', 2000, 1000)], selectedNodeId: null, readonly: true, ...props },
+    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+  })
+}
+
+/** Parses `.canvas-content`'s inline transform into { x, y, scale }. */
+function transform(wrapper: ReturnType<typeof mountCanvas>): { x: number; y: number; scale: number } {
+  const style = wrapper.get('.canvas-content').attributes('style') ?? ''
+  const match = style.match(/translate\(([-\d.]+)px, ([-\d.]+)px\) scale\(([-\d.]+)\)/)
+  if (!match) throw new Error(`could not parse transform from "${style}"`)
+  return { x: Number(match[1]), y: Number(match[2]), scale: Number(match[3]) }
+}
+
+describe('reset stays fixed (#14611: a second control, not a change to it)', () => {
+  it('resetZoom keeps its exact pan(50,50)/zoom(1), unaffected by the new fit button', async () => {
+    const wrapper = mountCanvas()
+    // Perturb the view first, so "reset" is actually observed doing something.
+    await wrapper.get('[data-testid="canvas-fit-view"]').trigger('click')
+    expect(transform(wrapper)).not.toEqual({ x: 50, y: 50, scale: 1 })
+
+    await wrapper.get('.tool-btn[aria-label="Fit to view"]').trigger('click')
+    expect(transform(wrapper)).toEqual({ x: 50, y: 50, scale: 1 })
+  })
+})
+
+describe('fit to selection or filter (#14611)', () => {
+  it('fits the selected node, clamped to ZOOM_MAX for a node this small on a 1000x700 view', async () => {
+    // A single 240x100 node, +60px padding each side, fills far less than the
+    // viewport — the fit would want to zoom in past 2x, so `clampZoom`'s own
+    // ZOOM_MAX must win. (880/240 ≈ 3.67, 580/100 = 5.8 — both above ZOOM_MAX.)
+    const wrapper = mountCanvas({ selectedNodeId: 'a' })
+
+    await wrapper.get('[data-testid="canvas-fit-view"]').trigger('click')
+
+    const result = transform(wrapper)
+    expect(result.scale).toBe(2)
+    // Centred on node 'a' (240x100 at 0,0 → centre (120, 50)) at scale 2.
+    expect(result.x).toBeCloseTo(VIEW_WIDTH / 2 - 120 * 2, 5)
+    expect(result.y).toBeCloseTo(VIEW_HEIGHT / 2 - 50 * 2, 5)
+  })
+
+  it('fits every drawn node — which, when a filter has narrowed `nodes`, IS the filter — when nothing is selected', async () => {
+    // Nodes 'a' (0,0) and 'b' (2000,1000): bounding box (0,0)-(2240,1100).
+    const wrapper = mountCanvas({ selectedNodeId: null })
+
+    await wrapper.get('[data-testid="canvas-fit-view"]').trigger('click')
+
+    const expectedScale = Math.min((VIEW_WIDTH - 120) / 2240, (VIEW_HEIGHT - 120) / 1100)
+    const result = transform(wrapper)
+    expect(result.scale).toBeCloseTo(expectedScale, 5)
+    expect(result.x).toBeCloseTo(VIEW_WIDTH / 2 - 1120 * expectedScale, 5)
+    expect(result.y).toBeCloseTo(VIEW_HEIGHT / 2 - 550 * expectedScale, 5)
+  })
+
+  it('respects clampZoom\'s ZOOM_MIN floor rather than zooming out further for a huge spread', async () => {
+    const wrapper = mountCanvas({
+      nodes: [node('a', 0, 0), node('b', 100000, 60000)],
+      selectedNodeId: null,
+    })
+
+    await wrapper.get('[data-testid="canvas-fit-view"]').trigger('click')
+
+    expect(transform(wrapper).scale).toBe(0.3)
+  })
+
+  it('is reachable with an accessible label, and never gated on readonly', () => {
+    const readonlyWrapper = mountCanvas({ readonly: true })
+    const authoringWrapper = mountCanvas({ readonly: false })
+
+    expect(readonlyWrapper.get('[data-testid="canvas-fit-view"]').attributes('aria-label')).toBe(
+      en.workflow.canvas.fitToSelection,
+    )
+    expect(authoringWrapper.find('[data-testid="canvas-fit-view"]').exists()).toBe(true)
+  })
+})
+
+describe('the inbound deep link\'s viewport jump (#14611 focus-node-id prop)', () => {
+  it('zooms to FOCUS_ZOOM and centres on the named node once mounted', async () => {
+    const wrapper = mountCanvas({ focusNodeId: 'a' })
+    await nextTick()
+    await nextTick()
+
+    const result = transform(wrapper)
+    expect(result.scale).toBe(1)
+    expect(result.x).toBeCloseTo(VIEW_WIDTH / 2 - 120, 5)
+    expect(result.y).toBeCloseTo(VIEW_HEIGHT / 2 - 50, 5)
+  })
+
+  it('is a no-op when the id names nothing currently drawn — never moves the viewport to nowhere', async () => {
+    const wrapper = mountCanvas({ focusNodeId: 'does-not-exist' })
+    await nextTick()
+    await nextTick()
+
+    // Left exactly at the component's own default — no jump attempted.
+    expect(transform(wrapper)).toEqual({ x: 50, y: 50, scale: 1 })
+  })
+
+  it('moves keyboard focus onto the node too, for a screen-reader user landing on the link', async () => {
+    const wrapper = mount(WorkflowCanvas, {
+      props: {
+        nodes: [node('a', 0, 0)],
+        selectedNodeId: null,
+        readonly: true,
+        focusNodeId: 'a',
+      },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+      attachTo: document.body,
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(wrapper.get('[data-node-id="a"]').element).toBe(document.activeElement)
+  })
+})

--- a/autobot-frontend/src/composables/workflow/__tests__/canvasNodeDeepLink.test.ts
+++ b/autobot-frontend/src/composables/workflow/__tests__/canvasNodeDeepLink.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14611: the "open this node" link contract shared by the Company OS org
+// canvas (consumer, `OrgChart.vue`) and whatever produces the link (a copied
+// URL from the address bar, or a future "copy link" affordance).
+//
+// Mirrors `workflowDeepLink.test.ts` (#13963) test-for-test: the failure mode
+// is the same silent one — a link that carries a node id the consumer cannot
+// parse still opens the canvas and simply focuses nothing. Nobody sees an
+// error; the click just does less than it promised.
+
+import { describe, it, expect } from 'vitest'
+import {
+  canvasNodeIdFromQuery,
+  canvasNodeLinkQuery,
+  CANVAS_NODE_QUERY_KEY,
+} from '../canvasNodeDeepLink'
+
+describe('canvasNodeIdFromQuery (#14611)', () => {
+  it('reads the node the link names', () => {
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: 'ceo' })).toBe('ceo')
+  })
+
+  it('takes the first when the key repeats', () => {
+    // vue-router types a repeated query parameter as an array. Focusing one
+    // node is the only sensible reading, and throwing would break a link a
+    // user can produce by accident.
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: ['a', 'b'] })).toBe('a')
+  })
+
+  it('keeps a namespaced id intact', () => {
+    // A process/tool/team-member canvas id embeds ':' internally
+    // (`process:<role>:<workflow>`, `org-team:<group>:member:<id>`).
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: 'process:role-1:wf-1' })).toBe(
+      'process:role-1:wf-1',
+    )
+  })
+
+  it('asks for nothing when the key is absent', () => {
+    expect(canvasNodeIdFromQuery({})).toBeNull()
+    expect(canvasNodeIdFromQuery(undefined)).toBeNull()
+    expect(canvasNodeIdFromQuery({ section: 'runner' })).toBeNull()
+  })
+
+  it('treats an empty or whitespace value as no request', () => {
+    // `?node=` is reachable by hand-editing the URL. Resolving a node named
+    // '' would match nothing and read as a broken feature.
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: '' })).toBeNull()
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: '   ' })).toBeNull()
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: [] })).toBeNull()
+  })
+
+  it('ignores a null or non-string value', () => {
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: null })).toBeNull()
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: undefined })).toBeNull()
+  })
+
+  it('trims surrounding whitespace rather than passing it through', () => {
+    expect(canvasNodeIdFromQuery({ [CANVAS_NODE_QUERY_KEY]: '  ceo  ' })).toBe('ceo')
+  })
+
+  it('never collides with the outbound workflow link\'s own query key', () => {
+    // #13963's `?workflow=` and #14611's `?node=` name different targets and
+    // must be able to coexist on the same URL without either shadowing the
+    // other.
+    expect(CANVAS_NODE_QUERY_KEY).not.toBe('workflow')
+  })
+})
+
+describe('canvasNodeLinkQuery (#14611)', () => {
+  it('builds a query object naming exactly one node', () => {
+    expect(canvasNodeLinkQuery('ceo')).toEqual({ [CANVAS_NODE_QUERY_KEY]: 'ceo' })
+  })
+
+  it('round-trips through canvasNodeIdFromQuery', () => {
+    const query = canvasNodeLinkQuery('user:123')
+    expect(canvasNodeIdFromQuery(query)).toBe('user:123')
+  })
+})

--- a/autobot-frontend/src/composables/workflow/canvasNodeDeepLink.ts
+++ b/autobot-frontend/src/composables/workflow/canvasNodeDeepLink.ts
@@ -1,0 +1,59 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * The "open this node" link contract (#14611).
+ *
+ * The inbound counterpart to `workflowDeepLink.ts`'s outbound `?workflow=<id>`
+ * link (#13963): a canvas node link is `?node=<id>` and `OrgChart.vue` opens
+ * whatever it names — panning/zooming the canvas to it and, for a real
+ * org-chart member, opening the same sidebar a click on it would.
+ *
+ * Kept as a sibling module rather than folded into `workflowDeepLink.ts`: the
+ * two name different query keys for different targets (a workflow vs. a
+ * canvas node), and a shared parser would have to thread which one a caller
+ * meant. Mirrors that module's shape exactly — one exported query key, one
+ * exported parser — so a rename on either side stays a compile error rather
+ * than a link that still looks specific and silently opens nothing.
+ */
+
+/** Query key naming the canvas node to focus. */
+export const CANVAS_NODE_QUERY_KEY = 'node'
+
+/**
+ * A route query, typed permissively on purpose — see `workflowDeepLink.ts`'s
+ * identical `QueryLike` for why: `vue-router`'s own `LocationQuery` is not
+ * assignable to a re-declared lookalike, and this module stays free of a
+ * router dependency either way.
+ */
+type QueryLike = Record<string, unknown>
+
+/**
+ * The canvas node a route query asks to focus, or null when it asks for none.
+ *
+ * `vue-router` types a repeated query parameter as an array (`?node=a&node=b`
+ * arrives as `['a', 'b']`); taking the first is deliberate, matching
+ * `workflowIdFromQuery` — focusing one node is the only sensible reading, and
+ * throwing would break a link a user can produce by accident.
+ */
+export function canvasNodeIdFromQuery(query: QueryLike | undefined): string | null {
+  const requested = query?.[CANVAS_NODE_QUERY_KEY]
+  const value = Array.isArray(requested) ? requested[0] : requested
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Build the query object for a shareable link to `nodeId` on the canvas.
+ *
+ * A plain object rather than a full URL: every caller so far already has a
+ * `RouteLocation`/`router.push` in hand (mirrors how `OrgChart.vue` builds the
+ * outbound `{ [WORKFLOW_QUERY_KEY]: workflowId }` query for #13963) — building
+ * a full URL here would mean owning origin/path assembly this module has no
+ * business doing.
+ */
+export function canvasNodeLinkQuery(nodeId: string): Record<string, string> {
+  return { [CANVAS_NODE_QUERY_KEY]: nodeId }
+}

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}، {state}",
       "a11yInstructions": "استخدم مفاتيح الأسهم لتحريك التركيز بين العقد. اضغط على Enter أو المسافة لتحديد العقدة التي عليها التركيز. اضغط على Escape لإلغاء التحديد.",
-      "a11yInstructionsMove": "اضغط مطولاً على Control ثم اضغط على مفتاح سهم لتحريك العقدة المحددة."
+      "a11yInstructionsMove": "اضغط مطولاً على Control ثم اضغط على مفتاح سهم لتحريك العقدة المحددة.",
+      "searchLabel": "البحث في العقد",
+      "searchPlaceholder": "ابحث بالاسم",
+      "searchClear": "مسح البحث",
+      "searchResultsStatus": "تم العثور على {count} لِـ \"{query}\"",
+      "searchNoResults": "لا توجد نتائج مطابقة لـ \"{query}\"",
+      "fitToSelection": "احتواء التحديد أو التصفية",
+      "minimapLabel": "نظرة عامة على اللوحة"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "تعذّرت إزالة هذه الأداة.",
       "toolDetach": "إزالة {tool} من {role}",
       "canvasToolsUnavailable": "معلومات الأدوات غير متاحة حاليًا — قد تكون هذه القائمة غير مكتملة.",
-      "canvasNoToolsDefined": "لا توجد أدوات مرفقة بأي دور في هذه الشركة."
+      "canvasNoToolsDefined": "لا توجد أدوات مرفقة بأي دور في هذه الشركة.",
+      "deepLinkNodeNotFound": "تشير هذه الوصلة إلى عقدة تعذر العثور عليها هنا. ربما تمت إزالتها، أو قد لا تملك صلاحية الوصول إليها."
     },
     "executorRollup": {
       "title": "ملخص المنفذين",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Verwenden Sie die Pfeiltasten, um den Fokus zwischen den Knoten zu bewegen. Drücken Sie Eingabe oder Leertaste, um den fokussierten Knoten auszuwählen. Drücken Sie Escape, um die Auswahl aufzuheben.",
-      "a11yInstructionsMove": "Halten Sie Strg gedrückt und drücken Sie eine Pfeiltaste, um den ausgewählten Knoten zu verschieben."
+      "a11yInstructionsMove": "Halten Sie Strg gedrückt und drücken Sie eine Pfeiltaste, um den ausgewählten Knoten zu verschieben.",
+      "searchLabel": "Knoten durchsuchen",
+      "searchPlaceholder": "Nach Namen suchen",
+      "searchClear": "Suche löschen",
+      "searchResultsStatus": "{count} Treffer für „{query}“",
+      "searchNoResults": "Keine Treffer für „{query}“",
+      "fitToSelection": "An Auswahl oder Filter anpassen",
+      "minimapLabel": "Canvas-Übersicht"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "Dieses Werkzeug konnte nicht entfernt werden.",
       "toolDetach": "{tool} von {role} entfernen",
       "canvasToolsUnavailable": "Werkzeuginformationen sind derzeit nicht verfügbar — diese Liste ist möglicherweise unvollständig.",
-      "canvasNoToolsDefined": "Diesem Unternehmen sind keiner Rolle Werkzeuge zugeordnet."
+      "canvasNoToolsDefined": "Diesem Unternehmen sind keiner Rolle Werkzeuge zugeordnet.",
+      "deepLinkNodeNotFound": "Dieser Link verweist auf einen Knoten, der hier nicht gefunden werden konnte. Er wurde möglicherweise entfernt, oder Sie haben keinen Zugriff darauf."
     },
     "executorRollup": {
       "title": "Ausführungs-Übersicht",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Use the arrow keys to move focus between nodes. Press Enter or Space to select the focused node. Press Escape to deselect.",
-      "a11yInstructionsMove": "Hold Control and press an arrow key to move the selected node."
+      "a11yInstructionsMove": "Hold Control and press an arrow key to move the selected node.",
+      "searchLabel": "Search nodes",
+      "searchPlaceholder": "Search by name",
+      "searchClear": "Clear search",
+      "searchResultsStatus": "{count} found for \"{query}\"",
+      "searchNoResults": "No matches for \"{query}\"",
+      "fitToSelection": "Fit to selection or filter",
+      "minimapLabel": "Canvas overview"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8310,7 +8317,8 @@
       "toolDetachError": "Could not detach that tool.",
       "toolDetach": "Detach {tool} from {role}",
       "canvasToolsUnavailable": "Tool information is unavailable right now — this list may be incomplete.",
-      "canvasNoToolsDefined": "No tools are attached to any role in this company."
+      "canvasNoToolsDefined": "No tools are attached to any role in this company.",
+      "deepLinkNodeNotFound": "This link points to a node that could not be found here. It may have been removed, or you may not have access to it."
     },
     "executorRollup": {
       "title": "Executor Rollup",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Use las teclas de flecha para mover el foco entre los nodos. Presione Enter o Espacio para seleccionar el nodo enfocado. Presione Escape para anular la selección.",
-      "a11yInstructionsMove": "Mantenga presionada la tecla Control y presione una tecla de flecha para mover el nodo seleccionado."
+      "a11yInstructionsMove": "Mantenga presionada la tecla Control y presione una tecla de flecha para mover el nodo seleccionado.",
+      "searchLabel": "Buscar nodos",
+      "searchPlaceholder": "Buscar por nombre",
+      "searchClear": "Borrar búsqueda",
+      "searchResultsStatus": "{count} resultados para \"{query}\"",
+      "searchNoResults": "Sin coincidencias para \"{query}\"",
+      "fitToSelection": "Ajustar a la selección o al filtro",
+      "minimapLabel": "Vista general del lienzo"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "No se pudo quitar esa herramienta.",
       "toolDetach": "Quitar {tool} de {role}",
       "canvasToolsUnavailable": "La información de herramientas no está disponible ahora mismo: esta lista puede estar incompleta.",
-      "canvasNoToolsDefined": "No hay herramientas adjuntas a ningún rol en esta empresa."
+      "canvasNoToolsDefined": "No hay herramientas adjuntas a ningún rol en esta empresa.",
+      "deepLinkNodeNotFound": "Este enlace apunta a un nodo que no se pudo encontrar aquí. Puede que se haya eliminado o que no tengas acceso a él."
     },
     "executorRollup": {
       "title": "Resumen de ejecutores",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -3819,7 +3819,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "برای انتقال فوکوس بین گره‌ها از کلیدهای جهت‌نما استفاده کنید. برای انتخاب گره فوکوس‌شده، Enter یا Space را فشار دهید. برای لغو انتخاب، Escape را فشار دهید.",
-      "a11yInstructionsMove": "کلید Control را نگه دارید و یک کلید جهت‌نما را فشار دهید تا گره انتخاب‌شده جابه‌جا شود."
+      "a11yInstructionsMove": "کلید Control را نگه دارید و یک کلید جهت‌نما را فشار دهید تا گره انتخاب‌شده جابه‌جا شود.",
+      "searchLabel": "جستجوی گره‌ها",
+      "searchPlaceholder": "جستجو بر اساس نام",
+      "searchClear": "پاک کردن جستجو",
+      "searchResultsStatus": "{count} مورد برای «{query}» یافت شد",
+      "searchNoResults": "هیچ نتیجه‌ای برای «{query}» یافت نشد",
+      "fitToSelection": "تنظیم اندازه بر اساس انتخاب یا فیلتر",
+      "minimapLabel": "نمای کلی بوم"
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "جدا کردن این ابزار ممکن نشد.",
       "toolDetach": "جدا کردن {tool} از {role}",
       "canvasToolsUnavailable": "اطلاعات ابزارها در حال حاضر در دسترس نیست — این فهرست ممکن است ناقص باشد.",
-      "canvasNoToolsDefined": "هیچ ابزاری به هیچ نقشی در این شرکت پیوست نشده است."
+      "canvasNoToolsDefined": "هیچ ابزاری به هیچ نقشی در این شرکت پیوست نشده است.",
+      "deepLinkNodeNotFound": "این پیوند به گره‌ای اشاره دارد که در اینجا یافت نشد. ممکن است حذف شده باشد یا شما به آن دسترسی نداشته باشید."
     },
     "executorRollup": {
       "title": "خلاصه مجریان",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind} : {name}",
       "nodeAriaLabelWithState": "{kind} : {name}, {state}",
       "a11yInstructions": "Utilisez les touches fléchées pour déplacer le focus entre les nœuds. Appuyez sur Entrée ou Espace pour sélectionner le nœud ciblé. Appuyez sur Échap pour désélectionner.",
-      "a11yInstructionsMove": "Maintenez Ctrl enfoncé et appuyez sur une touche fléchée pour déplacer le nœud sélectionné."
+      "a11yInstructionsMove": "Maintenez Ctrl enfoncé et appuyez sur une touche fléchée pour déplacer le nœud sélectionné.",
+      "searchLabel": "Rechercher des nœuds",
+      "searchPlaceholder": "Rechercher par nom",
+      "searchClear": "Effacer la recherche",
+      "searchResultsStatus": "{count} résultats pour « {query} »",
+      "searchNoResults": "Aucun résultat pour « {query} »",
+      "fitToSelection": "Ajuster à la sélection ou au filtre",
+      "minimapLabel": "Aperçu du canevas"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "Impossible de détacher cet outil.",
       "toolDetach": "Détacher {tool} de {role}",
       "canvasToolsUnavailable": "Les informations sur les outils sont indisponibles pour le moment — cette liste peut être incomplète.",
-      "canvasNoToolsDefined": "Aucun outil n'est associé à un rôle dans cette entreprise."
+      "canvasNoToolsDefined": "Aucun outil n'est associé à un rôle dans cette entreprise.",
+      "deepLinkNodeNotFound": "Ce lien pointe vers un nœud introuvable ici. Il a peut-être été supprimé, ou vous n'y avez pas accès."
     },
     "executorRollup": {
       "title": "Récapitulatif des exécutants",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -3819,7 +3819,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "השתמשו במקשי החצים כדי להזיז את המיקוד בין הצמתים. הקישו Enter או Space כדי לבחור בצומת הממוקד. הקישו Escape כדי לבטל את הבחירה.",
-      "a11yInstructionsMove": "החזיקו את מקש Control ולחצו על מקש חץ כדי להזיז את הצומת הנבחרת."
+      "a11yInstructionsMove": "החזיקו את מקש Control ולחצו על מקש חץ כדי להזיז את הצומת הנבחרת.",
+      "searchLabel": "חיפוש בצמתים",
+      "searchPlaceholder": "חיפוש לפי שם",
+      "searchClear": "נקה חיפוש",
+      "searchResultsStatus": "נמצאו {count} תוצאות עבור \"{query}\"",
+      "searchNoResults": "אין התאמות עבור \"{query}\"",
+      "fitToSelection": "התאם לבחירה או למסנן",
+      "minimapLabel": "סקירה כללית של הקנבס"
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "לא ניתן היה להסיר כלי זה.",
       "toolDetach": "הסר את {tool} מ-{role}",
       "canvasToolsUnavailable": "מידע על כלים אינו זמין כעת — רשימה זו עשויה להיות חלקית.",
-      "canvasNoToolsDefined": "לא צורפו כלים לאף תפקיד בחברה זו."
+      "canvasNoToolsDefined": "לא צורפו כלים לאף תפקיד בחברה זו.",
+      "deepLinkNodeNotFound": "קישור זה מפנה לצומת שלא נמצא כאן. ייתכן שהוא הוסר, או שאין לך גישה אליו."
     },
     "executorRollup": {
       "title": "סיכום מבצעים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Izmantojiet bulttaustiņus, lai pārvietotu fokusu starp mezgliem. Nospiediet Enter vai atstarpi, lai atlasītu fokusēto mezglu. Nospiediet Escape, lai atceltu atlasi.",
-      "a11yInstructionsMove": "Turiet nospiestu Control un nospiediet bulttaustiņu, lai pārvietotu atlasīto mezglu."
+      "a11yInstructionsMove": "Turiet nospiestu Control un nospiediet bulttaustiņu, lai pārvietotu atlasīto mezglu.",
+      "searchLabel": "Meklēt mezglus",
+      "searchPlaceholder": "Meklēt pēc nosaukuma",
+      "searchClear": "Notīrīt meklēšanu",
+      "searchResultsStatus": "Atrasti {count} rezultāti vaicājumam \"{query}\"",
+      "searchNoResults": "Nav atbilstību vaicājumam \"{query}\"",
+      "fitToSelection": "Pielāgot atlasei vai filtram",
+      "minimapLabel": "Audekla pārskats"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "Neizdevās noņemt šo rīku.",
       "toolDetach": "Noņemt {tool} no {role}",
       "canvasToolsUnavailable": "Rīku informācija pašlaik nav pieejama — šis saraksts var būt nepilnīgs.",
-      "canvasNoToolsDefined": "Šim uzņēmumam nevienai lomai nav pievienots neviens rīks."
+      "canvasNoToolsDefined": "Šim uzņēmumam nevienai lomai nav pievienots neviens rīks.",
+      "deepLinkNodeNotFound": "Šī saite norāda uz mezglu, kas šeit nav atrasts. Iespējams, tas ir noņemts, vai jums nav piekļuves tam."
     },
     "executorRollup": {
       "title": "Izpildītāju kopsavilkums",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Użyj klawiszy strzałek, aby przenieść fokus między węzłami. Naciśnij Enter lub Spację, aby wybrać zaznaczony węzeł. Naciśnij Escape, aby anulować wybór.",
-      "a11yInstructionsMove": "Przytrzymaj Control i naciśnij klawisz strzałki, aby przenieść wybrany węzeł."
+      "a11yInstructionsMove": "Przytrzymaj Control i naciśnij klawisz strzałki, aby przenieść wybrany węzeł.",
+      "searchLabel": "Szukaj węzłów",
+      "searchPlaceholder": "Szukaj po nazwie",
+      "searchClear": "Wyczyść wyszukiwanie",
+      "searchResultsStatus": "Znaleziono {count} dla „{query}”",
+      "searchNoResults": "Brak wyników dla „{query}”",
+      "fitToSelection": "Dopasuj do zaznaczenia lub filtra",
+      "minimapLabel": "Podgląd całego obszaru roboczego"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "Nie udało się odłączyć tego narzędzia.",
       "toolDetach": "Odłącz {tool} od {role}",
       "canvasToolsUnavailable": "Informacje o narzędziach są obecnie niedostępne — ta lista może być niepełna.",
-      "canvasNoToolsDefined": "Żadne narzędzie nie jest dołączone do żadnej roli w tej firmie."
+      "canvasNoToolsDefined": "Żadne narzędzie nie jest dołączone do żadnej roli w tej firmie.",
+      "deepLinkNodeNotFound": "Ten link wskazuje węzeł, którego nie można tu znaleźć. Mógł zostać usunięty lub nie masz do niego dostępu."
     },
     "executorRollup": {
       "title": "Zestawienie wykonawców",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -4380,7 +4380,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "Use as teclas de seta para mover o foco entre os nós. Pressione Enter ou Espaço para selecionar o nó focado. Pressione Escape para desmarcar.",
-      "a11yInstructionsMove": "Mantenha pressionado Control e pressione uma tecla de seta para mover o nó selecionado."
+      "a11yInstructionsMove": "Mantenha pressionado Control e pressione uma tecla de seta para mover o nó selecionado.",
+      "searchLabel": "Pesquisar nós",
+      "searchPlaceholder": "Pesquisar por nome",
+      "searchClear": "Limpar pesquisa",
+      "searchResultsStatus": "{count} resultados para \"{query}\"",
+      "searchNoResults": "Nenhum resultado para \"{query}\"",
+      "fitToSelection": "Ajustar à seleção ou ao filtro",
+      "minimapLabel": "Visão geral da tela"
     },
     "editStep": {
       "title": "Edit Step {step}",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "Não foi possível remover essa ferramenta.",
       "toolDetach": "Remover {tool} de {role}",
       "canvasToolsUnavailable": "As informações de ferramentas estão indisponíveis neste momento — esta lista pode estar incompleta.",
-      "canvasNoToolsDefined": "Nenhuma ferramenta está anexada a nenhuma função nesta empresa."
+      "canvasNoToolsDefined": "Nenhuma ferramenta está anexada a nenhuma função nesta empresa.",
+      "deepLinkNodeNotFound": "Este link aponta para um nó que não foi encontrado aqui. Ele pode ter sido removido ou você pode não ter acesso a ele."
     },
     "executorRollup": {
       "title": "Resumo de executores",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -3819,7 +3819,14 @@
       "nodeAriaLabel": "{kind}: {name}",
       "nodeAriaLabelWithState": "{kind}: {name}, {state}",
       "a11yInstructions": "نوڈز کے درمیان فوکس منتقل کرنے کے لیے ایرو کیز استعمال کریں۔ فوکس شدہ نوڈ کو منتخب کرنے کے لیے Enter یا Space دبائیں۔ انتخاب ختم کرنے کے لیے Escape دبائیں۔",
-      "a11yInstructionsMove": "منتخب نوڈ کو حرکت دینے کے لیے Control دبائے رکھیں اور ایک ایرو کی دبائیں۔"
+      "a11yInstructionsMove": "منتخب نوڈ کو حرکت دینے کے لیے Control دبائے رکھیں اور ایک ایرو کی دبائیں۔",
+      "searchLabel": "نوڈز تلاش کریں",
+      "searchPlaceholder": "نام سے تلاش کریں",
+      "searchClear": "تلاش صاف کریں",
+      "searchResultsStatus": "\"{query}\" کے لیے {count} نتائج ملے",
+      "searchNoResults": "\"{query}\" کے لیے کوئی نتیجہ نہیں ملا",
+      "fitToSelection": "انتخاب یا فلٹر کے مطابق فٹ کریں",
+      "minimapLabel": "کینوس کا جائزہ"
     },
     "notifications": {
       "emailRecipients": "Email Recipients",
@@ -8322,7 +8329,8 @@
       "toolDetachError": "یہ ٹول الگ نہیں ہو سکا۔",
       "toolDetach": "{tool} کو {role} سے الگ کریں",
       "canvasToolsUnavailable": "ٹول کی معلومات اس وقت دستیاب نہیں ہیں — یہ فہرست نامکمل ہو سکتی ہے۔",
-      "canvasNoToolsDefined": "اس کمپنی میں کسی کردار کے ساتھ کوئی ٹول منسلک نہیں۔"
+      "canvasNoToolsDefined": "اس کمپنی میں کسی کردار کے ساتھ کوئی ٹول منسلک نہیں۔",
+      "deepLinkNodeNotFound": "یہ لنک ایک ایسے نوڈ کی طرف اشارہ کرتا ہے جو یہاں نہیں ملا۔ ہو سکتا ہے یہ ہٹا دیا گیا ہو، یا آپ کو اس تک رسائی حاصل نہ ہو۔"
     },
     "executorRollup": {
       "title": "عمل کنندہ خلاصہ",

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -11,7 +11,7 @@ import { useLlcCompanyContext } from '@/composables/llc/useLlcCompanyContext'
 import OrgTreeNode from './OrgTreeNode.vue'
 import type { OrgNode } from './OrgTreeNode.vue'
 import HireAgentModal from '@/components/llc/HireAgentModal.vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
 import type { CanvasNode, CanvasTab } from '@/components/workflow/canvasNode'
 import {
@@ -29,6 +29,7 @@ import {
 } from '@/composables/llc/orgCanvasGraph'
 import type { ProcessNodeSource, ToolNodeSource } from '@/composables/llc/orgCanvasGraph'
 import { WORKFLOW_QUERY_KEY } from '@/composables/workflow/workflowDeepLink'
+import { canvasNodeIdFromQuery } from '@/composables/workflow/canvasNodeDeepLink'
 import OrgPeopleList from '@/components/llc/OrgPeopleList.vue'
 import CanvasNodeSidebar from '@/components/llc/CanvasNodeSidebar.vue'
 import {
@@ -48,6 +49,11 @@ const logger = createLogger('OrgChart')
 const api = useApiClient()
 const { t, locale } = useI18n()
 const router = useRouter()
+// #14611: cast to allow `undefined` — several existing tests mount this view
+// with no router plugin installed at all, and `useRoute()` (like `useRouter()`
+// above) simply returns `undefined` there rather than throwing; `route?.query`
+// below must tolerate that exactly the same way.
+const route = useRoute() as ReturnType<typeof useRoute> | undefined
 const { companyId, resolveCompanyId } = useLlcCompanyContext()
 
 const tree = ref<OrgNode[]>([])
@@ -753,10 +759,91 @@ function onCanvasNodeMoved(nodeId: string, position: { x: number; y: number }) {
   if (node) node.position = position
 }
 
+/* ------------------------------------------------------------------ *
+ * #14611: the inbound deep link — the counterpart to #13963's outbound
+ * `?workflow=<id>` link. A `?node=<id>` query names a canvas node to open the
+ * canvas already focused on, so a colleague can be sent a link to what the
+ * sender is looking at rather than told to pan until they find it.
+ * ------------------------------------------------------------------ */
+
+/**
+ * Read once via a computed rather than copied into plain state: only its
+ * value at mount matters here (`deepLinkHandled` below claims the request
+ * exactly once), so a later unrelated query change can never re-trigger a
+ * jump the user has since panned away from.
+ */
+const deepLinkTargetId = computed<string | null>(() => canvasNodeIdFromQuery(route?.query))
+
+/**
+ * Every lazy source a deep-linked node could live in has answered (or
+ * failed) — the tree itself, processes, tools, teams. Only once all four are
+ * settled can "not found" be told apart from "not loaded yet"
+ * (#14064/#13617/#14556's repeat conflation, the same reasoning every other
+ * "unavailable" banner on this view already follows).
+ */
+const deepLinkSourcesReady = computed(
+  () => !isLoading.value && processNodesLoaded.value && toolNodesLoaded.value && teamsAttempted.value,
+)
+
+/** The canvas node `deepLinkTargetId` names among the nodes the canvas is
+ *  actually about to draw (`lensedCanvasNodes`) — including a team-roster
+ *  alias of a real org-chart member, the same lookup `onCanvasNodeSelected`
+ *  already performs for a click. */
+const deepLinkResolvedNode = computed<CanvasNode | null>(() => {
+  const targetId = deepLinkTargetId.value
+  if (!targetId) return null
+  return (
+    lensedCanvasNodes.value.find(
+      (node) => node.id === targetId || teamMemberOrgNodeId(node.id) === targetId,
+    ) ?? null
+  )
+})
+
+/** The id actually handed to `WorkflowCanvas`'s `focus-node-id` prop — only
+ *  once resolution has confirmed the node is really drawn, so the canvas is
+ *  never asked to jump to something it does not have. */
+const canvasFocusNodeId = ref<string | null>(null)
+/** A link that names a node this company does not have (removed, or the
+ *  reader lacks access) must read as "not found", never as an empty or
+ *  unresponsive canvas (#14611 acceptance; #14064/#13617/#14556's repeat
+ *  defect). */
+const deepLinkNodeNotFound = ref(false)
+
+/** One attempt per link, not a retry loop re-firing on every unrelated
+ *  reactive change once the sources are ready (mirrors `WorkflowCanvas.vue`'s
+ *  own `focusNodeId` prop watcher, which makes the same one-shot choice for
+ *  the same reason: a fixed jump must not fight a pan the user made since). */
+let deepLinkHandled = false
+
+watch(deepLinkSourcesReady, (ready) => {
+  const targetId = deepLinkTargetId.value
+  if (!ready || !targetId || deepLinkHandled) return
+  deepLinkHandled = true
+  const match = deepLinkResolvedNode.value
+  if (!match) {
+    deepLinkNodeNotFound.value = true
+    return
+  }
+  canvasFocusNodeId.value = match.id
+  // A process/tool node's "focus" is the pan/zoom alone — auto-opening the
+  // sidebar, or (for a process node) navigating straight to the workflow
+  // builder via `onCanvasNodeSelected`, would hijack a shared link before the
+  // reader has looked at anything. A real org-chart member (bare, or a team-
+  // roster alias of one) DOES open the same drawer a click on it would: for a
+  // person, "focused on it" reasonably includes the detail a click shows.
+  const realId = teamMemberOrgNodeId(match.id) ?? match.id
+  const orgNode = flattenOrgNodes(tree.value).get(realId)
+  if (orgNode) openDrawer(orgNode)
+})
+
 onMounted(() => {
   void fetchTree()
   // #13942: company-wide, independent of tree/view-mode — loads once, like fetchTree.
   void loadExecutorRollup()
+  // #14611: a deep link opens straight onto the canvas, triggering the same
+  // lazy fetches a manual click into it already does (`setViewMode`) — the
+  // sources `deepLinkSourcesReady` above waits on would otherwise never load.
+  if (deepLinkTargetId.value) setViewMode('canvas')
 })
 </script>
 
@@ -1069,6 +1156,19 @@ onMounted(() => {
         {{ t('llc.orgChart.peopleNoTeamsDefined') }}
       </p>
 
+      <!-- #14611: a `?node=` link that names a node this company does not
+           have (removed, or the reader lacks access) must say so — never
+           read as an unresponsive or empty canvas
+           (#14064/#13617/#14556's repeat conflation). -->
+      <div
+        v-if="deepLinkNodeNotFound"
+        class="border-b border-autobot-border bg-autobot-error-bg text-autobot-error px-3 py-2 text-sm"
+        role="alert"
+        data-testid="canvas-deeplink-not-found"
+      >
+        {{ t('llc.orgChart.deepLinkNodeNotFound') }}
+      </div>
+
       <!-- GH#13943: the lens's own affordance. Shown whenever a role is
            selected, independent of whether it still matches anything, so a
            reduced (or emptied) canvas reads as "filtered by view", never as
@@ -1116,6 +1216,7 @@ onMounted(() => {
         :selected-node-id="selectedNode?.id ?? null"
         :tabs="canvasTabs"
         :active-tab-id="effectiveTabId"
+        :focus-node-id="canvasFocusNodeId"
         @node-selected="onCanvasNodeSelected"
         @node-moved="onCanvasNodeMoved"
         @tab-selected="activeTabId = $event"

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.deepLink.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.deepLink.test.ts
@@ -1,0 +1,206 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14611: the inbound deep link — `?node=<id>` opens the canvas already
+// focused on a node, the counterpart to #13963's outbound `?workflow=<id>`
+// link. These tests pin:
+//
+//  * no `?node=` query leaves the view exactly as before (tree, not canvas);
+//  * a real node auto-opens the canvas, focuses it, and opens the same
+//    drawer a click would;
+//  * a node this company does not have (removed, or the reader lacks access)
+//    reads as "not found" — never as an empty or unresponsive canvas
+//    (#14064/#13617/#14556's repeat conflation);
+//  * "not found" cannot appear before the lazy canvas sources have actually
+//    answered — an unresolved request must not look decided.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+// A mutable query the mock reads fresh on every `useRoute()` call, so each
+// test can point a fresh mount at a different `?node=` without a second
+// `vi.mock` factory.
+let currentQuery: Record<string, unknown> = {}
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ params: { companyId: 'c1' }, query: currentQuery }),
+}))
+
+const companyRef = ref('c1')
+
+vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
+  useLlcCompanyContext: () => ({
+    companyId: companyRef,
+    resolveCompanyId: () => Promise.resolve(companyRef.value),
+  }),
+}))
+
+import OrgChart from '../OrgChart.vue'
+import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
+
+const CEO = {
+  id: 'ceo',
+  name: 'Ada Lovelace',
+  title: 'CEO',
+  status: 'idle',
+  adapter_type: 'claude',
+  is_human: false,
+  last_heartbeat: null,
+  budget_spent: 0,
+  budget_total: 0,
+  assigned_item_count: 0,
+  parent_id: null,
+  children: [],
+}
+
+/** Resolves every request instantly — used by every test except the one
+ *  pinning the "not found before the sources answer" ordering, which needs
+ *  to hold `/process-nodes` open on purpose. */
+function respond({ processNodesDeferred = false }: { processNodesDeferred?: boolean } = {}) {
+  let resolveProcessNodes: (() => void) | null = null
+  const processNodesPromise = processNodesDeferred
+    ? new Promise<{ nodes: unknown[] }>((resolve) => {
+        resolveProcessNodes = () => resolve({ nodes: [] })
+      })
+    : Promise.resolve({ nodes: [] })
+
+  get.mockImplementation((url: string) => {
+    if (url === '/api/llc/companies/c1/org-chart') return Promise.resolve({ nodes: [CEO] })
+    if (url === '/api/llc/companies/c1/process-nodes') return processNodesPromise
+    if (url === '/api/llc/companies/c1/tool-nodes') return Promise.resolve({ nodes: [] })
+    if (url === '/api/llc/roles/c1') return Promise.resolve([])
+    if (url === '/api/llc/contacts/c1/involved') return Promise.resolve({ with_role: [], unassigned: [] })
+    if (url === '/api/llc/companies/c1/teams') return Promise.resolve({ teams: [] })
+    if (url === '/api/llc/companies/c1/work-items/executor-rollup') return Promise.resolve({ cells: [] })
+    throw new Error(`unexpected GET ${url}`)
+  })
+  return { resolveProcessNodes: () => resolveProcessNodes?.() }
+}
+
+async function mountChart() {
+  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+  const wrapper = mount(OrgChart, {
+    global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, HireAgentModal: true, OrgPeopleList: true } },
+  })
+  await flushPromises()
+  return wrapper
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  push.mockReset()
+  currentQuery = {}
+})
+
+describe('no ?node= query (#14611)', () => {
+  it('leaves the default tree view exactly as before', async () => {
+    respond()
+    const wrapper = await mountChart()
+
+    expect(wrapper.find('[data-testid="org-canvas"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="canvas-deeplink-not-found"]').exists()).toBe(false)
+  })
+})
+
+describe('a link to a real node (#14611)', () => {
+  it('auto-opens the canvas, focused on the node — no not-found banner', async () => {
+    currentQuery = { node: 'ceo' }
+    respond()
+    const wrapper = await mountChart()
+
+    expect(wrapper.find('[data-testid="org-canvas"]').exists()).toBe(true)
+    expect(wrapper.findComponent(WorkflowCanvas).props('focusNodeId')).toBe('ceo')
+    expect(wrapper.find('[data-testid="canvas-deeplink-not-found"]').exists()).toBe(false)
+    // Paired positive: the canvas is not empty — the node the link named is
+    // actually among what it draws.
+    const nodeIds = (wrapper.findComponent(WorkflowCanvas).props('nodes') as { id: string }[]).map(
+      (n) => n.id,
+    )
+    expect(nodeIds).toContain('ceo')
+  })
+
+  it('opens the same sidebar drawer a click on the node would', async () => {
+    currentQuery = { node: 'ceo' }
+    respond()
+    const wrapper = await mountChart()
+
+    const sidebar = wrapper.findComponent({ name: 'CanvasNodeSidebar' })
+    expect(sidebar.exists()).toBe(true)
+    expect(sidebar.props('node')).toMatchObject({ id: 'ceo', name: 'Ada Lovelace' })
+  })
+
+  it('a stale/repeated query param takes the first, matching workflowIdFromQuery\'s own rule', async () => {
+    currentQuery = { node: ['ceo', 'someone-else'] }
+    respond()
+    const wrapper = await mountChart()
+
+    expect(wrapper.findComponent(WorkflowCanvas).props('focusNodeId')).toBe('ceo')
+  })
+})
+
+describe('a link to a node this company does not have (#14611)', () => {
+  it('reads as "not found", never as an empty or unresponsive canvas', async () => {
+    currentQuery = { node: 'ghost' }
+    respond()
+    const wrapper = await mountChart()
+
+    expect(wrapper.get('[data-testid="canvas-deeplink-not-found"]').text()).toBe(
+      en.llc.orgChart.deepLinkNodeNotFound,
+    )
+    // Paired positive: switching to canvas mode still drew the real graph —
+    // the banner is a fact about the link, not a crashed/empty render.
+    const nodeIds = (wrapper.findComponent(WorkflowCanvas).props('nodes') as { id: string }[]).map(
+      (n) => n.id,
+    )
+    expect(nodeIds).toContain('ceo')
+    expect(wrapper.findComponent(WorkflowCanvas).props('focusNodeId')).toBeNull()
+  })
+
+  it('does not report "not found" until every lazy canvas source has actually answered', async () => {
+    currentQuery = { node: 'ghost' }
+    const { resolveProcessNodes } = respond({ processNodesDeferred: true })
+    const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+    const wrapper = mount(OrgChart, {
+      global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, HireAgentModal: true, OrgPeopleList: true } },
+    })
+    await flushPromises()
+
+    // The tree itself, tools, roles and teams have all answered — only
+    // /process-nodes is still pending — so "not found" must not have fired yet.
+    expect(wrapper.find('[data-testid="canvas-deeplink-not-found"]').exists()).toBe(false)
+
+    resolveProcessNodes()
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="canvas-deeplink-not-found"]').text()).toBe(
+      en.llc.orgChart.deepLinkNodeNotFound,
+    )
+  })
+})
+
+describe('an empty or whitespace ?node= (#14611)', () => {
+  it('is treated as no request at all, same as workflowIdFromQuery', async () => {
+    currentQuery = { node: '   ' }
+    respond()
+    const wrapper = await mountChart()
+
+    expect(wrapper.find('[data-testid="org-canvas"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="canvas-deeplink-not-found"]').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #14611 · Parent #13935 · **Base of a 3-PR stack** (#14612 and #14608 follow)

## Thinking Path

Measured before building: no canvas search (the four `search` matches in `WorkflowCanvas.vue` were all icon names), no minimap, no zoom-to-node — `resetZoom()` sets a fixed `(50,50)` at scale 1 — and no inbound deep link, since `OrgChart.vue` never read `route.query`. A company with a few dozen people and their processes produces a canvas larger than a screen, and the only way to find someone was to pan until you saw them.

Now that teams (#14596), processes (#13963) and tools (#14597) all render, that is four kinds of node to lose things among.

## What Changed

- **Search** across all four node kinds, keyboard-operable, with the match count announced through a live region — consistent with #14609's patterns rather than a second a11y convention.
- **Zoom to node** and **fit to selection or filter**, both routed through the existing `clampZoom` rather than new bounds. The existing reset button is untouched.
- **Minimap** with viewport position and click-to-pan.
- **Inbound deep link** — `?node=<id>` in a new `canvasNodeDeepLink.ts` mirroring the shape of the existing outbound `workflowDeepLink.ts`, not a second convention.
- **No match reads as "no match"**, and an unresolvable deep link says so rather than showing an empty canvas — the conflation this area produced three times (#14064, #13617, #14556).
- 8 keys across all 11 locales.

Nothing is gated on `readonly`: search, zoom, minimap and deep links are view concerns, and #14610 recorded what happens when a view gesture gets gated by mistake.

## Verification

I re-derived two of the load-bearing mutations myself:

| Mutation | Result |
|---|---|
| search matcher returns nothing | **12 of 17** search tests red |
| deep-link "not found" testid renamed | both "not found" tests red |

Plus the implementer's: the results/no-results branch, the empty-state `v-if`, `centerOnNode`, `fitToSelectionOrView` ignoring the selection, `clampZoom` stripped from `fitToNodes`, `zoomToNode`'s not-found guard, `minimapGeometry` forced null (7/8 red), and the deep-link source-readiness gate.

**Two pre-existing tests changed** — both pin the read-only toolbar at "3 buttons" and now pin 4, because this adds a fit button. The assertions are otherwise identical and still gate the same way; `git diff` on those files shows only the count and the test names.

- `vitest run src/components/workflow src/composables/workflow` — **15 files, 166 tests, all passed**
- `vue-tsc` 0 · `check:i18n` 0 · `eslint` / `oxlint` clean

The implementer hit the #14613 flake twice across four combined runs (`OrgChart.roleLens`, and once one of its own search tests), confirmed both non-reproducible in isolation, and did **not** add `--no-file-parallelism` anywhere.

## Honest gaps

- **No "copy shareable link" affordance.** The inbound `?node=` path is wired and tested; nothing writes that param as you browse. Automatic URL-syncing on selection would break several existing `OrgChart.*` tests that mock `useRouter()` with only `{ push }` and no `replace`. Deliberately deferred rather than smuggled in.
- The minimap's "never changes zoom" companion assertion is **not** independently mutation-sensitive — recorded rather than presented as a guard.
- A `teamMemberOrgNodeId` fallback branch in deep-link resolution has no reachable test path (a bare `org-person` node always resolves first). Kept for symmetry with the identical fallback in `onCanvasNodeSelected`, and flagged as unproven.

## Found, not fixed

`nodeAriaLabel` renders `"Process: Process"` and `"Tool: Tool"` for `org-process`/`org-tool`, because `nodeTitle` returns the generic type caption for those two kinds. A real pre-existing a11y defect on exactly the node types #13963 and #14597 added. Not touched here to keep this surface contained — filing separately.

## Model Used

Claude Opus 5 (1M context)
