### PR TITLE
build(deps): key the tokenizers exclusion to the real transformers cap (#14431)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -415,11 +415,15 @@ updates:
           - "*"
     ignore:
       - dependency-name: "tokenizers"
-        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
-        # above that is unsatisfiable. The requirements files already carry the
-        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
-        # it on every run. Unblock when transformers raises its cap.
-        versions: [">=0.24.0"]
+        # #14431: exclude >=0.23.1 — transformers 5.14.1 AND 5.15.0 both declare
+        # tokenizers<=0.23.0, so 0.23.1 is the FIRST unsatisfiable version, not
+        # 0.24.0. The requirements files' <0.24 is a looser safety bound; keying
+        # the exclusion to it (as this entry first did) still let dependabot
+        # propose 0.23.1 — which is exactly what #14441 and #14442 carry.
+        # scripts/tokenizers_transformers_range_test.py pins the real cap at
+        # (0, 23, 0). Raise this only alongside a transformers bump that raises
+        # _TRANSFORMERS_CAP there.
+        versions: [">=0.23.1"]
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
       - dependency-name: "numpy"
@@ -447,11 +451,15 @@ updates:
           - "*"
     ignore:
       - dependency-name: "tokenizers"
-        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
-        # above that is unsatisfiable. The requirements files already carry the
-        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
-        # it on every run. Unblock when transformers raises its cap.
-        versions: [">=0.24.0"]
+        # #14431: exclude >=0.23.1 — transformers 5.14.1 AND 5.15.0 both declare
+        # tokenizers<=0.23.0, so 0.23.1 is the FIRST unsatisfiable version, not
+        # 0.24.0. The requirements files' <0.24 is a looser safety bound; keying
+        # the exclusion to it (as this entry first did) still let dependabot
+        # propose 0.23.1 — which is exactly what #14441 and #14442 carry.
+        # scripts/tokenizers_transformers_range_test.py pins the real cap at
+        # (0, 23, 0). Raise this only alongside a transformers bump that raises
+        # _TRANSFORMERS_CAP there.
+        versions: [">=0.23.1"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"


### PR DESCRIPTION
## Thinking Path

**Correcting my own change from #14696.** I set the `tokenizers` exclusion at `>=0.24.0`, which does not stop the bump that is actually failing.

I keyed it to the **requirements files'** `<0.24` cap. That is a looser safety bound. The real constraint is what `transformers` declares, and `scripts/tokenizers_transformers_range_test.py:41-45` states it exactly:

```python
# The highest `tokenizers` that the pinned `transformers` accepts. Verified
# against transformers 5.14.1 and 5.15.0, both of which declare
# `tokenizers<=0.23.0,>=0.22.0`.
_TRANSFORMERS_CAP = (0, 23, 0)
```

So **`0.23.1` is the first unsatisfiable version, not `0.24.0`** — and `0.23.1` is precisely what the two open PRs carry:

```
#14441  -tokenizers>=0.22.0,<0.24   +tokenizers>=0.23.1,<0.24
#14442  -tokenizers>=0.22.0,<0.24   +tokenizers>=0.23.1,<0.24
```

Both also bump `transformers` 5.14.1 → 5.15.0, which does **not** raise the cap — the guard's comment says it verified both versions. So the bump is unsatisfiable with or without the transformers change.

My exclusion sat above the failing version and would have let this regenerate indefinitely. The `openai >=3.0.0` half was correct and is untouched.

## Why this recurs

`#10416` did this once already — a grouped bump raised the floor back to `>=0.23.1` after `#10331`/`#10332` had fixed it to `>=0.22.0`. The guard test exists because of that. This is the third time the same floor has been pushed above the same cap.

## What Changed

Both `tokenizers` entries move from `versions: [">=0.24.0"]` to `versions: [">=0.23.1"]`, with a comment stating the real cap, naming the guard that pins it, and recording why the file's `<0.24` is the wrong thing to key on.

## Verification

Asserted the replacement count (exactly 2 blocks, so neither entry was missed and nothing else matched) and re-parsed with `yaml.safe_load`:

```
/autobot-backend                                  openai      ['>=3.0.0']
/autobot-infrastructure/shared/docker/ai-stack    tokenizers  ['>=0.23.1']
/autobot-infrastructure/autobot-npu-worker/docker tokenizers  ['>=0.23.1']
```

The effect is only observable after merge to the default branch — dependabot reads this config from `main`.

## Model Used

Claude Opus 5 (1M context)

Refs #14431
