### PR TITLE
tech-debt(frontend): derive canvas edge geometry from the shared constants (#14690)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -436,7 +436,7 @@ import { ref, reactive, computed, nextTick, useId, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useConfirmDialog } from '@/composables/useConfirmDialog';
 import type { WorkflowNode } from '@/composables/useWorkflowBuilder';
-import { CANVAS_NODE_WIDTH } from './canvasNode';
+import { CANVAS_NODE_WIDTH, CANVAS_NODE_HEIGHT, CANVAS_NODE_PORT_Y } from './canvasNode';
 import type { CanvasNode, CanvasNodeType, CanvasTab } from './canvasNode';
 import {
   SELECTABLE_RULE_DIMENSIONS,
@@ -933,8 +933,8 @@ const connections = computed(() => {
     node.connections.forEach(targetId => {
       const target = props.nodes.find(n => n.id === targetId);
       if (target) {
-        const x1 = node.position.x + 240, y1 = node.position.y + 50;
-        const x2 = target.position.x, y2 = target.position.y + 50;
+        const x1 = node.position.x + CANVAS_NODE_WIDTH, y1 = node.position.y + CANVAS_NODE_PORT_Y;
+        const x2 = target.position.x, y2 = target.position.y + CANVAS_NODE_PORT_Y;
         const mx = (x1 + x2) / 2;
         result.push({ id: `${node.id}-${targetId}`, path: `M${x1},${y1} C${mx},${y1} ${mx},${y2} ${x2},${y2}` });
       }
@@ -1064,9 +1064,9 @@ function isRtl(): boolean {
 }
 
 /** A node's approximate visual centre, in canvas space — same anchor the
- *  connection-line paths already use (`x + 240`, `y + 50`, see `connections`). */
+ *  connection-line paths already use (`CANVAS_NODE_WIDTH`, `CANVAS_NODE_PORT_Y`). */
 function nodeCenter(node: CanvasNode): { x: number; y: number } {
-  return { x: node.position.x + CANVAS_NODE_WIDTH / 2, y: node.position.y + 50 };
+  return { x: node.position.x + CANVAS_NODE_WIDTH / 2, y: node.position.y + CANVAS_NODE_PORT_Y };
 }
 
 /**
@@ -1622,7 +1622,7 @@ function startConnect(nodeId: string, port: string, e: PointerEvent) {
   if (node) {
     lineStart.nodeId = nodeId;
     lineStart.x = node.position.x + (port === 'out' ? 240 : 0);
-    lineStart.y = node.position.y + 50;
+    lineStart.y = node.position.y + CANVAS_NODE_PORT_Y;
   }
   mousePos.x = e.clientX; mousePos.y = e.clientY;
   capturePointer(e);
@@ -1659,7 +1659,7 @@ function endInteraction(e: PointerEvent) {
     if (rect) {
       const x = (e.clientX - rect.left - pan.x) / zoom.value;
       const y = (e.clientY - rect.top - pan.y) / zoom.value;
-      const target = props.nodes.find(n => x >= n.position.x && x <= n.position.x + 240 && y >= n.position.y && y <= n.position.y + 100);
+      const target = props.nodes.find(n => x >= n.position.x && x <= n.position.x + CANVAS_NODE_WIDTH && y >= n.position.y && y <= n.position.y + CANVAS_NODE_HEIGHT);
       if (target && target.id !== lineStart.nodeId) emit('nodes-connected', lineStart.nodeId, target.id);
     }
   }

--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -1317,10 +1317,14 @@ function onSearchKeydown(e: KeyboardEvent): void {
  * ------------------------------------------------------------------ */
 
 /** Node footprint the layout builders assume, for a node type that carries no
- *  size of its own — the same 100px row `endInteraction` below already uses
+ *  size of its own — the same row height `endInteraction` below already uses
  *  for its connection-drop hit test, and `org-group`'s own `data.width`/
- *  `data.height` (`nodeStyle` above) when the node IS sized. */
-const NODE_APPROX_HEIGHT = 100;
+ *  `data.height` (`nodeStyle` above) when the node IS sized.
+ *
+ *  #14690: this was a second, independent `100`. The comment already said it
+ *  was "the same" height as the hit test, which is exactly the claim a shared
+ *  constant should be making instead of prose. */
+const NODE_APPROX_HEIGHT = CANVAS_NODE_HEIGHT;
 
 /** A zoom level comfortable for looking at one node up close — fixed, rather
  *  than a maximal fit, so repeatedly jumping between search hits or deep
@@ -1621,7 +1625,7 @@ function startConnect(nodeId: string, port: string, e: PointerEvent) {
   const node = props.nodes.find(n => n.id === nodeId);
   if (node) {
     lineStart.nodeId = nodeId;
-    lineStart.x = node.position.x + (port === 'out' ? 240 : 0);
+    lineStart.x = node.position.x + (port === 'out' ? CANVAS_NODE_WIDTH : 0);
     lineStart.y = node.position.y + CANVAS_NODE_PORT_Y;
   }
   mousePos.x = e.clientX; mousePos.y = e.clientY;

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
@@ -1,0 +1,60 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14690: the renderer computed edge anchors from bare literals (240, 50, 100)
+// while the layout builders used CANVAS_NODE_WIDTH. Two sources for one fact,
+// agreeing only by coincidence — change the constant and every node moves
+// while every edge stays anchored to the old width.
+//
+// A test cannot catch a literal-vs-constant swap while the two values happen
+// to be equal; that is exactly why this was debt rather than a bug. What a
+// test CAN pin is the relationship: an edge must start at the node's trailing
+// edge and at its mid-line, expressed in terms of the constants, so that
+// changing a constant moves the assertion with it.
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import { CANVAS_NODE_WIDTH, CANVAS_NODE_HEIGHT, CANVAS_NODE_PORT_Y } from '../canvasNode'
+import type { CanvasNode } from '../canvasNode'
+
+const SOURCE = { x: 100, y: 200 }
+const TARGET = { x: 700, y: 500 }
+
+const NODES: CanvasNode[] = [
+  { id: 'a', type: 'step', position: { ...SOURCE }, data: { label: 'A' }, connections: ['b'] },
+  { id: 'b', type: 'step', position: { ...TARGET }, data: { label: 'B' }, connections: [] },
+]
+
+function mountCanvas() {
+  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+  return mount(WorkflowCanvas, {
+    props: { nodes: NODES, selectedNodeId: null, readonly: true },
+    global: { plugins: [i18n] },
+  })
+}
+
+describe('canvas edge geometry derives from the shared constants (#14690)', () => {
+  it('anchors an edge at the source node trailing edge and mid-line', () => {
+    const path = mountCanvas().find('path.connection-line').attributes('d') ?? ''
+
+    // Expressed via the constants, never as 340/250 — so if a constant
+    // changes, this assertion changes with it instead of silently passing
+    // against stale geometry.
+    expect(path).toContain(`M${SOURCE.x + CANVAS_NODE_WIDTH},${SOURCE.y + CANVAS_NODE_PORT_Y}`)
+  })
+
+  it('lands the edge on the target node leading edge and mid-line', () => {
+    const path = mountCanvas().find('path.connection-line').attributes('d') ?? ''
+
+    expect(path).toContain(`${TARGET.x},${TARGET.y + CANVAS_NODE_PORT_Y}`)
+  })
+
+  it('keeps the port anchored at exactly half the node height', () => {
+    // The relationship that was previously two independent literals. If
+    // someone reintroduces a standalone 50, this is what catches the drift
+    // the moment the height changes.
+    expect(CANVAS_NODE_PORT_Y).toBe(CANVAS_NODE_HEIGHT / 2)
+  })
+})

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
@@ -27,10 +27,10 @@ const NODES: CanvasNode[] = [
   { id: 'b', type: 'step', position: { ...TARGET }, data: { label: 'B' }, connections: [] },
 ]
 
-function mountCanvas() {
+function mountCanvas(readonly = true) {
   const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(WorkflowCanvas, {
-    props: { nodes: NODES, selectedNodeId: null, readonly: true },
+    props: { nodes: NODES, selectedNodeId: null, readonly },
     global: { plugins: [i18n] },
   })
 }
@@ -56,5 +56,31 @@ describe('canvas edge geometry derives from the shared constants (#14690)', () =
     // someone reintroduces a standalone 50, this is what catches the drift
     // the moment the height changes.
     expect(CANVAS_NODE_PORT_Y).toBe(CANVAS_NODE_HEIGHT / 2)
+  })
+
+  it('starts the drag line at the source node trailing edge, not a literal', async () => {
+    // #14690 review: this anchor kept a bare 240 while the line directly below
+    // it was converted, and nothing exercised `startConnect`, so the gap was
+    // invisible. The drag line and the rendered edge must leave the node at
+    // the same place — that is the property, and it is what breaks when only
+    // one of the two reads the constant.
+    const wrapper = mountCanvas(false)
+
+    await wrapper.findAll('.port-out')[0].trigger('pointerdown')
+
+    const path = wrapper.find('path.drawing-line').attributes('d') ?? ''
+    expect(path).toContain(`M${SOURCE.x + CANVAS_NODE_WIDTH},${SOURCE.y + CANVAS_NODE_PORT_Y}`)
+  })
+
+  it('starts the drag line at the node leading edge for an inbound port', async () => {
+    // The `port === 'out'` branch offsets by the width; the other branch must
+    // stay at the node's own x, so the width constant applies to exactly one
+    // of the two.
+    const wrapper = mountCanvas(false)
+
+    await wrapper.findAll('.port-in')[0].trigger('pointerdown')
+
+    const path = wrapper.find('path.drawing-line').attributes('d') ?? ''
+    expect(path).toContain(`M${SOURCE.x},${SOURCE.y + CANVAS_NODE_PORT_Y}`)
   })
 })

--- a/autobot-frontend/src/components/workflow/canvasNode.ts
+++ b/autobot-frontend/src/components/workflow/canvasNode.ts
@@ -40,3 +40,22 @@ export interface CanvasTab {
 
 /** Canvas geometry shared by the renderer and the layout builders. */
 export const CANVAS_NODE_WIDTH = 240
+
+/**
+ * A node's effective height for geometry — hit-testing and port anchoring.
+ *
+ * Named because the renderer previously carried it as a bare `100` in the
+ * connection hit-test while `240` was already a constant, so half the geometry
+ * had a single source and half did not.
+ */
+export const CANVAS_NODE_HEIGHT = 100
+
+/**
+ * Where a connection attaches vertically: the node's mid-line.
+ *
+ * Derived rather than written as `50`, so it cannot drift from the height. The
+ * two were independent literals before, which meant changing the height moved
+ * every node while leaving every edge anchored to the old mid-line — a failure
+ * that renders as edges detached from their nodes and fails no test.
+ */
+export const CANVAS_NODE_PORT_Y = CANVAS_NODE_HEIGHT / 2


### PR DESCRIPTION
Closes #14690

## Thinking Path

The renderer computed edge anchors from bare literals — `240` for node width, `50` for the port mid-line, `100` for the hit-test height — while every layout builder used `CANVAS_NODE_WIDTH`. Two sources for one fact, agreeing only by coincidence.

The failure mode is quiet: change the constant for a denser canvas or a new node kind, and every node moves while every edge stays anchored to the old width. It renders as edges detached from their nodes, and nothing fails.

## What Changed

Six literals replaced. Two new constants, the second **derived**:

```ts
export const CANVAS_NODE_HEIGHT = 100
export const CANVAS_NODE_PORT_Y = CANVAS_NODE_HEIGHT / 2
```

The port offset was an independent `50` before. Deriving it means the mid-line cannot drift from the height — the specific pairing that made this dangerous rather than merely untidy.

## Verification

The proof is a **pair**, because a single mutation cannot show this:

| Mutation | Result | What it proves |
|---|---|---|
| `CANVAS_NODE_WIDTH` 240 → 300 | **green** | the renderer genuinely reads the constant — edges moved with the nodes |
| …and reintroduce one literal `240` | **red** | the two sites disagree the moment they are allowed to |

A constant change staying green is the desired outcome here, which is why the second half is necessary: on its own, green could just as well mean the test ignores geometry entirely.

The tests express positions via the constants (`SOURCE.x + CANVAS_NODE_WIDTH`), never as precomputed numbers, so an assertion moves with the value it describes.

- `vitest run src/components/workflow src/composables/llc` — **28 files, 309 tests, all passed**
- `vue-tsc` 0 · `oxlint -D correctness` 0 · `eslint` 0

## The honest limit

**No test can catch a literal-vs-constant swap while the two values happen to be equal.** Reintroducing `240` today breaks nothing observable, because `CANVAS_NODE_WIDTH` *is* 240. That is precisely why this was filed as debt rather than a bug, and why the tests pin the *relationship* rather than the number — the drift only becomes visible when someone changes the constant, which is exactly the moment the old code would have broken silently.

## Model Used

Claude Opus 5 (1M context)
