### PR TITLE
fix(slm-frontend): carry unreachable_roles through the node mapper (#14794)

### DIFF
--- a/autobot-slm-frontend/src/composables/useSlmApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.test.ts
@@ -282,7 +282,8 @@ describe('useSlmApi — migrated onto slmApiClient (#12420 Phase 2 batch 5)', ()
 
       const result = await useSlmApi().getNodes()
 
-      expect(result.nodes[0].unreachable_roles).toEqual(['my-custom-role'])
+      // getNodes returns SLMNode[], not the raw { nodes, total } envelope.
+      expect(result[0]!.unreachable_roles).toEqual(['my-custom-role'])
     })
 
     it('defaults to an empty list when the backend omits the field', async () => {

--- a/autobot-slm-frontend/src/composables/useSlmApi.test.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.test.ts
@@ -240,4 +240,59 @@ describe('useSlmApi — migrated onto slmApiClient (#12420 Phase 2 batch 5)', ()
       await expect(useSlmApi().getSecretValue('K')).resolves.toBeNull()
     })
   })
+
+  describe('unreachable_roles survives the mapper (#14794)', () => {
+    // The field was computed by the backend and read by SetupWizardView, but
+    // mapBackendNode never copied it, so the wizard's warning could not fire.
+    // Both ends were built and only the hop between them was missing, which is
+    // why nothing looked wrong. These drive the real seam rather than the
+    // helper: the previous coverage was backend-only and could not see this.
+    const backendNode = (extra: Record<string, unknown> = {}) => ({
+      id: 1,
+      node_id: 'n1',
+      hostname: 'h1',
+      ip_address: '10.0.0.1',
+      status: 'online',
+      roles: ['my-custom-role'],
+      cpu_percent: 1,
+      memory_percent: 2,
+      disk_percent: 3,
+      last_heartbeat: null,
+      agent_version: null,
+      os_info: null,
+      created_at: 'c',
+      updated_at: 'u',
+      ...extra,
+    })
+
+    it('updateNodeRoles carries unreachable_roles through to the caller', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse(backendNode({ unreachable_roles: ['my-custom-role'] }))
+      )
+
+      const result = await useSlmApi().updateNodeRoles('n1', ['my-custom-role'] as never)
+
+      expect(result.unreachable_roles).toEqual(['my-custom-role'])
+    })
+
+    it('getNodes carries unreachable_roles through the list mapper too', async () => {
+      mockRaw.mockResolvedValue(
+        jsonResponse({ nodes: [backendNode({ unreachable_roles: ['my-custom-role'] })], total: 1 })
+      )
+
+      const result = await useSlmApi().getNodes()
+
+      expect(result.nodes[0].unreachable_roles).toEqual(['my-custom-role'])
+    })
+
+    it('defaults to an empty list when the backend omits the field', async () => {
+      // Consumers iterate it directly, so undefined would throw rather than
+      // simply show nothing.
+      mockRaw.mockResolvedValue(jsonResponse(backendNode()))
+
+      const result = await useSlmApi().updateNodeRoles('n1', [] as never)
+
+      expect(result.unreachable_roles).toEqual([])
+    })
+  })
 })

--- a/autobot-slm-frontend/src/composables/useSlmApi.ts
+++ b/autobot-slm-frontend/src/composables/useSlmApi.ts
@@ -133,6 +133,10 @@ interface BackendNodeResponse {
   auth_method?: string
   code_status?: string
   code_version?: string
+  // #14794: the backend reports roles that reach no deploy path. It was absent
+  // here, so the mapper below silently dropped it and the setup wizard's toast
+  // could never fire — producer and consumer both built, the hop missing.
+  unreachable_roles?: string[]
 }
 
 interface NodesResponse {
@@ -169,6 +173,10 @@ function mapBackendNode(node: BackendNodeResponse): SLMNode {
     updated_at: node.updated_at,
     code_status: (node.code_status as SLMNode['code_status']) || undefined,
     code_version: node.code_version || undefined,
+    // #14794: carry it through. Defaulted so an older backend that does not
+    // send the field yields an empty list rather than undefined, which is what
+    // the consumers iterate.
+    unreachable_roles: node.unreachable_roles ?? [],
   }
 }
 


### PR DESCRIPTION
Closes #14794

## Thinking Path

This is a defect in work I merged, and it slipped past the gate designed to catch exactly this. #14794 was filed at `10:41:53Z` labelled `blocks-merge` and referencing #14684; I merged #14684 at `10:42:38Z`, 45 seconds later, reading a `No open blocks-merge issues reference this PR` result that had been computed on an earlier head before the finding existed. That gate's own header says it exists to close the review-to-merge race. I hit the race by trusting a check result older than the finding.

The defect itself is the shape I find hardest to see: producer and consumer both fully built, and only the hop between them missing. The backend computed `unreachable_roles`, `SetupWizardView` read it, and `mapBackendNode` silently dropped it because it was not declared on `BackendNodeResponse`. Nothing looks wrong at either end.

Verified in base after the merge — `api/nodes.py` 3 occurrences, `useSlmApi.ts` **0**, `SetupWizardView.vue` 1.

## What Changed

- `useSlmApi.ts` — `unreachable_roles` declared on `BackendNodeResponse` and carried through `mapBackendNode`, defaulted to `[]` so an older backend that omits it yields something consumers can iterate rather than `undefined`.

The single-role path in `OrchestrationView` was never affected: `useRoles.assignRole` returns `response.data` directly with no mapper involved. So the surface that worked was the less-used one, and the one I called "the more likely way to assign a role" in the original PR was the inert one.

## Verification

Static analysis of the seam rather than a claim, comparing the declared response fields against what the mapper actually reads:

```
declared on BackendNodeResponse: 21
read by mapBackendNode:          18
unreachable_roles now mapped:    True
updateNodeRoles  routes through mapBackendNode: True
getNodes         routes through mapBackendNode: True
assignRole returns raw response.data (no mapper): True
```

Tests drive the composable, not the helper — that is the gap that let this through, since every test shipped with the feature was backend-only and none crossed the broken seam. Covered: `updateNodeRoles` carries the field, `getNodes` carries it through the list mapper, and an omitted field maps to `[]`.

While checking, the same comparison flagged `id`, `agent_version` and `os_info` as declared-but-unmapped. Those are deliberate: `SLMNode` does not declare them, and the one `os_info` consumer reads a different object. Not filed.

## Model Used

Claude Opus 5
