### PR TITLE
tenancy(chat): scope LLC agent conversations out of the general session list (#12685)

### DIFF
--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -465,7 +465,7 @@ def _is_agent_scoped_session(session: dict) -> bool:
     it. Such legacy sessions keep showing in the general list exactly as they
     did before (no data loss, no silent re-scoping). A backfill/admin cleanup
     for pre-existing "CEO · <company_id>" sessions is a separate, explicit,
-    one-time operation — filed as a follow-up, not folded into this filter.
+    one-time operation — #14756, not folded into this filter.
     """
     return bool(session.get("companyId")) or session.get("sessionKind") == "agent"
 

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -414,8 +414,14 @@ async def list_sessions(
     if scope in ("org", "team"):
         return await _list_scoped_sessions(request, request_id, chat_history_manager, scope, team_id)
 
-    # Default: list all sessions (fast mode, no decryption)
+    # Default: list all sessions (fast mode)
     sessions = await chat_history_manager.list_sessions_fast()
+
+    # #12685: exclude company/agent-scoped conversations (e.g. LLC CEO chat)
+    # from the ordinary user list — first-class scoping fields, not a title
+    # parse. See _is_agent_scoped_session for the migration story on sessions
+    # created before this fix.
+    sessions = [s for s in sessions if not _is_agent_scoped_session(s)]
 
     # Filter to authenticated user's own sessions
     username = current_user.get("username")
@@ -434,6 +440,34 @@ async def list_sessions(
         message="Sessions retrieved successfully",
         request_id=request_id,
     )
+
+
+def _is_agent_scoped_session(session: dict) -> bool:
+    """A company/agent conversation (e.g. LLC CEO chat), not an ordinary user chat.
+
+    #12685: the leak this closes — LLC agent heartbeat/CEO-chat conversations
+    were registered in the same session store as ordinary chats and returned by
+    the default ``GET /api/chat/sessions`` list with no company scoping. The
+    only thing distinguishing them was a display title ("CEO · <company_id>"),
+    which is exactly the fragility that let two companies' agent chats pile
+    into one flat list.
+
+    ``companyId`` / ``sessionKind`` are first-class metadata fields written at
+    session creation (``CeoChatView.vue`` -> ``POST /chat/sessions`` ->
+    ``create_session`` here) and surfaced by ``list_sessions_fast`` /
+    ``list_sessions`` (``chat_history/session_listing.py``). Either field being
+    set is sufficient — a session can carry a ``company_id`` without an
+    explicit ``session_kind`` (or vice versa for a future non-company agent).
+
+    Migration: sessions created before this fix have neither field. They are
+    NOT retroactively reclassified — there is no reliable non-title signal to
+    do that with, and title-matching is the bug this closes, not the fix for
+    it. Such legacy sessions keep showing in the general list exactly as they
+    did before (no data loss, no silent re-scoping). A backfill/admin cleanup
+    for pre-existing "CEO · <company_id>" sessions is a separate, explicit,
+    one-time operation — filed as a follow-up, not folded into this filter.
+    """
+    return bool(session.get("companyId")) or session.get("sessionKind") == "agent"
 
 
 async def _filter_user_sessions(sessions: list, username: str) -> list:

--- a/autobot-backend/api/chat_sessions_tenancy_scope_test.py
+++ b/autobot-backend/api/chat_sessions_tenancy_scope_test.py
@@ -63,9 +63,7 @@ async def _list_sessions_for(username: str, sessions=None):
 
     with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
         with patch.object(chat_sessions, "get_chat_history_manager", return_value=_manager(sessions)):
-            with patch.object(
-                chat_sessions, "_build_ownership_validator", return_value=_validator_owning_everything()
-            ):
+            with patch.object(chat_sessions, "_build_ownership_validator", return_value=_validator_owning_everything()):
                 response = await chat_sessions.list_sessions(request, current_user, scope=None, team_id=None)
 
     return response

--- a/autobot-backend/api/chat_sessions_tenancy_scope_test.py
+++ b/autobot-backend/api/chat_sessions_tenancy_scope_test.py
@@ -1,0 +1,136 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""LLC agent (CEO) conversations must not leak into the ordinary chat list (#12685).
+
+Before this fix, ``GET /api/chat/sessions`` returned every session owned by the
+caller with no company/agent scoping at all — an LLC agent heartbeat/CEO-chat
+conversation was indistinguishable from an ordinary chat except by parsing its
+display title ("CEO · <company_id>"). With more than one company, every
+company's agent conversations piled into that one flat list.
+
+These tests drive ``list_sessions`` — the real ``GET /chat/sessions`` route
+function, not ``_is_agent_scoped_session`` in isolation — so the assertion is
+at the same boundary the reported symptom was observed at.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api import chat_sessions
+
+_ALL_SESSIONS = [
+    {"id": "s-mine", "title": "My chat", "companyId": "", "sessionKind": "user"},
+    {
+        "id": "s-ceo-company-a",
+        "title": "CEO · company-a",
+        "companyId": "company-a",
+        "sessionKind": "agent",
+    },
+    {
+        "id": "s-ceo-company-b",
+        "title": "CEO · company-b",
+        "companyId": "company-b",
+        "sessionKind": "agent",
+    },
+    # A session created before this fix shipped: no scoping fields at all.
+    # #12685's migration decision — NOT retroactively reclassified, so it
+    # must keep showing exactly as it did before (no data loss).
+    {"id": "s-legacy-untagged", "title": "Untitled", "companyId": "", "sessionKind": "user"},
+]
+
+
+def _manager(sessions=None):
+    manager = MagicMock(spec=["list_sessions_fast"])
+    manager.list_sessions_fast = AsyncMock(return_value=list(sessions if sessions is not None else _ALL_SESSIONS))
+    return manager
+
+
+def _validator_owning_everything():
+    """Ownership validator that owns every session — isolates the assertions
+    below to the tenancy-scoping filter, not the (separately tested)
+    ownership filter."""
+    v = MagicMock()
+    v.get_user_sessions = AsyncMock(return_value=[s["id"] for s in _ALL_SESSIONS])
+    return v
+
+
+async def _list_sessions_for(username: str, sessions=None):
+    request = MagicMock()
+    current_user = {"username": username}
+
+    with patch("autobot_shared.redis_client.get_redis_client", new=AsyncMock()):
+        with patch.object(chat_sessions, "get_chat_history_manager", return_value=_manager(sessions)):
+            with patch.object(
+                chat_sessions, "_build_ownership_validator", return_value=_validator_owning_everything()
+            ):
+                response = await chat_sessions.list_sessions(request, current_user, scope=None, team_id=None)
+
+    return response
+
+
+def _session_ids(response) -> set:
+    import json
+
+    payload = response.body if hasattr(response, "body") else response
+    if isinstance(payload, (bytes, bytearray)):
+        payload = json.loads(payload)
+    data = payload.get("data", payload)
+    return {s["id"] for s in data["sessions"]}
+
+
+class TestAgentSessionsExcludedFromOrdinaryList:
+    """AC: an agent session does not appear in an ordinary user's GET /api/chat/sessions."""
+
+    @pytest.mark.asyncio
+    async def test_ceo_chat_session_is_excluded(self):
+        response = await _list_sessions_for("alice")
+        ids = _session_ids(response)
+
+        assert "s-ceo-company-a" not in ids
+        assert "s-ceo-company-b" not in ids
+        assert "s-mine" in ids, "the caller's own ordinary session must still be returned"
+
+    @pytest.mark.asyncio
+    async def test_agent_scoped_session_absent_regardless_of_which_company(self):
+        """The reported symptom: with two companies, BOTH piled into one flat
+        list. Post-fix, neither company's agent session is in the list at all
+        — company A's session does not leak next to company B's, or anyone
+        else's, in the general list."""
+        response = await _list_sessions_for("alice")
+        ids = _session_ids(response)
+
+        agent_ids = {s["id"] for s in _ALL_SESSIONS if chat_sessions._is_agent_scoped_session(s)}
+        assert agent_ids == {"s-ceo-company-a", "s-ceo-company-b"}
+        assert ids.isdisjoint(agent_ids)
+
+
+class TestLegacyUntaggedSessionsAreNotLost:
+    """Migration safety: a session predating #12685 (no companyId/sessionKind)
+    must not be dropped or silently re-scoped — it keeps appearing exactly as
+    it did before this fix."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_session_without_scoping_fields_still_appears(self):
+        response = await _list_sessions_for("alice")
+        ids = _session_ids(response)
+
+        assert "s-legacy-untagged" in ids
+
+
+class TestIsAgentScopedSessionHelper:
+    """Cheap structural pins on the discriminator itself."""
+
+    def test_company_id_alone_is_sufficient(self):
+        assert chat_sessions._is_agent_scoped_session({"companyId": "co-1"}) is True
+
+    def test_session_kind_alone_is_sufficient(self):
+        assert chat_sessions._is_agent_scoped_session({"sessionKind": "agent"}) is True
+
+    def test_ordinary_session_is_not_agent_scoped(self):
+        assert chat_sessions._is_agent_scoped_session({"companyId": "", "sessionKind": "user"}) is False
+
+    def test_missing_fields_default_to_not_agent_scoped(self):
+        assert chat_sessions._is_agent_scoped_session({}) is False

--- a/autobot-backend/chat_history/session_listing.py
+++ b/autobot-backend/chat_history/session_listing.py
@@ -43,6 +43,29 @@ def _extract_chat_id_from_filename(filename: str) -> str | None:
     return None
 
 
+def _extract_session_scope(chat_data: Dict[str, Any]) -> tuple[str, str]:
+    """Pull the tenancy-scoping fields out of a session's stored metadata (#12685).
+
+    ``company_id`` and ``session_kind`` are written into ``metadata`` at session
+    creation time (see ``api/chat_sessions.create_session``) — the structural
+    replacement for parsing the display title ("CEO · <company_id>") that let
+    every company's agent conversations pile into one unscoped list. Sessions
+    created before this fix carry neither field; they are deliberately left as
+    ``("", "user")`` rather than reclassified, so they keep appearing in the
+    general list exactly as they did before (no data loss, no silent re-scoping
+    — see #12685's migration note).
+
+    Returns:
+        (company_id, session_kind) — empty string / "user" when absent.
+    """
+    metadata = chat_data.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        return "", "user"
+    company_id = metadata.get("company_id") or ""
+    session_kind = metadata.get("session_kind") or "user"
+    return str(company_id), str(session_kind)
+
+
 def _generate_chat_name(chat_id: str) -> str:
     """Generate a display name for a chat (Issue #315: extracted).
 
@@ -101,6 +124,7 @@ class SessionListingMixin:
             async with aiofiles.open(chat_path, "r", encoding="utf-8") as f:
                 file_content = await f.read()
                 chat_data = self._decrypt_data(file_content)
+                company_id, session_kind = _extract_session_scope(chat_data)
 
                 return {
                     "chatId": chat_id,
@@ -108,6 +132,9 @@ class SessionListingMixin:
                     "messageCount": len(chat_data.get("messages", [])),
                     "createdTime": chat_data.get("created_time", ""),
                     "lastModified": chat_data.get("last_modified", ""),
+                    # #12685: first-class tenancy scoping, not a title parse.
+                    "companyId": company_id,
+                    "sessionKind": session_kind,
                 }
         except Exception as e:
             logger.error("Error reading chat file %s: %s", filename, str(e))
@@ -142,26 +169,41 @@ class SessionListingMixin:
             logger.error("Error listing chat sessions: %s", str(e))
             return []
 
-    async def _read_chat_file_metadata(self, chat_path: str) -> tuple[str | None, int]:
-        """Read chat name and message count from file (Issue #315: extracted).
+    async def _read_chat_file_metadata(self, chat_path: str) -> tuple[str | None, int, str, str]:
+        """Read chat name, message count and tenancy scope from file.
+
+        Issue #315: extracted. Issue #12685: also returns (company_id,
+        session_kind) so the fast listing path used by the default
+        ``GET /api/chat/sessions`` can filter agent/company conversations out
+        without a second, decrypting read.
+
+        Prefers ``self._decrypt_data`` (the same method the slow ``list_sessions``
+        path uses) over a raw ``json.loads`` so the scoping fields are readable
+        on installs with encryption enabled — the file is read into memory
+        either way, so this costs nothing extra. Falls back to ``json.loads``
+        when the mixed-in manager does not provide ``_decrypt_data`` (e.g. a
+        minimal ``SessionListingMixin``-only manager in tests), preserving the
+        prior raw-JSON behaviour for that case exactly.
 
         Args:
             chat_path: Path to chat JSON file
 
         Returns:
-            Tuple of (chat_name or None, message_count)
+            Tuple of (chat_name or None, message_count, company_id, session_kind)
         """
         try:
             async with aiofiles.open(chat_path, "r", encoding="utf-8") as f:
                 content = await f.read()
-                chat_data = json.loads(content)
-                chat_name = chat_data.get("name", "").strip() or None
+                decrypt = getattr(self, "_decrypt_data", None)
+                chat_data = decrypt(content) if decrypt else json.loads(content)
+                chat_name = (chat_data.get("name", "") or "").strip() or None
                 messages = chat_data.get("messages", [])
                 message_count = len(messages) if isinstance(messages, list) else 0
-                return chat_name, message_count
+                company_id, session_kind = _extract_session_scope(chat_data)
+                return chat_name, message_count, company_id, session_kind
         except Exception as read_err:
             logger.debug("Could not read chat file content: %s", read_err)
-            return None, 0
+            return None, 0, "", "user"
 
     async def _build_session_entry(self, chat_id: str, chat_path: str, filename: str) -> Dict[str, Any] | None:
         """Build a session entry from file metadata (Issue #315: extracted).
@@ -180,7 +222,7 @@ class SessionListingMixin:
             last_modified = datetime.fromtimestamp(stat.st_mtime).isoformat()
             file_size = stat.st_size
 
-            chat_name, message_count = await self._read_chat_file_metadata(chat_path)
+            chat_name, message_count, company_id, session_kind = await self._read_chat_file_metadata(chat_path)
             if not chat_name:
                 chat_name = _generate_chat_name(chat_id)
 
@@ -204,6 +246,12 @@ class SessionListingMixin:
                 "isActive": False,
                 "fileSize": file_size,
                 "fast_mode": True,
+                # #12685: first-class tenancy scoping, not a title parse. Empty
+                # companyId / sessionKind == "user" means an ordinary human
+                # session (or a legacy one predating this fix — see the
+                # migration note on _extract_session_scope).
+                "companyId": company_id,
+                "sessionKind": session_kind,
             }
         except Exception as e:
             # #14248: loud and excluded, matching the malformed-timestamp precedent

--- a/autobot-frontend/src/models/controllers/ChatController.ts
+++ b/autobot-frontend/src/models/controllers/ChatController.ts
@@ -649,14 +649,18 @@ export class ChatController {
   }
 
   // Enhanced session operations with error handling
-  async createNewSession(title?: string): Promise<string> {
+  // #12685: optional metadata is forwarded to the backend as-is so callers
+  // (e.g. CeoChatView) can stamp first-class tenancy scoping (company_id,
+  // session_kind) on creation, instead of the title being the only signal —
+  // the fragility that let agent conversations leak into the general list.
+  async createNewSession(title?: string, metadata?: Record<string, unknown>): Promise<string> {
     // MVA-164: Client-mint UUID before any API call (server-round-trip-first pattern)
     // Generate UUID upfront
     const sessionId = crypto.randomUUID()
 
     // Call backend immediately with the client-minted UUID
     try {
-      await chatRepository.createNewChat(title, undefined, sessionId)
+      await chatRepository.createNewChat(title, metadata, sessionId)
       logger.debug('New chat session created on backend:', sessionId)
     } catch (error) {
       // Backend create failed - don't create local session if backend fails

--- a/autobot-frontend/src/views/llc/CeoChatView.vue
+++ b/autobot-frontend/src/views/llc/CeoChatView.vue
@@ -55,7 +55,15 @@ async function enterScope(id: string) {
     if (mapped && chatStore.sessions.some((s) => s.id === mapped)) {
       await controller.switchToSession(mapped)
     } else {
-      const sid = await controller.createNewSession(`CEO · ${id}`)
+      // #12685: stamp first-class tenancy scoping (company_id/session_kind) on
+      // the session, not just the display title — the backend filters
+      // GET /api/chat/sessions on these fields so this company's CEO chat
+      // does not leak into the operator's general chat list or another
+      // company's.
+      const sid = await controller.createNewSession(`CEO · ${id}`, {
+        company_id: id,
+        session_kind: 'agent',
+      })
       ceoSessions.set(id, sid)
     }
   } catch (err) {


### PR DESCRIPTION
Refs #12685. **Deliberately not `Closes`** — see "What this does not fix".

## Thinking Path

LLC agent (CEO) conversations were registered in the same chat-session store as
ordinary user chats and returned by `GET /api/chat/sessions` with no company
scoping. With two companies, every company's agent chats pile into one flat
list.

Tracing it changed the diagnosis. This is not an LLC-adapter path writing into
the wrong store — the session is created **client-side**:

```
views/llc/CeoChatView.vue:58   controller.createNewSession(`CEO · ${id}`)
  -> ChatController.createNewSession   -> createNewChat(title, undefined, id)   metadata always undefined
  -> ChatRepository.createNewChat      -> POST {id, title, metadata: {}}
  -> api/chat_sessions.py create_session
```

So the persisted session carried **no company or agent signal at all** — the
company id existed only inside a display string.

And the store has no schema to add a column to: it is per-session JSON files
(`chat_history/session.py`, `session_listing.py`), where `owner`, `org_id` and
`team_id` are already metadata keys. More importantly, `list_sessions_fast`'s
entry builder did not surface `metadata` at all — so even a correctly-tagged
session could not have been filtered.

## What Changed

- `CeoChatView.vue` — sends `metadata: { company_id, session_kind: 'agent' }`.
- `ChatController.ts` — `createNewSession` forwards optional metadata
  (backward compatible; existing callers unchanged).
- `session_listing.py` — surfaces `companyId` / `sessionKind` as top-level
  fields on both the fast and slow listing paths.
- `chat_sessions.py` — `_is_agent_scoped_session` excludes them from the
  default list, before the ownership filter.

The filter reads structural fields, never the title. Title-matching is the
fragility this issue exists to remove, so it is not used to build the fix.

Also fixed incidentally: the fast listing path used a raw `json.loads` where the
slow path decrypts, so on encryption-enabled installs it could not read the
title either. It now prefers `_decrypt_data` with a `json.loads` fallback,
preserving the minimal-manager contract in
`session_listing_stat_failure_test.py`.

## Verification

`chat_sessions_tenancy_scope_test.py` drives the real `list_sessions` route —
not the predicate in isolation — mocking only the history manager, Redis and
the ownership validator (set to "owns everything", so the assertions isolate
company scoping from the separately-tested ownership filter):

- two companies' agent sessions are both absent from the caller's list
- the caller's own ordinary session still appears
- a legacy untagged session still appears

Mutation evidence, with the filter reverted:

```
FIXED    count=2  ['s-legacy-untagged', 's-mine']
REVERTED count=4  ['s-ceo-company-a', 's-ceo-company-b', 's-legacy-untagged', 's-mine']
```

Both companies' agent chats leak back — the exact pile-up reported.

## What this does not fix

**Sessions created before this change still appear in the general list**,
including the one named in the issue (`CEO · 22d907a9-…`). They carry no
scoping fields, and the only signal they have is the title — which this fix
deliberately refuses to match on. `_is_agent_scoped_session` returns `False` for
them: no data loss, no silent re-scoping, and the reported instance stays
visible until backfilled. **#14756** covers that as an explicit, dry-run-first
operation.

**Scoping is client-supplied.** The backend filters `company_id`/`session_kind`
but does not derive them, so a session created by any other caller that omits
them is not scoped. That is a real limit of this shape, and the reason this is
`Refs` rather than `Closes` — the leak is closed for the path that caused it,
not made structurally impossible for every future caller.

`scope=org` / `team` / `shared` listing paths are untouched — a different
visibility model, deliberately out of scope rather than half-done.

**Single-session-by-id access is not governed by this filter at all.** `get`,
update, delete, export, share and the activities routes are gated only by the
pre-existing `validate_session_ownership` control, which is untouched here and
defaults to `disabled` in the three cases tracked by **#14010**. Reading this PR
as "the tenancy boundary is closed" would be wrong — it closes the default
list-view symptom; by-id reads remain governed by that separate control.

**An empty ownership set still widens the general list.** `_filter_user_sessions`
returns the company-filtered but otherwise unfiltered list when the requester's
own ownership-id set is empty (new account, TTL lapse, or an install predating
ownership tracking). This PR fixes the *exception* branch of that function to
fail closed, but the empty-set branch is **#12867 "path (a)"**, still an open
product decision. Legacy untagged sessions are therefore not strictly confined
to their original viewer in that one case.

## Model Used

Claude Opus 5

