### PR TITLE
fix(deploy): the self-update path must refresh the systemd unit, not just the code (#14624)

### DIFF
--- a/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/update-all-nodes.yml
@@ -287,6 +287,23 @@
       become: true
       tags: [slm]
 
+    # #14624: render the systemd unit from the SAME task file the role uses.
+    #
+    # This play deploys the backend by unarchive and never runs slm_manager, so
+    # the unit was refreshed only on a full provision. A host was found running
+    # one from two months earlier, predating the AUTOBOT_PROJECT_ROOT line the
+    # template has carried since #14575 -- and once #14544 raised instead of
+    # guessing, the backend crash-looped with no in-band recovery, because the
+    # endpoints that deploy a fix live in the service that will not start.
+    #
+    # `tasks_from` rather than a copied template task: a second copy is what
+    # drifts, and the marker-write above is that mistake already made once.
+    - name: "[PLAY 1] SLM | Refresh the backend systemd unit (#14624)"
+      ansible.builtin.include_role:
+        name: slm_manager
+        tasks_from: service_units.yml
+      tags: [slm, systemd]
+
     - name: "[PLAY 1] SLM | Own the deployed-commit marker (#12223)"
       file:
         path: /opt/autobot/autobot-slm-backend/.deployed_commit

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -616,21 +616,13 @@
 # ==========================================================
 # Backend systemd service
 # ==========================================================
-- name: "SLM | Deploy backend systemd service"
-  ansible.builtin.template:
-    src: autobot-slm-backend.service.j2
-    dest: /etc/systemd/system/{{ slm_backend_service }}.service
-    mode: "0644"
-  notify:
-    - reload systemd
-    - restart slm backend
-  tags: ['slm', 'backend', 'systemd']
-
-- name: "SLM | Enable backend service"
-  ansible.builtin.systemd:
-    name: "{{ slm_backend_service }}"
-    enabled: true
-    daemon_reload: true
+# #14624: the unit definition lives in service_units.yml so the self-update
+# path can render it too. Play 1 of update-all-nodes.yml deploys the backend by
+# unarchive and never runs this role, so a unit rendered only here drifted --
+# one host's was two months stale, predating the AUTOBOT_PROJECT_ROOT line, and
+# the service could not start once #14544 began raising.
+- name: "SLM | Deploy and enable the backend systemd unit (#14624)"
+  ansible.builtin.include_tasks: service_units.yml
   tags: ['slm', 'backend', 'systemd']
 
 # ==========================================================

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/service_units.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/service_units.yml
@@ -1,0 +1,34 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# The SLM backend systemd unit, in ONE place (#14624).
+#
+# Two callers render it: this role's main.yml on a full provision, and Play 1 of
+# update-all-nodes.yml on the self-update path, which deploys the backend by
+# unarchive and deliberately does not run the whole role. Before this split the
+# unit was rendered only by the role, so the self-update path never refreshed
+# it: a host was found running a unit from two months earlier that predated the
+# `AUTOBOT_PROJECT_ROOT` line, and once #14544 started raising rather than
+# guessing, the backend crash-looped with no in-band way to recover.
+#
+# Kept as a separate file rather than duplicated into the playbook because a
+# second copy is what drifts. The marker-write above it in that play is exactly
+# that mistake, carried since #12223.
+- name: "SLM | Deploy backend systemd service"
+  ansible.builtin.template:
+    src: autobot-slm-backend.service.j2
+    dest: /etc/systemd/system/{{ slm_backend_service }}.service
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart slm backend
+  tags: ['slm', 'backend', 'systemd']
+
+- name: "SLM | Enable backend service"
+  ansible.builtin.systemd:
+    name: "{{ slm_backend_service }}"
+    enabled: true
+    daemon_reload: true
+  tags: ['slm', 'backend', 'systemd']

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/autobot-slm-backend.service.j2
@@ -37,7 +37,7 @@ Environment="AUTOBOT_PROJECT_ROOT={{ slm_base_dir }}"
 # explicitly, the same way slm-agent's own unit already does.
 Environment="REDIS_HOST={{ slm_manager_redis_host }}"
 Environment="AUTOBOT_REDIS_HOST={{ slm_manager_redis_host }}"
-EnvironmentFile=-{{ postgresql_credentials_dir }}/{{ postgresql_credentials_file }}
+EnvironmentFile=-{{ postgresql_credentials_dir | default('/etc/autobot') }}/{{ postgresql_credentials_file | default('db-credentials.env') }}
 EnvironmentFile=-{{ slm_credentials_dir }}/{{ slm_credentials_file }}
 # #11668: bound uvicorn's SIGTERM shutdown (see autobot-backend.service.j2) so the
 # SLM restart during code-sync self-update doesn't hang on lingering connections.

--- a/autobot-slm-backend/services/slm_unit_refresh_test.py
+++ b/autobot-slm-backend/services/slm_unit_refresh_test.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The self-update path must refresh the systemd unit, not just the code (#14624).
+
+A deployed SLM backend crash-looped for ~11 hours — uvicorn exiting 1 at import,
+5658 restarts, API unreachable. The cause was a unit file dated two months
+earlier that predated the `AUTOBOT_PROJECT_ROOT` line its template had carried
+since #14575, so once `resolve_project_root` began raising rather than guessing
+(#14544) the service could not start. Recovery needed root on the box, because
+the code-sync and self-update endpoints live in the service that would not run.
+
+The diagnosis that mattered came after the fix: a full self-update propagated
+new code in 53 seconds and left the unit untouched. Play 1 of
+`update-all-nodes.yml` deploys the backend by unarchive and deliberately does
+not run the `slm_manager` role — the playbook says so itself, in the comment
+above its duplicated marker-write.
+
+So the unit definition now lives in one task file that both callers include,
+and these rules pin that arrangement. A second copy of the template task would
+pass a naive "does Play 1 render the unit" check while drifting from the role's
+version, which is precisely the failure being fixed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ANSIBLE = Path(__file__).resolve().parent.parent / "ansible"
+_ROLE_TASKS = _ANSIBLE / "roles" / "slm_manager" / "tasks"
+_SHARED_UNIT_TASKS = _ROLE_TASKS / "service_units.yml"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+
+
+def _tasks(path: Path):
+    """Every task in a file, including those nested in block/rescue/always."""
+
+    def walk(items):
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            yield item
+            for key in ("block", "rescue", "always", "tasks", "pre_tasks", "post_tasks"):
+                if isinstance(item.get(key), list):
+                    yield from walk(item[key])
+
+    for document in yaml.safe_load_all(path.read_text(encoding="utf-8")):
+        if isinstance(document, list):
+            yield from walk(document)
+        elif isinstance(document, dict):
+            yield from walk([document])
+
+
+def test_the_shared_unit_task_file_exists_and_renders_the_template():
+    """The single definition both callers depend on."""
+    assert _SHARED_UNIT_TASKS.is_file(), "service_units.yml is gone — the shared definition was removed"
+
+    templated = [
+        t
+        for t in _tasks(_SHARED_UNIT_TASKS)
+        if isinstance(t.get("ansible.builtin.template"), dict)
+        and "autobot-slm-backend.service.j2" in str(t["ansible.builtin.template"].get("src", ""))
+    ]
+
+    assert templated, "service_units.yml no longer renders the backend unit template"
+
+
+def test_the_self_update_play_refreshes_the_unit():
+    """The #14624 regression: Play 1 deployed code and left the unit stale."""
+    including = [
+        t
+        for t in _tasks(_PLAYBOOK)
+        if isinstance(t.get("ansible.builtin.include_role"), dict)
+        and t["ansible.builtin.include_role"].get("tasks_from") == "service_units.yml"
+    ]
+
+    assert including, (
+        "update-all-nodes.yml no longer includes service_units.yml — the self-update path "
+        "would deploy new code against a stale systemd unit again (#14624)"
+    )
+
+
+def test_the_playbook_does_not_carry_its_own_copy_of_the_unit_task():
+    """A second copy is what drifts.
+
+    The marker-write in this same play is exactly that mistake, duplicated from
+    the role since #12223. Rendering the unit by a copied `template:` task would
+    satisfy the rule above while reintroducing the divergence.
+    """
+    copies = [
+        t
+        for t in _tasks(_PLAYBOOK)
+        if isinstance(t.get("ansible.builtin.template"), dict)
+        and "autobot-slm-backend.service.j2" in str(t["ansible.builtin.template"].get("src", ""))
+    ]
+
+    assert not copies, (
+        "the playbook renders the unit template directly instead of including the shared "
+        "task file — that copy will drift from the role's (#14624)"
+    )
+
+
+def test_the_role_still_reaches_the_shared_file():
+    """Extraction must not have orphaned it from a full provision."""
+    main = _ROLE_TASKS / "main.yml"
+
+    including = [
+        t
+        for t in _tasks(main)
+        if str(t.get("ansible.builtin.include_tasks", "")).endswith("service_units.yml")
+    ]
+
+    assert including, "slm_manager/main.yml no longer includes service_units.yml — a full provision would skip the unit"
+
+
+def test_the_unit_template_survives_a_caller_without_the_postgresql_role():
+    """The include runs from a play that has not applied the postgresql role.
+
+    `postgresql_credentials_dir` is defined in THAT role's defaults, so rendering
+    from Play 1 would fail on an undefined variable. It resolved before only
+    because the role happened to run alongside — a coincidence, not a contract.
+    """
+    template = (_ANSIBLE / "roles" / "slm_manager" / "templates" / "autobot-slm-backend.service.j2").read_text(
+        encoding="utf-8"
+    )
+
+    for var in ("postgresql_credentials_dir", "postgresql_credentials_file"):
+        for line in template.splitlines():
+            if var in line:
+                assert "default(" in line, f"{var} is referenced without a default; rendering from Play 1 would fail"

--- a/autobot-slm-backend/services/slm_unit_refresh_test.py
+++ b/autobot-slm-backend/services/slm_unit_refresh_test.py
@@ -110,9 +110,7 @@ def test_the_role_still_reaches_the_shared_file():
     main = _ROLE_TASKS / "main.yml"
 
     including = [
-        t
-        for t in _tasks(main)
-        if str(t.get("ansible.builtin.include_tasks", "")).endswith("service_units.yml")
+        t for t in _tasks(main) if str(t.get("ansible.builtin.include_tasks", "")).endswith("service_units.yml")
     ]
 
     assert including, "slm_manager/main.yml no longer includes service_units.yml — a full provision would skip the unit"


### PR DESCRIPTION
## Thinking Path

Closing the half of #14624 that outlived its fix.

The resolver change (#14661) removed the dependency on a unit setting for *that* variable. It did not address why the unit was stale in the first place, and the evidence says this is systemic rather than one unlucky host: a full self-update propagated new code in **53 seconds** and left the unit exactly as it was.

```
deployed unit AUTOBOT_PROJECT_ROOT count: 0
deployed unit mtime:                     2026-06-18 19:05:37
```

`update-all-nodes.yml` Play 1 says why, in its own comment: *"the self-update path deploys the SLM backend via the unarchive above and never runs the slm_manager role"*. The unit template is rendered only by that role, so the self-update path never refreshes it.

The consequence is not cosmetic. Any change needing a new unit setting lands on hosts that cannot satisfy it, and the failure mode is a service that will not start — with no in-band recovery, because the code-sync and self-update endpoints live inside the service that is down. That is exactly how this host spent ~11 hours crash-looping at 5658 restarts.

## What Changed

The unit definition moves to `roles/slm_manager/tasks/service_units.yml`, included by both callers:

- `slm_manager/main.yml` — full provision, unchanged behaviour
- `update-all-nodes.yml` Play 1 — via `include_role: tasks_from: service_units.yml`, right after the unarchive

**Deliberately a shared file, not a copied task.** The marker-write immediately below it in that same play is the duplicate-and-drift mistake already made once, carried since #12223. A second `template:` task would satisfy "does Play 1 render the unit" while diverging from the role's version — the failure being fixed, relocated.

One latent trap surfaced while wiring it: the template references `{{ postgresql_credentials_dir }}` with no default, and that variable is defined in the **postgresql** role's defaults. `slm_manager` declares no dependency on it, so it resolved only because the roles happened to run together. Rendering from Play 1 would have failed on an undefined variable. Both cross-role references now carry defaults matching the postgresql role's own values.

## Verification

Not run from the checkout, by instruction — CI verifies correctness, the deployment verifies runtime.

Guard logic executed against the tree:

```
shared file renders the unit : True
Play 1 includes it           : True
no duplicate template task   : True
role main.yml includes it    : True
cross-role vars defaulted    : True
```

Mutation-checked: with Play 1's include removed the second rule fails; with a copied `template:` task in the playbook the third fails.

Host evidence for the underlying outage is on #14624 — the backend now starts with the override drop-in **removed**, which is the only way to prove the resolver rather than the workaround is carrying it.

## Model Used

Claude Opus 5

Closes #14624
