### PR TITLE
build(deps): hard-exclude the unsatisfiable openai and tokenizers majors (#14431)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,14 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "openai"
+        # #14431: cap <3.0 — every published llama-index-llms-openai release pins
+        # openai<3, so a grouped bump to 3.x is unsatisfiable and dies with
+        # ResolutionImpossible at the Docker pip layer, taking smoke-test with it.
+        # semver-major ignore alone does NOT stop the grouped all-dependencies bump
+        # from re-proposing it (same lesson as protobuf above). Hard-exclude so it
+        # stops. Unblock when llama-index-llms-openai supports 3.x.
+        versions: [">=3.0.0"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"
@@ -406,6 +414,12 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "tokenizers"
+        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
+        # above that is unsatisfiable. The requirements files already carry the
+        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
+        # it on every run. Unblock when transformers raises its cap.
+        versions: [">=0.24.0"]
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
       - dependency-name: "numpy"
@@ -432,6 +446,12 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "tokenizers"
+        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
+        # above that is unsatisfiable. The requirements files already carry the
+        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
+        # it on every run. Unblock when transformers raises its cap.
+        versions: [">=0.24.0"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"


### PR DESCRIPTION
## Thinking Path

**This targets `main`, deliberately.** GitHub reads `.github/dependabot.yml` from the **default branch**, which is `main` here — not `Dev_new_gui`. A `Dev_new_gui` PR would be correct in the source of truth and completely inert, and the regeneration loop would keep running. That is why this is the one change I am not routing through the normal base.

`main` and `Dev_new_gui` currently hold **byte-identical** copies of this file (blob `cd59285988d9`), so this does not create drift that did not already need managing — but it does mean a matching `Dev_new_gui` PR should follow, and I will open one.

## The problem, measured

Five PRs regenerated on two unsatisfiable pins, each burning a full container build plus smoke-test jobs before dying:

- **`openai`** — `autobot-backend/requirements.txt:39` pins `>=2.53.0`; every published `llama-index-llms-openai` release pins `openai<3`. A grouped bump to `3.x` is `ResolutionImpossible` at the Docker pip layer. Confirmed still failing at current head: #14437 and #14439 both show `smoke-test = failure`.
- **`tokenizers`** — pinned `>=0.22.0,<0.24` in two requirements files, because `transformers` caps `tokenizers<=0.23.0`. #14441 and #14442 carry it.

Neither package is ignored anywhere in this config today.

## Why `semver-major` is not the fix

This repo already learned that, and wrote it down at `.github/dependabot.yml:42-48`:

> `#10474/#10615/#10616`: cap `<7.0` — opentelemetry-proto requires protobuf<7.0. **semver-major ignore alone did NOT stop the grouped all-dependencies bump from re-proposing 7.x** (unsatisfiable → ResolutionImpossible on every PR). Hard-exclude `>=7.0.0` so it stops.

Because `all-dependencies` matches `"*"`, a member is re-proposed through the group even when its major bump is ignored individually. The mechanism that works is the `versions:` hard-exclude, already used four times here — three `versions:` entries plus `46b592db2` ("hard-exclude oxlint >=1.74 from dependabot group").

## What Changed

Three `versions:` excludes, one per affected entry, each with a comment naming the upstream constraint and the unblock condition — matching the style of every existing exclusion:

| entry | exclude |
|---|---|
| `pip` · `/autobot-backend` | `openai >=3.0.0` |
| `pip` · `/autobot-infrastructure/shared/docker/ai-stack` | `tokenizers >=0.24.0` |
| `pip` · `/autobot-infrastructure/autobot-npu-worker/docker` | `tokenizers >=0.24.0` |

The `tokenizers` bound matches the `<0.24` cap the requirements files already carry.

## Verification

Parsed with `yaml.safe_load` and asserted placement programmatically rather than by eye — each exclude resolves under the intended `package-ecosystem`/`directory` pair:

```
pip  /autobot-backend                                  -> [('openai', ['>=3.0.0'])]
pip  /autobot-infrastructure/shared/docker/ai-stack    -> [('tokenizers', ['>=0.24.0'])]
pip  /autobot-infrastructure/autobot-npu-worker/docker -> [('tokenizers', ['>=0.24.0'])]
```

20 update entries before and after — nothing displaced.

I cannot verify the *effect* from a PR: dependabot only reads this once merged to the default branch. The observable test is that the next scheduled run stops proposing these two majors, and that the other thirteen grouped members — several security-relevant — start resolving again.

## What this does not do

It does not fix the four open PRs (#14437, #14439, #14441, #14442). They carry the unsatisfiable pins in their own diffs and should be closed once this lands; dependabot will regenerate the group without the excluded members.

It also does not address the third `tokenizers` pin under the windows npu-worker tree, which sits below a configured directory and is likely unscanned — that is **#14562**.

## Model Used

Claude Opus 5 (1M context)

Closes #14431
