### PR TITLE
fix(tooling): check plain 'import x.y' at the layer boundary (#14742)

### DIFF
--- a/tools/lint/check_extension_import_boundaries.py
+++ b/tools/lint/check_extension_import_boundaries.py
@@ -148,6 +148,61 @@ def _is_waived(line: str, rule_id: str) -> bool:
     return f"nosemgrep: {rule_id}" in line
 
 
+def _module_violations(
+    module: str,
+    path: Path,
+    lineno: int,
+    raw_line: str,
+    layer: str,
+    is_init: bool,
+    core_packages: frozenset[str],
+) -> list[str]:
+    """Apply the three layer rules to one imported module name.
+
+    Split out of _check_file so both import forms run the identical checks
+    (#14742). A rule that lives inside one AST branch is a rule that only
+    applies to one spelling.
+    """
+    violations: list[str] = []
+    if not module:
+        return violations
+
+    top = module.split(".")[0]
+
+    # Rule: no core-backend internals
+    allowed = _ALLOWED_TOP_LEVEL | _OWN_LAYER_PACKAGES | _LAYER_EXTRA_ALLOWED.get(layer, set())
+    if top in core_packages and top not in allowed and not _is_grandfathered(path, top):
+        rule = "extension-no-core-internals"
+        if not _is_waived(raw_line, rule):
+            violations.append(
+                f"{path}:{lineno}: [{rule}] {layer} imports core "
+                f"module '{module}' — use autobot_shared instead  "
+                f"(waiver: # nosemgrep: {rule})"
+            )
+
+    # Rule: no sibling extension imports (skip __init__.py)
+    if not is_init and layer == "extension" and module.startswith("middleware.builtin."):
+        rule = "extension-no-sibling-import"
+        if not _is_waived(raw_line, rule):
+            violations.append(
+                f"{path}:{lineno}: [{rule}] extension imports sibling "
+                f"'{module}' — use ExtensionManager hooks or "
+                f"autobot_shared  (waiver: # nosemgrep: {rule})"
+            )
+
+    # Rule: no sibling skill imports (skip __init__.py)
+    if not is_init and layer == "skill" and module.startswith("skills.builtin."):
+        rule = "skill-no-sibling-import"
+        if not _is_waived(raw_line, rule):
+            violations.append(
+                f"{path}:{lineno}: [{rule}] skill imports sibling "
+                f"'{module}' — share logic via autobot_shared  "
+                f"(waiver: # nosemgrep: {rule})"
+            )
+
+    return violations
+
+
 def _check_file(path: Path, source: str) -> list[str]:
     core_packages = _core_packages()
     violations: list[str] = []
@@ -167,40 +222,24 @@ def _check_file(path: Path, source: str) -> list[str]:
         lineno = getattr(node, "lineno", 0)
         raw_line = lines[lineno - 1] if 0 < lineno <= len(lines) else ""
 
+        # #14742: both import forms, not just `from x import y`.
+        #
+        # This checked ast.ImportFrom only, so `import services.llm_service`
+        # crossed the layer with a green check while the `from` spelling of the
+        # same import was caught. That enforced a *syntax*, not a boundary — and
+        # anyone who happened to write the plain form would never learn the rule
+        # existed.
         if isinstance(node, ast.ImportFrom):
-            module = node.module or ""
-            top = module.split(".")[0] if module else ""
+            modules = [node.module or ""]
+        elif isinstance(node, ast.Import):
+            modules = [alias.name for alias in node.names]
+        else:
+            continue
 
-            # Rule: no core-backend internals
-            allowed = _ALLOWED_TOP_LEVEL | _OWN_LAYER_PACKAGES | _LAYER_EXTRA_ALLOWED.get(layer, set())
-            if top in core_packages and top not in allowed and not _is_grandfathered(path, top):
-                rule = "extension-no-core-internals"
-                if not _is_waived(raw_line, rule):
-                    violations.append(
-                        f"{path}:{lineno}: [{rule}] {layer} imports core "
-                        f"module '{module}' — use autobot_shared instead  "
-                        f"(waiver: # nosemgrep: {rule})"
-                    )
-
-            # Rule: no sibling extension imports (skip __init__.py)
-            if not is_init and layer == "extension" and module.startswith("middleware.builtin."):
-                rule = "extension-no-sibling-import"
-                if not _is_waived(raw_line, rule):
-                    violations.append(
-                        f"{path}:{lineno}: [{rule}] extension imports sibling "
-                        f"'{module}' — use ExtensionManager hooks or "
-                        f"autobot_shared  (waiver: # nosemgrep: {rule})"
-                    )
-
-            # Rule: no sibling skill imports (skip __init__.py)
-            if not is_init and layer == "skill" and module.startswith("skills.builtin."):
-                rule = "skill-no-sibling-import"
-                if not _is_waived(raw_line, rule):
-                    violations.append(
-                        f"{path}:{lineno}: [{rule}] skill imports sibling "
-                        f"'{module}' — share logic via autobot_shared  "
-                        f"(waiver: # nosemgrep: {rule})"
-                    )
+        for module in modules:
+            violations.extend(
+                _module_violations(module, path, lineno, raw_line, layer, is_init, core_packages)
+            )
 
     return violations
 

--- a/tools/lint/check_extension_import_boundaries_test.py
+++ b/tools/lint/check_extension_import_boundaries_test.py
@@ -63,6 +63,63 @@ def test_a_newly_added_core_package_is_blocked_without_editing_the_checker(check
     assert "a_package_invented_today" in violations[0]
 
 
+def test_a_plain_import_of_a_core_package_is_caught(checker, tmp_path, monkeypatch):
+    """#14742: `import services.x` crossed the layer while `from services.x import y` did not.
+
+    The rule enforced a syntax rather than a boundary, so the plain spelling was
+    a silent bypass — and nobody writing it would learn the rule existed.
+    """
+    monkeypatch.setattr(checker, "_core_packages", lambda: frozenset({"services"}))
+    probe = _skill_file(tmp_path, "import services.llm_service\n")
+
+    violations = checker._check_file(probe, probe.read_text(encoding="utf-8"))
+
+    assert violations, "a plain import of a core package must be a violation"
+    assert "services.llm_service" in violations[0]
+
+
+def test_an_aliased_plain_import_is_caught(checker, tmp_path, monkeypatch):
+    """`import agents.x as y` is the form that surfaced this."""
+    monkeypatch.setattr(checker, "_core_packages", lambda: frozenset({"agents"}))
+    probe = _skill_file(tmp_path, "import agents.summarization_agent as agent_mod\n")
+
+    assert checker._check_file(probe, probe.read_text(encoding="utf-8"))
+
+
+def test_a_plain_import_can_be_waived(checker, tmp_path, monkeypatch):
+    """The waiver mechanism must apply to both spellings, not just one."""
+    monkeypatch.setattr(checker, "_core_packages", lambda: frozenset({"services"}))
+    probe = _skill_file(
+        tmp_path,
+        "import services.llm_service  # nosemgrep: extension-no-core-internals\n",
+    )
+
+    assert checker._check_file(probe, probe.read_text(encoding="utf-8")) == []
+
+
+def test_both_import_forms_report_identically(checker, tmp_path, monkeypatch):
+    """One boundary, one verdict — the spelling must not change the answer."""
+    monkeypatch.setattr(checker, "_core_packages", lambda: frozenset({"services"}))
+
+    plain = _skill_file(tmp_path, "import services.llm_service\n")
+    plain_violations = checker._check_file(plain, plain.read_text(encoding="utf-8"))
+
+    from_form = _skill_file(tmp_path, "from services.llm_service import get_llm_service\n")
+    from_violations = checker._check_file(from_form, from_form.read_text(encoding="utf-8"))
+
+    assert len(plain_violations) == len(from_violations) == 1
+    assert "extension-no-core-internals" in plain_violations[0]
+    assert "extension-no-core-internals" in from_violations[0]
+
+
+def test_a_plain_stdlib_or_thirdparty_import_is_untouched(checker, tmp_path, monkeypatch):
+    """Only the backend namespace is closed; ordinary imports must stay silent."""
+    monkeypatch.setattr(checker, "_core_packages", lambda: frozenset({"services"}))
+    probe = _skill_file(tmp_path, "import json\nimport pytest\n")
+
+    assert checker._check_file(probe, probe.read_text(encoding="utf-8")) == []
+
+
 def test_autobot_shared_is_allowed(checker, tmp_path):
     probe = _skill_file(tmp_path, "from autobot_shared.logging_manager import get_logger\n")
     assert checker._check_file(probe, probe.read_text(encoding="utf-8")) == []


### PR DESCRIPTION
## Thinking Path

Reproducing a boundary failure on #14541 turned up a hole in the guard **I landed in
#14329**. The checker inspects `ast.ImportFrom` only:

```
$ grep -nE "ast\.Import|ast\.ImportFrom" tools/lint/check_extension_import_boundaries.py
170:        if isinstance(node, ast.ImportFrom):
```

So from a skill:

```python
import services.llm_service          # passed, exit 0
from services.llm_service import x   # caught
```

Same boundary, same package, opposite verdicts. The rule enforced a **syntax**, not
a boundary — and anyone who happened to write the plain form would never learn the
rule existed.

It is the same shape as the defect #14329 fixed, one level down: that one silently
permitted whatever package nobody remembered to *list*; this one silently permitted
whatever import form nobody remembered to *handle*.

## What Changed

The three rules move into `_module_violations`, called for both `ast.ImportFrom`
(one module) and `ast.Import` (one per alias). A rule can no longer apply to a
single spelling by virtue of living inside a single AST branch.

The sibling rules — `extension-no-sibling-import`, `skill-no-sibling-import` — sat in
that same branch and had the same gap. They are covered by the same move.

Waivers behave identically on both forms.

## Verification

The case that used to pass:

```
$ python3 tools/lint/check_extension_import_boundaries.py .../skills/builtin/probe.py
probe.py:1: [extension-no-core-internals] skill imports core module 'services.llm_service'
probe.py:2: [extension-no-core-internals] skill imports core module 'agents.summarization_agent'
exit=1
```

Waiver still honoured on the plain form (`exit=0`), and ordinary stdlib/third-party
imports stay silent.

Base is clean under the stricter rule — the workflow's own invocation exits 0 and
`--audit-baseline` reports 4 entries, all live. **This was a latent hole, not an
active bypass.**

Mutation-tested: reverting to `ImportFrom`-only fails 3 of the 11 tests.

## Note on #14541

Branch `issue-14258` has one plain `import agents.summarization_agent`, added by a
review response. It is legitimate — that test deliberately meets the real agent
rather than a stub — but it will need the inline waiver once this lands. I will add
it there rather than weaken the rule here.

## Model Used

Claude Opus 5 (1M context)

Closes #14742.
