### PR TITLE
fix(skills): waive the core-internals import the widened checker now sees (#14742)

### DIFF
--- a/autobot-backend/skills/builtin/document_analysis_test.py
+++ b/autobot-backend/skills/builtin/document_analysis_test.py
@@ -488,7 +488,7 @@ async def test_the_real_agent_error_branch_produces_the_shape_this_skill_reads()
     # Imported directly, NOT via importorskip: this is the one test that meets
     # the real agent, so an environment where it cannot run must fail loudly
     # rather than skip back into the all-stubs state the review found.
-    import agents.summarization_agent as agents_pkg
+    import agents.summarization_agent as agents_pkg  # nosemgrep: extension-no-core-internals
 
     agent = agents_pkg.SummarizationAgent.__new__(agents_pkg.SummarizationAgent)
     agent.model_name = "a-model"


### PR DESCRIPTION
Refs #14742. **Base is red on `code-quality` — this restores it.**

## What happened

Two PRs that were each correct alone are incompatible in the order they merged:

* **#14743** (`f1d2bfdb8`) widened the layer-boundary checker to catch plain
  `import x.y`, where it previously only saw `from x.y import z`.
* **#14541** (`06eae3ecf`) added, in a test, a plain
  `import agents.summarization_agent as agents_pkg` with no waiver.

#14743 merged **first**. #14541's green was computed on a branch based before
that, so its lint result was already stale when it landed — the rule changed
under it. Nothing was wrong with either review; the interaction only exists
once both are on the same tree.

Base now fails:

```
autobot-backend/skills/builtin/document_analysis_test.py:491:
  [extension-no-core-internals] skill imports core module 'agents.summarization_agent'
```

That is a required check, so it reddens every open PR — #14651 is where I first
saw it, on a failure that had nothing to do with its own diff.

## The fix

One waiver, matching the form the same file already uses on line 22 for its
sibling import:

```python
import agents.summarization_agent as agents_pkg  # nosemgrep: extension-no-core-internals
```

The import is deliberate and was argued for in #14541: it is the one test that
drives the **real** `SummarizationAgent` rather than a stub, and it imports
directly rather than via `importorskip` so a broken environment fails loudly
instead of skipping back into the all-mocks state that let #13897's defect
through. Waiving is right here; removing the import would remove the only test
that meets the real agent.

## Verification

Ran the exact command `code-quality.yml` runs, in the real checkout — not a
scratch copy, because this checker resolves its root relative to `__file__` and
a copy outside a checkout scans nothing and exits 0 for the wrong reason:

```
files in scope: 37
with the waiver:     exit 0, no findings
without the waiver:  :491: [extension-no-core-internals] ...   <- still flagged
```

The control is the point: exit 0 means the rule ran and passed, not that it
looked at nothing.

## Model Used

Claude Opus 5
