### PR TITLE
fix(secrets): mirror SLM secret creates and updates to the vault (#14759)

### DIFF
--- a/autobot-slm-backend/api/secrets.py
+++ b/autobot-slm-backend/api/secrets.py
@@ -31,7 +31,11 @@ from services.auth import require_permission
 from services.database import get_db
 from services.encryption import encrypt_data
 from services.hf_token_validator import probe_hf_token
-from services.system_secrets_vault import delete_vault_copy, retrieve_secret
+from services.system_secrets_vault import (
+    delete_vault_copy,
+    mirror_secret_to_vault,
+    retrieve_secret,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/secrets", tags=["secrets"])
@@ -99,6 +103,10 @@ async def create_secret(
     db.add(secret)
     await db.commit()
     await db.refresh(secret)
+
+    # #14759: the delete path already maintained the vault copy; create did not,
+    # so a migrated key edited later served its superseded value to vault readers.
+    await mirror_secret_to_vault(data.key, data.value)
 
     logger.info("System secret created: %s [%s]", data.key, data.category)
     response = SecretResponse.model_validate(secret)
@@ -184,6 +192,11 @@ async def update_secret(
 
     await db.commit()
     await db.refresh(secret)
+
+    # Only when the value moved: a category/description edit leaves the stored
+    # secret untouched, so re-writing the vault copy would be pure churn.
+    if data.value is not None:
+        await mirror_secret_to_vault(key, data.value)
 
     logger.info("System secret updated: %s", key)
     response = SecretResponse.model_validate(secret)

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -117,7 +117,15 @@ async def _find_vault_id_by_name(name: str, *, expected_type: str | None = None)
             # uuid.UUID raises AttributeError on an int/list and TypeError on None,
             # neither of which is a ValueError — a non-string id would otherwise
             # propagate past db.commit() as a 500 from a best-effort lookup.
-            logger.warning("system-secrets-vault: skipping malformed vault entry for name=%s", name)
+            # The name is deliberately NOT logged here: CodeQL traces it from a
+            # secret source into this sink (py/clear-text-logging-sensitive-data).
+            # The entry's type is a label rather than a credential, and it is the
+            # more useful diagnostic anyway — the callers already log which key
+            # the operation was for.
+            logger.warning(
+                "system-secrets-vault: skipping a vault entry with a malformed id (type=%s)",
+                entry.get("type"),
+            )
             continue
     return None
 

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -168,6 +168,61 @@ async def delete_vault_copy(key: str) -> None:
         logger.warning("system-secrets-vault: delete failed key=%s: %s", key, type(exc).__name__)
 
 
+async def mirror_secret_to_vault(key: str, plaintext: str) -> bool:
+    """Keep *key*'s vault copy in step with a create or update (#14759).
+
+    The delete half of this already existed — :func:`delete_vault_copy` runs
+    whenever the legacy row is deleted — but create and update did not mirror at
+    all. A secret migrated to the vault and then edited kept serving its
+    pre-update value to anything reading the vault by name, with no error.
+    Reads from inside the SLM are legacy-first, so the divergence was invisible
+    from here; only an external vault reader saw it, and it saw a plausible
+    value rather than a failure.
+
+    Best-effort, never raises: the legacy row remains the live write path, so a
+    flaky vault must not make a secret un-editable.
+
+    On failure the vault copy is REMOVED rather than left behind. A reader that
+    gets nothing raises or falls back; a reader that gets last week's password
+    proceeds confidently with the wrong credential. Absent is recoverable,
+    stale is not detectable.
+    """
+    if not is_migratable(key):
+        return False
+
+    from user_management.services.vault_client import (
+        VaultClientError,
+        VaultSecretNotFound,
+        is_configured,
+        vault_create,
+        vault_rotate,
+    )
+
+    if not is_configured():
+        return False
+
+    try:
+        vault_id = await _find_vault_id_by_name(key)
+        if vault_id is None:
+            await vault_create(key, _SECRET_TYPE, plaintext)
+            logger.info("system-secrets-vault: created vault copy key=%s", key)
+        else:
+            await vault_rotate(vault_id, plaintext)
+            logger.info("system-secrets-vault: rotated vault copy key=%s", key)
+        return True
+    except (VaultClientError, VaultSecretNotFound) as exc:
+        # Logged at error, not warning: an unmirrored write is the defect this
+        # function exists to close, so it must not read as routine noise.
+        logger.error(
+            "system-secrets-vault: mirror failed key=%s: %s — dropping the vault copy "
+            "so no reader is served the superseded value",
+            key,
+            type(exc).__name__,
+        )
+        await delete_vault_copy(key)
+        return False
+
+
 async def migrate_key_to_vault(session: AsyncSession, key: str) -> bool:
     """Copy one ``system_secrets`` row into the System vault (idempotent).
 

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -85,17 +85,37 @@ async def _legacy_get(session: AsyncSession, key: str) -> str | None:
     return decrypt_data(row.encrypted_value)
 
 
-async def _find_vault_id_by_name(name: str) -> uuid.UUID | None:
-    """Scan the System vault listing for an entry named *name* (no cached id available)."""
+async def _find_vault_entries_by_name(name: str) -> list[dict]:
+    """Every System vault entry named *name* (best-effort, never raises).
+
+    The vault namespace is FLAT and shared: `provider_key_vault` stores LLM
+    provider credentials under plain names like ``OPENAI_API_KEY`` with
+    ``secret_type="api_key"``. A name match alone therefore does not mean the
+    entry is ours, so callers that write must check the type (#14759).
+    """
     from user_management.services.vault_client import VaultClientError, vault_list
 
     try:
         entries = await vault_list()
     except VaultClientError:
-        return None
-    for entry in entries:
-        if entry.get("name") == name:
+        return []
+    return [e for e in entries if e.get("name") == name]
+
+
+async def _find_vault_id_by_name(name: str, *, expected_type: str | None = None) -> uuid.UUID | None:
+    """Id of the entry named *name*, optionally restricted to one secret type.
+
+    A malformed listing row is skipped rather than raised through: this is a
+    best-effort lookup and its callers document themselves as never raising.
+    """
+    for entry in await _find_vault_entries_by_name(name):
+        if expected_type is not None and entry.get("type") != expected_type:
+            continue
+        try:
             return uuid.UUID(entry["id"])
+        except (KeyError, ValueError):
+            logger.warning("system-secrets-vault: skipping malformed vault entry for name=%s", name)
+            continue
     return None
 
 
@@ -124,7 +144,7 @@ async def retrieve_secret(session: AsyncSession, key: str) -> str | None:
     if not is_configured():
         return None
 
-    vault_id = await _find_vault_id_by_name(key)
+    vault_id = await _find_vault_id_by_name(key, expected_type=_SECRET_TYPE)
     if vault_id is None:
         return None
     try:
@@ -156,7 +176,7 @@ async def delete_vault_copy(key: str) -> None:
 
     if not is_configured():
         return
-    vault_id = await _find_vault_id_by_name(key)
+    vault_id = await _find_vault_id_by_name(key, expected_type=_SECRET_TYPE)
     if vault_id is None:
         return
     try:
@@ -201,8 +221,25 @@ async def mirror_secret_to_vault(key: str, plaintext: str) -> bool:
     if not is_configured():
         return False
 
+    entries = await _find_vault_entries_by_name(key)
+    ours = [e for e in entries if e.get("type") == _SECRET_TYPE]
+    if entries and not ours:
+        # The vault namespace is flat and shared. `provider_key_vault` stores
+        # live LLM provider credentials under plain names like OPENAI_API_KEY,
+        # and the SLM secret key is free text, so the names can collide. Taking
+        # the entry over would rotate a credential that belongs to another
+        # subsystem — and its reader treats absence as "no credential" and falls
+        # back to "", so a later failed mirror deleting it would be worse still.
+        logger.error(
+            "system-secrets-vault: refusing to mirror key=%s — a vault entry of type %r "
+            "already owns that name; the copy is left untouched",
+            key,
+            [e.get("type") for e in entries],
+        )
+        return False
+
     try:
-        vault_id = await _find_vault_id_by_name(key)
+        vault_id = await _find_vault_id_by_name(key, expected_type=_SECRET_TYPE)
         if vault_id is None:
             await vault_create(key, _SECRET_TYPE, plaintext)
             logger.info("system-secrets-vault: created vault copy key=%s", key)
@@ -240,7 +277,7 @@ async def migrate_key_to_vault(session: AsyncSession, key: str) -> bool:
     if not is_configured():
         return False
 
-    if await _find_vault_id_by_name(key) is not None:
+    if await _find_vault_id_by_name(key, expected_type=_SECRET_TYPE) is not None:
         logger.info("system-secrets-vault: migrate skip key=%s (already migrated)", key)
         return False
 

--- a/autobot-slm-backend/services/system_secrets_vault.py
+++ b/autobot-slm-backend/services/system_secrets_vault.py
@@ -113,7 +113,10 @@ async def _find_vault_id_by_name(name: str, *, expected_type: str | None = None)
             continue
         try:
             return uuid.UUID(entry["id"])
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, TypeError, AttributeError):
+            # uuid.UUID raises AttributeError on an int/list and TypeError on None,
+            # neither of which is a ValueError — a non-string id would otherwise
+            # propagate past db.commit() as a 500 from a best-effort lookup.
             logger.warning("system-secrets-vault: skipping malformed vault entry for name=%s", name)
             continue
     return None

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -134,6 +134,13 @@ class _FakeVault:
     async def vault_list(self) -> list:
         return list(self.entries.values())
 
+    async def vault_rotate(self, secret_id: uuid.UUID, new_value: str) -> dict:
+        entry = self.entries.get(secret_id)
+        if entry is None:
+            raise _real_vc.VaultSecretNotFound(str(secret_id))
+        entry["value"] = new_value
+        return entry
+
     async def vault_delete(self, secret_id: uuid.UUID) -> None:
         self.entries.pop(secret_id, None)
 
@@ -147,6 +154,7 @@ def fake_vault(monkeypatch):
         monkeypatch.setattr(_real_vc, "vault_create", fv.vault_create)
         monkeypatch.setattr(_real_vc, "vault_read", fv.vault_read)
         monkeypatch.setattr(_real_vc, "vault_list", fv.vault_list)
+        monkeypatch.setattr(_real_vc, "vault_rotate", fv.vault_rotate)
         monkeypatch.setattr(_real_vc, "vault_delete", fv.vault_delete)
         yield fv
 
@@ -332,3 +340,72 @@ class TestNoSecretValueLogged:
             assert value == secret_value
             for record in caplog.records:
                 assert secret_value not in record.getMessage()
+
+
+class TestMirrorSecretToVault:
+    """#14759: create/update never mirrored, so an edited key served a stale value.
+
+    The delete half was already correct, which is what made this easy to miss —
+    someone clearly understood the vault copy needs maintaining and did only one
+    of the three write paths.
+    """
+
+    async def test_create_writes_the_vault_copy(self, fake_vault):
+        with _real_modules_swapped():
+            assert await ssv.mirror_secret_to_vault("hf_token", "first") is True
+            vault_id = await ssv._find_vault_id_by_name("hf_token")
+            assert vault_id is not None
+            assert await _real_vc.vault_read(vault_id) == "first"
+
+    async def test_update_rotates_in_place_rather_than_recreating(self, fake_vault):
+        """The id must survive: a delete+create would break anything holding it."""
+        with _real_modules_swapped():
+            await ssv.mirror_secret_to_vault("hf_token", "first")
+            original_id = await ssv._find_vault_id_by_name("hf_token")
+
+            assert await ssv.mirror_secret_to_vault("hf_token", "second") is True
+
+            assert await ssv._find_vault_id_by_name("hf_token") == original_id
+            assert await _real_vc.vault_read(original_id) == "second"
+            assert len(fake_vault.entries) == 1, "rotation must not leave a second copy"
+
+    async def test_the_stale_value_is_never_left_behind_on_failure(self, fake_vault, monkeypatch):
+        """A failed mirror drops the copy instead of serving the superseded value.
+
+        This is the whole point of the issue: a reader that gets nothing raises
+        or falls back, while a reader handed last week's credential proceeds
+        confidently with the wrong one. Absent is recoverable; stale is not
+        detectable.
+        """
+        with _real_modules_swapped():
+            await ssv.mirror_secret_to_vault("hf_token", "first")
+            assert len(fake_vault.entries) == 1
+
+            async def _boom(secret_id, new_value):
+                raise _real_vc.VaultClientError("vault unreachable")
+
+            monkeypatch.setattr(_real_vc, "vault_rotate", _boom)
+
+            assert await ssv.mirror_secret_to_vault("hf_token", "second") is False
+            assert fake_vault.entries == {}, (
+                "the pre-update value is still readable from the vault — "
+                "this is exactly the stale read #14759 reports"
+            )
+
+    async def test_no_op_when_the_vault_is_not_configured(self, fake_vault):
+        with _real_modules_swapped():
+            fake_vault.configured = False
+            assert await ssv.mirror_secret_to_vault("hf_token", "value") is False
+            assert fake_vault.entries == {}
+
+    async def test_irreducible_key_is_never_mirrored(self, fake_vault):
+        """The auth-bootstrap key gates the vault; mirroring it is a deputy cycle."""
+        with _real_modules_swapped():
+            assert await ssv.mirror_secret_to_vault("autobot_internal_api_key", "v") is False
+            assert fake_vault.entries == {}
+
+    async def test_sso_prefixed_key_is_never_mirrored(self, fake_vault):
+        with _real_modules_swapped():
+            assert await ssv.mirror_secret_to_vault("sso:provider:okta:secret", "v") is False
+            assert fake_vault.entries == {}
+

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -426,9 +426,9 @@ class TestMirrorSecretToVault:
 
             surviving = list(fake_vault.entries.values())
             assert len(surviving) == 1, "refusing to mirror must not add a second entry"
-            assert surviving[0]["value"] == "the-real-provider-key", (
-                "the foreign provider credential was overwritten by an SLM secret"
-            )
+            assert (
+                surviving[0]["value"] == "the-real-provider-key"
+            ), "the foreign provider credential was overwritten by an SLM secret"
             assert surviving[0]["type"] == "api_key"
 
     async def test_delete_never_removes_a_foreign_entry_sharing_the_name(self, fake_vault):
@@ -462,4 +462,3 @@ class TestMirrorSecretToVault:
 
             # Must not raise ValueError out through the create/update path.
             assert await ssv.mirror_secret_to_vault("hf_token", "value") is True
-

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -445,8 +445,12 @@ class TestMirrorSecretToVault:
         """Scoping by type must not stop us maintaining our own copy."""
         with _real_modules_swapped():
             await _real_vc.vault_create("shared_name", "api_key", "foreign")
-            await ssv.mirror_secret_to_vault("shared_name", "ours")  # refused: foreign owns it
-            assert len(fake_vault.entries) == 1
+
+            assert await ssv.mirror_secret_to_vault("shared_name", "ours") is False
+            foreign = [e for e in fake_vault.entries.values() if e["name"] == "shared_name"]
+            assert len(foreign) == 1, "the refused mirror must not add a second entry"
+            assert foreign[0]["value"] == "foreign", "the foreign entry was rotated — type scoping regressed"
+            assert foreign[0]["type"] == "api_key"
 
             # A key we do own rotates normally, unaffected by the foreign entry.
             assert await ssv.mirror_secret_to_vault("hf_token", "first") is True
@@ -462,3 +466,19 @@ class TestMirrorSecretToVault:
 
             # Must not raise ValueError out through the create/update path.
             assert await ssv.mirror_secret_to_vault("hf_token", "value") is True
+
+    async def test_a_non_string_vault_id_does_not_raise(self, fake_vault):
+        """uuid.UUID raises AttributeError on an int and TypeError on None.
+
+        Neither is a ValueError, so a non-string id would propagate out of a
+        best-effort lookup and surface as a 500 after the row had committed.
+        """
+        with _real_modules_swapped():
+            for bad in (None, 12345, ["a", "b"]):
+                fake_vault.entries.clear()
+                fake_vault.entries[uuid.uuid4()] = {
+                    "id": bad,
+                    "name": "hf_token",
+                    "type": "system-secret",
+                }
+                assert await ssv.mirror_secret_to_vault("hf_token", "value") is True

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -408,3 +408,58 @@ class TestMirrorSecretToVault:
         with _real_modules_swapped():
             assert await ssv.mirror_secret_to_vault("sso:provider:okta:secret", "v") is False
             assert fake_vault.entries == {}
+
+    async def test_a_foreign_entry_sharing_the_name_is_never_taken_over(self, fake_vault):
+        """The vault namespace is flat and shared with the provider-key store.
+
+        `provider_key_vault` keeps live LLM credentials under plain names like
+        OPENAI_API_KEY, and the SLM secret key is free text, so the names can
+        collide. Rotating that entry would silently replace another
+        subsystem's credential — and its reader falls back to "" on absence,
+        so deleting it on a later failed mirror would be worse still.
+        """
+        with _real_modules_swapped():
+            await _real_vc.vault_create("OPENAI_API_KEY", "api_key", "the-real-provider-key")
+            assert len(fake_vault.entries) == 1
+
+            assert await ssv.mirror_secret_to_vault("OPENAI_API_KEY", "an-slm-secret") is False
+
+            surviving = list(fake_vault.entries.values())
+            assert len(surviving) == 1, "refusing to mirror must not add a second entry"
+            assert surviving[0]["value"] == "the-real-provider-key", (
+                "the foreign provider credential was overwritten by an SLM secret"
+            )
+            assert surviving[0]["type"] == "api_key"
+
+    async def test_delete_never_removes_a_foreign_entry_sharing_the_name(self, fake_vault):
+        """Deleting an SLM secret must not delete another subsystem's credential."""
+        with _real_modules_swapped():
+            await _real_vc.vault_create("OPENAI_API_KEY", "api_key", "the-real-provider-key")
+
+            await ssv.delete_vault_copy("OPENAI_API_KEY")
+
+            assert len(fake_vault.entries) == 1, "a foreign vault entry was deleted"
+            assert list(fake_vault.entries.values())[0]["value"] == "the-real-provider-key"
+
+    async def test_our_own_entry_is_still_rotated_when_a_foreign_name_exists(self, fake_vault):
+        """Scoping by type must not stop us maintaining our own copy."""
+        with _real_modules_swapped():
+            await _real_vc.vault_create("shared_name", "api_key", "foreign")
+            await ssv.mirror_secret_to_vault("shared_name", "ours")  # refused: foreign owns it
+            assert len(fake_vault.entries) == 1
+
+            # A key we do own rotates normally, unaffected by the foreign entry.
+            assert await ssv.mirror_secret_to_vault("hf_token", "first") is True
+            assert await ssv.mirror_secret_to_vault("hf_token", "second") is True
+            ours = [e for e in fake_vault.entries.values() if e["name"] == "hf_token"]
+            assert len(ours) == 1 and ours[0]["value"] == "second"
+
+    async def test_a_malformed_vault_entry_does_not_raise(self, fake_vault):
+        """The lookup is best-effort; a bad row must be skipped, not propagated."""
+        with _real_modules_swapped():
+            bad_id = uuid.uuid4()
+            fake_vault.entries[bad_id] = {"id": "not-a-uuid", "name": "hf_token", "type": "system-secret"}
+
+            # Must not raise ValueError out through the create/update path.
+            assert await ssv.mirror_secret_to_vault("hf_token", "value") is True
+

--- a/autobot-slm-backend/services/system_secrets_vault_test.py
+++ b/autobot-slm-backend/services/system_secrets_vault_test.py
@@ -408,4 +408,3 @@ class TestMirrorSecretToVault:
         with _real_modules_swapped():
             assert await ssv.mirror_secret_to_vault("sso:provider:okta:secret", "v") is False
             assert fake_vault.entries == {}
-


### PR DESCRIPTION
Closes #14759. Refs #12684.

## Thinking Path

`api/secrets.py` mirrored **deletes** to the canonical System vault and nothing
else:

```
autobot-slm-backend/api/secrets.py:228  DELETE -> delete_vault_copy(key)   ✓
autobot-slm-backend/api/secrets.py:78   create -> no mirror                ✗
autobot-slm-backend/api/secrets.py:161  update -> no rotate                ✗
```

So a secret migrated into the vault and then edited kept serving its **pre-update
value** to anything reading the vault by name.

The delete half being correct is what made this easy to miss. Whoever wrote
`delete_vault_copy` clearly understood the vault copy needs maintaining — one of
the three write paths was simply not done.

It is silent because `retrieve_secret` is **legacy-first**: reads from inside the
SLM keep returning the right value, so nothing local ever disagrees. Only an
external vault reader sees the divergence, and it receives a plausible value
rather than an error.

**This stopped being theoretical today.** Before #14758 landed, the vault was
unreachable on essentially every deployment, so nothing could observe the stale
copy. Now that the root key is provisioned, every edited-after-migration secret
starts serving a stale value to vault readers.

## What Changed

`mirror_secret_to_vault(key, plaintext)` in `services/system_secrets_vault.py`,
called from create and from update.

Three decisions worth stating, because the obvious implementation gets each wrong:

**Best-effort, never raises** — matching `delete_vault_copy`. The legacy row is the
live write path, so a flaky vault must not make a secret un-editable. Failing the
API call would be worse than the bug.

**On failure the vault copy is removed, not left.** Plain best-effort mirroring
would leave the superseded value in place, which is precisely the defect. A reader
that gets nothing raises or falls back; a reader handed last week's credential
proceeds confidently with the wrong one. **Absent is recoverable, stale is not
detectable.** Logged at `error` rather than `warning`, since silence is the thing
being fixed.

**Update rotates in place** rather than delete-then-create, so the secret id
survives for anything holding it, and only fires when the value actually moved — a
category or description edit leaves the stored secret untouched.

No-ops for an unconfigured vault, the irreducible auth-bootstrap key (mirroring it
would be a confused-deputy cycle), and SSO keys that have their own path.

## Verification

The slm test suite is not run here, so the logic was verified against a scratch
replica with a fake vault — never against the repo tree or a live vault:

```
create      : True  -> ['first']
rotate      : True  -> ['second']
id survived : True   entries: 1
on failure  : False -> entries: {}   (stale value dropped)
unconfigured: False  entries: {}
irreducible : False  entries: {}
sso key     : False  entries: {}
```

The failure line is the one that matters: had the copy been left behind, a reader
would still get `second` after an update to `third`.

Ten tests in `system_secrets_vault_test.py`, using the module's existing
`_FakeVault` double (extended with `vault_rotate`, which it did not have because
nothing rotated before). The distinctive one asserts the vault is **empty** after a
failed mirror, with the failure injected by patching `vault_rotate` to raise —
it fails if the copy is left behind, which is the regression worth pinning.

Also covered: rotation keeps a single entry and the same id, so a delete+create
implementation would fail the suite.

## What this does not fix

Not the store consolidation — that is #12684's architecture decision and still
`needs-decision`. This keeps the two copies in step under the *current* dual-store
arrangement, which is correct regardless of which store is eventually chosen as
canonical.

## Model Used

Claude Opus 5

