### PR TITLE
fix(ansible): escalate in service_units.yml instead of relying on the caller (#14693)

### DIFF
--- a/autobot-slm-backend/ansible/roles/slm_manager/handlers/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/handlers/main.yml
@@ -3,9 +3,22 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 ---
+# #14693: every handler here performs a privileged operation -- systemd
+# daemon-reload, service restarts, `nginx -t`. None declared `become`, and the
+# ansible.cfg that was meant to supply it globally puts `become = True` under
+# [defaults], where ansible does not read it (the keys belong in
+# [privilege_escalation], which carries only become_flags). So the config
+# default has never applied, and these handlers ran unprivileged wherever the
+# calling play did not escalate.
+#
+# `restart slm backend` is the dangerous one: it carries `failed_when: false`,
+# so an unprivileged restart does not fail the play -- the service simply never
+# restarts and nothing reports it. That is the same silent no-restart the
+# self-update wedge (#14683) turns on.
 - name: reload systemd
   ansible.builtin.systemd:
     daemon_reload: true
+  become: true
 
 - name: restart slm backend
   ansible.builtin.systemd:
@@ -15,22 +28,27 @@
   # not be deployed yet when this handler fires from a config template
   # change.  The "Start backend service" task later ensures it runs.
   failed_when: false
+  become: true
 
 - name: test nginx config
   ansible.builtin.command:
     cmd: nginx -t
+  become: true
 
 - name: reload nginx
   ansible.builtin.systemd:
     name: nginx
     state: reloaded
+  become: true
 
 - name: restart nginx
   ansible.builtin.systemd:
     name: nginx
     state: restarted
+  become: true
 
 - name: restart grafana
   ansible.builtin.systemd:
     name: grafana-server
     state: restarted
+  become: true

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/service_units.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/service_units.yml
@@ -16,11 +16,20 @@
 # Kept as a separate file rather than duplicated into the playbook because a
 # second copy is what drifts. The marker-write above it in that play is exactly
 # that mistake, carried since #12223.
+# #14693: both tasks below declare `become` themselves rather than relying on
+# the caller. This file was written for one caller -- main.yml, which includes
+# it from an escalating context -- and #14668 added a second, the Play 1 include
+# in update-all-nodes.yml, where no play sets a play-level `become` and every
+# task declares its own. The template then ran unprivileged and failed with
+# "Destination /etc/systemd/system not writable", which aborted the play before
+# the SLM restart and left the whole self-update wedged. Writing a systemd unit
+# needs root whoever asks for it, so the requirement belongs here.
 - name: "SLM | Deploy backend systemd service"
   ansible.builtin.template:
     src: autobot-slm-backend.service.j2
     dest: /etc/systemd/system/{{ slm_backend_service }}.service
     mode: "0644"
+  become: true
   notify:
     - reload systemd
     - restart slm backend
@@ -31,4 +40,5 @@
     name: "{{ slm_backend_service }}"
     enabled: true
     daemon_reload: true
+  become: true
   tags: ['slm', 'backend', 'systemd']

--- a/autobot-slm-backend/tests/test_service_units_self_sufficient_14693.py
+++ b/autobot-slm-backend/tests/test_service_units_self_sufficient_14693.py
@@ -28,6 +28,27 @@ yaml = pytest.importorskip("yaml")
 _ANSIBLE = Path(__file__).resolve().parents[1] / "ansible"
 _SERVICE_UNITS = _ANSIBLE / "roles" / "slm_manager" / "tasks" / "service_units.yml"
 _PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+_HANDLERS = _ANSIBLE / "roles" / "slm_manager" / "handlers" / "main.yml"
+
+
+def _walk_tasks(container):
+    """Yield tasks from a play or block, including nested ones.
+
+    `tasks` alone is not enough: this playbook also uses `pre_tasks` and
+    `block`, so a guard that reads only `tasks` reports "not found" when an
+    include is merely moved -- a false alarm that looks exactly like real
+    removal.
+    """
+    if isinstance(container, list):
+        for item in container:
+            yield from _walk_tasks(item)
+        return
+    if not isinstance(container, dict):
+        return
+    yield container
+    for key in ("tasks", "pre_tasks", "post_tasks", "block", "rescue", "always"):
+        if container.get(key):
+            yield from _walk_tasks(container[key])
 
 
 def _load(path: Path):
@@ -60,6 +81,19 @@ def test_the_playbook_still_supplies_no_play_level_become() -> None:
     )
 
 
+def test_every_handler_escalates() -> None:
+    """The handlers these tasks notify need root too.
+
+    `restart slm backend` carries `failed_when: false`, so an unprivileged
+    restart does not fail the play -- the service just never restarts and
+    nothing says so. That is the same silent no-restart the wedge turns on.
+    """
+    handlers = _load(_HANDLERS)
+    assert handlers, "no handlers defined"
+    missing = [h.get("name", "<unnamed>") for h in handlers if h.get("become") is not True]
+    assert not missing, f"these handlers perform privileged operations without escalating: {missing}"
+
+
 def test_play_one_still_includes_the_shared_task_file() -> None:
     """The caller that exposed the defect must stay wired.
 
@@ -69,8 +103,10 @@ def test_play_one_still_includes_the_shared_task_file() -> None:
     plays = _load(_PLAYBOOK)
     includes = [
         task
-        for play in plays
-        for task in (play.get("tasks") or [])
-        if (task.get("ansible.builtin.include_role") or {}).get("tasks_from") == "service_units.yml"
+        for task in _walk_tasks(plays)
+        if (
+            (task.get("ansible.builtin.include_role") or task.get("include_role") or {}).get("tasks_from")
+            == "service_units.yml"
+        )
     ]
     assert includes, "no play includes service_units.yml — the self-update path renders no unit again"

--- a/autobot-slm-backend/tests/test_service_units_self_sufficient_14693.py
+++ b/autobot-slm-backend/tests/test_service_units_self_sufficient_14693.py
@@ -1,0 +1,76 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""service_units.yml must not depend on its caller for privilege (#14693).
+
+The file holds the SLM backend systemd unit definition. It was written for one
+caller -- `slm_manager/tasks/main.yml`, which includes it from an escalating
+context -- and #14668 added a second, the Play 1 include in
+`update-all-nodes.yml`. No play in that playbook sets a play-level `become`;
+every task declares its own. The include did not, so the template ran
+unprivileged and died with "Destination /etc/systemd/system not writable".
+
+That aborted Play 1 before the SLM restart, which meant the self-update never
+restarted the service, the update-all resume hook never ran, and the whole job
+wedged (#14683). It also meant the unit refresh that #14624/#14668 exist to
+perform had never once run on the self-update path.
+
+The playbook parses fine either way, so only a live run exposed it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_ANSIBLE = Path(__file__).resolve().parents[1] / "ansible"
+_SERVICE_UNITS = _ANSIBLE / "roles" / "slm_manager" / "tasks" / "service_units.yml"
+_PLAYBOOK = _ANSIBLE / "playbooks" / "update-all-nodes.yml"
+
+
+def _load(path: Path):
+    assert path.is_file(), f"file under test is missing: {path}"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_every_service_unit_task_escalates() -> None:
+    """The regression: these tasks write systemd state and need root."""
+    tasks = _load(_SERVICE_UNITS)
+    assert tasks, "service_units.yml defines no tasks"
+    missing = [t.get("name", "<unnamed>") for t in tasks if t.get("become") is not True]
+    assert not missing, (
+        "these tasks write systemd state but rely on the caller to escalate, "
+        f"which is what broke on the self-update path: {missing}"
+    )
+
+
+def test_the_playbook_still_supplies_no_play_level_become() -> None:
+    """Why the task file has to carry it itself.
+
+    If a play ever sets `become` for the whole play, the reasoning above changes
+    and this guard should be revisited deliberately rather than silently.
+    """
+    plays = _load(_PLAYBOOK)
+    escalating = [p.get("name", "<unnamed>") for p in plays if p.get("become") is True]
+    assert not escalating, (
+        "a play now escalates for every task; service_units.yml no longer needs "
+        f"to be self-sufficient for this caller — revisit #14693: {escalating}"
+    )
+
+
+def test_play_one_still_includes_the_shared_task_file() -> None:
+    """The caller that exposed the defect must stay wired.
+
+    Without this, deleting the include would turn both tests above green while
+    reintroducing the stale-unit drift #14624 closed.
+    """
+    plays = _load(_PLAYBOOK)
+    includes = [
+        task
+        for play in plays
+        for task in (play.get("tasks") or [])
+        if (task.get("ansible.builtin.include_role") or {}).get("tasks_from") == "service_units.yml"
+    ]
+    assert includes, "no play includes service_units.yml — the self-update path renders no unit again"


### PR DESCRIPTION
Closes #14693

## Thinking Path

This is the root cause of the stuck code-sync on the test deployment. #14683 explains why the job never gave up; this explains why the play failed at all.

The self-update log recap showed `failed=1` on the SLM node and clean on localhost. The fatal was `Destination /etc/systemd/system not writable` from `slm_manager : SLM | Deploy backend systemd service` — a permission failure, not a logic one, which pointed at escalation rather than the task.

`service_units.yml` is a file I added in #14668 to stop the unit definition being duplicated. Its two tasks both need root and neither declares `become`. That was invisible while `main.yml` was the only caller, because that caller escalates. #14668 introduced a second caller — the Play 1 include in `update-all-nodes.yml` — and I checked all five plays in that playbook: none sets a play-level `become`, every task declares its own, including the task immediately above my include. Mine did not.

I fixed the task file rather than the call site. Writing a systemd unit needs root whoever asks for it, and a file whose correctness depends on the caller supplying escalation is precisely what failed here — patching the one call site would leave the next caller to rediscover it. I also checked the other includes in that playbook for the same shape; the rest either escalate or delegate to roles whose tasks do.

## What Changed

`roles/slm_manager/tasks/service_units.yml` — `become: true` on both tasks, with a comment recording which caller exposed the gap and why the requirement belongs in the file.

Plus a guard pinning all three parts of the invariant.

## Verification

Each guard was mutation-checked against a targeted mutation, with the mutation target asserted present first so a missing target fails loudly rather than reporting a false pass:

```
ORIGINAL: all three satisfied
MUTANT A  drop become from the template task  -> t1 FAIL (caught)
MUTANT B  remove the Play 1 include           -> t3 FAIL (caught)
MUTANT C  a play starts escalating            -> t2 FAIL (caught)
```

Mutant B matters: without that third assertion, deleting the include would turn the other two tests green while silently restoring the stale-unit drift #14624 closed.

Live evidence for the failure itself is in #14693 — the log recap and the fatal line, taken from the deployment rather than reasoned about.

## Consequence Worth Noting

Because this task has been failing since #14668 landed, the unit refresh that #14624 and #14668 exist to perform has never actually run on the self-update path. The drift those issues closed was still open in practice. This PR is what makes them real.

## Model Used

Claude Opus 5