### PR TITLE
fix(config): register AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS (#14763)

### DIFF
--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -887,6 +887,20 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS",
+        type=float,
+        default=15.0,
+        description=(
+            "Ceiling on a proxied request from the SLM to a node's backend. "
+            "The aggregator fans out across the fleet, so without a bound one "
+            "unresponsive node would hold the whole lifecycle view open."
+        ),
+        component="slm",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_GRAPH_PATH_TIMEOUT_SECONDS",
         type=float,
         default=10.0,

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -502,6 +502,7 @@ To add a new variable:
 | `AUTOBOT_MAX_DELEGATION_DEPTH` | ai | int | `2` | How deep delegation may nest before it is refused, bounding runaway recursive delegation. |
 | `AUTOBOT_MULTIMODAL_VOICE_CONFIDENCE_THRESHOLD` | voice | float | `0.7` | Fallback confidence threshold for VoiceProcessor when the multimodal.voice config section omits it (#13207). Range: 0.0–1.0. |
 | `AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT` | voice | int | `30` | Fallback processing timeout in seconds for VoiceProcessor when the multimodal.voice config section omits it (#13207). |
+| `AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS` | slm | float | `15.0` | Ceiling on a proxied request from the SLM to a node's backend. The aggregator fans out across the fleet, so without a bound one unresponsive node would hold the whole lifecycle view open. |
 | `AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS` | auth | int | `90000` | Milliseconds a connector holds the single-flight lock while refreshing an OAuth token. Derived as three times the token request timeout — 90000 with the default 30s timeout — so it tracks that timeout instead of drifting from it (knowledge/connectors/credential_store.py). This variable can only RAISE it: a smaller value is floored back to the derived TTL and a warning is logged, because the lease is held across the store write as well as the HTTP call, and one that expires mid-refresh lets two workers rotate the same token (#14238). |
 | `AUTOBOT_OAUTH_REFRESH_POLL_S` | auth | float | `0.2` | Polling interval while waiting on another worker's token refresh. Floored at 0.05s, since zero would busy-loop the executor. |
 | `AUTOBOT_OAUTH_REFRESH_WAIT_S` | auth | float | `0.0` | Seconds a caller waits for another worker's in-flight token refresh before refreshing itself. The effective value is floored at the lock TTL plus five seconds — 95 with the defaults — because a caller that gives up before the lease expires abandons a refresh still in progress. Setting it below that floor therefore has no effect. |
@@ -577,5 +578,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*139 variables registered as of last generation.*
+*140 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->


### PR DESCRIPTION
Closes #14763

## Thinking Path

Chased a `python-suite shard 12/12` failure on #14685 and found the offending name appears zero times in that PR's diff. Checking the base head directly, `python-suite shard 12/12` reports `failure` on `Dev_new_gui` itself with shards 1-11 green — so this is a base breakage every PR inherits by merging base in, not a defect in the PR that surfaced it.

`git log -S` traces the reader to #14653, which added `os.getenv("AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS", "15")` without a registry entry.

Registering beats baselining: the baseline silences the check while leaving the timeout undiscoverable, which defeats the point of having a registry at all.

While reading the checker I noticed it does two things, not one — `check_docs_freshness()` compares an autogenerated table in `CLAUDE_RULES.md` against `_build_table(REGISTRY)`. Registering without regenerating that table would have moved the failure from one assertion to another rather than fixing it.

## What Changed

- `autobot_shared/env_registry.py` — the entry: `float`, default `15.0`, component `slm`.
- `docs/developer/CLAUDE_RULES.md` — the matching table row, and the count from 139 to 140.

## Verification

No repo code was executed. The docs row was checked against the registry by parsing the spec out of the registry source with AST and rendering it through the same formatting rules `_build_table` applies:

```
registry-derived: | `AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS` | slm | float | `15.0` | Ceiling on a proxied req...
docs row        : | `AUTOBOT_NODE_PROXY_TIMEOUT_SECONDS` | slm | float | `15.0` | Ceiling on a proxied req...
IDENTICAL: True
```

Placement was computed with the generator's own ordering rather than eyeballed — it lands between `AUTOBOT_MULTIMODAL_VOICE_PROCESSING_TIMEOUT` and `AUTOBOT_OAUTH_REFRESH_LOCK_TTL_MS`.

## Model Used

Claude Opus 5
