### PR TITLE
build(deps): mirror the corrected tokenizers cap onto the working base (#14431)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -415,11 +415,15 @@ updates:
           - "*"
     ignore:
       - dependency-name: "tokenizers"
-        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
-        # above that is unsatisfiable. The requirements files already carry the
-        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
-        # it on every run. Unblock when transformers raises its cap.
-        versions: [">=0.24.0"]
+        # #14431: exclude >=0.23.1 — transformers 5.14.1 AND 5.15.0 both declare
+        # tokenizers<=0.23.0, so 0.23.1 is the FIRST unsatisfiable version, not
+        # 0.24.0. The requirements files' <0.24 is a looser safety bound; keying
+        # the exclusion to it (as this entry first did) still let dependabot
+        # propose 0.23.1 — which is exactly what #14441 and #14442 carry.
+        # scripts/tokenizers_transformers_range_test.py pins the real cap at
+        # (0, 23, 0). Raise this only alongside a transformers bump that raises
+        # _TRANSFORMERS_CAP there.
+        versions: [">=0.23.1"]
       - dependency-name: "torch"
         update-types: ["version-update:semver-major"]
       - dependency-name: "numpy"
@@ -447,11 +451,15 @@ updates:
           - "*"
     ignore:
       - dependency-name: "tokenizers"
-        # #14431: cap <0.24 — transformers pins tokenizers<=0.23.0, so a floor
-        # above that is unsatisfiable. The requirements files already carry the
-        # <0.24 cap and a #10331 comment; this stops dependabot re-proposing past
-        # it on every run. Unblock when transformers raises its cap.
-        versions: [">=0.24.0"]
+        # #14431: exclude >=0.23.1 — transformers 5.14.1 AND 5.15.0 both declare
+        # tokenizers<=0.23.0, so 0.23.1 is the FIRST unsatisfiable version, not
+        # 0.24.0. The requirements files' <0.24 is a looser safety bound; keying
+        # the exclusion to it (as this entry first did) still let dependabot
+        # propose 0.23.1 — which is exactly what #14441 and #14442 carry.
+        # scripts/tokenizers_transformers_range_test.py pins the real cap at
+        # (0, 23, 0). Raise this only alongside a transformers bump that raises
+        # _TRANSFORMERS_CAP there.
+        versions: [">=0.23.1"]
       - dependency-name: "numpy"
         update-types: ["version-update:semver-major"]
       - dependency-name: "pydantic"


### PR DESCRIPTION
Follow-up to #14708 (merged to `main`). Part of #14431.

## Thinking Path

Dependabot reads its config from the repository's **default** branch (`main`),
so #14708 alone is enough to change dependabot's behaviour. But `Dev_new_gui`
is the working base, and #14697 mirrored the *earlier, wrong* boundary onto it.
Leaving that in place means the two branches disagree about a value whose whole
purpose is to state a hard constraint:

| branch | tokenizers exclusion |
|---|---|
| `main` (after #14708) | `>=0.23.1` |
| `Dev_new_gui` (before this PR) | `>=0.24.0` |

A stale `>=0.24.0` on the working base is worse than a missing entry: it reads
as a deliberate, documented decision, and its comment argues for the wrong
number. Anyone editing from `Dev_new_gui` would carry it forward.

## What Changed

`.github/dependabot.yml` — both `tokenizers` exclusion blocks (the `ai-stack`
and `npu-worker` pip directories) updated from `>=0.24.0` to `>=0.23.1`, with
the comment replaced by the corrected one from `main`.

## Verification

The real boundary was confirmed independently in review of #14708 via the PyPI
JSON API: `transformers==5.14.1` and `transformers==5.15.0` both declare
`tokenizers<=0.23.0,>=0.22.0`, so `0.23.1` is the first genuinely unsatisfiable
version. This agrees with `scripts/tokenizers_transformers_range_test.py`,
which pins `_TRANSFORMERS_CAP = (0, 23, 0)`.

Both blocks were required to match before the change was accepted:

```
corrected 2 tokenizers blocks
  tokenizers blocks match main
  YAML ok
```

The replacement asserts it found exactly two occurrences, so a partial mirror
fails rather than silently correcting one of the two.

Diff is confined to `.github/dependabot.yml`; no other exclusion is touched.

## Model Used

Claude Opus 5
