### PR TITLE
fix(provision): install the LLC agent CLIs on ansible-deployed hosts (#12681)

### DIFF
--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -83,6 +83,11 @@ backend_cors_origins: "*"
 # Internal API key shared with SLM backend for proxy authentication (#1779, #3512).
 # REQUIRED for personality and voice proxies — set via Ansible Vault or inventory.
 autobot_internal_api_key: ""
+
+# #12681: pin an exact claude-code package version (e.g. "2.1.89") for a
+# reproducible provision. Empty takes the current stable-channel build, matching
+# the CLAUDE_CLI_VERSION build arg the backend image already exposes.
+backend_claude_cli_version: ""
 # SLM WebSocket auth bearer value — populated from /etc/autobot/slm-secrets.env at deploy time (#7689).
 backend_slm_auth_tok: ""
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -327,6 +327,10 @@
     url: "{{ item.url }}"
     dest: "{{ item.dest }}"
     mode: "0644"
+    # #2835 precedent: bound the fetch. lock_timeout below bounds the dpkg lock,
+    # not a hung TCP connection to a third-party host — an unbounded fetch stalls
+    # the whole play rather than failing it.
+    timeout: 120
   loop:
     - url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
       dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -266,6 +266,113 @@
 # handles the task-failure/mid-deploy-error case, which is what left the backend
 # dead today.
 # ============================================================
+# Placed BEFORE the restart-guarded window below on purpose (#12681): these
+# tasks reach two third-party apt repos, and inside that block a transient
+# outage would abort the whole deploy — code sync, config, workers, nginx and
+# the health check — after the service was already stopped. Out here a repo
+# hiccup fails this feature loudly and leaves a running backend running.
+# #12681: the LLC agent CLIs. docker/backend/Dockerfile installs `claude` and
+# `gh` from signed apt repos and proves both resolve at build time, but NOTHING
+# installed them on an ansible-provisioned host. `resolve_cli_binary` therefore
+# returned None for every claude_code / copilot_local agent hired on a systemd
+# deployment, so the agent could be hired and could never run — which is the
+# "provisioning fails invisibly" symptom the issue reports.
+#
+# Same signed repos as the image, fetched with get_url rather than piped to a
+# shell. Failing loudly here is deliberate: a host that cannot install the CLI
+# should fail provisioning rather than come up hosting agents that cannot run.
+- name: "Backend | Ensure the apt keyring directory exists (#12681)"
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: "0755"
+  become: true
+  tags: ['backend', 'packages', 'llc']
+
+- name: "Backend | Read the dpkg architecture for the CLI apt sources (#12681)"
+  ansible.builtin.command:
+    cmd: dpkg --print-architecture
+  register: _backend_dpkg_arch
+  changed_when: false
+  tags: ['backend', 'packages', 'llc']
+
+- name: "Backend | Install the agent CLI repository signing keys (#12681)"
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    mode: "0644"
+  loop:
+    - url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+      dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    - url: https://downloads.claude.ai/keys/claude-code.asc
+      dest: /etc/apt/keyrings/claude-code.asc
+  loop_control:
+    label: "{{ item.dest }}"
+  become: true
+  register: _backend_cli_keys
+  tags: ['backend', 'packages', 'llc']
+
+- name: "Backend | Add the agent CLI apt sources (#12681)"
+  ansible.builtin.copy:
+    dest: "/etc/apt/sources.list.d/{{ item.file }}"
+    content: "{{ item.line }}\n"
+    mode: "0644"
+  loop:
+    - file: github-cli.list
+      line: >-
+        deb [arch={{ _backend_dpkg_arch.stdout | trim }}
+        signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg]
+        https://cli.github.com/packages stable main
+    - file: claude-code.list
+      line: >-
+        deb [signed-by=/etc/apt/keyrings/claude-code.asc]
+        https://downloads.claude.ai/claude-code/apt/stable stable main
+  loop_control:
+    label: "{{ item.file }}"
+  become: true
+  register: _backend_cli_sources
+  tags: ['backend', 'packages', 'llc']
+
+# Also refreshed when a version is pinned: the keys and sources only change on
+# first install, so a converged host would otherwise never refresh, and pinning a
+# newly-released version would fail against a stale cache — defeating the point
+# of the pin.
+- name: "Backend | Refresh apt after adding the agent CLI sources (#12681)"
+  ansible.builtin.apt:
+    update_cache: true
+    lock_timeout: 60
+  become: true
+  when: >-
+    _backend_cli_sources is changed
+    or _backend_cli_keys is changed
+    or (backend_claude_cli_version | default('') | trim | length > 0)
+  tags: ['backend', 'packages', 'llc']
+
+# An empty version takes the current stable-channel build; set
+# backend_claude_cli_version to pin an exact package version.
+- name: "Backend | Install the LLC agent CLIs (#12681)"
+  ansible.builtin.apt:
+    name: "{{ ['gh'] + ['claude-code' + ('=' + backend_claude_cli_version if (backend_claude_cli_version | default('') | trim | length > 0) else '')] }}"
+    state: present
+    install_recommends: false
+    lock_timeout: 60
+  become: true
+  tags: ['backend', 'packages', 'llc']
+
+# The image runs `claude --version` at build time so an install regression
+# fails the build instead of silently breaking dispatch. The equivalent here is
+# to resolve them on the host: a task that installs without checking would let
+# a broken PATH look identical to a successful provision.
+- name: "Backend | Verify the agent CLIs resolve on PATH (#12681)"
+  ansible.builtin.command:
+    cmd: "{{ item }} --version"
+  loop:
+    - gh
+    - claude
+  changed_when: false
+  tags: ['backend', 'packages', 'llc']
+
+
 - name: "Backend | Restart-guarded env-update + heavy-work window (#12139)"
   block:
   # MVA-1633: Prevent systemd Restart=always race during env updates.
@@ -366,98 +473,6 @@
         - postgresql-client
       state: present
     tags: ['backend', 'packages']
-
-  # #12681: the LLC agent CLIs. docker/backend/Dockerfile installs `claude` and
-  # `gh` from signed apt repos and proves both resolve at build time, but NOTHING
-  # installed them on an ansible-provisioned host. `resolve_cli_binary` therefore
-  # returned None for every claude_code / copilot_local agent hired on a systemd
-  # deployment, so the agent could be hired and could never run — which is the
-  # "provisioning fails invisibly" symptom the issue reports.
-  #
-  # Same signed repos as the image, fetched with get_url rather than piped to a
-  # shell. Failing loudly here is deliberate: a host that cannot install the CLI
-  # should fail provisioning rather than come up hosting agents that cannot run.
-  - name: "Backend | Ensure the apt keyring directory exists (#12681)"
-    ansible.builtin.file:
-      path: /etc/apt/keyrings
-      state: directory
-      mode: "0755"
-    become: true
-    tags: ['backend', 'packages', 'llc']
-
-  - name: "Backend | Read the dpkg architecture for the CLI apt sources (#12681)"
-    ansible.builtin.command:
-      cmd: dpkg --print-architecture
-    register: _backend_dpkg_arch
-    changed_when: false
-    tags: ['backend', 'packages', 'llc']
-
-  - name: "Backend | Install the agent CLI repository signing keys (#12681)"
-    ansible.builtin.get_url:
-      url: "{{ item.url }}"
-      dest: "{{ item.dest }}"
-      mode: "0644"
-    loop:
-      - url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
-        dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
-      - url: https://downloads.claude.ai/keys/claude-code.asc
-        dest: /etc/apt/keyrings/claude-code.asc
-    loop_control:
-      label: "{{ item.dest }}"
-    become: true
-    register: _backend_cli_keys
-    tags: ['backend', 'packages', 'llc']
-
-  - name: "Backend | Add the agent CLI apt sources (#12681)"
-    ansible.builtin.copy:
-      dest: "/etc/apt/sources.list.d/{{ item.file }}"
-      content: "{{ item.line }}\n"
-      mode: "0644"
-    loop:
-      - file: github-cli.list
-        line: >-
-          deb [arch={{ _backend_dpkg_arch.stdout | trim }}
-          signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg]
-          https://cli.github.com/packages stable main
-      - file: claude-code.list
-        line: >-
-          deb [signed-by=/etc/apt/keyrings/claude-code.asc]
-          https://downloads.claude.ai/claude-code/apt/stable stable main
-    loop_control:
-      label: "{{ item.file }}"
-    become: true
-    register: _backend_cli_sources
-    tags: ['backend', 'packages', 'llc']
-
-  - name: "Backend | Refresh apt after adding the agent CLI sources (#12681)"
-    ansible.builtin.apt:
-      update_cache: true
-    become: true
-    when: _backend_cli_sources is changed or _backend_cli_keys is changed
-    tags: ['backend', 'packages', 'llc']
-
-  # An empty version takes the current stable-channel build; set
-  # backend_claude_cli_version to pin an exact package version.
-  - name: "Backend | Install the LLC agent CLIs (#12681)"
-    ansible.builtin.apt:
-      name: "{{ ['gh'] + ['claude-code' + ('=' + backend_claude_cli_version if (backend_claude_cli_version | default('') | trim | length > 0) else '')] }}"
-      state: present
-      install_recommends: false
-    become: true
-    tags: ['backend', 'packages', 'llc']
-
-  # The image runs `claude --version` at build time so an install regression
-  # fails the build instead of silently breaking dispatch. The equivalent here is
-  # to resolve them on the host: a task that installs without checking would let
-  # a broken PATH look identical to a successful provision.
-  - name: "Backend | Verify the agent CLIs resolve on PATH (#12681)"
-    ansible.builtin.command:
-      cmd: "{{ item }} --version"
-    loop:
-      - gh
-      - claude
-    changed_when: false
-    tags: ['backend', 'packages', 'llc']
 
 
   - name: Create autobot user

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -367,6 +367,98 @@
       state: present
     tags: ['backend', 'packages']
 
+  # #12681: the LLC agent CLIs. docker/backend/Dockerfile installs `claude` and
+  # `gh` from signed apt repos and proves both resolve at build time, but NOTHING
+  # installed them on an ansible-provisioned host. `resolve_cli_binary` therefore
+  # returned None for every claude_code / copilot_local agent hired on a systemd
+  # deployment, so the agent could be hired and could never run — which is the
+  # "provisioning fails invisibly" symptom the issue reports.
+  #
+  # Same signed repos as the image, fetched with get_url rather than piped to a
+  # shell. Failing loudly here is deliberate: a host that cannot install the CLI
+  # should fail provisioning rather than come up hosting agents that cannot run.
+  - name: "Backend | Ensure the apt keyring directory exists (#12681)"
+    ansible.builtin.file:
+      path: /etc/apt/keyrings
+      state: directory
+      mode: "0755"
+    become: true
+    tags: ['backend', 'packages', 'llc']
+
+  - name: "Backend | Read the dpkg architecture for the CLI apt sources (#12681)"
+    ansible.builtin.command:
+      cmd: dpkg --print-architecture
+    register: _backend_dpkg_arch
+    changed_when: false
+    tags: ['backend', 'packages', 'llc']
+
+  - name: "Backend | Install the agent CLI repository signing keys (#12681)"
+    ansible.builtin.get_url:
+      url: "{{ item.url }}"
+      dest: "{{ item.dest }}"
+      mode: "0644"
+    loop:
+      - url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+        dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+      - url: https://downloads.claude.ai/keys/claude-code.asc
+        dest: /etc/apt/keyrings/claude-code.asc
+    loop_control:
+      label: "{{ item.dest }}"
+    become: true
+    register: _backend_cli_keys
+    tags: ['backend', 'packages', 'llc']
+
+  - name: "Backend | Add the agent CLI apt sources (#12681)"
+    ansible.builtin.copy:
+      dest: "/etc/apt/sources.list.d/{{ item.file }}"
+      content: "{{ item.line }}\n"
+      mode: "0644"
+    loop:
+      - file: github-cli.list
+        line: >-
+          deb [arch={{ _backend_dpkg_arch.stdout | trim }}
+          signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg]
+          https://cli.github.com/packages stable main
+      - file: claude-code.list
+        line: >-
+          deb [signed-by=/etc/apt/keyrings/claude-code.asc]
+          https://downloads.claude.ai/claude-code/apt/stable stable main
+    loop_control:
+      label: "{{ item.file }}"
+    become: true
+    register: _backend_cli_sources
+    tags: ['backend', 'packages', 'llc']
+
+  - name: "Backend | Refresh apt after adding the agent CLI sources (#12681)"
+    ansible.builtin.apt:
+      update_cache: true
+    become: true
+    when: _backend_cli_sources is changed or _backend_cli_keys is changed
+    tags: ['backend', 'packages', 'llc']
+
+  # An empty version takes the current stable-channel build; set
+  # backend_claude_cli_version to pin an exact package version.
+  - name: "Backend | Install the LLC agent CLIs (#12681)"
+    ansible.builtin.apt:
+      name: "{{ ['gh'] + ['claude-code' + ('=' + backend_claude_cli_version if (backend_claude_cli_version | default('') | trim | length > 0) else '')] }}"
+      state: present
+      install_recommends: false
+    become: true
+    tags: ['backend', 'packages', 'llc']
+
+  # The image runs `claude --version` at build time so an install regression
+  # fails the build instead of silently breaking dispatch. The equivalent here is
+  # to resolve them on the host: a task that installs without checking would let
+  # a broken PATH look identical to a successful provision.
+  - name: "Backend | Verify the agent CLIs resolve on PATH (#12681)"
+    ansible.builtin.command:
+      cmd: "{{ item }} --version"
+    loop:
+      - gh
+      - claude
+    changed_when: false
+    tags: ['backend', 'packages', 'llc']
+
 
   - name: Create autobot user
     ansible.builtin.user:

--- a/repo_tests/llc_agent_cli_provisioned_test.py
+++ b/repo_tests/llc_agent_cli_provisioned_test.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+
+"""#12681: every deployment path that runs LLC agents must provision their CLIs.
+
+`resolve_cli_binary` returns None when the binary is absent, and a hired agent
+then fails at dispatch rather than at hire time. The container image installed
+`claude` and `gh` and proved they resolved at build time; the ansible path
+installed neither, so an agent hired on a systemd deployment could never run.
+
+These assert the PROVISIONING, not the resolver. A test over `resolve_cli_binary`
+passes whether or not anything ever installs the binary — which is exactly how
+this stayed invisible.
+
+Deliberately no `shutil.which("claude")` gate anywhere: a test skipped for a
+missing binary is indistinguishable from a pass (#14550).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "docker/backend/Dockerfile"
+ANSIBLE_TASKS = REPO_ROOT / "autobot-slm-backend/ansible/roles/backend/tasks/main.yml"
+
+# The adapters that shell out to a CLI, and the binary each one resolves.
+AGENT_CLIS = ["claude", "gh"]
+
+
+@pytest.mark.parametrize("path", [DOCKERFILE, ANSIBLE_TASKS], ids=["image", "ansible"])
+@pytest.mark.parametrize("binary", AGENT_CLIS)
+def test_every_deployment_path_installs_the_agent_cli(path: Path, binary: str) -> None:
+    assert path.is_file(), f"{path} missing — this guard would otherwise pass vacuously"
+    text = path.read_text(encoding="utf-8")
+    package = "claude-code" if binary == "claude" else binary
+    assert package in text, (
+        f"{path.name} does not install '{package}'. A deployment that runs LLC "
+        f"agents without {binary} on PATH hires agents that cannot dispatch (#12681)."
+    )
+
+
+@pytest.mark.parametrize("path", [DOCKERFILE, ANSIBLE_TASKS], ids=["image", "ansible"])
+def test_every_deployment_path_proves_the_cli_resolves(path: Path) -> None:
+    """Installing without checking lets a broken PATH look like a clean provision."""
+    text = path.read_text(encoding="utf-8")
+    assert re.search(r"claude\s+--version", text), (
+        f"{path.name} installs the CLI but never resolves it; an install regression "
+        "would be silent (#12681)"
+    )
+
+
+def test_the_signing_keys_are_fetched_not_piped_to_a_shell() -> None:
+    """Both repos are signed; neither CLI may be installed by curl|bash."""
+    text = ANSIBLE_TASKS.read_text(encoding="utf-8")
+    assert "/etc/apt/keyrings/claude-code.asc" in text
+    assert "/etc/apt/keyrings/githubcli-archive-keyring.gpg" in text
+    # A pipe-to-shell install of either CLI would defeat the signed-repo choice.
+    assert not re.search(r"curl[^\n|]*\|\s*(sudo\s+)?(ba)?sh", text), (
+        "an agent CLI must not be installed by piping a download into a shell"
+    )
+
+
+def test_the_version_pin_is_optional_and_renders_both_ways() -> None:
+    """An empty pin must yield a bare package name, not a trailing '='."""
+    jinja2 = pytest.importorskip("jinja2")
+
+    text = ANSIBLE_TASKS.read_text(encoding="utf-8")
+    match = re.search(r"name:\s*\"(\{\{ \['gh'\].*?\}\})\"", text, re.DOTALL)
+    assert match, "could not locate the CLI package-name expression to check"
+
+    env = jinja2.Environment()  # nosec B701  # compiling a repo-owned expression, never rendering user input
+    template = env.from_string(match.group(1))
+    assert template.render(backend_claude_cli_version="") == "['gh', 'claude-code']"
+    assert template.render(backend_claude_cli_version="2.1.89") == "['gh', 'claude-code=2.1.89']"

--- a/repo_tests/llc_agent_cli_provisioned_test.py
+++ b/repo_tests/llc_agent_cli_provisioned_test.py
@@ -11,56 +11,130 @@ then fails at dispatch rather than at hire time. The container image installed
 installed neither, so an agent hired on a systemd deployment could never run.
 
 These assert the PROVISIONING, not the resolver. A test over `resolve_cli_binary`
-passes whether or not anything ever installs the binary — which is exactly how
-this stayed invisible.
+passes whether or not anything ever installs the binary — which is how this
+stayed invisible.
 
-Deliberately no `shutil.which("claude")` gate anywhere: a test skipped for a
-missing binary is indistinguishable from a pass (#14550).
+The ansible assertions parse the task file and inspect the actual tasks. An
+earlier version of this guard matched raw source text and was **vacuous**: `"gh"
+in text` is satisfied by the word *Copyright* in the licence header, and a
+`claude --version` regex matched an explanatory comment rather than the templated
+`cmd`, so deleting the real verify task left the test green. Substring checks
+against a whole file are not evidence.
+
+Deliberately no `shutil.which(...)` gate anywhere: a test skipped for a missing
+binary is indistinguishable from a pass (#14550).
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
+
+yaml = pytest.importorskip("yaml")
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "docker/backend/Dockerfile"
 ANSIBLE_TASKS = REPO_ROOT / "autobot-slm-backend/ansible/roles/backend/tasks/main.yml"
 
-# The adapters that shell out to a CLI, and the binary each one resolves.
-AGENT_CLIS = ["claude", "gh"]
+AGENT_CLIS = ("gh", "claude")
+PACKAGES = ("gh", "claude-code")
 
 
-@pytest.mark.parametrize("path", [DOCKERFILE, ANSIBLE_TASKS], ids=["image", "ansible"])
-@pytest.mark.parametrize("binary", AGENT_CLIS)
-def test_every_deployment_path_installs_the_agent_cli(path: Path, binary: str) -> None:
-    assert path.is_file(), f"{path} missing — this guard would otherwise pass vacuously"
-    text = path.read_text(encoding="utf-8")
-    package = "claude-code" if binary == "claude" else binary
-    assert package in text, (
-        f"{path.name} does not install '{package}'. A deployment that runs LLC "
-        f"agents without {binary} on PATH hires agents that cannot dispatch (#12681)."
+def _tasks() -> list[dict[str, Any]]:
+    """Every task in the backend role, including those nested in block/rescue/always."""
+    assert ANSIBLE_TASKS.is_file(), f"{ANSIBLE_TASKS} missing — this guard would pass vacuously"
+    loaded = yaml.safe_load(ANSIBLE_TASKS.read_text(encoding="utf-8"))
+    out: list[dict[str, Any]] = []
+
+    def walk(items: Any) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            out.append(item)
+            for key in ("block", "rescue", "always"):
+                walk(item.get(key))
+
+    walk(loaded)
+    assert out, "parsed no tasks — the guard would pass on an empty set"
+    return out
+
+
+def _install_task() -> dict[str, Any]:
+    for task in _tasks():
+        apt = task.get("ansible.builtin.apt")
+        if isinstance(apt, dict) and "claude-code" in str(apt.get("name", "")):
+            return task
+    raise AssertionError("no apt task installs claude-code (#12681)")
+
+
+def _verify_task() -> dict[str, Any]:
+    for task in _tasks():
+        cmd = task.get("ansible.builtin.command")
+        cmd_str = cmd.get("cmd", "") if isinstance(cmd, dict) else str(cmd or "")
+        if "--version" in cmd_str and task.get("loop"):
+            return task
+    raise AssertionError("no task resolves the agent CLIs with --version (#12681)")
+
+
+@pytest.mark.parametrize("package", PACKAGES)
+def test_ansible_installs_each_agent_cli(package: str) -> None:
+    """Asserted against the apt task's package list, never against file text."""
+    names = _install_task()["ansible.builtin.apt"]["name"]
+    rendered = names if isinstance(names, str) else " ".join(map(str, names))
+    assert re.search(rf"(?<![\w-]){re.escape(package)}(?![\w-])", rendered), (
+        f"the apt task does not install '{package}'; it installs: {rendered!r}. "
+        f"A deployment running LLC agents without it hires agents that cannot dispatch."
     )
 
 
-@pytest.mark.parametrize("path", [DOCKERFILE, ANSIBLE_TASKS], ids=["image", "ansible"])
-def test_every_deployment_path_proves_the_cli_resolves(path: Path) -> None:
-    """Installing without checking lets a broken PATH look like a clean provision."""
-    text = path.read_text(encoding="utf-8")
-    assert re.search(r"claude\s+--version", text), (
-        f"{path.name} installs the CLI but never resolves it; an install regression "
-        "would be silent (#12681)"
+@pytest.mark.parametrize("binary", AGENT_CLIS)
+def test_ansible_proves_each_cli_resolves(binary: str) -> None:
+    """Installing without resolving lets a broken PATH look like a clean provision."""
+    task = _verify_task()
+    loop = task.get("loop") or []
+    assert binary in [str(x) for x in loop], (
+        f"the verify task does not resolve '{binary}' (loop={loop!r}); an install "
+        "regression for it would be silent"
+    )
+
+
+def test_the_cli_install_is_outside_the_restart_guarded_window() -> None:
+    """#12139: a failure inside that block aborts the deploy with the service stopped.
+
+    These tasks reach two third-party apt repos, so a transient outage there must
+    not take down code sync, workers, nginx and the health check with it.
+    """
+    text = ANSIBLE_TASKS.read_text(encoding="utf-8")
+    guarded = text.index("Restart-guarded env-update")
+    first_cli = text.index("Ensure the apt keyring directory exists")
+    assert first_cli < guarded, (
+        "the agent-CLI tasks sit inside the restart-guarded window; a CLI-repo "
+        "outage would abort the whole backend deploy after the service was stopped"
+    )
+
+
+@pytest.mark.parametrize("binary", AGENT_CLIS)
+def test_the_image_installs_and_resolves_each_cli(binary: str) -> None:
+    assert DOCKERFILE.is_file(), f"{DOCKERFILE} missing — this guard would pass vacuously"
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    package = "claude-code" if binary == "claude" else binary
+    assert re.search(rf"(?<![\w-]){re.escape(package)}(?![\w-])", text), (
+        f"the image no longer installs '{package}' (#12681)"
+    )
+    assert re.search(rf"{re.escape(binary)}\s+--version", text), (
+        f"the image installs '{package}' but never proves it resolves"
     )
 
 
 def test_the_signing_keys_are_fetched_not_piped_to_a_shell() -> None:
-    """Both repos are signed; neither CLI may be installed by curl|bash."""
     text = ANSIBLE_TASKS.read_text(encoding="utf-8")
     assert "/etc/apt/keyrings/claude-code.asc" in text
     assert "/etc/apt/keyrings/githubcli-archive-keyring.gpg" in text
-    # A pipe-to-shell install of either CLI would defeat the signed-repo choice.
     assert not re.search(r"curl[^\n|]*\|\s*(sudo\s+)?(ba)?sh", text), (
         "an agent CLI must not be installed by piping a download into a shell"
     )
@@ -70,11 +144,8 @@ def test_the_version_pin_is_optional_and_renders_both_ways() -> None:
     """An empty pin must yield a bare package name, not a trailing '='."""
     jinja2 = pytest.importorskip("jinja2")
 
-    text = ANSIBLE_TASKS.read_text(encoding="utf-8")
-    match = re.search(r"name:\s*\"(\{\{ \['gh'\].*?\}\})\"", text, re.DOTALL)
-    assert match, "could not locate the CLI package-name expression to check"
-
-    env = jinja2.Environment()  # nosec B701  # compiling a repo-owned expression, never rendering user input
-    template = env.from_string(match.group(1))
+    names = _install_task()["ansible.builtin.apt"]["name"]
+    env = jinja2.Environment()  # nosec B701  # compiling a repo-owned expression, never user input
+    template = env.from_string(names if isinstance(names, str) else str(names))
     assert template.render(backend_claude_cli_version="") == "['gh', 'claude-code']"
     assert template.render(backend_claude_cli_version="2.1.89") == "['gh', 'claude-code=2.1.89']"


### PR DESCRIPTION
Refs #12681 — **item 1 of the three** the issue covers. Not `Closes`; item 2 remains.

## Thinking Path

The issue reports that setup-wizard provisioning fails invisibly. Item 1 is the
blunt half: **nothing installs the `claude` CLI onto the service PATH.**

`docker/backend/Dockerfile` does it properly — both agent CLIs from official signed
apt repos, with `gh --version && claude --version` at build time so an install
regression fails the build instead of silently breaking LLC dispatch.

The ansible path had nothing. Searching the whole ansible tree for `claude`
returned **zero files**. So on a systemd-deployed node:

- `resolve_cli_binary("claude", ...)` returns `None`
- the agent was already hired successfully — `llc/api/agent_hires.py` validates
  that the adapter type is *registered*, never that it is *available*
- the run surfaces as `SKIPPED`, not as a provisioning error

Which is precisely the invisible-provisioning symptom, and why item 3 (rendering
the skip reason, merged as #14761) was worth doing first: it makes this failure
legible while it exists.

**`gh` is included deliberately.** `copilot_local_adapter._resolve_gh_cli` resolves
it exactly the same way, so installing only `claude` would leave that adapter's
agents equally unrunnable — half-fixing the same defect. The image installs both
together for the same reason.

## What Changed

`autobot-slm-backend/ansible/roles/backend/tasks/main.yml` — the same signed repos
as the image:

- keyring directory, then both signing keys via `get_url` (**not** piped into a
  shell), `dpkg --print-architecture` read for the GitHub source line
- both apt sources written, apt refreshed only when a key or source changed
- `gh` + `claude-code` installed with `install_recommends: false`
- **a resolve check on the host** (`gh --version`, `claude --version`)

`backend_claude_cli_version` (defaults, empty) pins an exact package version,
mirroring the image's existing `CLAUDE_CLI_VERSION` build arg.

The resolve check is the point rather than a nicety: installing without checking
lets a broken PATH look identical to a clean provision, which is the failure mode
this issue is about.

## Verification

I cannot run ansible here, so this is verified structurally and by rendering — not
against a host.

**Jinja compiles and renders**, with Ansible's filters stubbed. I checked this
explicitly because on my previous PR (#14784) I validated files as YAML, which says
nothing about Jinja, and shipped a nested-brace `TemplateSyntaxError` that a
security review caught:

```
compiled 8 new expressions, 0 failures
unpinned -> ['gh', 'claude-code']
pinned   -> ['gh', 'claude-code=2.1.89']
```

The empty pin yields a bare package name rather than a trailing `=`, which would
otherwise be an apt error on every unpinned provision.

**The guard fails on base and passes here:**

```
CONTROL — base (pre-fix) ansible tasks:
  installs claude-code: False   <- must be False
  proves it resolves  : False   <- must be False
control result: PASS — the guard would have failed on base
```

It asserts the *provisioning*, not the resolver: a test over `resolve_cli_binary`
passes whether or not anything ever installs the binary, which is how this stayed
invisible. It contains no `shutil.which` gate anywhere — a test skipped for a
missing binary is indistinguishable from a pass (#14550).

## What this does not fix

**Item 2 — `llc/api/agent_hires.py:365-372` still accepts an unavailable adapter.**
That is deliberate and the ordering matters: today an operator can hire an agent
and hand-install the CLI afterwards. Rejecting the hire while nothing installs the
binary would make provisioning strictly *worse*. This PR is what makes item 2 safe
to land, and item 2 should follow it, not precede it.

Nothing here touches a live host — it changes what a future provision installs.

## Model Used

Claude Opus 5
