### PR TITLE
fix(ci): make the runaway PR-queue gate warn instead of failing (#14718)

### DIFF
--- a/.github/workflows/pr-queue-gate.yml
+++ b/.github/workflows/pr-queue-gate.yml
@@ -25,6 +25,12 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      # #14718: the notice's open-PR list is built by a script in the repo, so
+      # this job needs the tree. Without a checkout the script is absent, the
+      # fallback fires, and the notice degrades silently — the exact fail-open
+      # shape this fix exists to remove.
+      - uses: actions/checkout@v7
+
       - name: Warn only on a runaway PR queue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,8 +54,11 @@ jobs:
           # rather than tune it.
           RUNAWAY_THRESHOLD=25
 
-          # Count open PRs excluding the one just opened
-          TOTAL=$(gh pr list --repo "$REPO" --state open --json number --jq 'length')
+          # Count open PRs excluding the one just opened. #14718: if the count
+          # itself fails there is no runaway to report, and a warn-only gate
+          # must not turn that into a red check — fall back to the quiet path.
+          TOTAL=$(gh pr list --repo "$REPO" --state open --json number --jq 'length') \
+            || { echo "Could not count open PRs — continuing, this gate never blocks."; TOTAL=0; }
           EXISTING=$(( TOTAL - 1 ))
 
           echo "Open PRs excluding this one: $EXISTING (runaway threshold $RUNAWAY_THRESHOLD)"
@@ -57,13 +66,12 @@ jobs:
           if [ "$EXISTING" -ge "$RUNAWAY_THRESHOLD" ]; then
             echo "Runaway threshold reached — posting a notice on PR #$PR_NUMBER"
 
-            # shellcheck disable=SC2016  # $skip is a jq variable, not a shell variable
-            OPEN_LIST=$(gh pr list \
-              --repo "$REPO" \
-              --state open \
-              --json number,title \
-              --jq --argjson skip "$PR_NUMBER" \
-              '[.[] | select(.number != $skip) | "- #\(.number) \(.title)"] | join("\n")')
+            # #14718: this used to pass `--argjson` to `gh pr list`, which has no
+            # such flag — gh took it as the VALUE of `--jq` and errored on the
+            # leftovers, killing the step under `set -e` before it could post.
+            # The list building now lives in a script so a test can execute it.
+            OPEN_LIST=$(bash pipeline-scripts/pr-queue-open-list.sh "$REPO" "$PR_NUMBER") \
+              || OPEN_LIST="_(could not list the open PRs — see this job's log)_"
 
             # Build the comment with an indented printf rather than a column-0
             # heredoc: an unindented heredoc body breaks out of the `run: |` YAML
@@ -86,7 +94,11 @@ jobs:
               "" \
               '> Warn-only runaway detector — `.github/workflows/pr-queue-gate.yml`. It never blocks a merge.')
 
-            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+            # Warn-only is a contract, so enforce it in code rather than only
+            # asserting it in prose: a detector whose own failure can redden a
+            # required check is worse than no detector at all (#14718).
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY" \
+              || echo "Could not post the runaway notice — continuing, this gate never blocks."
           else
             echo "No runaway — $EXISTING open PRs, below the $RUNAWAY_THRESHOLD threshold"
           fi

--- a/.github/workflows/pr-queue-gate.yml
+++ b/.github/workflows/pr-queue-gate.yml
@@ -23,6 +23,9 @@ jobs:
   check-pr-limit:
     runs-on: ubuntu-latest
     permissions:
+      # Declaring any `permissions:` sets every unlisted scope to `none`, so the
+      # checkout below needs `contents` named explicitly (#14718).
+      contents: read
       pull-requests: write
     steps:
       # #14718: the notice's open-PR list is built by a script in the repo, so
@@ -30,6 +33,11 @@ jobs:
       # fallback fires, and the notice degrades silently — the exact fail-open
       # shape this fix exists to remove.
       - uses: actions/checkout@v7
+        # A warn-only job must not go red because a checkout blipped. The run
+        # block below already degrades gracefully when the script is absent,
+        # so tolerating this step keeps the never-blocks contract whole
+        # (#14718) — same idiom as ssot-coverage.yml and trajectory-eval.yml.
+        continue-on-error: true
 
       - name: Warn only on a runaway PR queue
         env:

--- a/pipeline-scripts/pr-queue-open-list.sh
+++ b/pipeline-scripts/pr-queue-open-list.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+#
+# Print a markdown bullet list of the repository's open PRs, excluding one.
+# Used by the warn-only runaway detector in
+# `.github/workflows/pr-queue-gate.yml` to fill in the "Currently open" section
+# of its notice.
+#
+# #14718: this was inline in the workflow as
+#
+#     gh pr list --json number,title --jq --argjson skip "$PR_NUMBER" '<expr>'
+#
+# `gh pr list` has no `--argjson` flag. `gh` consumed `--argjson` as the VALUE
+# of `--jq` and then rejected the leftovers as unknown positional arguments, so
+# the step died under `set -e` before it could post anything. The detector is
+# documented as warn-only and never-blocking; in practice it had never once
+# warned, and it failed the check every time the threshold was crossed — which
+# is precisely when the PR queue could least afford another red check.
+#
+# It lives in its own file so the behaviour can be executed by a test rather
+# than asserted in a workflow comment (#13880: a guard's own test must run).
+#
+# Usage: pipeline-scripts/pr-queue-open-list.sh <repo> <pr-number-to-exclude>
+#   stdout — the markdown list (empty when no other PR is open)
+#   exit 0 — list produced
+#   exit 1 — arguments missing, or `gh`/`jq` failed
+#
+# The CALLER is responsible for making a failure here non-fatal. This script
+# reports honestly and does not swallow errors; the workflow decides that a
+# broken notice must never block a merge.
+
+set -euo pipefail
+
+REPO="${1:?usage: pr-queue-open-list.sh <repo> <pr-number-to-exclude>}"
+SKIP="${2:?usage: pr-queue-open-list.sh <repo> <pr-number-to-exclude>}"
+
+case "$SKIP" in
+    '' | *[!0-9]*)
+        echo "pr-queue-open-list.sh: PR number must be numeric, got '$SKIP'" >&2
+        exit 1
+        ;;
+esac
+
+# `--argjson` binds $skip as a NUMBER so the `!=` compares like with like;
+# `.number` from `gh` is numeric, and a string bound with --arg would never
+# match, silently leaving the current PR in its own "currently open" list.
+gh pr list --repo "$REPO" --state open --json number,title \
+    | jq -r --argjson skip "$SKIP" \
+        '[.[] | select(.number != $skip) | "- #\(.number) \(.title)"] | join("\n")'

--- a/pipeline-scripts/pr_queue_open_list_test.py
+++ b/pipeline-scripts/pr_queue_open_list_test.py
@@ -1,0 +1,194 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The runaway PR-queue detector must warn, and must never fail a check.
+
+#14718: `check-pr-limit` in `.github/workflows/pr-queue-gate.yml` calls itself
+a warn-only runaway detector — its own notice text ends "It never blocks a
+merge." It built the open-PR list by passing `--argjson` to `gh pr list`, which
+has no such flag, so `gh` errored and `set -e` killed the step. The check went
+red every time the threshold was crossed, and the notice was never posted once:
+the step died before reaching `gh pr comment`.
+
+Two properties are covered here, both by execution rather than by reading the
+YAML:
+
+* the list builder produces the right list, and rejects input it cannot trust;
+* the workflow's own `run` block exits 0 even when `gh` fails underneath it,
+  because a detector whose failure can redden a required check is worse than
+  no detector.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "pipeline-scripts" / "pr-queue-open-list.sh"
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-queue-gate.yml"
+
+# Enough open PRs to put the stubbed repo past the workflow's threshold, so the
+# tests exercise the runaway branch rather than the quiet one.
+_OPEN_PRS = [{"number": 100 + i, "title": f"pr number {100 + i}"} for i in range(30)]
+
+
+def _write_gh_stub(directory: Path, *, list_rc: int = 0, comment_rc: int = 0) -> None:
+    """Put a fake `gh` on PATH that mimics the two calls the gate makes."""
+    payload = "".join(
+        f'{{"number": {p["number"]}, "title": "{p["title"]}"}},' for p in _OPEN_PRS
+    ).rstrip(",")
+    stub = directory / "gh"
+    stub.write_text(
+        "#!/bin/bash\n"
+        # Real `gh pr list` has no --argjson; it takes the next token as the
+        # value of --jq and then rejects the leftovers. Emulating that is what
+        # makes this stub able to reproduce #14718 at all.
+        'for a in "$@"; do [ "$a" = "--argjson" ] && {\n'
+        '  echo "unknown arguments; please quote all values that have spaces" >&2\n'
+        "  exit 1; }; done\n"
+        'for a in "$@"; do [ "$a" = "comment" ] && exit %d; done\n'
+        "if [ %d -ne 0 ]; then echo 'stub: gh failed' >&2; exit %d; fi\n"
+        'for a in "$@"; do [ "$a" = "length" ] && { echo %d; exit 0; }; done\n'
+        "echo '[%s]'\n" % (comment_rc, list_rc, list_rc, len(_OPEN_PRS), payload),
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+
+def _env_with_stub(directory: Path) -> dict[str, str]:
+    env = dict(os.environ)
+    env["PATH"] = f"{directory}{os.pathsep}{env['PATH']}"
+    env["REPO"] = "owner/repo"
+    env["PR_NUMBER"] = "105"
+    env["GH_TOKEN"] = "stub-token-not-a-real-credential"
+    return env
+
+
+def test_the_script_is_where_the_workflow_calls_it() -> None:
+    """A missing script would make every assertion below vacuous."""
+    assert _SCRIPT.is_file(), f"{_SCRIPT} is missing"
+    assert _WORKFLOW.is_file(), f"{_WORKFLOW} is missing"
+
+
+def test_open_list_excludes_the_current_pr(tmp_path: Path) -> None:
+    """The whole point of the `$skip` binding that #14718 broke."""
+    _write_gh_stub(tmp_path)
+    result = subprocess.run(
+        ["bash", str(_SCRIPT), "owner/repo", "105"],
+        capture_output=True,
+        text=True,
+        env=_env_with_stub(tmp_path),
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "- #105 " not in result.stdout, "the current PR must not list itself"
+    assert "- #104 pr number 104" in result.stdout
+    assert result.stdout.count("- #") == len(_OPEN_PRS) - 1
+
+
+def test_a_non_numeric_pr_number_is_rejected(tmp_path: Path) -> None:
+    """`--argjson` needs a number; a string would silently match nothing."""
+    _write_gh_stub(tmp_path)
+    result = subprocess.run(
+        ["bash", str(_SCRIPT), "owner/repo", "not-a-number"],
+        capture_output=True,
+        text=True,
+        env=_env_with_stub(tmp_path),
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "must be numeric" in result.stderr
+
+
+def test_the_script_reports_a_gh_failure_rather_than_hiding_it(tmp_path: Path) -> None:
+    """The script is honest; making it non-fatal is the caller's job."""
+    _write_gh_stub(tmp_path, list_rc=1)
+    result = subprocess.run(
+        ["bash", str(_SCRIPT), "owner/repo", "105"],
+        capture_output=True,
+        text=True,
+        env=_env_with_stub(tmp_path),
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode != 0, "a gh failure must not be swallowed here"
+
+
+def _gate_run_block() -> str:
+    """The `run:` script the workflow actually executes."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["check-pr-limit"]["steps"]
+    blocks = [step["run"] for step in steps if "run" in step]
+    assert len(blocks) == 1, f"expected one run block, found {len(blocks)}"
+    return blocks[0]
+
+
+@pytest.mark.parametrize(
+    ("label", "kwargs"),
+    [
+        ("everything works", {}),
+        ("posting the notice fails", {"comment_rc": 1}),
+        ("listing the PRs fails", {"list_rc": 1}),
+    ],
+)
+def test_the_gate_never_fails_the_check(
+    tmp_path: Path, label: str, kwargs: dict[str, int]
+) -> None:
+    """Warn-only, enforced by running it — this is the #14718 regression.
+
+    Before the fix the third case exited non-zero, turning a detector into a
+    blocker on every PR opened above the threshold.
+    """
+    _write_gh_stub(tmp_path, **kwargs)
+    script = tmp_path / "gate.sh"
+    script.write_text(_gate_run_block(), encoding="utf-8")
+    result = subprocess.run(
+        # GitHub Actions runs a `run:` block as `bash -e {0}`. Invoking plain
+        # `bash` here would let a failed command slide and under-reproduce the
+        # very failure this test exists for.
+        ["bash", "-e", str(script)],
+        capture_output=True,
+        text=True,
+        env=_env_with_stub(tmp_path),
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"the runaway gate exited {result.returncode} when {label}. It is "
+        f"documented warn-only and must never fail a check.\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_the_threshold_branch_is_actually_reached(tmp_path: Path) -> None:
+    """Guard the guard: 30 stubbed PRs must trip the runaway branch.
+
+    If the stub ever fell below the threshold the tests above would pass by
+    running the quiet path and would prove nothing about the failure mode.
+    """
+    _write_gh_stub(tmp_path)
+    script = tmp_path / "gate.sh"
+    script.write_text(_gate_run_block(), encoding="utf-8")
+    result = subprocess.run(
+        # GitHub Actions runs a `run:` block as `bash -e {0}`. Invoking plain
+        # `bash` here would let a failed command slide and under-reproduce the
+        # very failure this test exists for.
+        ["bash", "-e", str(script)],
+        capture_output=True,
+        text=True,
+        env=_env_with_stub(tmp_path),
+        cwd=_REPO_ROOT,
+        check=False,
+    )
+    assert "Runaway threshold reached" in result.stdout, (
+        "the stub no longer trips the threshold, so the warn-only tests are "
+        f"exercising the quiet path and prove nothing.\nstdout:\n{result.stdout}"
+    )

--- a/pipeline-scripts/pr_queue_open_list_test.py
+++ b/pipeline-scripts/pr_queue_open_list_test.py
@@ -38,8 +38,19 @@ _WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "pr-queue-gate.yml"
 _OPEN_PRS = [{"number": 100 + i, "title": f"pr number {100 + i}"} for i in range(30)]
 
 
-def _write_gh_stub(directory: Path, *, list_rc: int = 0, comment_rc: int = 0) -> None:
-    """Put a fake `gh` on PATH that mimics the two calls the gate makes."""
+def _write_gh_stub(
+    directory: Path, *, count_rc: int = 0, list_rc: int = 0, comment_rc: int = 0
+) -> None:
+    """Put a fake `gh` on PATH that mimics the three calls the gate makes.
+
+    The gate calls `gh pr list` TWICE and they must be controllable
+    separately. The first asks jq for `length` to get the count; the second
+    (inside `pr-queue-open-list.sh`) fetches the list itself and only happens
+    on the runaway branch. A single failure switch for both made the count
+    fail first, which sent the gate down the quiet path — so the case meant to
+    exercise the list fallback never reached it, and passed for the wrong
+    reason.
+    """
     payload = "".join(
         f'{{"number": {p["number"]}, "title": "{p["title"]}"}},' for p in _OPEN_PRS
     ).rstrip(",")
@@ -53,9 +64,13 @@ def _write_gh_stub(directory: Path, *, list_rc: int = 0, comment_rc: int = 0) ->
         '  echo "unknown arguments; please quote all values that have spaces" >&2\n'
         "  exit 1; }; done\n"
         'for a in "$@"; do [ "$a" = "comment" ] && exit %d; done\n'
-        "if [ %d -ne 0 ]; then echo 'stub: gh failed' >&2; exit %d; fi\n"
-        'for a in "$@"; do [ "$a" = "length" ] && { echo %d; exit 0; }; done\n'
-        "echo '[%s]'\n" % (comment_rc, list_rc, list_rc, len(_OPEN_PRS), payload),
+        # `--jq length` identifies the count call and nothing else.
+        'for a in "$@"; do [ "$a" = "length" ] && {\n'
+        "  if [ %d -ne 0 ]; then echo 'stub: gh count failed' >&2; exit %d; fi\n"
+        "  echo %d; exit 0; }; done\n"
+        "if [ %d -ne 0 ]; then echo 'stub: gh list failed' >&2; exit %d; fi\n"
+        "echo '[%s]'\n"
+        % (comment_rc, count_rc, count_rc, len(_OPEN_PRS), list_rc, list_rc, payload),
         encoding="utf-8",
     )
     stub.chmod(0o755)
@@ -132,29 +147,33 @@ def _gate_run_block() -> str:
 
 
 @pytest.mark.parametrize(
-    ("label", "kwargs"),
+    ("label", "kwargs", "reaches_runaway"),
     [
-        ("everything works", {}),
-        ("posting the notice fails", {"comment_rc": 1}),
-        ("listing the PRs fails", {"list_rc": 1}),
+        ("everything works", {}, True),
+        ("posting the notice fails", {"comment_rc": 1}, True),
+        ("listing the PRs fails", {"list_rc": 1}, True),
+        ("counting the PRs fails", {"count_rc": 1}, False),
     ],
 )
 def test_the_gate_never_fails_the_check(
-    tmp_path: Path, label: str, kwargs: dict[str, int]
+    tmp_path: Path, label: str, kwargs: dict[str, int], reaches_runaway: bool
 ) -> None:
     """Warn-only, enforced by running it — this is the #14718 regression.
 
-    Before the fix the third case exited non-zero, turning a detector into a
-    blocker on every PR opened above the threshold.
+    `reaches_runaway` is asserted, not assumed. Without it a case can fail its
+    way onto the quiet path and pass for the wrong reason: when a single switch
+    failed both `gh pr list` calls, the count died first, the gate skipped the
+    runaway branch entirely, and the case nominally covering the open-list
+    fallback exercised none of it. Deleting that fallback left the suite green.
     """
     _write_gh_stub(tmp_path, **kwargs)
     script = tmp_path / "gate.sh"
     script.write_text(_gate_run_block(), encoding="utf-8")
     result = subprocess.run(
-        # GitHub Actions runs a `run:` block as `bash -e {0}`. Invoking plain
-        # `bash` here would let a failed command slide and under-reproduce the
+        # Actions runs a `run:` block as `bash --noprofile --norc -eo pipefail`.
+        # Plain `bash` would let a failed command slide and under-reproduce the
         # very failure this test exists for.
-        ["bash", "-e", str(script)],
+        ["bash", "-eo", "pipefail", str(script)],
         capture_output=True,
         text=True,
         env=_env_with_stub(tmp_path),
@@ -165,6 +184,13 @@ def test_the_gate_never_fails_the_check(
         f"the runaway gate exited {result.returncode} when {label}. It is "
         f"documented warn-only and must never fail a check.\n"
         f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    reached = "Runaway threshold reached" in result.stdout
+    assert reached is reaches_runaway, (
+        f"when {label} the gate {'reached' if reached else 'did not reach'} the "
+        f"runaway branch, expected the opposite. A case that silently takes the "
+        f"quiet path proves nothing about the branch it is meant to cover.\n"
+        f"stdout:\n{result.stdout}"
     )
 
 
@@ -181,7 +207,7 @@ def test_the_threshold_branch_is_actually_reached(tmp_path: Path) -> None:
         # GitHub Actions runs a `run:` block as `bash -e {0}`. Invoking plain
         # `bash` here would let a failed command slide and under-reproduce the
         # very failure this test exists for.
-        ["bash", "-e", str(script)],
+        ["bash", "-eo", "pipefail", str(script)],
         capture_output=True,
         text=True,
         env=_env_with_stub(tmp_path),
@@ -192,3 +218,42 @@ def test_the_threshold_branch_is_actually_reached(tmp_path: Path) -> None:
         "the stub no longer trips the threshold, so the warn-only tests are "
         f"exercising the quiet path and prove nothing.\nstdout:\n{result.stdout}"
     )
+
+
+def test_every_step_outside_the_run_block_tolerates_failure() -> None:
+    """Steps around the `run:` block must not be able to redden the check.
+
+    The tests above execute the `run:` block and prove it swallows its own
+    failures. They cannot reach the other steps in the job, and a job fails if
+    *any* step fails — so a checkout blip would reproduce the exact "warn-only
+    job goes red" failure this gate was fixed for, from a step no execution
+    test touches. Structure is the only place left to assert it.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["check-pr-limit"]
+
+    unguarded = [
+        step.get("name") or step.get("uses")
+        for step in job["steps"]
+        if "run" not in step and step.get("continue-on-error") is not True
+    ]
+    assert not unguarded, (
+        f"these steps can fail the warn-only gate: {unguarded}. Give each "
+        f"`continue-on-error: true`, or move its work into the run block where "
+        f"the tests above can prove it degrades instead of failing."
+    )
+
+
+def test_the_job_declares_the_scopes_its_steps_need() -> None:
+    """Naming any permission sets every unnamed scope to `none`."""
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    job = workflow["jobs"]["check-pr-limit"]
+    permissions = job.get("permissions", {})
+
+    if any("uses" in step and "checkout" in step["uses"] for step in job["steps"]):
+        assert permissions.get("contents") == "read", (
+            "the job checks out the repository but does not declare "
+            "`contents: read`; declaring any permission drops every unlisted "
+            "scope to `none`"
+        )
+    assert permissions.get("pull-requests") == "write", "the gate posts a comment"

--- a/pipeline-scripts/pr_queue_open_list_test.py
+++ b/pipeline-scripts/pr_queue_open_list_test.py
@@ -23,6 +23,7 @@ YAML:
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -194,29 +195,30 @@ def test_the_gate_never_fails_the_check(
     )
 
 
-def test_the_threshold_branch_is_actually_reached(tmp_path: Path) -> None:
-    """Guard the guard: 30 stubbed PRs must trip the runaway branch.
+def test_the_stub_stays_above_the_workflow_threshold() -> None:
+    """Tie the stub's size to the gate's own threshold, not to a guess.
 
-    If the stub ever fell below the threshold the tests above would pass by
-    running the quiet path and would prove nothing about the failure mode.
+    The parametrised cases above already assert which branch each one took, so
+    a stub that silently stopped tripping the runaway branch would be caught —
+    but caught as three confusing failures that all look like the gate broke.
+
+    The real hazard is drift in one direction: raise ``RUNAWAY_THRESHOLD`` in
+    the workflow and the stub's PR count quietly stops exceeding it. Reading
+    the threshold out of the workflow and comparing it here turns that into one
+    failure that names the actual cause.
     """
-    _write_gh_stub(tmp_path)
-    script = tmp_path / "gate.sh"
-    script.write_text(_gate_run_block(), encoding="utf-8")
-    result = subprocess.run(
-        # GitHub Actions runs a `run:` block as `bash -e {0}`. Invoking plain
-        # `bash` here would let a failed command slide and under-reproduce the
-        # very failure this test exists for.
-        ["bash", "-eo", "pipefail", str(script)],
-        capture_output=True,
-        text=True,
-        env=_env_with_stub(tmp_path),
-        cwd=_REPO_ROOT,
-        check=False,
+    match = re.search(r"RUNAWAY_THRESHOLD=(\d+)", _gate_run_block())
+    assert match, (
+        "could not find RUNAWAY_THRESHOLD in the gate's run block — if it was "
+        "renamed, repoint this test rather than dropping the check"
     )
-    assert "Runaway threshold reached" in result.stdout, (
-        "the stub no longer trips the threshold, so the warn-only tests are "
-        f"exercising the quiet path and prove nothing.\nstdout:\n{result.stdout}"
+    threshold = int(match.group(1))
+
+    assert len(_OPEN_PRS) > threshold, (
+        f"the stub builds {len(_OPEN_PRS)} open PRs but the gate's threshold is "
+        f"{threshold}. The runaway branch can no longer be reached, so every "
+        f"case that expects it would fail for a reason that looks like the gate "
+        f"is broken. Raise the stub above the threshold."
     )
 
 


### PR DESCRIPTION
Closes #14718.

## Thinking Path

While sweeping the dependabot fleet for failures I found #14706 and #14707 red
on `check-pr-limit`. That job describes itself, in its own source comments, as
warn-only — *"it posts a comment and never fails a check"* — and the notice it
builds ends with *"Warn-only runaway detector … It never blocks a merge."*

It was failing. The log says why:

```
Open PRs excluding this one: 29 (runaway threshold 25)
Runaway threshold reached — posting a notice on PR #14706
unknown arguments ["skip" "14706" "[.[] | select(.number != $skip) | ...]"]
Usage:  gh pr list [flags]
##[error]Process completed with exit code 1.
```

`gh pr list` has no `--argjson` flag. `gh` took `--argjson` as the *value* of
`--jq` and rejected the leftovers, so under `set -e` the step died while
building the list — before ever reaching the `gh pr comment` call.

Two things follow, and the second is worse than the first:

1. The check goes red on every PR opened above the threshold — precisely when
   the queue is busiest and least able to absorb another blocker. A runaway
   *detector* had become a runaway *amplifier*.
2. **The notice has never once been posted.** Execution never reached the
   comment call, so every line of guidance in that carefully written body has
   been unreachable since it was added.

The failure only manifests above the threshold, which is why it sat latent
through every run below 25.

## What Changed

- `pipeline-scripts/pr-queue-open-list.sh` *(new)* — builds the open-PR list
  with a real `jq` invocation (`gh pr list --json … | jq -r --argjson skip …`).
  Extracted to a file so its behaviour can be **executed** by a test rather
  than asserted in a YAML comment (#13880).
- `.github/workflows/pr-queue-gate.yml` — calls the script; guards all three
  `gh` interactions so the job cannot fail; adds the `actions/checkout` the job
  never had.
- `pipeline-scripts/pr_queue_open_list_test.py` *(new)* — extracts the job's
  actual `run:` block from the YAML and executes it against a stubbed `gh`.

Warn-only is now enforced by the code rather than only claimed in prose. A
detector whose own failure can redden a required check is worse than no
detector.

## Verification

Baseline vs this branch, same final test file:

| tree | result |
|---|---|
| `origin/Dev_new_gui` (old workflow, no extracted script) | **7 failed**, 4 passed |
| this branch | **11 passed** |

All three warn-only cases fail on the baseline — including *"everything
works"*. That is the proof of point 2 above: above the threshold the gate
failed unconditionally, not just in some error corner.

Two fidelity details, because both changed the result and either would have
made this test prove nothing:

- **The stub had to reject `--argjson` the way real `gh` does.** A permissive
  stub let the broken call succeed and the regression vanished.
- **The gate must be run as `bash -e`**, which is how Actions executes a `run:`
  block. Invoking plain `bash` let the failed assignment slide, and the
  baseline reported only 1 failure instead of 3.

The test also caught a hole in my own first fix: I had guarded the list call
and the comment call but left the initial `TOTAL=$(gh pr list …)` count
unguarded, so a failure there still reddened the check. That is now guarded and
falls back to the quiet path — if the count cannot be taken there is no runaway
to report, and that is never a reason to block a merge.

`test_the_threshold_branch_is_actually_reached` pins the stub above the
threshold, so the warn-only cases cannot silently start exercising the quiet
path and passing for the wrong reason.

Not verified here: that the notice renders correctly once posted. The comment
body itself is unchanged by this PR, and this is the first change that lets it
be reached at all — the next time the queue crosses 25 will be its first real
outing.

## Model Used

Claude Opus 5


---

## Review round 2

Both blocking findings from review were real and are fixed in `8bc81be50`; see
the [response comment](#issuecomment-5372682079) for the detail.

- `actions/checkout` now carries `continue-on-error: true`, and the job
  declares `contents: read` (naming any permission drops the rest to `none`).
- The `listing the PRs fails` case was a **false positive** — one failure
  switch failed both `gh pr list` calls, the count died first, and the gate
  took the quiet path without ever exercising the open-list fallback. The stub
  now separates the two calls and every case asserts which branch it took.

Each fix is mutation-checked:

| mutation | before | after |
|---|---|---|
| remove the `OPEN_LIST` fallback | 8 passed — not caught | **1 failed** |
| remove `continue-on-error` | not covered | **1 failed** |
| remove `contents: read` | not covered | **1 failed** |

The baseline row above is also corrected: the earlier figure measured the old
workflow against a tree that already contained the new script, which is not a
state that exists on the base branch.
