### PR TITLE
a11y(llc/frontend): name a process by its workflow and a tool by its roles (#14657)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -559,6 +559,21 @@ function nodeFlag(node: CanvasNode, key: string): boolean {
 }
 
 /**
+ * The "{kind}: {name}" text shared by a node's accessible name and the
+ * canvas search result label (#14611) — one construction of it, not two.
+ *
+ * #14657: `name` is `nodeDisplayName`, not `nodeTitle` — for org-process and
+ * org-tool, `nodeTitle` is the generic type caption (the same string `kind`
+ * already carries), which announced e.g. "Process: Process" with nothing
+ * identifying which node it was.
+ */
+function nodeKindAndName(node: CanvasNode): string {
+  const kind = nodeKindLabel(node);
+  const name = nodeDisplayName(node);
+  return kind ? t('workflow.canvas.nodeAriaLabel', { kind, name }) : name;
+}
+
+/**
  * Accessible name for a node (#14609): kind, name and — for an org-person,
  * the only node type carrying a status concept — its current state.
  *
@@ -568,12 +583,13 @@ function nodeFlag(node: CanvasNode, key: string): boolean {
  * legend happens to be colouring by.
  */
 function nodeAriaLabel(node: CanvasNode): string {
-  const kind = nodeKindLabel(node);
-  const name = nodeTitle(node);
   const state = nodeStatusLabel(node);
-  return state
-    ? t('workflow.canvas.nodeAriaLabelWithState', { kind, name, state })
-    : t('workflow.canvas.nodeAriaLabel', { kind, name });
+  if (!state) return nodeKindAndName(node);
+  return t('workflow.canvas.nodeAriaLabelWithState', {
+    kind: nodeKindLabel(node),
+    name: nodeDisplayName(node),
+    state,
+  });
 }
 
 /** The "kind" component of a node's accessible name. */
@@ -1189,14 +1205,24 @@ watch(searchQuery, () => { searchActiveIndex.value = -1; });
  * A node's own name, independent of its type's generic caption.
  *
  * `nodeTitle` returns the *type* label ("Process", "Tool") for an org-process
- * or org-tool node — correct for the node's header, wrong for search, which
- * needs the workflow's role or the tool's name to find anything.
+ * or org-tool node — correct for the node's header, wrong for search and for
+ * the accessible name (#14657), both of which need something identifying
+ * *which* node this is: the workflow (and role) a process runs, or the tool
+ * name (and the roles carrying it).
  */
 function nodeDisplayName(node: CanvasNode): string {
   const label = nodeText(node, 'label');
   if (label) return label;
-  if (node.type === 'org-process') return nodeText(node, 'role_name');
-  if (node.type === 'org-tool') return nodeText(node, 'tool_name');
+  if (node.type === 'org-process') {
+    const workflow = nodeText(node, 'workflow_id');
+    const role = nodeText(node, 'role_name');
+    return role ? t('llc.orgChart.processDisplayName', { workflow, role }) : workflow;
+  }
+  if (node.type === 'org-tool') {
+    const tool = nodeText(node, 'tool_name');
+    const roles = toolRoles(node).map((role) => role.role_name).join(', ');
+    return roles ? t('llc.orgChart.toolDisplayName', { tool, roles }) : tool;
+  }
   return nodeTitle(node);
 }
 
@@ -1209,11 +1235,11 @@ function nodeSearchText(node: CanvasNode): string {
   return parts.filter(Boolean).join(' ');
 }
 
-/** The result list's visible (and screen-reader-read) label for `node`. */
+/** The result list's visible (and screen-reader-read) label for `node` —
+ *  the same "{kind}: {name}" text as the node's own accessible name (#14657),
+ *  not a second construction of it. */
 function nodeSearchLabel(node: CanvasNode): string {
-  const kind = nodeKindLabel(node);
-  const name = nodeDisplayName(node);
-  return kind ? `${kind}: ${name}` : name;
+  return nodeKindAndName(node);
 }
 
 const searchHasQuery = computed(() => searchQuery.value.trim().length > 0);

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.nodeAriaLabel.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.nodeAriaLabel.test.ts
@@ -1,0 +1,166 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * #14657: `nodeAriaLabel` built its "name" half from `nodeTitle`, which for
+ * `org-process` and `org-tool` is the generic type caption — the same string
+ * `nodeKindLabel` already returns as the "kind" half. A screen reader heard
+ * "Process: Process" and "Tool: Tool" for every process/tool node, with
+ * nothing identifying which one it was.
+ *
+ * One case per node kind (person, group, process, tool), per the acceptance
+ * criteria, so a regression on any single kind is caught — including the two
+ * kinds (`org-person`, `org-group`) that were already correct, to guard the
+ * `{kind}: {name}` template staying unchanged for them.
+ *
+ * Fixtures come from the real layout builders (`buildOrgCanvasGraph`,
+ * `buildProcessCanvasNodes`, `buildToolCanvasNodes`) rather than a
+ * hand-rolled node object — see `WorkflowCanvas.search.test.ts` for the same
+ * reasoning: a hand-written node can drift into a shape nothing emits.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import ar from '@/i18n/locales/ar.json'
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import {
+  buildOrgCanvasGraph,
+  buildProcessCanvasNodes,
+  buildToolCanvasNodes,
+  canvasBottom,
+} from '@/composables/llc/orgCanvasGraph'
+import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+
+function orgNode(id: string, name: string, children: OrgNode[] = []): OrgNode {
+  return {
+    id,
+    name,
+    title: 'Engineer',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children,
+  }
+}
+
+// One unit (a manager with a report, so it draws an org-group container too),
+// one process and one tool carried by two roles — the four node kinds this
+// issue's acceptance criteria names.
+const FOREST: OrgNode[] = [orgNode('ceo', 'Ada Lovelace', [orgNode('dev', 'Bo Diddley')])]
+const PEOPLE_NODES = buildOrgCanvasGraph(FOREST, (name) => `${name} unit`)
+const PROCESS_NODES = buildProcessCanvasNodes(
+  [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+  canvasBottom(PEOPLE_NODES),
+)
+const TOOL_NODES = buildToolCanvasNodes(
+  [
+    { role_id: 'r1', role_name: 'Head of Sales', tool_name: 'Salesforce' },
+    { role_id: 'r2', role_name: 'Head of Ops', tool_name: 'Salesforce' },
+  ],
+  [{ role_id: 'r1', role_name: 'Head of Sales', workflow_id: 'wf-quarterly' }],
+  canvasBottom([...PEOPLE_NODES, ...PROCESS_NODES]),
+)
+
+const ALL_NODES = [...PEOPLE_NODES, ...PROCESS_NODES, ...TOOL_NODES]
+
+function mountCanvas(locale: 'en' | 'ar' = 'en') {
+  return mount(WorkflowCanvas, {
+    props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
+    global: {
+      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
+    },
+  })
+}
+
+function ariaLabel(wrapper: ReturnType<typeof mountCanvas>, nodeId: string): string | undefined {
+  return wrapper.get(`[data-node-id="${nodeId}"]`).attributes('aria-label')
+}
+
+describe('node accessible name identifies the node, not only its type (#14657)', () => {
+  it('org-person: names the person (unaffected by the fix, guards the template staying "{kind}: {name}")', () => {
+    const wrapper = mountCanvas()
+    const expected = en.workflow.canvas.nodeAriaLabelWithState
+      .replace('{kind}', en.llc.orgChart.aiAgent)
+      .replace('{name}', 'Ada Lovelace')
+      .replace('{state}', en.llc.canvasRules.status.idle)
+
+    expect(ariaLabel(wrapper, 'ceo')).toBe(expected)
+  })
+
+  it('org-group: names the unit (unaffected by the fix, guards the template staying "{kind}: {name}")', () => {
+    const wrapper = mountCanvas()
+    const expected = en.workflow.canvas.nodeAriaLabel
+      .replace('{kind}', en.llc.orgChart.canvasGroupKind)
+      .replace('{name}', 'Ada Lovelace unit')
+
+    expect(ariaLabel(wrapper, 'org-group:ceo')).toBe(expected)
+  })
+
+  it('org-process: names the workflow and role, not the generic "Process" caption twice', () => {
+    const wrapper = mountCanvas()
+    const displayName = en.llc.orgChart.processDisplayName
+      .replace('{workflow}', 'wf-quarterly')
+      .replace('{role}', 'Head of Sales')
+    const expected = en.workflow.canvas.nodeAriaLabel
+      .replace('{kind}', en.llc.orgChart.processNodeLabel)
+      .replace('{name}', displayName)
+
+    expect(ariaLabel(wrapper, 'process:r1:wf-quarterly')).toBe(expected)
+    expect(ariaLabel(wrapper, 'process:r1:wf-quarterly')).not.toBe(
+      `${en.llc.orgChart.processNodeLabel}: ${en.llc.orgChart.processNodeLabel}`,
+    )
+  })
+
+  it('org-tool: names the tool and the roles carrying it, not the generic "Tool" caption twice', () => {
+    const wrapper = mountCanvas()
+    const displayName = en.llc.orgChart.toolDisplayName
+      .replace('{tool}', 'Salesforce')
+      .replace('{roles}', 'Head of Ops, Head of Sales')
+    const expected = en.workflow.canvas.nodeAriaLabel
+      .replace('{kind}', en.llc.orgChart.toolNodeLabel)
+      .replace('{name}', displayName)
+
+    expect(ariaLabel(wrapper, 'tool:Salesforce')).toBe(expected)
+    expect(ariaLabel(wrapper, 'tool:Salesforce')).not.toBe(
+      `${en.llc.orgChart.toolNodeLabel}: ${en.llc.orgChart.toolNodeLabel}`,
+    )
+  })
+
+  it('reads and identifies the tool node correctly in an RTL locale (ar)', () => {
+    const wrapper = mountCanvas('ar')
+    const displayName = ar.llc.orgChart.toolDisplayName
+      .replace('{tool}', 'Salesforce')
+      .replace('{roles}', 'Head of Ops, Head of Sales')
+    const expected = ar.workflow.canvas.nodeAriaLabel
+      .replace('{kind}', ar.llc.orgChart.toolNodeLabel)
+      .replace('{name}', displayName)
+
+    expect(ariaLabel(wrapper, 'tool:Salesforce')).toBe(expected)
+    expect(ariaLabel(wrapper, 'tool:Salesforce')).not.toBe(
+      `${ar.llc.orgChart.toolNodeLabel}: ${ar.llc.orgChart.toolNodeLabel}`,
+    )
+  })
+
+  it('the search result label draws on the same "{kind}: {name}" text as the accessible name (#14611 consolidation)', async () => {
+    const wrapper = mount(WorkflowCanvas, {
+      props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
+      global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+      attachTo: document.body,
+    })
+
+    await wrapper.get('[data-testid="canvas-search-input"]').setValue('Salesforce')
+    const result = wrapper.get('[data-testid="canvas-search-result"]')
+    const nodeAriaLabelText = ariaLabel(wrapper, 'tool:Salesforce')
+
+    expect(result.text()).toBe(nodeAriaLabelText)
+  })
+})

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8332,6 +8332,7 @@
       "attachError": "تعذّر إرفاق سير العمل هذا.",
       "detachError": "تعذّرت إزالة سير العمل هذا.",
       "processDetach": "إزالة {workflow} من {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "تعذّر تحميل الأدوار، لذا قد تكون هذه القائمة غير مكتملة.",
       "canvasGroupKind": "مجموعة",
       "toolNodeLabel": "أداة",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "تعذّر إرفاق هذه الأداة.",
       "toolDetachError": "تعذّرت إزالة هذه الأداة.",
       "toolDetach": "إزالة {tool} من {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "معلومات الأدوات غير متاحة حاليًا — قد تكون هذه القائمة غير مكتملة.",
       "canvasNoToolsDefined": "لا توجد أدوات مرفقة بأي دور في هذه الشركة.",
       "deepLinkNodeNotFound": "تشير هذه الوصلة إلى عقدة تعذر العثور عليها هنا. ربما تمت إزالتها، أو قد لا تملك صلاحية الوصول إليها."

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8332,6 +8332,7 @@
       "attachError": "Dieser Workflow konnte nicht zugeordnet werden.",
       "detachError": "Dieser Workflow konnte nicht entfernt werden.",
       "processDetach": "{workflow} von {role} entfernen",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Rollen konnten nicht geladen werden, daher ist diese Liste möglicherweise unvollständig.",
       "canvasGroupKind": "Gruppe",
       "toolNodeLabel": "Werkzeug",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "Dieses Werkzeug konnte nicht zugeordnet werden.",
       "toolDetachError": "Dieses Werkzeug konnte nicht entfernt werden.",
       "toolDetach": "{tool} von {role} entfernen",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "Werkzeuginformationen sind derzeit nicht verfügbar — diese Liste ist möglicherweise unvollständig.",
       "canvasNoToolsDefined": "Diesem Unternehmen sind keiner Rolle Werkzeuge zugeordnet.",
       "deepLinkNodeNotFound": "Dieser Link verweist auf einen Knoten, der hier nicht gefunden werden konnte. Er wurde möglicherweise entfernt, oder Sie haben keinen Zugriff darauf."

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8320,6 +8320,7 @@
       "attachError": "Could not attach that workflow.",
       "detachError": "Could not detach that workflow.",
       "processDetach": "Detach {workflow} from {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Roles could not be loaded, so this list may be incomplete.",
       "canvasGroupKind": "Group",
       "toolNodeLabel": "Tool",
@@ -8328,6 +8329,7 @@
       "toolAttachError": "Could not attach that tool.",
       "toolDetachError": "Could not detach that tool.",
       "toolDetach": "Detach {tool} from {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "Tool information is unavailable right now — this list may be incomplete.",
       "canvasNoToolsDefined": "No tools are attached to any role in this company.",
       "deepLinkNodeNotFound": "This link points to a node that could not be found here. It may have been removed, or you may not have access to it."

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8332,6 +8332,7 @@
       "attachError": "No se pudo adjuntar ese flujo.",
       "detachError": "No se pudo quitar ese flujo.",
       "processDetach": "Quitar {workflow} de {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "No se pudieron cargar los roles, por lo que esta lista puede estar incompleta.",
       "canvasGroupKind": "Grupo",
       "toolNodeLabel": "Herramienta",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "No se pudo adjuntar esa herramienta.",
       "toolDetachError": "No se pudo quitar esa herramienta.",
       "toolDetach": "Quitar {tool} de {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "La información de herramientas no está disponible ahora mismo: esta lista puede estar incompleta.",
       "canvasNoToolsDefined": "No hay herramientas adjuntas a ningún rol en esta empresa.",
       "deepLinkNodeNotFound": "Este enlace apunta a un nodo que no se pudo encontrar aquí. Puede que se haya eliminado o que no tengas acceso a él."

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8332,6 +8332,7 @@
       "attachError": "پیوست کردن این گردش‌کار ممکن نشد.",
       "detachError": "جدا کردن این گردش‌کار ممکن نشد.",
       "processDetach": "جدا کردن {workflow} از {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "نقش‌ها بارگیری نشدند، بنابراین این فهرست ممکن است ناقص باشد.",
       "canvasGroupKind": "گروه",
       "toolNodeLabel": "ابزار",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "پیوست کردن این ابزار ممکن نشد.",
       "toolDetachError": "جدا کردن این ابزار ممکن نشد.",
       "toolDetach": "جدا کردن {tool} از {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "اطلاعات ابزارها در حال حاضر در دسترس نیست — این فهرست ممکن است ناقص باشد.",
       "canvasNoToolsDefined": "هیچ ابزاری به هیچ نقشی در این شرکت پیوست نشده است.",
       "deepLinkNodeNotFound": "این پیوند به گره‌ای اشاره دارد که در اینجا یافت نشد. ممکن است حذف شده باشد یا شما به آن دسترسی نداشته باشید."

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8332,6 +8332,7 @@
       "attachError": "Impossible d'associer ce workflow.",
       "detachError": "Impossible de détacher ce workflow.",
       "processDetach": "Détacher {workflow} de {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Les rôles n'ont pas pu être chargés, cette liste peut donc être incomplète.",
       "canvasGroupKind": "Groupe",
       "toolNodeLabel": "Outil",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "Impossible d'associer cet outil.",
       "toolDetachError": "Impossible de détacher cet outil.",
       "toolDetach": "Détacher {tool} de {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "Les informations sur les outils sont indisponibles pour le moment — cette liste peut être incomplète.",
       "canvasNoToolsDefined": "Aucun outil n'est associé à un rôle dans cette entreprise.",
       "deepLinkNodeNotFound": "Ce lien pointe vers un nœud introuvable ici. Il a peut-être été supprimé, ou vous n'y avez pas accès."

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8332,6 +8332,7 @@
       "attachError": "לא ניתן היה לצרף תהליך זה.",
       "detachError": "לא ניתן היה להסיר תהליך זה.",
       "processDetach": "הסר את {workflow} מ-{role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "לא ניתן היה לטעון את התפקידים, ולכן ייתכן שרשימה זו חלקית.",
       "canvasGroupKind": "קבוצה",
       "toolNodeLabel": "כלי",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "לא ניתן היה לצרף כלי זה.",
       "toolDetachError": "לא ניתן היה להסיר כלי זה.",
       "toolDetach": "הסר את {tool} מ-{role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "מידע על כלים אינו זמין כעת — רשימה זו עשויה להיות חלקית.",
       "canvasNoToolsDefined": "לא צורפו כלים לאף תפקיד בחברה זו.",
       "deepLinkNodeNotFound": "קישור זה מפנה לצומת שלא נמצא כאן. ייתכן שהוא הוסר, או שאין לך גישה אליו."

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8332,6 +8332,7 @@
       "attachError": "Neizdevās pievienot šo darbplūsmu.",
       "detachError": "Neizdevās noņemt šo darbplūsmu.",
       "processDetach": "Noņemt {workflow} no {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Lomas neizdevās ielādēt, tāpēc šis saraksts var būt nepilnīgs.",
       "canvasGroupKind": "Grupa",
       "toolNodeLabel": "Rīks",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "Neizdevās pievienot šo rīku.",
       "toolDetachError": "Neizdevās noņemt šo rīku.",
       "toolDetach": "Noņemt {tool} no {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "Rīku informācija pašlaik nav pieejama — šis saraksts var būt nepilnīgs.",
       "canvasNoToolsDefined": "Šim uzņēmumam nevienai lomai nav pievienots neviens rīks.",
       "deepLinkNodeNotFound": "Šī saite norāda uz mezglu, kas šeit nav atrasts. Iespējams, tas ir noņemts, vai jums nav piekļuves tam."

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8332,6 +8332,7 @@
       "attachError": "Nie udało się dołączyć tego przepływu.",
       "detachError": "Nie udało się odłączyć tego przepływu.",
       "processDetach": "Odłącz {workflow} od {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Nie udało się wczytać ról, więc ta lista może być niekompletna.",
       "canvasGroupKind": "Grupa",
       "toolNodeLabel": "Narzędzie",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "Nie udało się dołączyć tego narzędzia.",
       "toolDetachError": "Nie udało się odłączyć tego narzędzia.",
       "toolDetach": "Odłącz {tool} od {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "Informacje o narzędziach są obecnie niedostępne — ta lista może być niepełna.",
       "canvasNoToolsDefined": "Żadne narzędzie nie jest dołączone do żadnej roli w tej firmie.",
       "deepLinkNodeNotFound": "Ten link wskazuje węzeł, którego nie można tu znaleźć. Mógł zostać usunięty lub nie masz do niego dostępu."

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8332,6 +8332,7 @@
       "attachError": "Não foi possível anexar esse fluxo.",
       "detachError": "Não foi possível remover esse fluxo.",
       "processDetach": "Remover {workflow} de {role}",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "Não foi possível carregar as funções, portanto esta lista pode estar incompleta.",
       "canvasGroupKind": "Grupo",
       "toolNodeLabel": "Ferramenta",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "Não foi possível anexar essa ferramenta.",
       "toolDetachError": "Não foi possível remover essa ferramenta.",
       "toolDetach": "Remover {tool} de {role}",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "As informações de ferramentas estão indisponíveis neste momento — esta lista pode estar incompleta.",
       "canvasNoToolsDefined": "Nenhuma ferramenta está anexada a nenhuma função nesta empresa.",
       "deepLinkNodeNotFound": "Este link aponta para um nó que não foi encontrado aqui. Ele pode ter sido removido ou você pode não ter acesso a ele."

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8332,6 +8332,7 @@
       "attachError": "یہ ورک فلو منسلک نہیں ہو سکا۔",
       "detachError": "یہ ورک فلو الگ نہیں ہو سکا۔",
       "processDetach": "{workflow} کو {role} سے الگ کریں",
+      "processDisplayName": "{workflow} ({role})",
       "attachRolesUnavailable": "کردار لوڈ نہیں ہو سکے، اس لیے یہ فہرست نامکمل ہو سکتی ہے۔",
       "canvasGroupKind": "گروپ",
       "toolNodeLabel": "ٹول",
@@ -8340,6 +8341,7 @@
       "toolAttachError": "یہ ٹول منسلک نہیں ہو سکا۔",
       "toolDetachError": "یہ ٹول الگ نہیں ہو سکا۔",
       "toolDetach": "{tool} کو {role} سے الگ کریں",
+      "toolDisplayName": "{tool} ({roles})",
       "canvasToolsUnavailable": "ٹول کی معلومات اس وقت دستیاب نہیں ہیں — یہ فہرست نامکمل ہو سکتی ہے۔",
       "canvasNoToolsDefined": "اس کمپنی میں کسی کردار کے ساتھ کوئی ٹول منسلک نہیں۔",
       "deepLinkNodeNotFound": "یہ لنک ایک ایسے نوڈ کی طرف اشارہ کرتا ہے جو یہاں نہیں ملا۔ ہو سکتا ہے یہ ہٹا دیا گیا ہو، یا آپ کو اس تک رسائی حاصل نہ ہو۔"


### PR DESCRIPTION
Closes #14657 · Parent #13935

## Thinking Path

`nodeAriaLabel` built the accessible name as `{kind}: {name}`, taking `name` from `nodeTitle`. For `org-process` and `org-tool`, `nodeTitle` returns the **generic type caption** — the same string `nodeKindLabel` already produced. So a screen reader announced "Process: Process" and "Tool: Tool", and two of the four Company OS node kinds were indistinguishable by ear.

Pre-existing: it arrived with the node types (#13963, #14597), not with #14609's keyboard work, which reasonably assumed `nodeTitle` returned a name.

It matters more than it looks. #14609 exists because the canvas could not be operated without a mouse — making every node focusable while two kinds announce nothing identifying is a thinner fix than it appears, since a keyboard user can now *reach* a process node and still not tell it from the next one.

The tell was in #14611: search had to build its **own** `nodeSearchLabel` because the aria name was unusable. That is a symptom of the aria name being wrong, not of search needing a separate path.

## What Changed

- `nodeDisplayName` now returns a real identifier for every kind — a process as `{workflow} ({role})`, a tool as `{tool} ({roles})`, unchanged for person and group.
- A single `nodeKindAndName` helper composes `"{kind}: {name}"` once, and **both** `nodeAriaLabel` and `nodeSearchLabel` call it. `nodeSearchLabel` previously hardcoded `${kind}: ${name}` outside i18n entirely — also fixed.
- Two keys across all 11 locales.
- **Visible node text is untouched.** This is an accessible-name fix, not a redesign.

## Verification

I re-derived the two decisive mutations myself. The first reproduces the reported defect exactly:

```
AssertionError: expected 'Process: Process' to be 'Process: wf-quarterly (Head of Sales)'
```

| Mutation | Went red |
|---|---|
| process branch falls back to `nodeTitle` | the process test, with the literal original bug string |
| tool branch falls back to `nodeTitle` | tool · RTL · **and** the consolidation test |

That third failure is the useful one: the consolidation test asserts a search result's text equals the node's own `aria-label`, so it fails if the two paths ever diverge again.

Plus the implementer's four: the `label` early-return (red on person *and* group — a shared line), the `org-group` kind branch (group only), `nodeKindAndName`'s name source (group/process/tool/RTL but **not** person, correctly showing person's state branch is a distinct path), and reverting `nodeSearchLabel` to its own construction (consolidation test only).

- `vitest run src/components/workflow` — **14 files, 155 tests, all passed**; `processNodeA11y`, `keyboardA11y`, `search`, `panClick`, `touch`, `minimap`, `zoomFit`, `groupKind`, `toolNodeDetach` all unregressed
- `vue-tsc` 0 · `check:i18n` 0 · `check-locale-completeness` 0 · `oxlint -D correctness` 0 · `eslint` 0

## An incident worth recording

Partway through, this worktree's `WorkflowCanvas.vue` was overwritten on disk with unrelated #14612 content — arriving as a raw filesystem write between two tool calls, with no fetch or merge in `git log`/`git status`. Recovery was `git checkout --` on that one file plus reapplying the intended patch; every subsequent mutation then ran from a static clean reference copy rather than the live file, with an integrity diff after each restore.

I verified the blast radius directly: `marqueeActive` (the #14612 marker) appears **only** in `.worktrees/issue-14612` — zero occurrences in the main tree, in committed base, and in every other worktree. The committed content here is clean.

Most likely a path-resolution mistake writing across worktrees. That is a known failure mode in this environment — I made the same class of error earlier in this programme, when a `cd` fallback resolved from the repo root instead of the worktree.

## Model Used

Claude Opus 5 (1M context)
