### PR TITLE
fix(slm): format inventory_sibling_groups_test.py so base code-quality passes (#14567)

### DIFF
--- a/autobot-slm-backend/services/inventory_sibling_groups_test.py
+++ b/autobot-slm-backend/services/inventory_sibling_groups_test.py
@@ -66,15 +66,14 @@ def test_the_closure_actually_widened_the_seed():
     assert gated - seed, "the closure added nothing; _ROLE_TO_GROUPS or the seed changed shape"
 
 
-def test_sibling_deploy_groups_are_gated_too(
-):
+def test_sibling_deploy_groups_are_gated_too():
     """The #14567 gap: the names other playbooks target by `hosts:`."""
     gated = set(inventory_builder._DECLARED_ONLY_GROUPS)
 
     for sibling in ("ai_stack", "npu_worker", "npu_workers", "browser_worker"):
-        assert sibling in gated, (
-            f"{sibling} is targeted by a setup playbook via `hosts:` but detection can still grant it"
-        )
+        assert (
+            sibling in gated
+        ), f"{sibling} is targeted by a setup playbook via `hosts:` but detection can still grant it"
 
 
 def test_agent_membership_groups_are_NOT_gated():
@@ -106,11 +105,32 @@ def test_a_contaminated_node_leaks_no_deploy_group():
     """The live shape: a vnc node whose detection reports the whole catalogue."""
     node = _node(
         ["vnc", "slm-agent"],
-        ["ai-stack", "npu-worker", "browser-service", "frontend", "backend", "slm-backend", "redis", "vnc", "slm-agent"],
+        [
+            "ai-stack",
+            "npu-worker",
+            "browser-service",
+            "frontend",
+            "backend",
+            "slm-backend",
+            "redis",
+            "vnc",
+            "slm-agent",
+        ],
     )
     groups = _groups(node)
 
-    for leaked in ("ai_stack", "npu_worker", "npu_workers", "browser_worker", "aiml", "npu", "browser", "frontend", "backend", "slm_server"):
+    for leaked in (
+        "ai_stack",
+        "npu_worker",
+        "npu_workers",
+        "browser_worker",
+        "aiml",
+        "npu",
+        "browser",
+        "frontend",
+        "backend",
+        "slm_server",
+    ):
         assert leaked not in groups, f"{leaked} still granted by detection alone"
 
     assert "redis" in groups, "ordinary groups must still come from detection"


### PR DESCRIPTION
## Thinking Path

`code-quality` is **failing on `origin/Dev_new_gui` itself** — confirmed by querying the check-runs for base's own head, not inferred from a PR:

```
2ba36f1cb5  code-quality  completed/failure   2026-08-21T07:40:36Z
```

The cause is one file, added by `2ba36f1cb5`:

```
would reformat autobot-slm-backend/services/inventory_sibling_groups_test.py
1 file would be reformatted, 4432 files would be left unchanged
```

**This blocks every open PR.** A red base means anything rebased onto it fails `code-quality` for a reason that has nothing to do with its own change — I found it because #14578 went red on this file, which it does not touch.

## What Changed

`black --line-length=120` on that one file. Nothing else. The diff is entirely formatting — a signature that fitted on one line, and two assertion bodies black wraps differently — with no semantic change, which is what black guarantees by construction.

## Verification

```
before:  1 file would be reformatted
after:   1 file would be left unchanged
```

Run with the system black (26.3.1), against a worktree off `origin/Dev_new_gui` — not against the checkout, and nothing installed.

Scope is deliberately one file. I have not reformatted anything else, so this cannot mask a second offender: if base is still red after this, the remaining cause is a different one and should be visible immediately.

## Not in this PR

**How this merged at all, given `code-quality` is a required context.** That is the more important question and it is not answerable from the merge commit alone — the check ran on base *after* the merge and failed, so either it did not run on the PR head, or it ran and the merge went ahead anyway. Both are worth knowing and neither is fixed by reformatting a file. Filing separately; it is closely related to **#14659**, where a path filter that skips a required job produces a green tick rather than a red one.

## Model Used

Claude Opus 5 (1M context)

Refs #14567