### PR TITLE
build(deps): mirror the openai and tokenizers hard-excludes onto the working base (#14431)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,14 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "openai"
+        # #14431: cap <3.0 — every published llama-index-llms-openai release pins
+        # openai<3, so a grouped bump to 3.x is unsatisfiable and dies with
+        # ResolutionImpossible at the Docker pip layer, taking smoke-test with it.
+        # semver-major ignore alone does NOT stop the grouped all-dependencies bump
+        # from re-proposing it (same lesson as protobuf above). Hard-exclude so it
+        # stops. Unblock when llama-index-llms-openai supports 3.x.
+        versions: [">=3.0.0"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"
@@ -406,6 +414,12 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "tokenizers"
+        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
+        # above that is unsatisfiable. The requirements files already carry the
+        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
+        # it on every run. Unblock when transformers raises its cap.
+        versions: [">=0.24.0"]
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
       - dependency-name: "numpy"
@@ -432,6 +446,12 @@ updates:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "tokenizers"
+        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
+        # above that is unsatisfiable. The requirements files already carry the
+        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
+        # it on every run. Unblock when transformers raises its cap.
+        versions: [">=0.24.0"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"


### PR DESCRIPTION
## Thinking Path

Companion to **#14696**, which carries the same change to `main`.

GitHub reads `.github/dependabot.yml` from the **default branch** (`main`), so #14696 is the one that actually stops the regeneration loop. This PR exists so the working base does not drift from it: the two copies are byte-identical today (blob `cd59285988d9`), and a fix that landed only on `main` would silently diverge the source of truth everyone actually edits.

Merge order does not matter for correctness — only #14696 has an effect on dependabot — but both should land.

## What Changed

Identical to #14696: three `versions:` hard-excludes, one per affected entry.

| entry | exclude |
|---|---|
| `pip` · `/autobot-backend` | `openai >=3.0.0` |
| `pip` · `/autobot-infrastructure/shared/docker/ai-stack` | `tokenizers >=0.24.0` |
| `pip` · `/autobot-infrastructure/autobot-npu-worker/docker` | `tokenizers >=0.24.0` |

`semver-major` alone does not work for a grouped `"*"` bump — this repo recorded that at `.github/dependabot.yml:42-48` for protobuf, and the `versions:` form is already used four times here. Full reasoning is in #14696.

## Verification

The file is a byte-for-byte copy of #14696's, re-parsed with `yaml.safe_load` on this branch: 20 update entries, unchanged count, three excludes resolving under the intended `package-ecosystem`/`directory` pairs.

## Model Used

Claude Opus 5 (1M context)

Refs #14431
