### PR TITLE
feat(llc/frontend): filter the canvas by role, team and tool together (#14608)

### DIFF
--- a/autobot-frontend/src/composables/llc/__tests__/orgCanvasFilters.test.ts
+++ b/autobot-frontend/src/composables/llc/__tests__/orgCanvasFilters.test.ts
@@ -1,0 +1,296 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14608: the Company OS canvas's multi-filter — role, team and tool
+// combining with AND. These tests pin the three contracts that matter:
+//
+//  * the axes intersect (removing either one changes the result — otherwise
+//    a test could not tell a real AND from an accidental OR);
+//  * every section keeps the same "org-group passes through untouched"
+//    reasoning `orgRoleLens.ts` already established for role, applied
+//    consistently to the new team and tool axes;
+//  * a value that matches nothing in the current data collapses its own
+//    section to an honest `[]`, never a node the reader would mistake for a
+//    match.
+//
+// Fixtures are built with the real producers (`buildOrgCanvasGraph`,
+// `buildTeamCanvasNodes`, `buildProcessCanvasNodes`, `buildToolCanvasNodes`),
+// not hand-rolled `CanvasNode` objects — so these tests exercise the exact
+// shapes `OrgChart.vue` renders, not an approximation of them.
+
+import { describe, it, expect } from 'vitest'
+import {
+  applyHierarchyFilters,
+  applyTeamSectionFilter,
+  applyProcessToolFilter,
+  applyToolSectionFilter,
+  buildTeamIdsByOrgNodeId,
+  buildToolRoleIndex,
+  teamFilterCounts,
+  toolFilterCounts,
+  hasActiveCanvasFilters,
+  hasCombinedCanvasFilters,
+  type CanvasFilterState,
+} from '../orgCanvasFilters'
+import {
+  buildOrgCanvasGraph,
+  buildTeamCanvasNodes,
+  buildProcessCanvasNodes,
+  buildToolCanvasNodes,
+  flattenOrgNodes,
+  ORG_GROUP_PREFIX,
+  TEAM_GROUP_PREFIX,
+  type ProcessNodeSource,
+  type ToolNodeSource,
+} from '../orgCanvasGraph'
+import { buildOrgPeople } from '../orgPeople'
+import type { CompanyTeam } from '../orgPeople'
+import type { OrgNode } from '@/views/llc/OrgTreeNode.vue'
+
+function orgNode(overrides: Partial<OrgNode> & { id: string; title: string }): OrgNode {
+  return {
+    name: overrides.name ?? overrides.id,
+    status: 'idle',
+    adapter_type: '',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+    ...overrides,
+  }
+}
+
+const unitLabel = (name: string) => `${name} unit`
+const teamLabel = (name: string) => `${name} team`
+
+// ceo unit: ceo (Manager) -> dev (Engineer). Three ungrouped users: Grace and
+// Ivan are both Engineers, on different teams; Hana is a Designer.
+const ROOTS: OrgNode[] = [
+  orgNode({
+    id: 'ceo',
+    title: 'Manager',
+    children: [orgNode({ id: 'dev', title: 'Engineer' })],
+  }),
+  orgNode({ id: 'user:U1', name: 'Grace', title: 'Engineer', is_human: true }),
+  orgNode({ id: 'user:U2', name: 'Hana', title: 'Designer', is_human: true }),
+  orgNode({ id: 'user:U3', name: 'Ivan', title: 'Engineer', is_human: true }),
+]
+
+const TEAMS: CompanyTeam[] = [
+  { id: 't-platform', name: 'Platform', member_user_ids: ['U1'] },
+  { id: 't-design', name: 'Design', member_user_ids: ['U2', 'U3'] },
+]
+
+const TOOLS: ToolNodeSource[] = [
+  { role_id: 'r-eng', role_name: 'Engineer', tool_name: 'web_search' },
+  { role_id: 'r-mgr', role_name: 'Manager', tool_name: 'jira' },
+]
+
+const PROCESSES: ProcessNodeSource[] = [
+  { role_id: 'r-eng', role_name: 'Engineer', workflow_id: 'wf-eng' },
+  { role_id: 'r-mgr', role_name: 'Manager', workflow_id: 'wf-mgr' },
+]
+
+const hierarchyNodes = buildOrgCanvasGraph(ROOTS, unitLabel)
+const people = buildOrgPeople(ROOTS, [])
+const orgNodesById = flattenOrgNodes(ROOTS)
+const teamNodes = buildTeamCanvasNodes(orgNodesById, people, TEAMS, 0, teamLabel, 'No team')
+const processNodes = buildProcessCanvasNodes(PROCESSES, 0)
+const toolNodes = buildToolCanvasNodes(TOOLS, PROCESSES, 0)
+
+const toolRoleIndex = buildToolRoleIndex(TOOLS)
+const ctx = {
+  teamIdsByOrgNodeId: buildTeamIdsByOrgNodeId(people, TEAMS),
+  toolRoleNames: toolRoleIndex.names,
+  toolRoleIds: toolRoleIndex.ids,
+}
+
+function ids(nodes: { id: string }[]): string[] {
+  return nodes.map((n) => n.id)
+}
+
+describe('hasActiveCanvasFilters / hasCombinedCanvasFilters', () => {
+  const none: CanvasFilterState = { role: null, team: null, tool: null }
+
+  it('is false when every axis is null', () => {
+    expect(hasActiveCanvasFilters(none)).toBe(false)
+    expect(hasCombinedCanvasFilters(none)).toBe(false)
+  })
+
+  it('active fires for role alone; combined does not — role is not one of the new axes', () => {
+    const filters = { ...none, role: 'Engineer' }
+    expect(hasActiveCanvasFilters(filters)).toBe(true)
+    expect(hasCombinedCanvasFilters(filters)).toBe(false)
+  })
+
+  it('combined fires for team or tool', () => {
+    expect(hasCombinedCanvasFilters({ ...none, team: 't-design' })).toBe(true)
+    expect(hasCombinedCanvasFilters({ ...none, tool: 'web_search' })).toBe(true)
+  })
+})
+
+describe('applyHierarchyFilters — role, team and tool combine with AND', () => {
+  it('role alone keeps every Engineer plus the unit container', () => {
+    const result = applyHierarchyFilters(hierarchyNodes, { role: 'Engineer', team: null, tool: null }, ctx)
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'dev', 'user:U1', 'user:U3'])
+  })
+
+  it('team alone keeps only that team\'s members plus the unit container', () => {
+    const result = applyHierarchyFilters(hierarchyNodes, { role: null, team: 't-design', tool: null }, ctx)
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'user:U2', 'user:U3'])
+  })
+
+  it('role + team combine to the intersection, not the union', () => {
+    const result = applyHierarchyFilters(
+      hierarchyNodes,
+      { role: 'Engineer', team: 't-design', tool: null },
+      ctx,
+    )
+    // Only Ivan is both an Engineer and on Design — dev (no team) and Grace
+    // (Platform) are each removed by exactly one of the two axes.
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'user:U3'])
+  })
+
+  it('removing the role axis widens the result — proves the axes are independent, not coincidentally equal', () => {
+    const combined = applyHierarchyFilters(
+      hierarchyNodes,
+      { role: 'Engineer', team: 't-design', tool: null },
+      ctx,
+    )
+    const teamOnly = applyHierarchyFilters(hierarchyNodes, { role: null, team: 't-design', tool: null }, ctx)
+    expect(ids(teamOnly)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'user:U2', 'user:U3'])
+    expect(ids(teamOnly).length).toBeGreaterThan(ids(combined).length)
+  })
+
+  it('removing the team axis widens the result the same way', () => {
+    const combined = applyHierarchyFilters(
+      hierarchyNodes,
+      { role: 'Engineer', team: 't-design', tool: null },
+      ctx,
+    )
+    const roleOnly = applyHierarchyFilters(hierarchyNodes, { role: 'Engineer', team: null, tool: null }, ctx)
+    expect(ids(roleOnly)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'dev', 'user:U1', 'user:U3'])
+    expect(ids(roleOnly).length).toBeGreaterThan(ids(combined).length)
+  })
+
+  it('team + tool combine (the two axes this module adds beside role)', () => {
+    const combined = applyHierarchyFilters(
+      hierarchyNodes,
+      { role: null, team: 't-design', tool: 'web_search' },
+      ctx,
+    )
+    // web_search is carried by "Engineer" — only Ivan is both Design and an
+    // Engineer; Hana (Design, Designer) is removed by the tool axis alone.
+    expect(ids(combined)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'user:U3'])
+
+    const toolOnly = applyHierarchyFilters(hierarchyNodes, { role: null, team: null, tool: 'web_search' }, ctx)
+    expect(ids(toolOnly)).toEqual([`${ORG_GROUP_PREFIX}ceo`, 'dev', 'user:U1', 'user:U3'])
+    expect(ids(toolOnly).length).toBeGreaterThan(ids(combined).length)
+  })
+
+  it('a role nobody currently carries empties the org-person set but keeps the unit container', () => {
+    const result = applyHierarchyFilters(hierarchyNodes, { role: 'nonexistent', team: null, tool: null }, ctx)
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`])
+  })
+
+  it('a team id present nowhere in the data empties every org-person, unit container survives', () => {
+    const result = applyHierarchyFilters(hierarchyNodes, { role: null, team: 'nonexistent', tool: null }, ctx)
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`])
+  })
+
+  it('a tool name present nowhere in the data empties every org-person, unit container survives', () => {
+    const result = applyHierarchyFilters(hierarchyNodes, { role: null, team: null, tool: 'nonexistent' }, ctx)
+    expect(ids(result)).toEqual([`${ORG_GROUP_PREFIX}ceo`])
+  })
+
+  it('passes every node through untouched when no axis is active', () => {
+    expect(applyHierarchyFilters(hierarchyNodes, { role: null, team: null, tool: null }, ctx)).toEqual(
+      hierarchyNodes,
+    )
+  })
+})
+
+describe('applyTeamSectionFilter — the team-roster section', () => {
+  it('is untouched when no team is selected', () => {
+    expect(applyTeamSectionFilter(teamNodes, null)).toEqual(teamNodes)
+  })
+
+  it('keeps every team container but only the selected team\'s members — the box is the filtered cue', () => {
+    const result = applyTeamSectionFilter(teamNodes, 't-design')
+
+    const platformBox = result.find((n) => n.id === `${TEAM_GROUP_PREFIX}t-platform`)
+    const designBox = result.find((n) => n.id === `${TEAM_GROUP_PREFIX}t-design`)
+    expect(platformBox).toBeDefined()
+    expect(designBox).toBeDefined()
+
+    const platformMembers = result.filter(
+      (n) => n.type === 'org-person' && n.id.startsWith(`${TEAM_GROUP_PREFIX}t-platform`),
+    )
+    const designMembers = result.filter(
+      (n) => n.type === 'org-person' && n.id.startsWith(`${TEAM_GROUP_PREFIX}t-design`),
+    )
+    expect(platformMembers).toHaveLength(0)
+    expect(designMembers).toHaveLength(2)
+  })
+
+  it('a team id present nowhere in the data leaves every roster empty of members', () => {
+    const result = applyTeamSectionFilter(teamNodes, 'nonexistent')
+    expect(result.filter((n) => n.type === 'org-person')).toHaveLength(0)
+    // Both containers still drawn — never a bare canvas.
+    expect(result.filter((n) => n.type === 'org-group')).toHaveLength(3)
+  })
+})
+
+describe('applyProcessToolFilter — the process grid', () => {
+  it('is untouched when no tool is selected', () => {
+    expect(applyProcessToolFilter(processNodes, null, ctx)).toEqual(processNodes)
+  })
+
+  it("narrows to the steps run by roles that carry the selected tool", () => {
+    const result = applyProcessToolFilter(processNodes, 'web_search', ctx)
+    expect(result.map((n) => (n.data as { role_id: string }).role_id)).toEqual(['r-eng'])
+  })
+
+  it('a tool name present nowhere in the data empties the whole grid — no lone leftover step', () => {
+    expect(applyProcessToolFilter(processNodes, 'nonexistent', ctx)).toEqual([])
+  })
+})
+
+describe('applyToolSectionFilter — the tool grid', () => {
+  it('is untouched when no tool is selected', () => {
+    expect(applyToolSectionFilter(toolNodes, null)).toEqual(toolNodes)
+  })
+
+  it('narrows to the one selected tool node', () => {
+    const result = applyToolSectionFilter(toolNodes, 'web_search')
+    expect(result.map((n) => n.id)).toEqual(['tool:web_search'])
+  })
+
+  it('a tool name present nowhere in the data empties the grid entirely', () => {
+    expect(applyToolSectionFilter(toolNodes, 'nonexistent')).toEqual([])
+  })
+})
+
+describe('teamFilterCounts / toolFilterCounts — mirror roleLensCounts', () => {
+  it('reports every person as shown when no team is selected', () => {
+    expect(teamFilterCounts(hierarchyNodes, null, ctx)).toEqual({ shown: 5, total: 5 })
+  })
+
+  it('counts only the people the selected team carries, against the true total', () => {
+    expect(teamFilterCounts(hierarchyNodes, 't-design', ctx)).toEqual({ shown: 2, total: 5 })
+  })
+
+  it('reports zero shown for a team nothing on the canvas carries', () => {
+    expect(teamFilterCounts(hierarchyNodes, 'nonexistent', ctx)).toEqual({ shown: 0, total: 5 })
+  })
+
+  it('reports every person as shown when no tool is selected', () => {
+    expect(toolFilterCounts(hierarchyNodes, null, ctx)).toEqual({ shown: 5, total: 5 })
+  })
+
+  it('counts only the people whose role carries the selected tool, against the true total', () => {
+    expect(toolFilterCounts(hierarchyNodes, 'web_search', ctx)).toEqual({ shown: 3, total: 5 })
+  })
+})

--- a/autobot-frontend/src/composables/llc/orgCanvasFilters.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasFilters.ts
@@ -1,0 +1,255 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Multi-property filtering for the Company OS canvas (#14608, parent #13935,
+ * extends #13943).
+ *
+ * `orgRoleLens.ts` filters by exactly one property — a person's role. Once
+ * teams (#14596) and tools (#14597) became canvas objects, that stopped
+ * being enough: a reader wants "this team, using this tool" narrowed
+ * together, not one property at a time.
+ *
+ * This module does not replace the role lens — it composes with it.
+ * `applyHierarchyFilters` below calls `applyRoleLens` first, unchanged, and
+ * only then narrows further by team and tool. The role lens's own exported
+ * functions (`applyRoleLens`, `roleLensCounts`, `availableLensRoles`) are
+ * untouched and still used directly by `OrgChart.vue` for the "View As:
+ * role" control — this file adds two new axes beside it, on the same
+ * per-node-type scoping decisions `orgRoleLens.ts` already established:
+ *
+ *   * Role narrows the reporting hierarchy only (`orgRoleLens.ts`'s own,
+ *     unmodified decision) — never the team roster, process grid or tool
+ *     grid, each of which "is a different grouping question" (#14596's own
+ *     comment on `OrgChart.vue`'s `lensedCanvasNodes`).
+ *   * Team narrows the reporting hierarchy (via real membership) *and* the
+ *     team-roster section itself — the roster's own axis is exactly what
+ *     "team" means, unlike role's relationship to it.
+ *   * Tool narrows the reporting hierarchy (a person's title is one of the
+ *     tool's carrying roles), the process grid (a step's `role_id` is one of
+ *     the tool's role ids — the "steps ... using this tool" example the
+ *     issue itself gives) and the tool grid (down to the one selected tool).
+ *
+ * Filters combine with AND: "team X, tool Y" means a person (or step) must
+ * satisfy both, not either — matching how the issue's own example reads
+ * ("owned by this team, using this tool, that are still manual" is a
+ * conjunction in plain English) and how a reader narrows a large map: each
+ * added filter should only ever remove nodes, never bring more back.
+ *
+ * Every filter here is presentation-only, same as the role lens: nothing in
+ * this module fetches, authorises or withholds a response. See
+ * `orgRoleLens.ts`'s module docstring for the fuller justification, which
+ * applies unchanged to team and tool.
+ */
+
+import type { CanvasNode } from '@/components/workflow/canvasNode'
+import { applyRoleLens, nodeTitle } from './orgRoleLens'
+import { teamGroupIdOfMemberNode } from './orgCanvasGraph'
+import type { ToolNodeSource } from './orgCanvasGraph'
+import { groupPeopleByTeam } from './orgPeople'
+import type { CompanyTeam, OrgPerson } from './orgPeople'
+
+/** The multi-filter's current selection. `null` means "no filter on this axis". */
+export interface CanvasFilterState {
+  role: string | null
+  team: string | null
+  tool: string | null
+}
+
+/** True once at least one axis narrows the canvas. */
+export function hasActiveCanvasFilters(filters: CanvasFilterState): boolean {
+  return filters.role !== null || filters.team !== null || filters.tool !== null
+}
+
+/** True once team or tool narrows the canvas — the two axes this module adds. */
+export function hasCombinedCanvasFilters(filters: CanvasFilterState): boolean {
+  return filters.team !== null || filters.tool !== null
+}
+
+/**
+ * Lookups the team and tool predicates need, built once per render from data
+ * `OrgChart.vue` already fetches — never a second request.
+ */
+export interface CanvasFilterContext {
+  /** Every team (or `UNGROUPED_TEAM_ID`) id a reporting-hierarchy person belongs to. */
+  teamIdsByOrgNodeId: ReadonlyMap<string, ReadonlySet<string>>
+  /** Role *names* (== a person's `title`) each tool is carried by. */
+  toolRoleNames: ReadonlyMap<string, ReadonlySet<string>>
+  /** Role *ids* (== a process node's `role_id`) each tool is carried by. */
+  toolRoleIds: ReadonlyMap<string, ReadonlySet<string>>
+}
+
+/**
+ * Every reporting-hierarchy org-chart node id, mapped to the team ids
+ * (`CompanyTeam.id`, or `UNGROUPED_TEAM_ID`) it belongs to.
+ *
+ * Built from `groupPeopleByTeam` — the exact function `buildTeamCanvasNodes`
+ * already groups the roster section by — so the hierarchy's team filter and
+ * the roster it is drawn beside can never disagree about who is on a team.
+ */
+export function buildTeamIdsByOrgNodeId(
+  people: OrgPerson[],
+  teams: CompanyTeam[],
+): Map<string, Set<string>> {
+  const byOrgNodeId = new Map<string, Set<string>>()
+  for (const group of groupPeopleByTeam(people, teams)) {
+    for (const person of group.people) {
+      if (!person.orgNodeId) continue
+      let ids = byOrgNodeId.get(person.orgNodeId)
+      if (!ids) {
+        ids = new Set()
+        byOrgNodeId.set(person.orgNodeId, ids)
+      }
+      ids.add(group.id)
+    }
+  }
+  return byOrgNodeId
+}
+
+/**
+ * Every tool name, mapped to the role names and role ids that carry it —
+ * the same (role, tool) attachment rows `buildToolCanvasNodes` groups, kept
+ * as two indices because the hierarchy only carries a person's `title`
+ * (role *name*) while a process node carries `role_id`.
+ */
+export function buildToolRoleIndex(tools: readonly ToolNodeSource[]): {
+  names: Map<string, Set<string>>
+  ids: Map<string, Set<string>>
+} {
+  const names = new Map<string, Set<string>>()
+  const ids = new Map<string, Set<string>>()
+  for (const row of tools) {
+    let nameSet = names.get(row.tool_name)
+    if (!nameSet) {
+      nameSet = new Set()
+      names.set(row.tool_name, nameSet)
+    }
+    nameSet.add(row.role_name)
+
+    let idSet = ids.get(row.tool_name)
+    if (!idSet) {
+      idSet = new Set()
+      ids.set(row.tool_name, idSet)
+    }
+    idSet.add(row.role_id)
+  }
+  return { names, ids }
+}
+
+/**
+ * Does this `org-person` node belong to `team`?
+ *
+ * A team-roster member node (`teamGroupIdOfMemberNode` recognises its id
+ * shape) carries its team in the id itself, by construction — it is drawn
+ * inside exactly one team's container. A reporting-hierarchy node has no
+ * such id shape and is looked up in `ctx.teamIdsByOrgNodeId` instead.
+ */
+function personMatchesTeam(node: CanvasNode, team: string | null, ctx: CanvasFilterContext): boolean {
+  if (!team) return true
+  const rosterTeam = teamGroupIdOfMemberNode(node.id)
+  if (rosterTeam !== null) return rosterTeam === team
+  return ctx.teamIdsByOrgNodeId.get(node.id)?.has(team) ?? false
+}
+
+/** Does this `org-person` node's role carry `tool`? */
+function personMatchesTool(node: CanvasNode, tool: string | null, ctx: CanvasFilterContext): boolean {
+  if (!tool) return true
+  const roles = ctx.toolRoleNames.get(tool)
+  if (!roles) return false
+  const title = nodeTitle(node)
+  return title !== null && roles.has(title)
+}
+
+/**
+ * The reporting-hierarchy canvas: role, team and tool combine with AND.
+ *
+ * Role is applied first via the unmodified `applyRoleLens` — the role lens
+ * keeps behaving exactly as it did before this module existed. Team and
+ * tool then narrow further, but only ever remove `org-person` nodes: an
+ * `org-group` (unit) container passes through untouched, same reasoning
+ * `applyRoleLens` already documents — the emptied box, not a missing one, is
+ * the "filtered by view" cue (#14064's failure shape).
+ */
+export function applyHierarchyFilters(
+  nodes: CanvasNode[],
+  filters: CanvasFilterState,
+  ctx: CanvasFilterContext,
+): CanvasNode[] {
+  const roleFiltered = applyRoleLens(nodes, filters.role)
+  if (!filters.team && !filters.tool) return roleFiltered
+  return roleFiltered.filter(
+    (node) =>
+      node.type !== 'org-person' ||
+      (personMatchesTeam(node, filters.team, ctx) && personMatchesTool(node, filters.tool, ctx)),
+  )
+}
+
+/**
+ * The team-roster section (#14596): only the team axis touches it, for the
+ * same reason `OrgChart.vue`'s `lensedCanvasNodes` already gives for why the
+ * role lens does not — a roster answers a different question than role or
+ * tool, and a person hidden from it here is still drawn on the
+ * reporting-hierarchy canvas above.
+ */
+export function applyTeamSectionFilter(nodes: CanvasNode[], team: string | null): CanvasNode[] {
+  if (!team) return nodes
+  return nodes.filter((node) => node.type !== 'org-person' || teamGroupIdOfMemberNode(node.id) === team)
+}
+
+/**
+ * The process grid (#13963): a step's tool is read from its own `role_id`,
+ * never re-derived from a person's title — the same id `buildToolCanvasNodes`
+ * already draws its tool -> process edges from, so the filter and the edges
+ * it sits beside can never disagree about which steps a tool touches.
+ *
+ * Role and team are deliberately not applied here: neither a role nor a team
+ * is carried on a process node's own data, and matching by the role *name*
+ * a person happens to display would be a guess this module does not make.
+ */
+export function applyProcessToolFilter(
+  nodes: CanvasNode[],
+  tool: string | null,
+  ctx: CanvasFilterContext,
+): CanvasNode[] {
+  if (!tool) return nodes
+  const roleIds = ctx.toolRoleIds.get(tool)
+  if (!roleIds) return []
+  return nodes.filter((node) => {
+    const data = node.data as Record<string, unknown>
+    return typeof data.role_id === 'string' && roleIds.has(data.role_id)
+  })
+}
+
+/** The tool grid (#14597): narrows to the one selected tool node. */
+export function applyToolSectionFilter(nodes: CanvasNode[], tool: string | null): CanvasNode[] {
+  if (!tool) return nodes
+  return nodes.filter((node) => {
+    const data = node.data as Record<string, unknown>
+    return node.type !== 'org-tool' || data.tool_name === tool
+  })
+}
+
+/** How many hierarchy people carry `team`, out of how many total. Mirrors `roleLensCounts`. */
+export function teamFilterCounts(
+  nodes: CanvasNode[],
+  team: string | null,
+  ctx: CanvasFilterContext,
+): { shown: number; total: number } {
+  const people = nodes.filter((node) => node.type === 'org-person')
+  const total = people.length
+  if (!team) return { shown: total, total }
+  return { shown: people.filter((node) => personMatchesTeam(node, team, ctx)).length, total }
+}
+
+/** How many hierarchy people carry `tool`, out of how many total. Mirrors `roleLensCounts`. */
+export function toolFilterCounts(
+  nodes: CanvasNode[],
+  tool: string | null,
+  ctx: CanvasFilterContext,
+): { shown: number; total: number } {
+  const people = nodes.filter((node) => node.type === 'org-person')
+  const total = people.length
+  if (!tool) return { shown: total, total }
+  return { shown: people.filter((node) => personMatchesTool(node, tool, ctx)).length, total }
+}

--- a/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
+++ b/autobot-frontend/src/composables/llc/orgCanvasGraph.ts
@@ -465,6 +465,24 @@ export function teamMemberOrgNodeId(nodeId: string): string | null {
 }
 
 /**
+ * The team (or `UNGROUPED_TEAM_ID`) id a team-roster canvas node belongs to,
+ * or `null` when `nodeId` does not name one.
+ *
+ * The multi-filter's team predicate (`orgCanvasFilters.ts`, #14608) needs this
+ * for a roster's duplicate `org-person` nodes, which carry no `data` field
+ * naming their team — the id (`teamMemberNodeId`'s `groupId`) is the only
+ * place it lives. A reporting-hierarchy `org-person` has no such id shape and
+ * gets `null`, same as `teamMemberOrgNodeId` above.
+ */
+export function teamGroupIdOfMemberNode(nodeId: string): string | null {
+  if (!nodeId.startsWith(TEAM_GROUP_PREFIX)) return null
+  const at = nodeId.indexOf(TEAM_MEMBER_MARK)
+  if (at < 0) return null
+  const groupId = nodeId.slice(TEAM_GROUP_PREFIX.length, at)
+  return groupId.length > 0 ? groupId : null
+}
+
+/**
  * One team's (or the ungrouped bucket's) people, packed in a grid inside
  * their own container — a team carries no hierarchy, so it lays out like the
  * ungrouped grid above, not like a unit's tree (#13994's same reasoning,

--- a/autobot-frontend/src/composables/llc/orgRoleLens.ts
+++ b/autobot-frontend/src/composables/llc/orgRoleLens.ts
@@ -47,8 +47,14 @@ export function availableLensRoles(roots: OrgNode[]): string[] {
   return [...seen].sort((a, b) => a.localeCompare(b))
 }
 
-/** `data.title` off a canvas node's payload, or `null` when absent/not a string. */
-function nodeTitle(node: CanvasNode): string | null {
+/**
+ * `data.title` off a canvas node's payload, or `null` when absent/not a
+ * string. Exported for `orgCanvasFilters.ts` (#14608): the team/tool filters
+ * that compose with this lens match an `org-person` node's role the same
+ * way — reading it once, here, keeps "what a person's role is" a single
+ * definition instead of a second reader guessing at the same field.
+ */
+export function nodeTitle(node: CanvasNode): string | null {
   const data = node.data as Record<string, unknown>
   return typeof data.title === 'string' ? data.title : null
 }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "فلتر العرض: {role} — يعرض {shown} من {total} عقدة. الوصول لا يتغيّر.",
       "roleLensEmpty": "فلتر العرض: لا توجد عقد مطابقة لـ «{role}» في هذا العرض. الوصول لا يتغيّر — امسح الفلتر لرؤية الجميع.",
       "roleLensClear": "مسح الفلتر",
+      "teamFilterLabel": "تصفية حسب الفريق",
+      "teamFilterAll": "كل الفرق",
+      "teamFilterBanner": "فلتر الفريق: {team} — يعرض {shown} من {total} أشخاص. الوصول لا يتغيّر.",
+      "toolFilterLabel": "تصفية حسب الأداة",
+      "toolFilterAll": "كل الأدوات",
+      "toolFilterBanner": "فلتر الأداة: {tool} — يعرض {shown} من {total} أشخاص. الوصول لا يتغيّر.",
       "sidebar": {
         "owner": "المالك",
         "tools": "الأدوات",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Ansichtsfilter: {role} — zeigt {shown} von {total} Knoten. Der Zugriff bleibt unverändert.",
       "roleLensEmpty": "Ansichtsfilter: Keine Knoten entsprechen „{role}“ in dieser Ansicht. Der Zugriff bleibt unverändert — Filter zurücksetzen, um alle zu sehen.",
       "roleLensClear": "Filter zurücksetzen",
+      "teamFilterLabel": "Nach Team filtern",
+      "teamFilterAll": "Alle Teams",
+      "teamFilterBanner": "Teamfilter: {team} — zeigt {shown} von {total} Personen. Der Zugriff bleibt unverändert.",
+      "toolFilterLabel": "Nach Werkzeug filtern",
+      "toolFilterAll": "Alle Werkzeuge",
+      "toolFilterBanner": "Werkzeugfilter: {tool} — zeigt {shown} von {total} Personen. Der Zugriff bleibt unverändert.",
       "sidebar": {
         "owner": "Inhaber",
         "tools": "Werkzeuge",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8291,6 +8291,12 @@
       "roleLensBanner": "View filter: {role} — showing {shown} of {total} nodes. Access is unchanged.",
       "roleLensEmpty": "View filter: no nodes match \"{role}\" here. Access is unchanged — clear the filter to see everyone.",
       "roleLensClear": "Clear filter",
+      "teamFilterLabel": "Filter by team",
+      "teamFilterAll": "All teams",
+      "teamFilterBanner": "Team filter: {team} — showing {shown} of {total} people. Access is unchanged.",
+      "toolFilterLabel": "Filter by tool",
+      "toolFilterAll": "All tools",
+      "toolFilterBanner": "Tool filter: {tool} — showing {shown} of {total} people. Access is unchanged.",
       "sidebar": {
         "owner": "Owner",
         "tools": "Tools",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Filtro de vista: {role} — mostrando {shown} de {total} nodos. El acceso no cambia.",
       "roleLensEmpty": "Filtro de vista: ningún nodo coincide con «{role}» en esta vista. El acceso no cambia — borra el filtro para ver a todos.",
       "roleLensClear": "Borrar filtro",
+      "teamFilterLabel": "Filtrar por equipo",
+      "teamFilterAll": "Todos los equipos",
+      "teamFilterBanner": "Filtro de equipo: {team} — mostrando {shown} de {total} personas. El acceso no cambia.",
+      "toolFilterLabel": "Filtrar por herramienta",
+      "toolFilterAll": "Todas las herramientas",
+      "toolFilterBanner": "Filtro de herramienta: {tool} — mostrando {shown} de {total} personas. El acceso no cambia.",
       "sidebar": {
         "owner": "Propietario",
         "tools": "Herramientas",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "فیلتر نمایش: {role} — نمایش {shown} از {total} گره. دسترسی بدون تغییر است.",
       "roleLensEmpty": "فیلتر نمایش: هیچ گره‌ای با «{role}» در این نما مطابقت ندارد. دسترسی بدون تغییر است — فیلتر را پاک کنید تا همه را ببینید.",
       "roleLensClear": "پاک کردن فیلتر",
+      "teamFilterLabel": "فیلتر بر اساس تیم",
+      "teamFilterAll": "همه تیم‌ها",
+      "teamFilterBanner": "فیلتر تیم: {team} — نمایش {shown} از {total} نفر. دسترسی بدون تغییر است.",
+      "toolFilterLabel": "فیلتر بر اساس ابزار",
+      "toolFilterAll": "همه ابزارها",
+      "toolFilterBanner": "فیلتر ابزار: {tool} — نمایش {shown} از {total} نفر. دسترسی بدون تغییر است.",
       "sidebar": {
         "owner": "مالک",
         "tools": "ابزارها",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Filtre d'affichage : {role} — affiche {shown} sur {total} nœuds. L'accès reste inchangé.",
       "roleLensEmpty": "Filtre d'affichage : aucun nœud ne correspond à « {role} » dans cette vue. L'accès reste inchangé — effacez le filtre pour tout voir.",
       "roleLensClear": "Effacer le filtre",
+      "teamFilterLabel": "Filtrer par équipe",
+      "teamFilterAll": "Toutes les équipes",
+      "teamFilterBanner": "Filtre d'équipe : {team} — affiche {shown} sur {total} personnes. L'accès reste inchangé.",
+      "toolFilterLabel": "Filtrer par outil",
+      "toolFilterAll": "Tous les outils",
+      "toolFilterBanner": "Filtre d'outil : {tool} — affiche {shown} sur {total} personnes. L'accès reste inchangé.",
       "sidebar": {
         "owner": "Titulaire",
         "tools": "Outils",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "מסנן תצוגה: {role} — מציג {shown} מתוך {total} צמתים. הגישה לא משתנה.",
       "roleLensEmpty": "מסנן תצוגה: אין צמתים התואמים ל-\"{role}\" בתצוגה זו. הגישה לא משתנה — נקה את המסנן כדי לראות את כולם.",
       "roleLensClear": "נקה מסנן",
+      "teamFilterLabel": "סנן לפי צוות",
+      "teamFilterAll": "כל הצוותים",
+      "teamFilterBanner": "מסנן צוות: {team} — מציג {shown} מתוך {total} אנשים. הגישה לא משתנה.",
+      "toolFilterLabel": "סנן לפי כלי",
+      "toolFilterAll": "כל הכלים",
+      "toolFilterBanner": "מסנן כלי: {tool} — מציג {shown} מתוך {total} אנשים. הגישה לא משתנה.",
       "sidebar": {
         "owner": "בעלים",
         "tools": "כלים",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Skata filtrs: {role} — rāda {shown} no {total} mezgliem. Piekļuve nemainās.",
       "roleLensEmpty": "Skata filtrs: nevienam mezglam neatbilst \"{role}\" šajā skatā. Piekļuve nemainās — notīriet filtru, lai redzētu visus.",
       "roleLensClear": "Notīrīt filtru",
+      "teamFilterLabel": "Filtrēt pēc komandas",
+      "teamFilterAll": "Visas komandas",
+      "teamFilterBanner": "Komandas filtrs: {team} — rāda {shown} no {total} cilvēkiem. Piekļuve nemainās.",
+      "toolFilterLabel": "Filtrēt pēc rīka",
+      "toolFilterAll": "Visi rīki",
+      "toolFilterBanner": "Rīka filtrs: {tool} — rāda {shown} no {total} cilvēkiem. Piekļuve nemainās.",
       "sidebar": {
         "owner": "Īpašnieks",
         "tools": "Rīki",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Filtr widoku: {role} — pokazano {shown} z {total} węzłów. Dostęp pozostaje bez zmian.",
       "roleLensEmpty": "Filtr widoku: żaden węzeł nie pasuje do „{role}” w tym widoku. Dostęp pozostaje bez zmian — wyczyść filtr, aby zobaczyć wszystkich.",
       "roleLensClear": "Wyczyść filtr",
+      "teamFilterLabel": "Filtruj według zespołu",
+      "teamFilterAll": "Wszystkie zespoły",
+      "teamFilterBanner": "Filtr zespołu: {team} — pokazano {shown} z {total} osób. Dostęp pozostaje bez zmian.",
+      "toolFilterLabel": "Filtruj według narzędzia",
+      "toolFilterAll": "Wszystkie narzędzia",
+      "toolFilterBanner": "Filtr narzędzia: {tool} — pokazano {shown} z {total} osób. Dostęp pozostaje bez zmian.",
       "sidebar": {
         "owner": "Właściciel",
         "tools": "Narzędzia",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "Filtro de visualização: {role} — mostrando {shown} de {total} nós. O acesso permanece inalterado.",
       "roleLensEmpty": "Filtro de visualização: nenhum nó corresponde a \"{role}\" nesta vista. O acesso permanece inalterado — limpe o filtro para ver todos.",
       "roleLensClear": "Limpar filtro",
+      "teamFilterLabel": "Filtrar por equipa",
+      "teamFilterAll": "Todas as equipas",
+      "teamFilterBanner": "Filtro de equipa: {team} — mostrando {shown} de {total} pessoas. O acesso permanece inalterado.",
+      "toolFilterLabel": "Filtrar por ferramenta",
+      "toolFilterAll": "Todas as ferramentas",
+      "toolFilterBanner": "Filtro de ferramenta: {tool} — mostrando {shown} de {total} pessoas. O acesso permanece inalterado.",
       "sidebar": {
         "owner": "Responsável",
         "tools": "Ferramentas",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8303,6 +8303,12 @@
       "roleLensBanner": "ویو فلٹر: {role} — {total} میں سے {shown} نوڈز دکھائے جا رہے ہیں۔ رسائی تبدیل نہیں ہوتی۔",
       "roleLensEmpty": "ویو فلٹر: اس منظر میں \"{role}\" سے کوئی نوڈ میل نہیں کھاتا۔ رسائی تبدیل نہیں ہوتی — سب کو دیکھنے کے لیے فلٹر صاف کریں۔",
       "roleLensClear": "فلٹر صاف کریں",
+      "teamFilterLabel": "ٹیم کے مطابق فلٹر کریں",
+      "teamFilterAll": "تمام ٹیمیں",
+      "teamFilterBanner": "ٹیم فلٹر: {team} — {total} میں سے {shown} افراد دکھائے جا رہے ہیں۔ رسائی تبدیل نہیں ہوتی۔",
+      "toolFilterLabel": "ٹول کے مطابق فلٹر کریں",
+      "toolFilterAll": "تمام ٹولز",
+      "toolFilterBanner": "ٹول فلٹر: {tool} — {total} میں سے {shown} افراد دکھائے جا رہے ہیں۔ رسائی تبدیل نہیں ہوتی۔",
       "sidebar": {
         "owner": "مالک",
         "tools": "اوزار",

--- a/autobot-frontend/src/views/llc/OrgChart.vue
+++ b/autobot-frontend/src/views/llc/OrgChart.vue
@@ -36,12 +36,24 @@ import {
   buildOrgPeople,
   countByKind,
   groupPeopleByTeam,
+  UNGROUPED_TEAM_ID,
 } from '@/composables/llc/orgPeople'
 import type { CompanyTeam, ContactSource } from '@/composables/llc/orgPeople'
 import ExecutorRollupPanel from '@/components/llc/ExecutorRollupPanel.vue'
 import { buildExecutorRollupMatrix } from '@/composables/llc/executorRollup'
 import type { ExecutorRollupCell, ExecutorRollupMatrix } from '@/composables/llc/executorRollup'
-import { availableLensRoles, applyRoleLens, roleLensCounts } from '@/composables/llc/orgRoleLens'
+import { availableLensRoles, roleLensCounts } from '@/composables/llc/orgRoleLens'
+import type { CanvasFilterState, CanvasFilterContext } from '@/composables/llc/orgCanvasFilters'
+import {
+  applyHierarchyFilters,
+  applyTeamSectionFilter,
+  applyProcessToolFilter,
+  applyToolSectionFilter,
+  buildTeamIdsByOrgNodeId,
+  buildToolRoleIndex,
+  teamFilterCounts,
+  toolFilterCounts,
+} from '@/composables/llc/orgCanvasFilters'
 import { describeApiError } from '@/composables/llc/apiErrorMessage'
 import BaseButton from '@/components/base/BaseButton.vue'
 
@@ -225,6 +237,29 @@ watch(statusById, (statuses) => {
 // reports zero matches instead (see `roleLens.value && lensCounts...` below).
 const roleLens = ref<string>('')
 const availableRoles = computed<string[]>(() => availableLensRoles(tree.value))
+
+// #14608: team and tool filters — the two axes `orgCanvasFilters.ts` adds
+// beside the role lens above. Same '' == "no filter" convention as `roleLens`.
+const teamFilter = ref<string>('')
+const toolFilter = ref<string>('')
+
+/**
+ * Team filter options, drawn from `groupPeopleByTeam` — the exact grouping
+ * `buildTeamCanvasNodes` already renders the roster section from — so the
+ * picker can never offer a bucket the canvas itself would not draw. Reuses
+ * `people.value`/`teams.value` (#13938/#14596), no new fetch.
+ */
+const availableTeamFilters = computed<{ id: string; name: string }[]>(() =>
+  groupPeopleByTeam(people.value, teams.value).map((group) => ({
+    id: group.id,
+    name: group.id === UNGROUPED_TEAM_ID ? t('llc.orgChart.peopleNoTeam') : group.name,
+  })),
+)
+
+/** Tool filter options — distinct tool names, alphabetised, mirroring `availableLensRoles`. */
+const availableToolFilters = computed<string[]>(() =>
+  [...new Set(toolNodes.value.map((row) => row.tool_name))].sort((a, b) => a.localeCompare(b)),
+)
 /**
  * Process nodes, derived rather than stored in `canvasNodes` (#13963).
  *
@@ -279,21 +314,40 @@ const toolCanvasNodes = computed<CanvasNode[]>(() =>
   ),
 )
 
+// #14608: the multi-filter's current selection and the lookups its team/tool
+// predicates need — see `orgCanvasFilters.ts`'s module docstring for why each
+// axis touches the sections it touches.
+const canvasFilters = computed<CanvasFilterState>(() => ({
+  role: roleLens.value || null,
+  team: teamFilter.value || null,
+  tool: toolFilter.value || null,
+}))
+const canvasFilterContext = computed<CanvasFilterContext>(() => {
+  const { names, ids } = buildToolRoleIndex(toolNodes.value)
+  return {
+    teamIdsByOrgNodeId: buildTeamIdsByOrgNodeId(people.value, teams.value),
+    toolRoleNames: names,
+    toolRoleIds: ids,
+  }
+})
+
 const lensedCanvasNodes = computed<CanvasNode[]>(() => [
-  ...applyRoleLens(canvasNodes.value, roleLens.value || null),
-  // Not lensed: the role lens filters *people* by role, and a process is not a
-  // person. Hiding processes when a lens is active would remove them for a
-  // reason that does not apply to them.
-  ...processCanvasNodes.value,
-  // #14596: a team roster is a different grouping question than the role
-  // lens's own filter, and it is never the only place a person is drawn
-  // (they are always still on the reporting-hierarchy canvas too), so it is
-  // left unlensed for the same reason process nodes are.
-  ...teamCanvasNodes.value,
-  // #14597: a tool is not a person either, same reasoning as processes.
-  ...toolCanvasNodes.value,
+  ...applyHierarchyFilters(canvasNodes.value, canvasFilters.value, canvasFilterContext.value),
+  ...applyProcessToolFilter(processCanvasNodes.value, canvasFilters.value.tool, canvasFilterContext.value),
+  ...applyTeamSectionFilter(teamCanvasNodes.value, canvasFilters.value.team),
+  ...applyToolSectionFilter(toolCanvasNodes.value, canvasFilters.value.tool),
 ])
 const lensCounts = computed(() => roleLensCounts(canvasNodes.value, roleLens.value || null))
+const teamLensCounts = computed(() =>
+  teamFilterCounts(canvasNodes.value, teamFilter.value || null, canvasFilterContext.value),
+)
+const toolLensCounts = computed(() =>
+  toolFilterCounts(canvasNodes.value, toolFilter.value || null, canvasFilterContext.value),
+)
+/** The selected team's display name, for the banner copy. */
+const teamFilterName = computed(
+  () => availableTeamFilters.value.find((team) => team.id === teamFilter.value)?.name ?? teamFilter.value,
+)
 
 /**
  * Load the two sources the People list needs beyond the org chart.
@@ -902,6 +956,59 @@ onMounted(() => {
           </select>
         </div>
 
+        <!-- #14608: team filter — same view-filter contract as the role lens
+             above, combining with it rather than replacing it
+             (`orgCanvasFilters.ts`). -->
+        <div
+          v-if="viewMode === 'canvas' && teams.length > 0"
+          class="flex items-center gap-2 pl-3 border-l border-autobot-border"
+          data-testid="team-filter-control"
+        >
+          <label
+            for="org-team-filter"
+            class="text-sm text-autobot-text-secondary"
+            :title="t('llc.orgChart.roleLensHint')"
+          >
+            {{ t('llc.orgChart.teamFilterLabel') }}
+          </label>
+          <select
+            id="org-team-filter"
+            v-model="teamFilter"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="team-filter-select"
+            :aria-label="t('llc.orgChart.teamFilterLabel')"
+          >
+            <option value="">{{ t('llc.orgChart.teamFilterAll') }}</option>
+            <option v-for="team in availableTeamFilters" :key="team.id" :value="team.id">{{ team.name }}</option>
+          </select>
+        </div>
+
+        <!-- #14608: tool filter — narrows the hierarchy, the process grid and
+             the tool grid together (`orgCanvasFilters.ts`). -->
+        <div
+          v-if="viewMode === 'canvas' && availableToolFilters.length > 0"
+          class="flex items-center gap-2 pl-3 border-l border-autobot-border"
+          data-testid="tool-filter-control"
+        >
+          <label
+            for="org-tool-filter"
+            class="text-sm text-autobot-text-secondary"
+            :title="t('llc.orgChart.roleLensHint')"
+          >
+            {{ t('llc.orgChart.toolFilterLabel') }}
+          </label>
+          <select
+            id="org-tool-filter"
+            v-model="toolFilter"
+            class="text-sm rounded-md border border-autobot-border bg-autobot-bg-card px-2 py-1 text-autobot-text-primary"
+            data-testid="tool-filter-select"
+            :aria-label="t('llc.orgChart.toolFilterLabel')"
+          >
+            <option value="">{{ t('llc.orgChart.toolFilterAll') }}</option>
+            <option v-for="tool in availableToolFilters" :key="tool" :value="tool">{{ tool }}</option>
+          </select>
+        </div>
+
         <button
           v-if="companyId"
           class="px-3 py-1.5 rounded-md bg-indigo-600 text-white text-sm hover:bg-indigo-700"
@@ -1193,6 +1300,46 @@ onMounted(() => {
         </button>
       </div>
 
+      <!-- #14608: the team filter's own affordance, alongside the role
+           lens's (both can be visible at once — that IS "several filters
+           combine, and the active set is visible" without opening a menu). -->
+      <div
+        v-if="teamFilter"
+        class="flex items-center justify-between gap-3 border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-sm"
+        role="status"
+        data-testid="team-filter-banner"
+      >
+        <span class="text-autobot-text-primary">
+          {{ t('llc.orgChart.teamFilterBanner', { team: teamFilterName, shown: teamLensCounts.shown, total: teamLensCounts.total }) }}
+        </span>
+        <button
+          class="shrink-0 underline text-autobot-text-secondary hover:text-autobot-text-primary"
+          data-testid="team-filter-clear"
+          @click="teamFilter = ''"
+        >
+          {{ t('llc.orgChart.roleLensClear') }}
+        </button>
+      </div>
+
+      <!-- #14608: the tool filter's own affordance, same pattern. -->
+      <div
+        v-if="toolFilter"
+        class="flex items-center justify-between gap-3 border-b border-autobot-border bg-autobot-bg-secondary px-3 py-2 text-sm"
+        role="status"
+        data-testid="tool-filter-banner"
+      >
+        <span class="text-autobot-text-primary">
+          {{ t('llc.orgChart.toolFilterBanner', { tool: toolFilter, shown: toolLensCounts.shown, total: toolLensCounts.total }) }}
+        </span>
+        <button
+          class="shrink-0 underline text-autobot-text-secondary hover:text-autobot-text-primary"
+          data-testid="tool-filter-clear"
+          @click="toolFilter = ''"
+        >
+          {{ t('llc.orgChart.roleLensClear') }}
+        </button>
+      </div>
+
       <!-- Only when the lens leaves literally nothing — no matching person AND
            no unit container to stand in for one (an ungrouped roster, #13994)
            — is WorkflowCanvas replaced outright: mounting it with an empty
@@ -1201,7 +1348,21 @@ onMounted(() => {
            as "no data" rather than "filtered by view". Whenever at least one
            `org-group` container survives, WorkflowCanvas stays mounted and
            renders that (now person-less) box — the emptied box is itself the
-           "filtered, not missing" cue, so it is the stronger default. -->
+           "filtered, not missing" cue, so it is the stronger default.
+
+           Unchanged from #13943 — this condition still only names `roleLens`.
+           #14608's team and tool axes never need a combined empty-state of
+           their own: both are only ever selectable from a value that already
+           exists in the fetched data (`availableTeamFilters`/
+           `availableToolFilters`), and `applyTeamSectionFilter`/
+           `applyToolSectionFilter` always keep that one team's or tool's own
+           container node — never removing every last node the way role can.
+           So `lensedCanvasNodes.length === 0` is only reachable when team and
+           tool are BOTH inactive, at which point this condition is exactly
+           the single-role lens's original one (proven, not assumed — see
+           `OrgChart.canvasFilters.test.ts`'s team/tool "still shows the …
+           box" tests, which pin that landmark for the new axes the same way
+           #13943 already pinned it for units). -->
       <div
         v-if="roleLens && lensedCanvasNodes.length === 0"
         class="flex-1 flex items-center justify-center text-center px-6 text-sm text-autobot-text-muted"

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
@@ -320,7 +320,6 @@ describe('OrgChart multi-filter (#14608): filtered, never "no data"', () => {
     ])
     // The reporting hierarchy's own unit box also survives, unaffected.
     expect(ids).toContain(`${ORG_GROUP_PREFIX}ceo`)
-    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="role-lens-empty-canvas"]').exists()).toBe(false)
     // Platform has exactly one match (Grace), out of five people company-wide.
     expect(wrapper.get('[data-testid="team-filter-banner"]').text()).toContain('showing 1 of 5')
@@ -338,7 +337,6 @@ describe('OrgChart multi-filter (#14608): filtered, never "no data"', () => {
 
     const ids = canvasNodeIds(wrapper)
     expect(ids).toContain('tool:jira')
-    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
     expect(wrapper.get('[data-testid="tool-filter-banner"]').text()).toContain('jira')
   })
 
@@ -363,9 +361,11 @@ describe('OrgChart multi-filter (#14608): filtered, never "no data"', () => {
     await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
     await flushPromises()
 
-    // Neither empty-canvas message fires — the team's own box is on screen.
+    // The role-lens empty message does NOT fire — the team's own box is on
+    // screen, so the canvas is not empty. This assertion is load-bearing here
+    // precisely because a role lens IS active: break the landmark invariant
+    // and this is one of the tests that reddens.
     expect(wrapper.find('[data-testid="role-lens-empty-canvas"]').exists()).toBe(false)
-    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
     const ids = canvasNodeIds(wrapper)
     // Both containers survive as landmarks — Design (the selected team)
     // and the honest "not in a team" bucket solo1 itself falls into (an

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
@@ -1,0 +1,417 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// #14608: the Company OS canvas filters by exactly one property. These tests
+// pin the multi-filter that composes with the existing "View As: role" lens
+// (#13943) rather than replacing it — role, team and tool combine with AND,
+// the active set is always visible without opening a menu, and an emptied
+// canvas still reads as filtered, never as "no data" (#14064, #13617,
+// #14556's repeat failure shape).
+//
+// `OrgChart.roleLens.test.ts` is re-run unmodified (in the same run this
+// suite is reported alongside) to pin the hard requirement that the
+// single-role lens keeps working exactly as it did before this issue.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
+import en from '@/i18n/locales/en.json'
+
+const get = vi.fn()
+const post = vi.fn()
+const push = vi.fn()
+
+vi.mock('@/plugins/api', () => ({
+  useApiClient: () => ({ get, post }),
+}))
+
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push }),
+  useRoute: () => ({ params: { companyId: 'c1' }, query: {} }),
+}))
+
+const companyRef = ref('c1')
+vi.mock('@/composables/llc/useLlcCompanyContext', () => ({
+  useLlcCompanyContext: () => ({
+    companyId: companyRef,
+    resolveCompanyId: () => Promise.resolve(companyRef.value),
+  }),
+}))
+
+import OrgChart from '../OrgChart.vue'
+import WorkflowCanvas from '@/components/workflow/WorkflowCanvas.vue'
+import { ORG_GROUP_PREFIX, TEAM_GROUP_PREFIX } from '@/composables/llc/orgCanvasGraph'
+
+const USER_ID_1 = '11111111-1111-1111-1111-111111111111'
+const USER_ID_2 = '22222222-2222-2222-2222-222222222222'
+const USER_ID_3 = '33333333-3333-3333-3333-333333333333'
+
+/** ceo unit: ceo (Manager) -> dev (agent, Engineer). Three ungrouped humans:
+ * Grace and Ivan are both Engineers on different teams; Hana is a Designer. */
+const PEOPLE = [
+  {
+    id: 'ceo',
+    name: 'Ada',
+    title: 'Manager',
+    status: 'idle',
+    adapter_type: 'claude',
+    is_human: false,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [
+      {
+        id: 'dev',
+        name: 'Deputy',
+        title: 'Engineer',
+        status: 'idle',
+        adapter_type: 'claude',
+        is_human: false,
+        last_heartbeat: null,
+        budget_spent: 0,
+        budget_total: 0,
+        assigned_item_count: 0,
+        parent_id: 'ceo',
+        children: [],
+      },
+    ],
+  },
+  {
+    id: `user:${USER_ID_1}`,
+    node_id: USER_ID_1,
+    name: 'Grace',
+    title: 'Engineer',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+  {
+    id: `user:${USER_ID_2}`,
+    node_id: USER_ID_2,
+    name: 'Hana',
+    title: 'Designer',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+  {
+    id: `user:${USER_ID_3}`,
+    node_id: USER_ID_3,
+    name: 'Ivan',
+    title: 'Engineer',
+    status: 'idle',
+    adapter_type: 'human',
+    is_human: true,
+    last_heartbeat: null,
+    budget_spent: 0,
+    budget_total: 0,
+    assigned_item_count: 0,
+    parent_id: null,
+    children: [],
+  },
+]
+
+const TEAMS = [
+  { id: 't-platform', name: 'Platform', member_user_ids: [USER_ID_1] },
+  { id: 't-design', name: 'Design', member_user_ids: [USER_ID_2, USER_ID_3] },
+]
+
+const TOOLS = [
+  { role_id: 'r-eng', role_name: 'Engineer', tool_name: 'web_search' },
+  { role_id: 'r-mgr', role_name: 'Manager', tool_name: 'jira' },
+]
+
+const PROCESSES = [
+  { role_id: 'r-eng', role_name: 'Engineer', workflow_id: 'wf-eng' },
+  { role_id: 'r-mgr', role_name: 'Manager', workflow_id: 'wf-mgr' },
+]
+
+interface Fixture {
+  people?: unknown[]
+  teams?: unknown[]
+  tools?: unknown[]
+  processes?: unknown[]
+}
+
+function mockApi({ people = PEOPLE, teams = TEAMS, tools = TOOLS, processes = PROCESSES }: Fixture = {}): void {
+  get.mockImplementation((url: string) => {
+    if (url === '/api/llc/companies/c1/org-chart') return Promise.resolve({ nodes: structuredClone(people) })
+    if (url === '/api/llc/companies/c1/work-items/executor-rollup') return Promise.resolve({ cells: [] })
+    if (url === '/api/llc/companies/c1/process-nodes') return Promise.resolve({ nodes: structuredClone(processes) })
+    if (url === '/api/llc/companies/c1/tool-nodes') return Promise.resolve({ nodes: structuredClone(tools) })
+    if (url === '/api/llc/roles/c1') return Promise.resolve([])
+    if (url === '/api/llc/contacts/c1/involved') return Promise.resolve({ with_role: [], unassigned: [] })
+    if (url === '/api/llc/companies/c1/teams') return Promise.resolve({ teams: structuredClone(teams) })
+    throw new Error(`unexpected GET ${url}`)
+  })
+}
+
+async function mountOnCanvas(fixture?: Fixture) {
+  mockApi(fixture)
+  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+  const wrapper = mount(OrgChart, { global: { plugins: [i18n], stubs: { HireAgentModal: true } } })
+  await flushPromises()
+  await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+function canvasNodeIds(wrapper: Awaited<ReturnType<typeof mountOnCanvas>>): string[] {
+  return wrapper.findComponent(WorkflowCanvas).props('nodes').map((n: { id: string }) => n.id)
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  push.mockReset()
+  post.mockResolvedValue({})
+})
+
+describe('OrgChart multi-filter (#14608): pickers and visibility', () => {
+  it('offers a team filter option per team, plus "all teams"', async () => {
+    const wrapper = await mountOnCanvas()
+    const options = wrapper.findAll('[data-testid="team-filter-select"] option').map((o) => o.text())
+    expect(options).toEqual([
+      en.llc.orgChart.teamFilterAll,
+      'Platform',
+      'Design',
+      en.llc.orgChart.peopleNoTeam,
+    ])
+  })
+
+  it('offers a tool filter option per tool, plus "all tools"', async () => {
+    const wrapper = await mountOnCanvas()
+    const options = wrapper.findAll('[data-testid="tool-filter-select"] option').map((o) => o.text())
+    expect(options).toEqual([en.llc.orgChart.toolFilterAll, 'jira', 'web_search'])
+  })
+
+  it('offers no team/tool controls when the company has neither', async () => {
+    const wrapper = await mountOnCanvas({ teams: [], tools: [] })
+    expect(wrapper.find('[data-testid="team-filter-control"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tool-filter-control"]').exists()).toBe(false)
+  })
+
+  it('shows every active filter banner at once — the set is visible without opening a menu', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="role-lens-select"]').setValue('Engineer')
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+
+    expect(wrapper.get('[data-testid="role-lens-banner"]').text()).toContain('Engineer')
+    expect(wrapper.get('[data-testid="team-filter-banner"]').text()).toContain('Design')
+    expect(wrapper.get('[data-testid="tool-filter-banner"]').text()).toContain('web_search')
+  })
+})
+
+describe('OrgChart multi-filter (#14608): team and tool combine with AND', () => {
+  it('role + team narrow to the intersection — removing either widens the result', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="role-lens-select"]').setValue('Engineer')
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await flushPromises()
+    const combinedIds = canvasNodeIds(wrapper)
+    // Only Ivan is both an Engineer and on Design.
+    expect(combinedIds).toContain(`user:${USER_ID_3}`)
+    expect(combinedIds).not.toContain(`user:${USER_ID_1}`) // Engineer, but Platform
+    expect(combinedIds).not.toContain(`user:${USER_ID_2}`) // Design, but Designer
+    expect(combinedIds).not.toContain('dev') // Engineer, but no team
+
+    // Removing team widens it — Grace and dev (also Engineers) come back.
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('')
+    await flushPromises()
+    const roleOnlyIds = canvasNodeIds(wrapper)
+    expect(roleOnlyIds).toContain(`user:${USER_ID_1}`)
+    expect(roleOnlyIds).toContain('dev')
+    expect(roleOnlyIds.length).toBeGreaterThan(combinedIds.length)
+  })
+
+  it('team + tool narrow to the intersection — removing either widens the result', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+    const combinedIds = canvasNodeIds(wrapper)
+    // web_search is carried by "Engineer" — only Ivan (Design + Engineer).
+    expect(combinedIds).toContain(`user:${USER_ID_3}`)
+    expect(combinedIds).not.toContain(`user:${USER_ID_2}`) // Design, but Designer
+
+    // Removing tool widens it — Hana (Design, any role) comes back.
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('')
+    await flushPromises()
+    const teamOnlyIds = canvasNodeIds(wrapper)
+    expect(teamOnlyIds).toContain(`user:${USER_ID_2}`)
+    expect(teamOnlyIds.length).toBeGreaterThan(combinedIds.length)
+  })
+
+  it('a tool filter also narrows the process grid to the steps that tool touches', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+
+    const ids = canvasNodeIds(wrapper)
+    expect(ids).toContain('process:r-eng:wf-eng')
+    expect(ids).not.toContain('process:r-mgr:wf-mgr')
+  })
+
+  it('a tool filter narrows the tool grid to the one selected tool', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+
+    const ids = canvasNodeIds(wrapper)
+    expect(ids).toContain('tool:web_search')
+    expect(ids).not.toContain('tool:jira')
+  })
+
+  it('never fetches or posts as a result of a team/tool selection — presentation only', async () => {
+    const wrapper = await mountOnCanvas()
+    get.mockClear()
+    post.mockClear()
+
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+    await wrapper.get('[data-testid="team-filter-clear"]').trigger('click')
+    await wrapper.get('[data-testid="tool-filter-clear"]').trigger('click')
+    await flushPromises()
+
+    expect(get).not.toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
+  })
+})
+
+describe('OrgChart multi-filter (#14608): filtered, never "no data"', () => {
+  it('a team matching nobody in the hierarchy still shows the roster box, not a blank canvas', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-platform')
+    await flushPromises()
+
+    // Design's roster container survives, emptied — the box is the cue, same
+    // as the role lens's own unit-container precedent.
+    const ids = canvasNodeIds(wrapper)
+    expect(ids).toContain(`${TEAM_GROUP_PREFIX}t-design`)
+    expect(ids.filter((id) => id.startsWith(`${TEAM_GROUP_PREFIX}t-design`))).toEqual([
+      `${TEAM_GROUP_PREFIX}t-design`,
+    ])
+    // The reporting hierarchy's own unit box also survives, unaffected.
+    expect(ids).toContain(`${ORG_GROUP_PREFIX}ceo`)
+    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="role-lens-empty-canvas"]').exists()).toBe(false)
+    // Platform has exactly one match (Grace), out of five people company-wide.
+    expect(wrapper.get('[data-testid="team-filter-banner"]').text()).toContain('showing 1 of 5')
+  })
+
+  it('a tool matching nobody in the hierarchy still shows the tool\'s own card, not a blank canvas', async () => {
+    // "jira" is carried only by "Manager" — no ungrouped person here holds
+    // it, but ceo (the unit root) does, so narrow the tab to prove the card
+    // survives even when the *unit* itself is filtered elsewhere. Simpler:
+    // assert the card and the banner's zero count together.
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('jira')
+    await flushPromises()
+
+    const ids = canvasNodeIds(wrapper)
+    expect(ids).toContain('tool:jira')
+    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="tool-filter-banner"]').text()).toContain('jira')
+  })
+
+  it('once team joins role, an emptied hierarchy shows the team box, never the role-only empty message', async () => {
+    // A single ungrouped AGENT — an agent can never be a team member (team
+    // membership keys on `users.id`), so combining its own matching role with
+    // ANY team guarantees the hierarchy has zero matches, while the selected
+    // team's own (unrelated, and here also empty) roster box still exists as
+    // a landmark — proving the branch correctly leaves the OLD single-role
+    // path once a second axis is active, rather than misreporting "no data".
+    const solo = [
+      {
+        id: 'solo1', name: 'Solo One', title: 'lead', status: 'idle', adapter_type: 'claude',
+        is_human: false, last_heartbeat: null, budget_spent: 0, budget_total: 0,
+        assigned_item_count: 0, parent_id: null, children: [],
+      },
+    ]
+    const teams = [{ id: 't-design', name: 'Design', member_user_ids: [] }]
+    const wrapper = await mountOnCanvas({ people: solo, teams, tools: [], processes: [] })
+
+    await wrapper.get('[data-testid="role-lens-select"]').setValue('lead')
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await flushPromises()
+
+    // Neither empty-canvas message fires — the team's own box is on screen.
+    expect(wrapper.find('[data-testid="role-lens-empty-canvas"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="canvas-filters-empty"]').exists()).toBe(false)
+    const ids = canvasNodeIds(wrapper)
+    // Both containers survive as landmarks — Design (the selected team)
+    // and the honest "not in a team" bucket solo1 itself falls into (an
+    // agent can never be a real team member) — but no org-person node does.
+    expect(ids.sort()).toEqual([`${TEAM_GROUP_PREFIX}__no_team__`, `${TEAM_GROUP_PREFIX}t-design`].sort())
+    // The role banner still reports its own (role-only) count, unaffected by
+    // team — solo1 matches "lead" on its own.
+    expect(wrapper.get('[data-testid="role-lens-banner"]').text()).toContain('showing 1 of 1')
+  })
+})
+
+describe('OrgChart multi-filter (#14608): clearing restores the full canvas', () => {
+  it('each filter\'s own clear button resets only that axis', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="role-lens-select"]').setValue('Engineer')
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+
+    await wrapper.get('[data-testid="team-filter-clear"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('[data-testid="team-filter-banner"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="role-lens-banner"]').exists()).toBe(true)
+    expect(wrapper.get('[data-testid="tool-filter-banner"]').exists()).toBe(true)
+  })
+
+  it('clearing every filter restores every node', async () => {
+    const wrapper = await mountOnCanvas()
+
+    await wrapper.get('[data-testid="role-lens-select"]').setValue('Engineer')
+    await wrapper.get('[data-testid="team-filter-select"]').setValue('t-design')
+    await wrapper.get('[data-testid="tool-filter-select"]').setValue('web_search')
+    await flushPromises()
+
+    await wrapper.get('[data-testid="role-lens-clear"]').trigger('click')
+    await wrapper.get('[data-testid="team-filter-clear"]').trigger('click')
+    await wrapper.get('[data-testid="tool-filter-clear"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="role-lens-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="team-filter-banner"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tool-filter-banner"]').exists()).toBe(false)
+    const ids = canvasNodeIds(wrapper)
+    expect(ids).toEqual(
+      expect.arrayContaining(['ceo', 'dev', `user:${USER_ID_1}`, `user:${USER_ID_2}`, `user:${USER_ID_3}`]),
+    )
+  })
+})


### PR DESCRIPTION
Closes #14608 · Parent #13935

## Thinking Path

The canvas filtered by exactly one property — the role lens from #13943. That was enough when the canvas held people and reporting units. It stopped being enough once teams (#14596), processes (#13963) and tools (#14597) landed: four kinds of node, one axis to narrow them by.

The issue's own example is a conjunction — *"steps owned by this team, using this tool, that are still manual"* — so filters **AND**. Each added filter only ever narrows, which is what a reader expects and what makes a filter stack predictable.

## What Changed

- `orgCanvasFilters.ts` composes **role + team + tool**. It calls `applyRoleLens` for the role axis rather than reimplementing it, so there is one definition of "what a person's role is".
- `orgRoleLens.ts` is behaviourally untouched — the only change is exporting its existing private `nodeTitle` so the new filters read the field through it instead of a second reader guessing at the same data.
- Per-axis scoping follows the precedent the role lens set: role touches the hierarchy; team narrows the hierarchy and the roster section; tool narrows the hierarchy, the process grid (via `role_id`, the same id the tool→process edges are drawn from) and the tool grid.
- 6 keys across all 11 locales.

**Executor kind was deliberately not added.** The only signal available is `is_human` on `org-person`; process and tool nodes carry no assignee data, so filtering by it would have meant inventing a cross-cutting mapping the data does not support. Named in the issue as a candidate, left out with the reason rather than guessed at.

## The judgement call worth reviewing

A "combined filters found nothing" empty state was built and then **removed as unreachable**. That is the kind of deletion that silently reintroduces #14064's conflation — an emptied canvas reading as "no data" — so I did not take the reasoning on trust.

The claim is that team and tool can never empty the canvas, because both are only selectable from values present in the data, and their section filters always keep the selected team's container or the tool's own node as a landmark. I tested it by breaking that invariant in the composable — making the team filter drop its container too:

```
× keeps every team container but only the selected team's members
× a team id present nowhere in the data leaves every roster empty of members
× a team matching nobody in the hierarchy still shows the roster box, not a blank canvas
× once team joins role, an emptied hierarchy shows the team box, never the role-only empty message
```

Four tests, including exactly the regression that would otherwise have been silent. The invariant is enforced, so the empty-state condition remains byte-identical to #13943's and the removed branch really was dead code.

## Verification

- `vitest run src/components/workflow src/views/llc src/composables/llc` — **60 files, 618 tests, all passed**
- `OrgChart.roleLens.test.ts` — **9 passed, unmodified**, so the existing lens is untouched in behaviour as well as in source
- `vue-tsc` 0 · `check:i18n` 0 · `oxlint -D correctness` 0 · `eslint` 0

Every exported function in the new composable was mutation-proven, as was the `OrgChart.vue` wiring (picker gates, banner counts, clear buttons). I re-derived the landmark mutation above myself rather than accepting the report.

## Model Used

Claude Opus 5 (1M context)
