### PR TITLE
perf(workflow/frontend): index edge targets instead of scanning nodes per edge (#14766)

### DIFF
--- a/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
+++ b/autobot-frontend/src/components/workflow/WorkflowCanvas.vue
@@ -1219,11 +1219,36 @@ function snapPosition(pos: { x: number; y: number }, free: boolean): { x: number
   return free ? pos : { x: snapToGrid(pos.x), y: snapToGrid(pos.y) };
 }
 
+/**
+ * Edge geometry for every drawn connection.
+ *
+ * #14766: the target of each edge is resolved through an index built once per
+ * recompute, not by scanning `props.nodes` per edge. The scan made this
+ * O(N x E), and it runs on the drag hot path: `onPointerMove` emits
+ * `node-moved` for every node in `dragStartPositions` on EVERY pointer event,
+ * the consumer writes `node.position`, and this computed re-resolves all E
+ * edges against all N nodes for each of those ticks.
+ *
+ * The index costs one O(N) pass, which is strictly cheaper than the scan for
+ * any E >= 1. The same structure already existed a few hundred lines below
+ * (`orgFacts` keys nodes by id) — this was a missed application of it, not an
+ * unfamiliar technique.
+ *
+ * Note the drop hit-test in `endInteraction` still uses a linear `find`, and
+ * deliberately so: it runs once per drop rather than once per edge, and a
+ * geometric hit-test cannot be answered by an id lookup anyway.
+ */
 const connections = computed(() => {
   const result: { id: string; path: string }[] = [];
+  // FIRST occurrence wins, exactly as `props.nodes.find(...)` did. A plain
+  // `byId.set(node.id, node)` would keep the LAST, so a list carrying a
+  // duplicate id would silently re-anchor its edges to the other node — a
+  // behaviour change smuggled in under a performance fix.
+  const byId = new Map<string, CanvasNode>();
+  for (const node of props.nodes) if (!byId.has(node.id)) byId.set(node.id, node);
   props.nodes.forEach(node => {
     node.connections.forEach(targetId => {
-      const target = props.nodes.find(n => n.id === targetId);
+      const target = byId.get(targetId);
       if (target) {
         const x1 = node.position.x + CANVAS_NODE_WIDTH, y1 = node.position.y + CANVAS_NODE_PORT_Y;
         const x2 = target.position.x, y2 = target.position.y + CANVAS_NODE_PORT_Y;

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * #14766: edge geometry.
+ *
+ * The `connections` computed used to resolve each edge's target with
+ * `props.nodes.find(...)`, making it O(N x E) — on the drag hot path, where
+ * `onPointerMove` emits `node-moved` per pointer event and the consumer's
+ * write re-triggers the computed. It now resolves through an index built once
+ * per recompute.
+ *
+ * That is a pure refactor, so the tests that matter are the ones that pin the
+ * OUTPUT: the rendered `d` attributes must be byte-identical to what the scan
+ * produced, including the cases where the two implementations could plausibly
+ * disagree — a dangling target, a self-edge, several edges from one node, and
+ * a duplicate id (`find` returns the FIRST match; a naive `Map.set` loop keeps
+ * the LAST).
+ *
+ * The expected path strings below are written out in full rather than
+ * recomputed from the same formula the component uses. A test that rebuilds
+ * the formula would keep passing if the formula itself changed.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+vi.mock('@/composables/useConfirmDialog', () => ({
+  useConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+import WorkflowCanvas from '../WorkflowCanvas.vue'
+import type { CanvasNode } from '../canvasNode'
+
+function step(id: string, x: number, y: number, connections: string[] = []): CanvasNode {
+  return {
+    id,
+    type: 'step',
+    position: { x, y },
+    data: { command: '', description: '', risk_level: 'low', requires_confirmation: true },
+    connections,
+  }
+}
+
+function mountCanvas(nodes: CanvasNode[]) {
+  return mount(WorkflowCanvas, {
+    props: { nodes, selectedNodeId: null },
+    global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+  })
+}
+
+/** Every rendered edge path, in render order. */
+function paths(w: ReturnType<typeof mountCanvas>): string[] {
+  return w.findAll('.connection-line').map((p) => p.attributes('d') ?? '')
+}
+
+describe('edge geometry is unchanged by the index (#14766)', () => {
+  it('draws the same path the linear scan produced', () => {
+    // n1 at (0, 0) -> n2 at (400, 200). Ports attach at the node mid-line
+    // (CANVAS_NODE_PORT_Y = 50) and leave the source's right edge
+    // (CANVAS_NODE_WIDTH = 240), so the curve runs (240,50) -> (400,250) with
+    // both control points on the midpoint x = 320.
+    const w = mountCanvas([step('n1', 0, 0, ['n2']), step('n2', 400, 200)])
+
+    expect(paths(w)).toEqual(['M240,50 C320,50 320,250 400,250'])
+  })
+
+  it('skips an edge whose target is not on the canvas rather than drawing to nowhere', () => {
+    const w = mountCanvas([step('n1', 0, 0, ['ghost']), step('n2', 400, 200)])
+
+    expect(paths(w)).toEqual([])
+  })
+
+  it('draws every edge of a node that has several', () => {
+    const w = mountCanvas([
+      step('n1', 0, 0, ['n2', 'n3']),
+      step('n2', 400, 200),
+      step('n3', 400, 600),
+    ])
+
+    expect(paths(w)).toEqual([
+      'M240,50 C320,50 320,250 400,250',
+      'M240,50 C320,50 320,650 400,650',
+    ])
+  })
+
+  it('draws a self-edge as the scan did rather than dropping it', () => {
+    const w = mountCanvas([step('n1', 0, 0, ['n1'])])
+
+    expect(paths(w)).toEqual(['M240,50 C120,50 120,50 0,50'])
+  })
+
+  it('resolves a duplicated id to the FIRST match, as find() did', () => {
+    // Two nodes share the id 'dup'. `find` returns the first; a `Map.set` loop
+    // that did not guard would keep the last and re-anchor the edge to
+    // (800, 400) instead of (400, 200).
+    const w = mountCanvas([
+      step('n1', 0, 0, ['dup']),
+      step('dup', 400, 200),
+      step('dup', 800, 400),
+    ])
+
+    expect(paths(w)).toEqual(['M240,50 C320,50 320,250 400,250'])
+  })
+})
+
+describe('the node count this canvas is known to carry (#14766)', () => {
+  // The canvas renders every node as live DOM with no virtualisation and no
+  // documented ceiling — before this, no test in the suite mounted more than a
+  // handful. This states the number rather than leaving it to be discovered by
+  // a real org graph. It is a floor on what we support, not a performance
+  // budget: raise it when a surface needs more.
+  // 200 leaves headroom under the suite's 10s `testTimeout` while still being
+  // an order of magnitude past anything the suite mounted before.
+  const SUPPORTED_NODES = 200
+
+  it(`renders ${SUPPORTED_NODES} nodes and their edges without dropping any`, () => {
+    const nodes = Array.from({ length: SUPPORTED_NODES }, (_, i) =>
+      step(`n${i}`, (i % 20) * 300, Math.floor(i / 20) * 200, i > 0 ? [`n${i - 1}`] : []),
+    )
+
+    const w = mountCanvas(nodes)
+
+    expect(w.findAll('.workflow-node')).toHaveLength(SUPPORTED_NODES)
+    // Every node but the first carries exactly one outgoing edge.
+    expect(paths(w)).toHaveLength(SUPPORTED_NODES - 1)
+    expect(paths(w).every((d) => d.startsWith('M'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #14766

PR 2 of 5 from the canvas review. Kept on its own because it is the only
hot-path change in the set and carries a verification burden the others do
not: a pure refactor has to prove its output did not move.

## Thinking Path

`connections` resolved each edge's target with `props.nodes.find(...)`, making
it O(N x E) per recompute. That matters because of *when* it recomputes:
`onPointerMove` emits `node-moved` for every node in `dragStartPositions` on
**every pointer event**, the consumer writes `node.position`, and the computed
re-resolves all E edges against all N nodes for each of those ticks.

The fix is an index built once per recompute — one O(N) pass, strictly cheaper
than the scan for any E >= 1. Worth saying plainly: this was a *missed
application*, not an unfamiliar technique. The same structure already exists a
few hundred lines below in the same file, where `orgFacts` keys nodes by id.

Two things I deliberately did **not** change:

**The drop hit-test still uses a linear `find`.** It runs once per drop rather
than once per edge, and it is a geometric containment test — an id lookup
cannot answer it.

**Duplicate ids still resolve to the FIRST match.** This is the trap in the
change. `find` returns the first match; the obvious
`for (const n of nodes) byId.set(n.id, n)` keeps the **last**. A node list
carrying a duplicate id would have silently re-anchored its edges to a
different node — a behaviour change smuggled in under a performance fix. The
index guards with `if (!byId.has(...))` and there is a test for exactly this.

## What Changed

**`WorkflowCanvas.vue`** — `connections` builds a first-wins `Map<string,
CanvasNode>` once and resolves through it. No signature change, no new state,
no API change. Six lines plus the comment explaining the drag-path pressure
and the first-wins guard.

**New `WorkflowCanvas.connections.test.ts`** — the output pin, plus the scale
case #14766 asks for.

## Verification

The claim is "edge paths are byte-identical for the same input", so the tests
assert the rendered `d` attributes directly, with the **expected strings
written out in full** rather than recomputed from the formula the component
uses. A test that rebuilds the formula would keep passing if the formula
itself changed — it would be checking my arithmetic, not the canvas's.

Cases chosen where the two implementations could plausibly disagree:

| Case | Why it is here |
|---|---|
| Plain edge | The baseline path string |
| Target not on the canvas | `find` returns `undefined` and the edge is skipped; `Map.get` must too, not draw to nowhere |
| Several edges from one node | Order and count preserved |
| Self-edge | The source is its own target — the one case where the index lookup hits the node being iterated |
| **Duplicate id** | `find` takes the first; an unguarded `Map.set` loop takes the last. This is the test that makes the first-wins guard real rather than a comment |

**Scale ceiling.** #14766's second acceptance criterion was to state the number
we support rather than leave it to be discovered by a real org graph. Before
this, no test in the 20-file suite mounted more than a handful of nodes. The
new case mounts **200** nodes with 199 edges and asserts none are dropped —
a floor on what we support, not a performance budget. 200 leaves headroom
under the suite's 10s `testTimeout`.

**Not verified here:** I did not benchmark the improvement, and the PR does not
claim a number. Per the note on #14766, any benchmark must run on a **workflow**
graph, not an org graph — org canvas nodes ship with `connections` hardcoded
empty (`orgCanvasGraph.ts`, four construction sites), so E = 0 there and a
measurement on that surface would show no difference and read as though the
issue were imaginary. If #14604 lands and gives org nodes real edges, that
surface inherits the same cost; doing this first is the cheaper order.

Not run locally, per the project rule that CI verifies correctness.

## Model Used

Claude Opus 5 (1M context)

## Relationship to the other PRs

Independent of PR #14773 (grid + geometry SSOT), which does not touch
`connections`. Both edit `WorkflowCanvas.vue`, so whichever merges second will
want a rebase; the edits are in different regions and should not conflict
textually.
