### PR TITLE
fix(secrets): provision the envelope root key so the canonical store is reachable (#14758)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -83,6 +83,13 @@ backend_cors_origins: "*"
 # Internal API key shared with SLM backend for proxy authentication (#1779, #3512).
 # REQUIRED for personality and voice proxies — set via Ansible Vault or inventory.
 autobot_internal_api_key: ""
+
+# #14758: root key for the canonical envelope secret store. Read back from
+# slm-secrets.env at deploy time so the backend and the SLM derive the same vault
+# keys. Empty here on purpose — never commit a real value; an empty render leaves
+# the store exactly as dark as it is today rather than sealing secrets under a
+# key the SLM does not share.
+autobot_secrets_root_key: ""
 # SLM WebSocket auth bearer value — populated from /etc/autobot/slm-secrets.env at deploy time (#7689).
 backend_slm_auth_tok: ""
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -211,6 +211,32 @@
   no_log: true
   tags: ['backend', 'config']
 
+# #14758: the envelope secret store raised at import on every provisioned
+# deployment because nothing ever wrote its root key, and each consumer swallowed
+# the failure, so an entirely absent store looked like "that secret does not
+# exist". slm_manager generates it into slm-secrets.env; read it here so both
+# services derive the same vault KEKs. The SLM's SSO vault migration states
+# outright that it needs the BACKEND's root key, so two values would be a silent
+# decryption failure rather than a config nuisance.
+- name: "Backend | Read AUTOBOT_SECRETS_ROOT_KEY from slm-secrets.env (#14758)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -oP '^AUTOBOT_SECRETS_ROOT_KEY=\K.*'
+      /etc/autobot/slm-secrets.env 2>/dev/null || true
+  register: _backend_secrets_root_key
+  changed_when: false
+  failed_when: false
+  when: _slm_secrets_stat.stat.exists | default(false)
+  no_log: true
+  tags: ['backend', 'config']
+
+- name: "Backend | Align autobot_secrets_root_key with slm-secrets.env when present (#14758)"
+  ansible.builtin.set_fact:
+    autobot_secrets_root_key: "{{ _backend_secrets_root_key.stdout | trim }}"
+  when: (_backend_secrets_root_key.stdout | default('') | trim) | length > 0
+  no_log: true
+  tags: ['backend', 'config']
+
 # #9914: Deploy the systemd unit BEFORE any stop/start so a fresh VM provisions
 # out-of-box. Previously the unit was deployed after the MVA-1633 start task, so
 # first-run on a clean node failed: "Could not find the requested service

--- a/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2
@@ -39,6 +39,11 @@ AUTOBOT_JWT_SECRET={{ backend_jwt_secret | default(backend_secret_key, true) }}
 CORS_ORIGINS={{ backend_cors_origins }}
 # Internal API key for SLM→backend proxy authentication (#1779)
 AUTOBOT_INTERNAL_API_KEY={{ autobot_internal_api_key }}
+
+# #14758: without this the canonical envelope secret store raises at import and
+# every consumer degrades silently. Read back from slm-secrets.env so the backend
+# and the SLM share one root key.
+AUTOBOT_SECRETS_ROOT_KEY={{ autobot_secrets_root_key }}
 # Audit log file path (#8936: ensure var is always set explicitly in prod)
 AUTOBOT_AUDIT_LOG_FILE={{ backend_audit_log_file | default('/opt/autobot/logs/audit.log') }}
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -424,7 +424,7 @@
     autobot_secrets_root_key: >-
       {{ autobot_secrets_root_key
          if (autobot_secrets_root_key | default('') | trim | length > 0)
-         else {{ (lookup('password', '/dev/null length=32 chars=ascii_letters,digits') | b64encode) | replace('+', '-') | replace('/', '_') }} }}
+         else (lookup('password', '/dev/null length=32 chars=ascii_letters,digits') | b64encode) | replace('+', '-') | replace('/', '_') }}
   when: not slm_secrets_stat.stat.exists
   no_log: true
   tags: ['slm', 'secrets']

--- a/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml
@@ -415,6 +415,16 @@
       {{ chromadb_auth_token
          if (chromadb_auth_token | default('') | trim | length > 0)
          else lookup('password', '/dev/null length=48 chars=ascii_letters,digits') }}
+    # #14758: the canonical envelope secret store's root key. Nothing generated
+    # it, so the store raised at import on every provisioned deployment and each
+    # consumer swallowed the failure — an absent store was indistinguishable
+    # from "that secret does not exist". `load_root_key` base64-DECODES this and
+    # requires exactly 32 bytes, so it is not interchangeable with the opaque
+    # 48-char secrets above: 32 chars b64-encoded decode back to 32 bytes.
+    autobot_secrets_root_key: >-
+      {{ autobot_secrets_root_key
+         if (autobot_secrets_root_key | default('') | trim | length > 0)
+         else {{ (lookup('password', '/dev/null length=32 chars=ascii_letters,digits') | b64encode) | replace('+', '-') | replace('/', '_') }} }}
   when: not slm_secrets_stat.stat.exists
   no_log: true
   tags: ['slm', 'secrets']
@@ -489,6 +499,37 @@
   when:
     - slm_secrets_stat.stat.exists
     - _slm_chroma_tok_check.rc != 0
+  no_log: true
+  tags: ['slm', 'secrets']
+
+# #14758: same back-fill for the envelope root key. Every host provisioned
+# before this change already has the secrets file, so the template task above is
+# skipped and the key would never appear — which is the state the issue reports.
+#
+# Gated on the grep finding nothing, so it only ever ADDS. Rotating this value
+# silently would be worse than leaving it absent: the root key derives every
+# vault KEK, so a new one makes every already-encrypted secret undecryptable.
+- name: "SLM | Check if AUTOBOT_SECRETS_ROOT_KEY present in secrets file (#14758)"
+  ansible.builtin.shell:
+    cmd: >-
+      grep -q '^AUTOBOT_SECRETS_ROOT_KEY=.\+'
+      {{ slm_credentials_dir }}/{{ slm_credentials_file }}
+  register: _slm_root_key_check
+  changed_when: false
+  failed_when: false
+  when: slm_secrets_stat.stat.exists
+  no_log: true
+  tags: ['slm', 'secrets']
+
+- name: "SLM | Add AUTOBOT_SECRETS_ROOT_KEY to existing secrets file (#14758)"
+  ansible.builtin.lineinfile:
+    path: "{{ slm_credentials_dir }}/{{ slm_credentials_file }}"
+    regexp: "^AUTOBOT_SECRETS_ROOT_KEY="
+    line: "AUTOBOT_SECRETS_ROOT_KEY={{ (lookup('password', '/dev/null length=32 chars=ascii_letters,digits') | b64encode) | replace('+', '-') | replace('/', '_') }}"
+    create: false
+  when:
+    - slm_secrets_stat.stat.exists
+    - _slm_root_key_check.rc != 0
   no_log: true
   tags: ['slm', 'secrets']
 

--- a/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
+++ b/autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2
@@ -22,6 +22,13 @@ AUTOBOT_INTERNAL_API_KEY={{ autobot_internal_api_key }}
 # kept forever — rotating it requires restarting chroma and every client together.
 AUTOBOT_CHROMADB_AUTH_TOKEN={{ chromadb_auth_token }}
 
+# #14758: root key for the canonical envelope secret store. The backend reads it
+# back from this file so both services derive the same vault keys — the SLM's SSO
+# vault migration explicitly requires the backend's root key, not its own.
+# Generated once and kept forever: rotating it makes every secret already sealed
+# under it undecryptable.
+AUTOBOT_SECRETS_ROOT_KEY={{ autobot_secrets_root_key }}
+
 # Override /opt/autobot/.env which has 0.0.0.0 (backend bind addr, not target)
 # SLM must connect to the backend at its actual IP (#915)
 AUTOBOT_BACKEND_HOST={{ main_host | default(infrastructure.hosts.backend if infrastructure is defined else '127.0.0.1') }}

--- a/docker/generate-secrets.sh
+++ b/docker/generate-secrets.sh
@@ -36,10 +36,20 @@ chmod 600 "$SECRETS_FILE"
 
 ensure_secret() {
     local key="$1"
+    # #14758: how the value is generated is per-key. The signing secrets are
+    # opaque strings, but the envelope root key is base64-DECODED and must be
+    # exactly 32 bytes, so `openssl rand -hex 32` (64 chars, decodes to 48) is
+    # rejected by load_root_key. Default to hex, override where it matters.
+    local generator="${2:-hex}"
     if grep -q "^${key}=" "$SECRETS_FILE" 2>/dev/null; then
         echo "  ${key}: already set — keeping existing value"
     else
-        printf '%s=%s\n' "$key" "$(openssl rand -hex 32)" >>"$SECRETS_FILE"
+        local value
+        case "$generator" in
+            b64_32) value="$(openssl rand -base64 32 | tr '+/' '-_')" ;;
+            *)      value="$(openssl rand -hex 32)" ;;
+        esac
+        printf '%s=%s\n' "$key" "$value" >>"$SECRETS_FILE"
         echo "  ${key}: generated"
     fi
 }
@@ -47,6 +57,9 @@ ensure_secret() {
 echo "Writing signing secrets to ${SECRETS_FILE}"
 ensure_secret AUTOBOT_JWT_SECRET
 ensure_secret SECRET_KEY
+# The canonical envelope secret store is unreachable without this, and every
+# consumer degrades silently, so its absence looked like "no such secret".
+ensure_secret AUTOBOT_SECRETS_ROOT_KEY b64_32
 
 echo ""
 echo "Done. Start the stack with both env files:"

--- a/docker/secrets-init.sh
+++ b/docker/secrets-init.sh
@@ -7,11 +7,12 @@
 # Compose secrets-init (GH#9905): auto-provision per-deployment signing secrets
 # so `docker compose up` works out of the box WITHOUT any committed secret.
 #
-# Generates AUTOBOT_JWT_SECRET / SECRET_KEY ONCE into the shared `autobot_secrets`
-# volume (mounted at /secrets) and reuses them on every subsequent start, so all
-# services (backend, worker, slm) share one stable, unique-per-deployment secret.
-# The file is written as _GEN_* keys; with-secrets.sh applies them only when the
-# corresponding env var is unset, so an explicit operator override still wins.
+# Generates AUTOBOT_JWT_SECRET / SECRET_KEY / AUTOBOT_SECRETS_ROOT_KEY ONCE into
+# the shared `autobot_secrets` volume (mounted at /secrets) and reuses them on
+# every subsequent start, so all services (backend, worker, slm) share one
+# stable, unique-per-deployment value. The file is written as _GEN_* keys;
+# with-secrets.sh applies them only when the corresponding env var is unset, so
+# an explicit operator override still wins.
 #
 # Secrets live only in the named volume — never in git, never printed.
 set -eu
@@ -23,21 +24,37 @@ gen_hex() {
     tr -dc 'a-f0-9' </dev/urandom | head -c 64
 }
 
-if [ -f "$SECRETS_FILE" ] && grep -q '^_GEN_JWT=' "$SECRETS_FILE" 2>/dev/null \
-    && grep -q '^_GEN_SECRET_KEY=' "$SECRETS_FILE" 2>/dev/null; then
-    echo "secrets-init: existing secrets found in $SECRETS_FILE — reusing."
-    exit 0
-fi
+# #14758: the envelope secret store's root key is not interchangeable with the
+# signing secrets above. `load_root_key` base64-decodes it and REQUIRES exactly
+# 32 bytes, so a 64-hex-char value decodes to 48 and is rejected. Emit url-safe
+# base64 of 32 random bytes instead.
+gen_b64_32() {
+    tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32 | base64 | tr '+/' '-_' | tr -d '\n'
+}
 
-echo "secrets-init: generating per-deployment signing secrets in $SECRETS_FILE"
+# Append one key only when it is absent. Per-key rather than all-or-nothing: an
+# existing deployment already carrying _GEN_JWT/_GEN_SECRET_KEY must be able to
+# GAIN the root key without its signing secrets being regenerated, which would
+# invalidate every issued session and every envelope-encrypted secret.
+ensure_key() {
+    key="$1"
+    gen="$2"
+    if [ -f "$SECRETS_FILE" ] && grep -q "^${key}=" "$SECRETS_FILE" 2>/dev/null; then
+        echo "secrets-init: ${key} already present — reusing."
+        return 0
+    fi
+    printf '%s=%s\n' "$key" "$($gen)" >>"$SECRETS_FILE"
+    echo "secrets-init: ${key} generated."
+}
+
 # Never world-readable, even momentarily: write under a restrictive umask, then
 # grant access by OWNERSHIP to the autobot service user (uid/gid 999, pinned in
 # both the backend and slm images) rather than by a permissive mode.
 umask 077
-{
-    printf '_GEN_JWT=%s\n' "$(gen_hex)"
-    printf '_GEN_SECRET_KEY=%s\n' "$(gen_hex)"
-} >"$SECRETS_FILE"
+touch "$SECRETS_FILE"
+ensure_key _GEN_JWT gen_hex
+ensure_key _GEN_SECRET_KEY gen_hex
+ensure_key _GEN_SECRETS_ROOT_KEY gen_b64_32
 chown 999:999 "$SECRETS_FILE"
 chmod 640 "$SECRETS_FILE"
 echo "secrets-init: done (values not printed)."

--- a/docker/with-secrets.sh
+++ b/docker/with-secrets.sh
@@ -32,7 +32,11 @@ if [ -r "$SECRETS_FILE" ]; then
     # JWTs with AUTOBOT_JWT_SECRET (_GEN_JWT), so SLM_SECRET_KEY MUST be the
     # same value — NOT _GEN_SECRET_KEY (GH#9852: signing-secret alignment).
     : "${SLM_SECRET_KEY:=${_GEN_JWT:-}}"
-    export AUTOBOT_JWT_SECRET SECRET_KEY SLM_SECRET_KEY
+    # #14758: the envelope secret store refuses to start without this, and every
+    # consumer degrades silently when it is absent, so an unset root key looked
+    # exactly like "that secret does not exist".
+    : "${AUTOBOT_SECRETS_ROOT_KEY:=${_GEN_SECRETS_ROOT_KEY:-}}"
+    export AUTOBOT_JWT_SECRET SECRET_KEY SLM_SECRET_KEY AUTOBOT_SECRETS_ROOT_KEY
 fi
 
 exec "$@"

--- a/repo_tests/secrets_root_key_provisioned_test.py
+++ b/repo_tests/secrets_root_key_provisioned_test.py
@@ -1,0 +1,95 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+
+"""#14758: every surface that provisions a deployment must provide the envelope root key.
+
+`AUTOBOT_SECRETS_ROOT_KEY` is mandatory for the canonical envelope secret store —
+`load_root_key` raises when it is unset — and nothing generated it, so the store
+was unreachable on every provisioned deployment. Each consumer swallowed the
+failure, which is why an entirely absent store was indistinguishable from "that
+secret does not exist".
+
+These assert the *provisioning* surfaces, not the consumers. A test that only
+checked the consumers would have passed for the whole time the bug was live.
+"""
+
+from __future__ import annotations
+
+import base64
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_KEY = "AUTOBOT_SECRETS_ROOT_KEY"
+
+# Each surface, and the sibling signing secret that proves the surface really is
+# where secrets get provisioned. Pinning the sibling means a file that is
+# reorganised out from under this test fails loudly instead of passing empty.
+SURFACES = [
+    ("docker/secrets-init.sh", "_GEN_SECRET_KEY", "_GEN_SECRETS_ROOT_KEY"),
+    ("docker/with-secrets.sh", "SECRET_KEY", ROOT_KEY),
+    ("docker/generate-secrets.sh", "AUTOBOT_JWT_SECRET", ROOT_KEY),
+    (
+        "autobot-slm-backend/ansible/roles/slm_manager/templates/slm-secrets.env.j2",
+        "SLM_SECRET_KEY",
+        ROOT_KEY,
+    ),
+    (
+        "autobot-slm-backend/ansible/roles/backend/templates/backend.env.j2",
+        "AUTOBOT_INTERNAL_API_KEY",
+        ROOT_KEY,
+    ),
+]
+
+
+@pytest.mark.parametrize("rel,sibling,needle", SURFACES, ids=[s[0] for s in SURFACES])
+def test_every_provisioning_surface_provides_the_root_key(rel: str, sibling: str, needle: str) -> None:
+    path = REPO_ROOT / rel
+    assert path.is_file(), f"{rel} is missing — this guard would otherwise pass vacuously"
+    text = path.read_text(encoding="utf-8")
+    assert sibling in text, (
+        f"{rel} no longer provisions {sibling}, so it may no longer be a secrets "
+        "surface at all — re-point this guard rather than deleting it"
+    )
+    assert needle in text, f"{rel} provisions {sibling} but not {needle} (#14758)"
+
+
+def test_the_generated_key_decodes_to_the_length_the_loader_demands() -> None:
+    """The root key is base64-DECODED and must be exactly 32 bytes.
+
+    This is why it cannot reuse the hex generator the signing secrets use:
+    `openssl rand -hex 32` is 64 characters, which decodes to 48 bytes and is
+    rejected. Encoding 32 characters yields exactly 32 bytes.
+    """
+
+    def decode(text: str) -> bytes:  # mirrors autobot_shared.secrets_envelope._b64d
+        stripped = text.rstrip("=")
+        return base64.urlsafe_b64decode(stripped + "=" * (-len(stripped) % 4))
+
+    sample = base64.b64encode(b"a" * 32).decode().replace("+", "-").replace("/", "_")
+    assert len(decode(sample)) == 32
+
+    # The control: the generator used for the signing secrets must NOT satisfy it.
+    hex_style = "0" * 64
+    assert len(decode(hex_style)) != 32, "a 64-char hex value must not pass for a root key"
+
+
+def test_the_ansible_generator_asks_for_the_right_length() -> None:
+    """The password lookup must request 32 chars, since b64 of N chars decodes to N bytes."""
+    tasks = (
+        REPO_ROOT
+        / "autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml"
+    ).read_text(encoding="utf-8")
+    assert ROOT_KEY in tasks or "autobot_secrets_root_key" in tasks
+
+    # Every generator feeding the root key must be length=32 — a 48-char lookup
+    # (the length the sibling secrets use) would decode to 48 bytes and be rejected.
+    generators = re.findall(
+        r"autobot_secrets_root_key.*?length=(\d+)", tasks, re.DOTALL
+    ) + re.findall(r"AUTOBOT_SECRETS_ROOT_KEY=.*?length=(\d+)", tasks)
+    assert generators, "found no generator for the root key to check"
+    assert set(generators) == {"32"}, f"root key generated at wrong length(s): {set(generators)}"

--- a/repo_tests/secrets_root_key_provisioned_test.py
+++ b/repo_tests/secrets_root_key_provisioned_test.py
@@ -93,3 +93,44 @@ def test_the_ansible_generator_asks_for_the_right_length() -> None:
     ) + re.findall(r"AUTOBOT_SECRETS_ROOT_KEY=.*?length=(\d+)", tasks)
     assert generators, "found no generator for the root key to check"
     assert set(generators) == {"32"}, f"root key generated at wrong length(s): {set(generators)}"
+
+
+def test_every_root_key_jinja_expression_compiles() -> None:
+    """A nested `{{ }}` inside an open expression is a hard TemplateSyntaxError.
+
+    YAML validity says nothing about Jinja validity, so a task file can parse
+    cleanly and still abort at run time. That matters more than it sounds here:
+    the generator lives in the same multi-key `set_fact` that produces the SLM's
+    signing key, encryption key, admin password and auth token, so one bad
+    expression fails all of them on every fresh install.
+    """
+    jinja2 = pytest.importorskip("jinja2")
+
+    env = jinja2.Environment()  # nosec B701  # compiling only, never rendering untrusted input
+    # Filters/lookups Ansible injects that core Jinja does not ship.
+    env.filters["b64encode"] = lambda v: v
+    env.globals["lookup"] = lambda *a, **k: "x"
+
+    task_files = [
+        REPO_ROOT / "autobot-slm-backend/ansible/roles/slm_manager/tasks/main.yml",
+        REPO_ROOT / "autobot-slm-backend/ansible/roles/backend/tasks/main.yml",
+    ]
+    checked = 0
+    for path in task_files:
+        assert path.is_file(), f"{path} missing — this guard would pass vacuously"
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"\{\{.*?\}\}", text, re.DOTALL):
+            expr = match.group(0)
+            context = text[max(0, match.start() - 200) : match.end()]
+            if ROOT_KEY not in context and "autobot_secrets_root_key" not in context:
+                continue
+            checked += 1
+            try:
+                env.compile(expr)
+            except jinja2.TemplateSyntaxError as exc:  # pragma: no cover - failure path
+                raise AssertionError(f"{path.name}: {exc}\n  {expr[:160]}") from exc
+
+    assert checked >= 3, (
+        f"only {checked} root-key expressions found — the extraction missed some, "
+        "so a passing result would not mean they are all valid"
+    )


### PR DESCRIPTION
Closes #14758. Refs #12684, #12681.

## Thinking Path

`AUTOBOT_SECRETS_ROOT_KEY` is mandatory for the canonical envelope secret store
(`autobot_shared/secrets_envelope.py:49,126` — `load_root_key` raises when unset),
and **nothing generated or wrote it**. Searching the tree, its only occurrences
outside `.py`/`.md` were generated artifacts (`api.ts`, `openapi.json`). It was
absent from `backend.env.j2`, `install.sh`, `docker/generate-secrets.sh`, and every
playbook — while those same files do provision `SECRET_KEY`, `AUTOBOT_JWT_SECRET`
and `AUTOBOT_INTERNAL_API_KEY`.

So the canonical store was unreachable on every provisioned deployment. What makes
it a silent failure rather than a loud one is that every consumer swallows it: the
SLM `vault_client` degrades to legacy-only, lifespan hydration catches broadly and
logs at **debug**, and `retrieve_secret` returns `None` on `VaultClientError`. An
entirely absent secret store is therefore indistinguishable from "that secret does
not exist" — which is the same class of invisible failure #12681 reports for agent
provisioning.

Two constraints ruled out copying the sibling secrets:

**The value is base64-decoded and must be exactly 32 bytes.** The signing secrets
use `openssl rand -hex 32`, which is 64 characters and decodes to **48** — rejected
by `load_root_key`. Encoding 32 random characters yields exactly 32 bytes. Verified
over 50,000 samples before writing any of it.

**It cannot ever be regenerated.** The root key derives every vault KEK via HKDF, so
a new value makes every secret already sealed under it undecryptable. That makes
"generate on every run" strictly worse than the current bug.

## What Changed

Provisioned on every surface that already generates the sibling secrets:

| Surface | Change |
|---|---|
| `docker/secrets-init.sh` | per-key `ensure_key`; adds `_GEN_SECRETS_ROOT_KEY` |
| `docker/with-secrets.sh` | exports `AUTOBOT_SECRETS_ROOT_KEY`, operator override still wins |
| `docker/generate-secrets.sh` | `ensure_secret … b64_32` generator |
| `slm_manager` role | generates on fresh installs + back-fills existing ones |
| `backend` role | reads it back from `slm-secrets.env`, renders it |

Every path only ever **adds**. `secrets-init.sh` previously exited early when both
signing secrets existed, so an existing deployment could never have gained the root
key; it is now per-key, so it gains the root key **without** its signing secrets
being reissued. The ansible back-fill mirrors the existing #7689 / #12513 pattern
and is gated on the key being absent.

The backend reads the value from `slm-secrets.env` rather than generating its own,
because `migrations/migrate_sso_to_unified_vault.py` states it needs *the backend's*
root key — two independently generated values would be a silent decryption failure,
not a config nuisance.

## Verification

I cannot run ansible or compose here, so the logic was verified against scratch
copies with the paths redirected — never against the repo tree or a live host.

**Idempotency and the upgrade path** (`secrets-init.sh`, three scenarios):

```
(a) fresh            -> _GEN_JWT, _GEN_SECRET_KEY, _GEN_SECRETS_ROOT_KEY generated
(b) re-run           -> all three "already present — reusing"; file byte-identical
(c) existing install -> JWT preserved: YES;  root key added: 1
```

Scenario (c) is the one that matters: an existing deployment gains the key while
its signing secrets are untouched. Had it regenerated them, every issued session
would have been invalidated.

**Key length**, against a replica of the loader's `_b64d`:

```
50000 samples -> all decode to exactly 32 bytes, roundtrip exact, failures=0
64-hex control -> decodes to 48 bytes  (correctly NOT a valid root key)
```

`docker/generate-secrets.sh` in scratch produced `AUTOBOT_SECRETS_ROOT_KEY -> 32
bytes` with the siblings still 64-char hex.

The guard test asserts the **provisioning** surfaces and pins a sibling secret in
each, so a reorganised file fails loudly instead of passing vacuously. A test over
the consumers would have passed for the entire time this bug was live.

One correction to my own working note: the url-safe `+/` → `-_` replacement never
actually fires, because an alphanumeric charset leaves bit 7 clear and the base64
groups cannot reach index 62/63. It is kept as defence against a future charset
change, not because it is load-bearing.

## What this does not fix

`AUTOBOT_SECRETS_ROOT_KEY` is still **not registered** in `env_registry.py`. The
registry checker only scans `.py` files and cannot see the indirect
`os.environ.get(ROOT_KEY_ENV)` read, which is why base is green without it.
Registering it requires regenerating the env docs, which I am not doing inside a
security fix; it belongs in its own change alongside the #14763 precedent.

This also does not consolidate the secret stores — that is #12684's architecture
decision, still `needs-decision`. It makes the canonical store *reachable*, which
that decision depends on either way.

## Model Used

Claude Opus 5
