### PR TITLE
fix(llc): surface the persisted skip reason in the heartbeat monitor (#12681)

### DIFF
--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "تم التخطي:",
+      "errorLabel": "خطأ:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Laufdauer",
       "colAction": "Aktion",
       "statusUnknown": "unbekannt",
+      "skipReasonLabel": "Übersprungen:",
+      "errorLabel": "Fehler:",
       "triggering": "Wird ausgelöst...",
       "triggerNow": "Jetzt auslösen",
       "runHistoryTitle": "Laufverlauf – {name}",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8039,6 +8039,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "Skipped:",
+      "errorLabel": "Error:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Duración de la ejecución",
       "colAction": "Acción",
       "statusUnknown": "desconocido",
+      "skipReasonLabel": "Omitido:",
+      "errorLabel": "Error:",
       "triggering": "Activando...",
       "triggerNow": "Activar ahora",
       "runHistoryTitle": "Historial de ejecuciones – {name}",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8051,7 +8051,7 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
-      "skipReasonLabel": "رد شد:",
+      "skipReasonLabel": "نادیده گرفته شد:",
       "errorLabel": "خطا:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "رد شد:",
+      "errorLabel": "خطا:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Durée d'exécution",
       "colAction": "Action",
       "statusUnknown": "inconnu",
+      "skipReasonLabel": "Ignoré :",
+      "errorLabel": "Erreur :",
       "triggering": "Déclenchement...",
       "triggerNow": "Déclencher maintenant",
       "runHistoryTitle": "Historique des exécutions – {name}",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "דולג:",
+      "errorLabel": "שגיאה:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "Izlaists:",
+      "errorLabel": "Kļūda:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "Pominięto:",
+      "errorLabel": "Błąd:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Duração da execução",
       "colAction": "Ação",
       "statusUnknown": "desconhecido",
+      "skipReasonLabel": "Ignorado:",
+      "errorLabel": "Erro:",
       "triggering": "Acionando...",
       "triggerNow": "Acionar agora",
       "runHistoryTitle": "Histórico de execuções – {name}",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8051,6 +8051,8 @@
       "colRunDuration": "Run Duration",
       "colAction": "Action",
       "statusUnknown": "unknown",
+      "skipReasonLabel": "چھوڑ دیا گیا:",
+      "errorLabel": "خرابی:",
       "triggering": "Triggering...",
       "triggerNow": "Trigger Now",
       "runHistoryTitle": "Run History – {name}",

--- a/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
+++ b/autobot-frontend/src/views/llc/HeartbeatMonitor.vue
@@ -73,6 +73,16 @@
                 {{ computeDuration(run.started_at, run.finished_at) }}
               </span>
             </div>
+            <div v-if="run.error" class="run-reason" :class="`reason-${run.status}`">
+              <span class="reason-label">
+                {{
+                  run.status === 'skipped'
+                    ? $t('llc.heartbeat.skipReasonLabel')
+                    : $t('llc.heartbeat.errorLabel')
+                }}
+              </span>
+              <span class="reason-text">{{ run.error }}</span>
+            </div>
             <div class="run-actions">
               <button class="toggle-payload" @click="toggleRun(run.id)">
                 {{ expandedRuns.has(run.id) ? $t('llc.heartbeat.hideContext') : $t('llc.heartbeat.showContext') }}
@@ -180,6 +190,8 @@ interface Agent {
 interface AgentRun {
   id: string
   status: string
+  /** Skip reason for SKIPPED runs, failure text for FAILED ones (#12681). */
+  error?: string | null
   started_at: string
   finished_at?: string
   completed_at?: string
@@ -512,6 +524,8 @@ onUnmounted(() => {
 .status-failed.status-dot { background: var(--color-error); }
 .status-timed_out { color: var(--color-error); }
 .status-timed_out.status-dot { background: var(--color-error); }
+.status-skipped { color: var(--color-warning); }
+.status-skipped.status-dot { background: var(--color-warning); }
 .status-unknown { color: var(--text-secondary); }
 .status-unknown.status-dot { background: var(--border-default); }
 
@@ -595,6 +609,25 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
+}
+
+.run-reason {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.run-reason .reason-label {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.run-reason.reason-failed .reason-label {
+  color: var(--color-error);
 }
 
 .run-date,

--- a/autobot-frontend/src/views/llc/__tests__/HeartbeatMonitor.skipReason.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/HeartbeatMonitor.skipReason.test.ts
@@ -13,7 +13,7 @@
 // field being present in the payload proves nothing while the template never
 // reads it, which is exactly how this stayed invisible.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import en from '@/i18n/locales/en.json'
@@ -37,6 +37,10 @@ const AGENT = { id: 'a1', name: 'Agent One', heartbeat_enabled: true }
 const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
 const LABELS = en.llc.heartbeat
 
+// The component starts a 15s auto-refresh interval on mount, cleared only by
+// onUnmounted. Without this the handle outlives every test in the file.
+let mounted: ReturnType<typeof mount> | null = null
+
 /** Mount the monitor and open one agent's run history. */
 async function mountWithRuns(runs: Record<string, unknown>[]) {
   get.mockImplementation((url: string) =>
@@ -49,12 +53,18 @@ async function mountWithRuns(runs: Record<string, unknown>[]) {
   await flushPromises()
   await wrapper.find('.agent-row').trigger('click')
   await flushPromises()
+  mounted = wrapper
   return wrapper
 }
 
 describe('HeartbeatMonitor surfaces why a run was skipped (#12681)', () => {
   beforeEach(() => {
     get.mockReset()
+  })
+
+  afterEach(() => {
+    mounted?.unmount()
+    mounted = null
   })
 
   it('renders the persisted reason for a skipped run', async () => {

--- a/autobot-frontend/src/views/llc/__tests__/HeartbeatMonitor.skipReason.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/HeartbeatMonitor.skipReason.test.ts
@@ -1,0 +1,97 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+
+// #12681: a heartbeat that never dispatched records SKIPPED and stores the
+// reason in `error`, which `GET /api/llc/agents/{id}/runs` has always returned.
+// The monitor rendered the status and dropped the reason, so "skipped" looked
+// identical whether the CLI was missing, a cooldown was active, or the agent
+// had no work — an operator had to read the database to tell them apart.
+//
+// These mount the component rather than asserting on the response shape: the
+// field being present in the payload proves nothing while the template never
+// reads it, which is exactly how this stayed invisible.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post: vi.fn() }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('@/utils/fetchWithAuth', () => ({ fetchWithAuth: vi.fn() }))
+vi.mock('@/config/ssot-config', () => ({ getApiBase: () => '' }))
+
+import HeartbeatMonitor from '../HeartbeatMonitor.vue'
+
+const AGENT = { id: 'a1', name: 'Agent One', heartbeat_enabled: true }
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+const LABELS = en.llc.heartbeat
+
+/** Mount the monitor and open one agent's run history. */
+async function mountWithRuns(runs: Record<string, unknown>[]) {
+  get.mockImplementation((url: string) =>
+    url.includes('/runs') ? Promise.resolve(runs) : Promise.resolve([AGENT]),
+  )
+  const wrapper = mount(HeartbeatMonitor, {
+    props: { companyId: 'c1' },
+    global: { plugins: [i18n] },
+  })
+  await flushPromises()
+  await wrapper.find('.agent-row').trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+describe('HeartbeatMonitor surfaces why a run was skipped (#12681)', () => {
+  beforeEach(() => {
+    get.mockReset()
+  })
+
+  it('renders the persisted reason for a skipped run', async () => {
+    const wrapper = await mountWithRuns([
+      {
+        id: 'r1',
+        status: 'skipped',
+        started_at: '2026-01-01T00:00:00Z',
+        error: 'adapter binary not available',
+      },
+    ])
+
+    const reason = wrapper.find('.run-reason')
+    expect(reason.exists()).toBe(true)
+    expect(reason.text()).toContain('adapter binary not available')
+    expect(reason.text()).toContain(LABELS.skipReasonLabel)
+  })
+
+  it('labels a failed run as an error rather than a skip', async () => {
+    const wrapper = await mountWithRuns([
+      { id: 'r2', status: 'failed', started_at: '2026-01-01T00:00:00Z', error: 'adapter crashed' },
+    ])
+
+    const reason = wrapper.find('.run-reason')
+    expect(reason.exists()).toBe(true)
+    expect(reason.text()).toContain(LABELS.errorLabel)
+    expect(reason.text()).not.toContain(LABELS.skipReasonLabel)
+  })
+
+  // The control: without it the first two would still pass if the row were
+  // rendered unconditionally, which would put an empty label on every run.
+  it('renders no reason row when the run carries none', async () => {
+    const wrapper = await mountWithRuns([
+      { id: 'r3', status: 'completed', started_at: '2026-01-01T00:00:00Z', error: null },
+    ])
+
+    expect(wrapper.find('.run-item').exists()).toBe(true)
+    expect(wrapper.find('.run-reason').exists()).toBe(false)
+  })
+})


### PR DESCRIPTION
Refs #12681. **Deliberately not `Closes`** — this is one of three items the issue
covers; see "What this does not fix".

## Thinking Path

#12681 reports that setup-wizard provisioning fails invisibly. Tracing where the
information is actually lost changed the fix.

A heartbeat that never dispatched raises `HeartbeatDispatchSkipped`, and the
scheduler already handles it deliberately — it records `SKIPPED` and stores
`exc.reason`:

```
except HeartbeatDispatchSkipped as exc:
    final_status = LLCRunStatus.SKIPPED.value
    error_msg = exc.reason
```

`_run_to_dict` already returns that field, so the reason survives all the way to
the client. It was never displayed: the component's `AgentRun` interface did not
declare `error`, and the run row rendered only status, date and duration.

So this is not a missing-plumbing problem. The reason is persisted, served, and
then dropped one line short of the screen. Every skip therefore looked identical
— a missing adapter binary, an active cooldown, and an agent with no work were
indistinguishable without querying the database directly, which is precisely the
"fails invisibly" symptom the issue describes.

I also found `SKIPPED` has no status colour: `.status-skipped` was never defined,
while `queued`, `running`, `failed`, `timed_out` and `unknown` all are. The one
status whose entire meaning is "this did not run" rendered as unstyled text.

## What Changed

- `AgentRun` declares `error?: string | null`.
- The run row renders a reason line when the run carries one, labelled by status
  so a `SKIPPED` run is not misread as a crash.
- `.status-skipped` styling added, matching the existing status colour scheme.
- `skipReasonLabel` / `errorLabel` added to **all 11 locales**.
- Three component tests.

## Verification

The tests mount `HeartbeatMonitor` and drive it through the real path
(`fetchAgents` → click row → `openHistory` → render), rather than asserting on
the response shape. That distinction is the point: the field was already present
in the payload, so any test written against the API would have passed for the
entire time the defect was live.

- skipped run with a reason → `.run-reason` present, contains the reason text
  and the skip label
- failed run → carries the error label, **not** the skip label
- completed run with `error: null` → **no** `.run-reason` element

The third is the control. Without it the first two would still pass if the row
were rendered unconditionally, which would put an empty label on every run.

Locale edits were made structurally and verified to be exactly two added lines
per file (`11 files changed, 22 insertions(+)`), with each file confirmed to
round-trip byte-for-byte beforehand so no reformatting is smuggled in.

Not verified locally: the frontend suite is not run here, so the component tests
are verified by CI, not by me.

## What this does not fix

#12681 covers three independent items. This is item 3 only.

Item 1 — nothing installs the `claude` CLI onto the service PATH — and item 2 —
`llc/api/agent_hires.py` validates that an adapter type is *registered* but never
that it is *available*, so a hire can succeed for an adapter that cannot run —
are both untouched here.

Those two are sequenced: **item 2 must not land before item 1.** Today an
operator can hire an agent and hand-install the CLI afterwards. Rejecting the
hire first, while nothing installs the binary, would make provisioning strictly
worse rather than better.

This item is independent of that ordering, which is why it goes first.

## Model Used

Claude Opus 5
