### PR TITLE
fix(llc/frontend): export the Gantt at display resolution and cull its axis to the viewport (#14767)

### DIFF
--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -32,7 +32,7 @@
             <option value="quarter">{{ $t('llc.gantt.zoomQuarter') }}</option>
           </select>
         </label>
-        <button class="gantt-btn" :disabled="!items.length" @click="exportPng">{{ $t('llc.gantt.exportPng') }}</button>
+        <button class="gantt-btn" data-testid="gantt-export-png" :disabled="!items.length" @click="exportPng">{{ $t('llc.gantt.exportPng') }}</button>
       </div>
     </header>
 
@@ -40,7 +40,7 @@
     <div v-else-if="!projects.length" class="gantt-state">{{ $t('llc.gantt.noProjects') }}</div>
     <div v-else-if="!items.length" class="gantt-state">{{ $t('llc.gantt.noItems') }}</div>
 
-    <div v-else class="gantt-scroll">
+    <div v-else ref="scrollEl" class="gantt-scroll" @scroll.passive="syncViewport">
       <svg
         ref="svgEl"
         class="gantt-svg"
@@ -66,8 +66,8 @@
         <!-- Time axis -->
         <g class="gantt-axis">
           <line
-            v-for="(t, i) in axisTicks"
-            :key="'tick' + i"
+            v-for="t in axisTicks"
+            :key="'tick' + t.ms"
             :x1="LABEL_W + t.x"
             :y1="HEADER_H"
             :x2="LABEL_W + t.x"
@@ -75,8 +75,8 @@
             class="gantt-gridline"
           />
           <text
-            v-for="(t, i) in axisTicks"
-            :key="'lbl' + i"
+            v-for="t in axisTicks"
+            :key="'lbl' + t.ms"
             :x="LABEL_W + t.x + 4"
             :y="HEADER_H - 6"
             class="gantt-axis-label"
@@ -138,7 +138,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useApiClient } from '@/plugins/api'
 import { createLogger } from '@/utils/debugUtils'
@@ -228,6 +228,11 @@ function xForMs(ms: number): number {
   return ((ms - rangeStart.value) / DAY_MS) * pxPerDay.value
 }
 
+/** Inverse of `xForMs`. Kept adjacent to it so the pair cannot drift (#14769). */
+function msForX(x: number): number {
+  return rangeStart.value + (x / pxPerDay.value) * DAY_MS
+}
+
 const chartWidth = computed(() => Math.max(xForMs(rangeEnd.value) + 40, 320))
 const chartHeight = computed(() => Math.max(items.value.length * ROW_H, ROW_H))
 
@@ -280,11 +285,90 @@ const dependencyArrows = computed<string[]>(() => {
   return out
 })
 
+// --- viewport (#14769) ----------------------------------------------------
+/**
+ * Horizontal window of `.gantt-scroll` that is actually on screen.
+ *
+ * `axisTicks` used to emit one tick for the whole data range regardless of
+ * what was visible. At `zoom: 'day'` the step is one day and `pxPerDay` is 40,
+ * so a multi-year range produced thousands of `<line>` + `<text>` pairs — each
+ * with its own `toLocaleDateString` call — nearly all of them scrolled far out
+ * of view.
+ */
+const scrollEl = ref<HTMLElement | null>(null)
+const viewLeft = ref(0)
+const viewWidth = ref(0)
+
+function syncViewport(): void {
+  const el = scrollEl.value
+  if (!el) return
+  viewLeft.value = el.scrollLeft
+  viewWidth.value = el.clientWidth
+}
+
+let viewportObserver: ResizeObserver | null = null
+
+/**
+ * `.gantt-scroll` sits behind `v-else`, so it does not exist until a timeline
+ * has loaded — an `onMounted`-only hookup would observe nothing and leave
+ * `viewWidth` at 0 forever, permanently taking the no-culling fallback.
+ * Watching the ref attaches whenever the element appears and detaches when it
+ * goes away (a project switch re-renders it).
+ */
+watch(scrollEl, (el) => {
+  viewportObserver?.disconnect()
+  viewportObserver = null
+  if (!el) {
+    viewWidth.value = 0
+    return
+  }
+  syncViewport()
+  if (typeof ResizeObserver !== 'undefined') {
+    viewportObserver = new ResizeObserver(syncViewport)
+    viewportObserver.observe(el)
+  }
+})
+
+/**
+ * Suspends culling while a PNG is being produced.
+ *
+ * An export must contain the WHOLE chart, not the slice that happened to be
+ * on screen — culling the ticks and then serialising would silently ship a
+ * PNG missing most of its gridlines and every date label outside the viewport.
+ */
+const exporting = ref(false)
+
+/** One screenful of ticks kept either side, so a scroll is never bare. */
+const TICK_OVERSCAN_PX = 400
+
 // --- axis ticks -----------------------------------------------------------
 const axisTicks = computed(() => {
-  const ticks: { x: number; label: string }[] = []
+  const ticks: { ms: number; x: number; label: string }[] = []
   const step = zoom.value === 'day' ? 1 : zoom.value === 'week' ? 7 : zoom.value === 'month' ? 30 : 91
-  for (let ms = rangeStart.value; ms <= rangeEnd.value; ms += step * DAY_MS) {
+
+  // #14769: cull to the visible window, converted back through `xForMs`'s own
+  // inverse so the two can never disagree about where a millisecond lands.
+  //
+  // The fallback matters more than the fast path: when the viewport has not
+  // been measured yet (before mount, or in a headless environment where
+  // `clientWidth` is 0) we render the FULL range rather than an empty axis.
+  // An unmeasurable viewport must not read as "nothing is visible" — that
+  // failure mode looks identical to a chart with no data.
+  const culling = !exporting.value && viewWidth.value > 0
+  let from = rangeStart.value
+  let to = rangeEnd.value
+  if (culling) {
+    const x0 = viewLeft.value - LABEL_W - TICK_OVERSCAN_PX
+    const x1 = viewLeft.value + viewWidth.value - LABEL_W + TICK_OVERSCAN_PX
+    from = Math.max(rangeStart.value, msForX(x0))
+    to = Math.min(rangeEnd.value, msForX(x1))
+    // Land on the same step lattice the unculled loop walks, so a tick sits at
+    // the same date whether or not culling is on.
+    const stepMs = step * DAY_MS
+    from = rangeStart.value + Math.floor((from - rangeStart.value) / stepMs) * stepMs
+  }
+
+  for (let ms = from; ms <= to; ms += step * DAY_MS) {
     const d = new Date(ms)
     const label =
       zoom.value === 'quarter'
@@ -292,7 +376,7 @@ const axisTicks = computed(() => {
         : zoom.value === 'month'
           ? d.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
           : d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-    ticks.push({ x: xForMs(ms), label })
+    ticks.push({ ms, x: xForMs(ms), label })
   }
   return ticks
 })
@@ -362,34 +446,77 @@ async function onDragEnd() {
 }
 
 // --- PNG export -----------------------------------------------------------
+
+/**
+ * Oversampling applied on top of the display's own pixel ratio.
+ *
+ * #14767: the export used to size its canvas in CSS pixels, so it was 1x —
+ * soft on every retina screen and unusable for print or a slide. Unlike a
+ * raster pipeline there is no source-resolution ceiling to respect here: the
+ * source is vector SVG, so it renders at whatever scale we are willing to pay
+ * for, and the only real limit is the canvas cap below.
+ */
+const EXPORT_OVERSAMPLE = 2
+/** Hard ceiling on either exported dimension — browsers refuse larger canvases. */
+const MAX_EXPORT_PX = 8192
+
+/** The scale an export can actually use for a chart of `w` x `h` CSS px. */
+function exportScale(w: number, h: number): number {
+  const wanted = Math.max(1, window.devicePixelRatio || 1) * EXPORT_OVERSAMPLE
+  // Never below 1x: a wide timeline should export whole and soft rather than
+  // sharp and cropped.
+  return Math.max(1, Math.min(wanted, MAX_EXPORT_PX / w, MAX_EXPORT_PX / h))
+}
+
 async function exportPng() {
   const svg = svgEl.value
   if (!svg) return
+  let url: string | null = null
+  // #14769 culls axis ticks to the visible window. An export must contain the
+  // WHOLE chart, so culling is suspended and Vue given a tick to repaint
+  // before the SVG is serialised — otherwise the PNG would silently ship
+  // missing every gridline and date label outside the viewport.
+  exporting.value = true
   try {
+    await nextTick()
     const xml = new XMLSerializer().serializeToString(svg)
     const blob = new Blob([xml], { type: 'image/svg+xml;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
+    url = URL.createObjectURL(blob)
     const img = new Image()
     await new Promise<void>((resolve, reject) => {
       img.onload = () => resolve()
       img.onerror = () => reject(new Error('SVG render failed'))
-      img.src = url
+      img.src = url as string
     })
+    const cssW = svg.width.baseVal.value
+    const cssH = svg.height.baseVal.value
+    const scale = exportScale(cssW, cssH)
     const canvas = document.createElement('canvas')
-    canvas.width = svg.width.baseVal.value
-    canvas.height = svg.height.baseVal.value
+    canvas.width = Math.round(cssW * scale)
+    canvas.height = Math.round(cssH * scale)
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    ctx.fillStyle = '#ffffff'
-    ctx.fillRect(0, 0, canvas.width, canvas.height)
-    ctx.drawImage(img, 0, 0)
-    URL.revokeObjectURL(url)
+    ctx.scale(scale, scale)
+    // #14767: the backdrop follows the active theme instead of a hardcoded
+    // white, which exported dark-theme chrome onto a light field. Read from
+    // the live element so it tracks whatever theme is applied, and fall back
+    // only if the token resolves to nothing.
+    ctx.fillStyle =
+      getComputedStyle(svg).getPropertyValue('--bg-surface').trim() || '#ffffff'
+    ctx.fillRect(0, 0, cssW, cssH)
+    ctx.drawImage(img, 0, 0, cssW, cssH)
     const link = document.createElement('a')
     link.download = `timeline-${selectedProjectId.value}.png`
     link.href = canvas.toDataURL('image/png')
     link.click()
   } catch (err) {
     logger.error('PNG export failed', err)
+  } finally {
+    // #14767: both of these leaked on the failure path before — the revoke sat
+    // after the `await`, so an `img.onerror` rejection jumped straight to the
+    // catch and the object URL was never released.
+    if (url) URL.revokeObjectURL(url)
+    exporting.value = false
   }
 }
 
@@ -477,6 +604,10 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   window.removeEventListener('mousemove', onDragMove)
   window.removeEventListener('mouseup', onDragEnd)
+  // #14769: the watcher detaches on element change, but a straight unmount
+  // never fires it with `null`, so the observer is released here too.
+  viewportObserver?.disconnect()
+  viewportObserver = null
 })
 </script>
 

--- a/autobot-frontend/src/views/llc/GanttTimelineView.vue
+++ b/autobot-frontend/src/views/llc/GanttTimelineView.vue
@@ -25,7 +25,7 @@
         </label>
         <label class="gantt-field">
           <span class="gantt-field-label">{{ $t('llc.gantt.zoom') }}</span>
-          <select v-model="zoom" class="gantt-select">
+          <select v-model="zoom" data-testid="gantt-zoom" class="gantt-select">
             <option value="day">{{ $t('llc.gantt.zoomDay') }}</option>
             <option value="week">{{ $t('llc.gantt.zoomWeek') }}</option>
             <option value="month">{{ $t('llc.gantt.zoomMonth') }}</option>
@@ -330,6 +330,26 @@ watch(scrollEl, (el) => {
 })
 
 /**
+ * #14799: resync when the pixel-to-date mapping changes without the container
+ * changing size.
+ *
+ * `syncViewport` was driven only by the scroll handler and the
+ * `ResizeObserver`. Changing zoom alters `pxPerDay` — so the SAME `scrollLeft`
+ * now names a different date — but does not resize `.gantt-scroll`, so neither
+ * driver fires and the cached `viewLeft`/`viewWidth` are reinterpreted against
+ * the new scale. Switching project does the same when the DOM node, and with
+ * it `scrollLeft`, survives the change.
+ *
+ * `nextTick` matters: the chart's width changes with zoom, and the browser
+ * clamps `scrollLeft` against the new width as part of that re-layout. Reading
+ * before the repaint would just re-cache the stale value.
+ */
+watch([zoom, selectedProjectId], async () => {
+  await nextTick()
+  syncViewport()
+})
+
+/**
  * Suspends culling while a PNG is being produced.
  *
  * An export must contain the WHOLE chart, not the slice that happened to be
@@ -362,10 +382,23 @@ const axisTicks = computed(() => {
     const x1 = viewLeft.value + viewWidth.value - LABEL_W + TICK_OVERSCAN_PX
     from = Math.max(rangeStart.value, msForX(x0))
     to = Math.min(rangeEnd.value, msForX(x1))
-    // Land on the same step lattice the unculled loop walks, so a tick sits at
-    // the same date whether or not culling is on.
-    const stepMs = step * DAY_MS
-    from = rangeStart.value + Math.floor((from - rangeStart.value) / stepMs) * stepMs
+    // #14799: a window that comes out EMPTY must not render an empty axis.
+    // The `viewWidth > 0` predicate above only covers a viewport that was
+    // never measured; a viewport measured under a *previous* `pxPerDay`
+    // reaches the same outcome by a different route — `msForX` reinterprets
+    // the stale pixel offset against the new scale and can push `from` past
+    // `to`, at which point the loop below runs zero times. Whatever the
+    // cause, "computed an empty window" falls back to the full range, because
+    // an axis with no ticks is indistinguishable from a chart with no data.
+    if (from > to) {
+      from = rangeStart.value
+      to = rangeEnd.value
+    } else {
+      // Land on the same step lattice the unculled loop walks, so a tick sits
+      // at the same date whether or not culling is on.
+      const stepMs = step * DAY_MS
+      from = rangeStart.value + Math.floor((from - rangeStart.value) / stepMs) * stepMs
+    }
   }
 
   for (let ms = from; ms <= to; ms += step * DAY_MS) {

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
@@ -62,10 +62,15 @@ const LONG_TIMELINE = {
   edges: [],
 }
 
+/** A project with nothing scheduled — renders the empty state, not the chart. */
+const EMPTY_TIMELINE = { project_id: 'p2', items: [], edges: [] }
+
 function wireApi() {
   h.api.get.mockImplementation((url: string) => {
-    if (url === '/api/llc/companies/c1/projects') return Promise.resolve([{ id: 'p1', name: 'Proj 1' }])
+    if (url === '/api/llc/companies/c1/projects')
+      return Promise.resolve([{ id: 'p1', name: 'Proj 1' }, { id: 'p2', name: 'Proj 2' }])
     if (url === '/api/llc/projects/p1/timeline') return Promise.resolve(LONG_TIMELINE)
+    if (url === '/api/llc/projects/p2/timeline') return Promise.resolve(EMPTY_TIMELINE)
     return Promise.reject(new Error(`unexpected url ${url}`))
   })
 }
@@ -204,6 +209,56 @@ describe('the axis never renders empty (#14799)', () => {
     const visible = w.findAll('.gantt-axis-label').map((n) => n.text())
     expect(visible).toContain(finalLabel)
     expect(visible.filter((l) => l === finalLabel)).toHaveLength(1)
+  })
+})
+
+describe('viewport bookkeeping is released with the element (#14769)', () => {
+  it('resets the measured width when the scroll container unrenders', async () => {
+    // Switching to a project with nothing scheduled swaps the chart for the
+    // empty state, so `.gantt-scroll` — and the `scrollLeft` cached from the
+    // previous project — goes away. If the measured width survived that, the
+    // next chart would be culled against a viewport belonging to a different
+    // project, which is the stale-mapping failure #14799 records by another
+    // route.
+    const w = await mountView()
+    await setViewport(w, 1000, 4000)
+    expect(w.find('.gantt-scroll').exists()).toBe(true)
+
+    await w.get('select.gantt-select').setValue('p2')
+    await flushPromises()
+    await flushPromises()
+
+    expect(w.find('.gantt-scroll').exists()).toBe(false)
+
+    // Back to a project that has items: the axis must render, which it only
+    // does if the stale measurement was cleared rather than reapplied.
+    await w.get('select.gantt-select').setValue('p1')
+    await flushPromises()
+    await flushPromises()
+
+    expect(tickCount(w)).toBeGreaterThan(0)
+  })
+
+  it('releases the resize observer on unmount', async () => {
+    // The watcher tears the observer down when the element CHANGES, but a
+    // straight unmount never fires it with `null` — so the teardown lives in
+    // `onBeforeUnmount` too. Without it the observer outlives the component
+    // and keeps a detached node reachable.
+    const disconnect = vi.fn()
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = disconnect
+      },
+    )
+    const w = await mountView()
+
+    w.unmount()
+
+    expect(disconnect).toHaveBeenCalled()
+    vi.unstubAllGlobals()
   })
 })
 

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
@@ -150,6 +150,63 @@ describe('axis ticks are culled to the viewport (#14769)', () => {
   })
 })
 
+describe('the axis never renders empty (#14799)', () => {
+  /** Pick a zoom level from the toolbar select. */
+  async function setZoom(w: Awaited<ReturnType<typeof mountView>>, level: string) {
+    await w.get('[data-testid="gantt-zoom"]').setValue(level)
+    await flushPromises()
+  }
+
+  it('still renders ticks after a zoom change while scrolled away from the start', async () => {
+    // The defect: `zoom` was not watched, so `viewLeft`/`viewWidth` kept the
+    // values measured under the PREVIOUS `pxPerDay`. Reinterpreted against a
+    // coarser scale, `from` could overshoot `to` and the loop ran zero times.
+    const w = await mountView()
+    await setViewport(w, 1000, 6000)
+    expect(tickCount(w)).toBeGreaterThan(0)
+
+    await setZoom(w, 'quarter')
+
+    expect(tickCount(w)).toBeGreaterThan(0)
+  })
+
+  it('still renders ticks after zooming in from a scrolled position', async () => {
+    const w = await mountView()
+    await setViewport(w, 1000, 6000)
+
+    await setZoom(w, 'day')
+
+    expect(tickCount(w)).toBeGreaterThan(0)
+  })
+
+  it('falls back to the full range when the computed window comes out empty', async () => {
+    // Belt-and-braces for the same invariant, independent of the resync: an
+    // impossible window (scrolled far past a chart that has since shrunk)
+    // must draw the whole axis rather than nothing.
+    const w = await mountView()
+    await setViewport(w, 1000, 5_000_000)
+
+    expect(tickCount(w)).toBeGreaterThan(0)
+  })
+
+  it('keeps the final tick exactly once when scrolled to the end of the range', async () => {
+    // Every other culling assertion uses scrollLeft 0 or an arbitrary
+    // mid-scroll, so the right-hand boundary was never exercised — the place
+    // an off-by-one drops or duplicates the last tick.
+    const w = await mountView()
+    const allLabels = w.findAll('.gantt-axis-label').map((n) => n.text())
+    const finalLabel = allLabels[allLabels.length - 1]
+
+    const svg = w.get('svg.gantt-svg').element
+    const width = Number(svg.getAttribute('width'))
+    await setViewport(w, 1000, Math.max(0, width - 1000))
+
+    const visible = w.findAll('.gantt-axis-label').map((n) => n.text())
+    expect(visible).toContain(finalLabel)
+    expect(visible.filter((l) => l === finalLabel)).toHaveLength(1)
+  })
+})
+
 describe('PNG export (#14767)', () => {
   const origCreate = URL.createObjectURL
   const origRevoke = URL.revokeObjectURL

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
@@ -164,7 +164,85 @@ describe('PNG export (#14767)', () => {
     URL.createObjectURL = origCreate
     URL.revokeObjectURL = origRevoke
     vi.unstubAllGlobals()
+    // `stubCanvas` spies on `document.createElement`; leaving that installed
+    // would hand the next file's mounts a fake canvas.
+    vi.restoreAllMocks()
   })
+
+  /**
+   * Replace the off-DOM canvas and anchor with inspectable stubs.
+   *
+   * jsdom's `getContext('2d')` returns null without the native `canvas`
+   * package, and the export bails on a null context — so without this the
+   * happy path cannot be reached at all and every assertion below would pass
+   * vacuously. Any other tag falls through to the real implementation, so
+   * Vue's own rendering is untouched.
+   */
+  function stubCanvas() {
+    const ctx = {
+      fillStyle: '',
+      scale: vi.fn(),
+      fillRect: vi.fn(),
+      drawImage: vi.fn(),
+    }
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ctx),
+      toDataURL: vi.fn(() => 'data:image/png;base64,STUB'),
+    }
+    const link = { download: '', href: '', click: vi.fn() }
+    const real = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation(((tag: string) => {
+      if (tag === 'canvas') return canvas as unknown as HTMLCanvasElement
+      if (tag === 'a') return link as unknown as HTMLAnchorElement
+      return real(tag)
+    }) as typeof document.createElement)
+    return { ctx, canvas, link }
+  }
+
+  /** Let the off-DOM `new Image()` resolve, exercising the success path. */
+  function passImageLoad() {
+    vi.stubGlobal(
+      'Image',
+      class {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        set src(_v: string) {
+          setTimeout(() => this.onload?.(), 0)
+        }
+      },
+    )
+  }
+
+  /**
+   * Pin the SVG's reported CSS size.
+   *
+   * jsdom's SVG support does not reliably provide `width.baseVal`, so the
+   * dimensions the export reads are defined outright. This also makes the
+   * scale assertions exact rather than dependent on layout maths that jsdom
+   * would not perform anyway.
+   */
+  function pinSvgSize(w: Awaited<ReturnType<typeof mountView>>, cssW: number, cssH: number) {
+    const svg = w.get('svg.gantt-svg').element
+    Object.defineProperty(svg, 'width', { value: { baseVal: { value: cssW } }, configurable: true })
+    Object.defineProperty(svg, 'height', { value: { baseVal: { value: cssH } }, configurable: true })
+  }
+
+  /** Resolve `--bg-surface` to `value` for the duration of a test. */
+  function stubToken(value: string) {
+    vi.stubGlobal(
+      'getComputedStyle',
+      () => ({ getPropertyValue: () => value }) as unknown as CSSStyleDeclaration,
+    )
+  }
+
+  async function runExport(w: Awaited<ReturnType<typeof mountView>>) {
+    await w.get('[data-testid="gantt-export-png"]').trigger('click')
+    await flushPromises()
+    await new Promise((r) => setTimeout(r, 5))
+    await flushPromises()
+  }
 
   /** Make the off-DOM `new Image()` reject, exercising the failure path. */
   function failImageLoad() {
@@ -186,12 +264,104 @@ describe('PNG export (#14767)', () => {
     failImageLoad()
     const w = await mountView()
 
-    await w.get('[data-testid="gantt-export-png"]').trigger('click')
-    await flushPromises()
-    await new Promise((r) => setTimeout(r, 5))
-    await flushPromises()
+    await runExport(w)
 
     expect(revoked).toContain('blob:gantt-test')
+  })
+
+  it('sizes the canvas by devicePixelRatio rather than exporting at 1x', async () => {
+    // The defect: the canvas was sized in CSS px, so every export was 1x and
+    // soft on any retina screen. With DPR 2 and an oversample of 2 the chart
+    // should come out at 4x its CSS size.
+    vi.stubGlobal('devicePixelRatio', 2)
+    stubToken('#101010')
+    passImageLoad()
+    const { ctx, canvas, link } = stubCanvas()
+    const w = await mountView()
+    pinSvgSize(w, 440, 66)
+
+    await runExport(w)
+
+    expect(canvas.width).toBe(440 * 4)
+    expect(canvas.height).toBe(66 * 4)
+    // The context is scaled to match, so every drawing coordinate below stays
+    // in CSS units — otherwise the chart would be drawn into one quadrant.
+    expect(ctx.scale).toHaveBeenCalledWith(4, 4)
+    expect(ctx.drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 440, 66)
+    expect(link.click).toHaveBeenCalled()
+  })
+
+  it('never scales below 1x, so a very wide chart exports whole rather than cropped', async () => {
+    // The cap exists because browsers refuse canvases past a dimension limit.
+    // Clamping must floor at 1x: a soft complete export beats a sharp
+    // truncated one.
+    vi.stubGlobal('devicePixelRatio', 3)
+    stubToken('#101010')
+    passImageLoad()
+    const { canvas } = stubCanvas()
+    const w = await mountView()
+    pinSvgSize(w, 40000, 66)
+
+    await runExport(w)
+
+    expect(canvas.width).toBe(40000)
+    expect(canvas.height).toBe(66)
+  })
+
+  it('paints the active theme surface, not a hardcoded white', async () => {
+    vi.stubGlobal('devicePixelRatio', 1)
+    stubToken('#123456')
+    passImageLoad()
+    const { ctx } = stubCanvas()
+    const w = await mountView()
+    pinSvgSize(w, 440, 66)
+
+    await runExport(w)
+
+    expect(ctx.fillStyle).toBe('#123456')
+  })
+
+  it('falls back to white when the theme token resolves to nothing', async () => {
+    vi.stubGlobal('devicePixelRatio', 1)
+    stubToken('')
+    passImageLoad()
+    const { ctx } = stubCanvas()
+    const w = await mountView()
+    pinSvgSize(w, 440, 66)
+
+    await runExport(w)
+
+    expect(ctx.fillStyle).toBe('#ffffff')
+  })
+
+  it('serialises the WHOLE axis, not the culled slice', async () => {
+    // The interaction between the two issues in this PR. With culling active,
+    // an export that did not suspend it would ship a PNG missing every
+    // gridline outside the viewport — and both a complete and a gutted export
+    // look identical from the outside, so only a test catches it.
+    vi.stubGlobal('devicePixelRatio', 1)
+    stubToken('#101010')
+    let ticksAtSerialise = -1
+    vi.stubGlobal(
+      'XMLSerializer',
+      class {
+        serializeToString(node: Node) {
+          ticksAtSerialise = (node as Element).querySelectorAll('.gantt-gridline').length
+          return '<svg/>'
+        }
+      },
+    )
+    passImageLoad()
+    stubCanvas()
+    const w = await mountView()
+    const uncounted = tickCount(w)
+    await setViewport(w, 1000)
+    expect(tickCount(w)).toBeLessThan(uncounted)
+    pinSvgSize(w, 440, 66)
+
+    await runExport(w)
+
+    expect(ticksAtSerialise).toBe(uncounted)
   })
 
   it('restores tick culling after a failed export rather than leaving the axis unculled', async () => {
@@ -202,10 +372,7 @@ describe('PNG export (#14767)', () => {
     await setViewport(w, 1000)
     const culled = tickCount(w)
 
-    await w.get('[data-testid="gantt-export-png"]').trigger('click')
-    await flushPromises()
-    await new Promise((r) => setTimeout(r, 5))
-    await flushPromises()
+    await runExport(w)
 
     expect(tickCount(w)).toBe(culled)
   })

--- a/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/GanttTimelineView.rendering.test.ts
@@ -1,0 +1,212 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * Gantt rendering: axis tick culling (#14769) and PNG export fidelity (#14767).
+ *
+ * #14769 — `axisTicks` emitted one `<line>` + `<text>` pair for the WHOLE data
+ *   range regardless of what was on screen. At `zoom: 'day'` the step is one
+ *   day and `pxPerDay` is 40, so a multi-year range produced thousands of
+ *   elements, each carrying its own `toLocaleDateString` call.
+ * #14767 — the export sized its canvas in CSS px (1x, soft on every retina
+ *   screen), leaked its object URL whenever the image failed to load, and
+ *   painted a hardcoded white backdrop under dark-theme chrome.
+ *
+ * The interaction between the two is the interesting part and has its own
+ * test: culling must be SUSPENDED during an export, or the PNG silently ships
+ * without the gridlines and date labels outside the viewport.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/i18n/locales/en.json'
+
+const h = vi.hoisted(() => ({
+  route: { params: {} as Record<string, string>, query: {} as Record<string, string> },
+  router: { replace: vi.fn() },
+  api: { get: vi.fn(), patch: vi.fn() },
+}))
+
+vi.mock('vue-router', () => ({ useRoute: () => h.route, useRouter: () => h.router }))
+vi.mock('@/plugins/api', () => ({ useApiClient: () => h.api }))
+vi.mock('@/composables/useNotificationBus', () => ({
+  useNotificationBus: () => ({ showToast: vi.fn() }),
+}))
+vi.mock('@/utils/debugUtils', () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}))
+
+import GanttTimelineView from '../GanttTimelineView.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
+/** One item spanning two years, so a day-zoom axis would run to ~730 ticks. */
+const LONG_TIMELINE = {
+  project_id: 'p1',
+  items: [
+    {
+      id: 'w1',
+      identifier: 'WI-1',
+      title: 'Long haul',
+      type: 'task',
+      status: 'todo',
+      scheduled_start: '2026-01-01T00:00:00Z',
+      scheduled_end: '2027-12-31T00:00:00Z',
+      started_at: null,
+      completed_at: null,
+      on_critical_path: false,
+    },
+  ],
+  edges: [],
+}
+
+function wireApi() {
+  h.api.get.mockImplementation((url: string) => {
+    if (url === '/api/llc/companies/c1/projects') return Promise.resolve([{ id: 'p1', name: 'Proj 1' }])
+    if (url === '/api/llc/projects/p1/timeline') return Promise.resolve(LONG_TIMELINE)
+    return Promise.reject(new Error(`unexpected url ${url}`))
+  })
+}
+
+async function mountView() {
+  const w = mount(GanttTimelineView, { global: { plugins: [i18n] } })
+  await flushPromises()
+  await flushPromises()
+  return w
+}
+
+/**
+ * Give `.gantt-scroll` a measurable viewport. jsdom reports `clientWidth` as 0
+ * for every element, and the component treats an unmeasured viewport as
+ * "render everything" — so without this a culling test would pass for the
+ * wrong reason.
+ */
+async function setViewport(w: Awaited<ReturnType<typeof mountView>>, width: number, scrollLeft = 0) {
+  const el = w.get('.gantt-scroll').element as HTMLElement
+  // jsdom reports 0 for both and its `scrollLeft` setter does not stick, so
+  // both are defined outright rather than assigned.
+  Object.defineProperty(el, 'clientWidth', { value: width, configurable: true })
+  Object.defineProperty(el, 'scrollLeft', { value: scrollLeft, configurable: true, writable: true })
+  await w.get('.gantt-scroll').trigger('scroll')
+  return el
+}
+
+function tickCount(w: Awaited<ReturnType<typeof mountView>>) {
+  return w.findAll('.gantt-gridline').length
+}
+
+beforeEach(() => {
+  h.route.params = { companyId: 'c1' }
+  h.route.query = {}
+  wireApi()
+})
+
+describe('axis ticks are culled to the viewport (#14769)', () => {
+  it('renders the FULL range when the viewport cannot be measured', async () => {
+    // The fallback, asserted first because it is the dangerous direction: an
+    // unmeasurable viewport must not read as "nothing is visible". A chart
+    // with no axis at all looks identical to a chart with no data.
+    const w = await mountView()
+
+    expect(tickCount(w)).toBeGreaterThan(50)
+  })
+
+  it('renders far fewer ticks once the viewport is known', async () => {
+    const w = await mountView()
+    const uncounted = tickCount(w)
+
+    await setViewport(w, 1000)
+
+    expect(tickCount(w)).toBeLessThan(uncounted)
+    // Bounded by the window, not by the two-year range behind it.
+    expect(tickCount(w)).toBeLessThan(50)
+  })
+
+  it('shows a different slice of the axis after scrolling', async () => {
+    const w = await mountView()
+    await setViewport(w, 1000, 0)
+    const atStart = w.findAll('.gantt-axis-label').map((n) => n.text())
+
+    await setViewport(w, 1000, 6000)
+    const scrolled = w.findAll('.gantt-axis-label').map((n) => n.text())
+
+    expect(scrolled.length).toBeGreaterThan(0)
+    expect(scrolled).not.toEqual(atStart)
+  })
+
+  it('puts a tick on the same date whether or not culling is on', async () => {
+    // Culling snaps its start back onto the step lattice, so a visible tick
+    // must land on a date the unculled axis would also have produced.
+    const w = await mountView()
+    const all = new Set(w.findAll('.gantt-axis-label').map((n) => n.text()))
+
+    await setViewport(w, 1000, 0)
+    const visible = w.findAll('.gantt-axis-label').map((n) => n.text())
+
+    expect(visible.length).toBeGreaterThan(0)
+    expect(visible.every((label) => all.has(label))).toBe(true)
+  })
+})
+
+describe('PNG export (#14767)', () => {
+  const origCreate = URL.createObjectURL
+  const origRevoke = URL.revokeObjectURL
+  let revoked: string[]
+
+  beforeEach(() => {
+    revoked = []
+    URL.createObjectURL = vi.fn(() => 'blob:gantt-test')
+    URL.revokeObjectURL = vi.fn((u: string) => void revoked.push(u))
+  })
+  afterEach(() => {
+    URL.createObjectURL = origCreate
+    URL.revokeObjectURL = origRevoke
+    vi.unstubAllGlobals()
+  })
+
+  /** Make the off-DOM `new Image()` reject, exercising the failure path. */
+  function failImageLoad() {
+    vi.stubGlobal(
+      'Image',
+      class {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        set src(_v: string) {
+          setTimeout(() => this.onerror?.(), 0)
+        }
+      },
+    )
+  }
+
+  it('releases the object URL even when the image fails to load', async () => {
+    // Before #14767 the revoke sat after the `await`, so a rejection jumped
+    // straight to the catch and the blob leaked for the life of the document.
+    failImageLoad()
+    const w = await mountView()
+
+    await w.get('[data-testid="gantt-export-png"]').trigger('click')
+    await flushPromises()
+    await new Promise((r) => setTimeout(r, 5))
+    await flushPromises()
+
+    expect(revoked).toContain('blob:gantt-test')
+  })
+
+  it('restores tick culling after a failed export rather than leaving the axis unculled', async () => {
+    // `exporting` suspends culling; if it were only reset on the happy path a
+    // failed export would silently leave every tick rendered from then on.
+    failImageLoad()
+    const w = await mountView()
+    await setViewport(w, 1000)
+    const culled = tickCount(w)
+
+    await w.get('[data-testid="gantt-export-png"]').trigger('click')
+    await flushPromises()
+    await new Promise((r) => setTimeout(r, 5))
+    await flushPromises()
+
+    expect(tickCount(w)).toBe(culled)
+  })
+})

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
@@ -11,8 +11,9 @@
 // suite is reported alongside) to pin the hard requirement that the
 // single-role lens keeps working exactly as it did before this issue.
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { ref } from 'vue'
 import en from '@/i18n/locales/en.json'
@@ -164,10 +165,31 @@ function mockApi({ people = PEOPLE, teams = TEAMS, tools = TOOLS, processes = PR
   })
 }
 
+/**
+ * #14799-adjacent: every mount is tracked so `afterEach` can tear it down.
+ *
+ * This file mounts the full OrgChart -> WorkflowCanvas tree 15 times and used
+ * to unmount none of them, and no global `enableAutoUnmount` is configured. So
+ * each test ran with every previous test's component tree still live in jsdom
+ * — watchers attached, DOM retained — and the cost grew across the file. It
+ * completes in ~3.4s on a quiet runner and timed out at the 10s per-test limit
+ * on a loaded one, failing on the FIRST test of a describe rather than
+ * anywhere that would point at the cause.
+ *
+ * Unmounting is the fix rather than a longer timeout: a longer timeout would
+ * keep the accumulation and simply raise the load needed to trip it.
+ */
+const mountedWrappers: VueWrapper[] = []
+
+afterEach(() => {
+  while (mountedWrappers.length) mountedWrappers.pop()?.unmount()
+})
+
 async function mountOnCanvas(fixture?: Fixture) {
   mockApi(fixture)
   const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   const wrapper = mount(OrgChart, { global: { plugins: [i18n], stubs: { HireAgentModal: true } } })
+  mountedWrappers.push(wrapper as unknown as VueWrapper)
   await flushPromises()
   await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
   await flushPromises()

--- a/docs/research/_index.md
+++ b/docs/research/_index.md
@@ -18,6 +18,7 @@ Research reports covering hardware integration, system conflicts, and technology
 | [[lean-hardware-model-loading]] | Large-model inference on lean hardware — target architecture and capability audit of `llm_shared/optimization/` (#13030) |
 | [[REDIS_OWNERSHIP_CONFLICT_RESEARCH_REPORT]] | Redis ownership conflict investigation and resolution research |
 | [[visual-operations-blueprint]] | Visual operations blueprint — capability research and Company OS audit; GUI-only adoption decision, canvas already owned, org-chart human branch unreachable (#13935) |
+| [[canvas-grid-rendering-review]] | Canvas and grid rendering review — techniques audit of `WorkflowCanvas`, the LLC Gantt and the graph charts; grid/geometry/edge-index gaps fixed, motion and safe-area gaps open (#14765, #14766, #14767, #14769, #14770, #14771) |
 | [[connector-credential-egress-audit]] | Connector, credential and egress layer audit — 2 live OAuth bugs, 2 fail-open guards, secrets-manager bypass (#13623, #13643) |
 | [[tiered-context-ab-13689]] | Tiered L0–L4 context stack — #5066 A/B result, **corrected**: measured against test doubles, 3 of 5 layers cannot render, flag reverted to off (#13689, #13742, #13866) |
 | [[layered-agent-memory-and-context-offload]] | Layered agent memory + symbolic context offload — tiered L0–L4 stack built but never ran, 2 of 5 layers structurally disconnected, memory plane untenanted (#13685) |

--- a/docs/research/canvas-grid-rendering-review.md
+++ b/docs/research/canvas-grid-rendering-review.md
@@ -1,0 +1,196 @@
+# Canvas & grid rendering review
+
+A review of how AutoBot's grid-based drawing surfaces — the workflow/org node
+canvas, the LLC Gantt, and the graph charts — hold up against established
+techniques for interactive canvas rendering. Prompted by a study of an
+external browser-based isometric grid renderer; that source is not named here
+per the repo convention against external product and author names in docs. The
+techniques below are general and are described on their own terms.
+
+Every finding is filed. Issue links are at the bottom.
+
+---
+
+## The techniques worth measuring against
+
+**Layered caching with version-counter invalidation.** Split the scene into
+layers by how often each changes (static backdrop, static content, the one
+thing currently moving). Rebuild a layer only when a monotonic version counter
+on its data changes. Composite per frame. An idle scene then costs nothing.
+
+**Pan/zoom as a pure transform.** If every world layer lives in one coordinate
+frame, panning and zooming is a transform change plus a composite — no layer is
+ever invalidated by camera movement. This only holds if everything that belongs
+to the world is *inside* that transform, and only chrome is outside it.
+
+**Derive resolution budgets from the worst case, then cap them.** Do not guess
+a supersample factor. Compute it from `max_zoom x devicePixelRatio`, cap it
+against the platform's real limit (canvas dimension ceilings), and write the
+arithmetic into the comment so the number can be re-derived rather than
+cargo-culted.
+
+**Move per-frame work to load time.** Anything expensive and static — blurs,
+silhouettes, resampling — is computed once and reduced to a transformed blit.
+The corollary is that this becomes a load-bearing invariant, and needs a test,
+not a comment asking contributors to respect it.
+
+**Index the lookups on the hot path.** A per-item linear scan inside a
+per-frame or per-drag computation is the classic O(N x M) trap. It is
+invisible at demo scale and dominant at real scale.
+
+**Quantise placement to the grid you draw.** A grid that positions nothing is
+decoration. Snapping makes it load-bearing.
+
+**Infer missing metadata by measurement.** Where generated or third-party
+assets carry no geometry metadata, measure it from the pixels and normalise
+away whatever will not tile — rather than trusting the producer to be
+consistent.
+
+---
+
+## Where AutoBot draws on a grid
+
+| Surface | File | Technique |
+|---|---|---|
+| Workflow / org node canvas | `autobot-frontend/src/components/workflow/WorkflowCanvas.vue` | Absolutely-positioned DOM nodes, SVG bezier edges, CSS-transform pan/zoom, CSS grid background |
+| Shared canvas geometry | `autobot-frontend/src/components/workflow/canvasNode.ts` | Constants SSOT |
+| Org graph host | `autobot-frontend/src/views/llc/OrgChart.vue` | Owns node positions |
+| LLC Gantt | `autobot-frontend/src/views/llc/GanttTimelineView.vue` | Hand-built SVG grid + canvas PNG export |
+| Call / knowledge graphs | `autobot-frontend/src/components/charts/FunctionCallGraph.vue`, `components/knowledge/KnowledgeGraph.vue` | Cytoscape |
+
+`WorkflowCanvas.vue` is the surface these techniques bear on most directly: our
+own grid, our own pan/zoom, our own hit-testing, our own edge geometry.
+
+---
+
+## What we already do as well or better
+
+- **Narrow-dependency invalidation beats a hand-maintained counter.**
+  `OrgChart.vue`'s `layoutKey` is a computed built from an explicit, shallow
+  projection of ids/nesting/labels and deliberately *not* `status`. Because it
+  is derived, no mutation path can forget to bump it — the failure mode a
+  manual version integer always carries. It exists because a status write once
+  rebuilt the graph and discarded every dragged position (#13996).
+
+- **Derived geometry constants, with the failure recorded.**
+  `CANVAS_NODE_PORT_Y = CANVAS_NODE_HEIGHT / 2` is derived rather than written
+  as `50`, because the two were independent literals and changing the height
+  detached every edge from its node while failing no test (#14690).
+
+- **A deliberate chrome boundary.** Pan/zoom is transform-only, and the legend,
+  minimap and instructions block are documented as intentionally outside the
+  transform. Most canvas code does not reason about that line at all.
+
+- **Undo/redo at gesture granularity.** A whole drag is one history entry, not
+  one per pointer tick (#14612).
+
+- **Accessibility and i18n.** Roving tabindex, focus trap/restore, keyboard
+  node movement, every string through `$t`. A canvas-only surface has none of
+  this for free.
+
+- **Interaction test coverage.** 20+ test files for `WorkflowCanvas` alone.
+
+---
+
+## What was missing, and is now fixed
+
+**The grid was chrome, not world content** (#14765). It was painted on
+`.canvas-area` — the fixed viewport — while the pan/zoom transform lived on its
+child `.canvas-content`. At 2x zoom the squares stayed 20 screen px while every
+node doubled, and panning slid nodes across a stationary backdrop. The file
+already reasoned about that boundary correctly for the legend and minimap; the
+grid was grouped with them by accident. Now bound to `zoom`/`pan`.
+
+**Nothing snapped to the grid we drew** (#14768). Positions were arbitrary
+floats. `CANVAS_GRID_SIZE` is now the single definition behind the CSS
+background, the drag snap, and the keyboard step. Two decisions worth
+recording:
+
+- A drop snaps *both* axes, including one the pointer did not move. Exempting
+  an unmoved axis leaves nodes half-aligned indefinitely.
+- Keyboard is deliberately not symmetric: an arrow press aligns to the
+  *adjacent* gridline and leaves the idle axis alone. `snap(position + step)`
+  overshoots the line it was reaching for.
+
+**Node width was defined in CSS and predicted in TypeScript** (#14726). Four
+functions guessed at a value only the CSS actually set. `nodeStyle()` now
+supplies it from the constant.
+
+**Edge targets were resolved by scanning** (#14766). `connections` ran
+`props.nodes.find(...)` per edge — O(N x E) on the drag hot path, where a
+pointer tick triggers a position write which re-triggers the computed. Now
+indexed, first-wins so a duplicate id resolves exactly as `find` did.
+
+**The Gantt export was 1x, leaked its blob URL, and hardcoded white** (#14767).
+Now scaled from `devicePixelRatio` with a canvas-dimension cap, revoked in a
+`finally`, and painted with the active theme's surface token.
+
+**Gantt axis ticks ignored the viewport** (#14769). One tick per step across
+the whole range; at day zoom over a multi-year range, thousands of SVG elements
+each with a `toLocaleDateString` call. Now culled to the visible window — with
+the fallback that an *unmeasurable* viewport renders the full range, because an
+empty axis is indistinguishable from a chart with no data.
+
+---
+
+## Still open
+
+**JS-driven motion ignores `prefers-reduced-motion`** (#14770). The CSS side is
+global — a universal kill switch in `assets/base.css`. A media query cannot
+reach motion a script starts: smooth scroll fires on every route navigation,
+and both graph components run their layout with `animate: true`. A force layout
+animating to equilibrium on every load is the largest piece of uncontrolled
+motion in the app, and it fires for the users who asked for less of it.
+
+**No safe-area inset handling anywhere** (#14771). Zero occurrences across the
+frontend, and the viewport meta lacks `viewport-fit=cover` — while 123 files
+carry breakpoint logic, a dedicated touch control exists, and the canvas has a
+full pinch/long-press gesture stack. Bottom-anchored fixed chrome sits under
+the home indicator; toasts are the sharpest case.
+
+---
+
+## Considered and rejected
+
+**Splitting static from moving during a drag.** Only edges incident to the
+dragged nodes change, so a static/live split would cut per-move cost. It also
+means two code paths producing edge geometry that must agree — precisely the
+drift failure `CANVAS_NODE_PORT_Y` exists to prevent. Deferred until a profile
+taken *after* #14766 shows the pressure is still there.
+
+**rAF-coalescing pointer moves.** Would cap work at the refresh rate rather
+than the pointer rate. But the gesture logic reads the live event per tick, and
+the semantics of several fixes are encoded in *when* the threshold checks fire;
+deferring the emit without deferring the bookkeeping would resurrect those
+bugs. Coalesce the emit only, if at all.
+
+**Per-material interaction feedback.** Not a fit for this product. The
+transferable half — debounce per channel rather than globally — is only worth
+revisiting if canvas actions ever flood the toast bus.
+
+---
+
+## Not gaps
+
+Recorded so the same ground is not re-searched: determinate progress
+(`ProgressBar.vue` with percentages, skeletons across 16 components), CSS-side
+reduced-motion, theming with a reactive `prefers-color-scheme` listener, i18n
+across 11 locales, and offline/permission degradation paths. These are all
+places our surfaces are ahead of the general pattern, not behind it.
+
+---
+
+## Issues
+
+| # | Status |
+|---|---|
+| #14765 grid does not pan or zoom with the graph | closed |
+| #14768 grid drawn but nothing snaps to it | closed |
+| #14726 node size in CSS and in the test's own math | closed |
+| #13961 literal colours bypassing theme tokens | closed |
+| #14103 order-dependent RTL pan assertion | closed |
+| #14766 edge targets resolved by an O(N) scan | closed |
+| #14767 PNG export is 1x, leaks its blob URL, hardcodes white | open |
+| #14769 axis ticks generated for the whole range | open |
+| #14770 JS-driven motion ignores `prefers-reduced-motion` | open |
+| #14771 no safe-area inset handling | open |


### PR DESCRIPTION
Closes #14767, #14769

PR 3 of 5 from the canvas review. Both issues are in `GanttTimelineView.vue`
and they interact, which is the main thing to look at.

## Thinking Path

They arrived as separate findings — one a bug in the PNG export, one a
performance gap in the axis — and they would have been separate PRs if they
did not collide. They do:

**#14769 culls axis ticks to the visible window. #14767 serialises the SVG to
produce a PNG.** Implemented independently, the export would silently ship a
chart missing every gridline and date label outside the viewport — a *worse*
defect than the 1x resolution being fixed, and one nothing would have caught,
because a soft-but-complete PNG and a sharp-but-gutted PNG both look like "an
export happened". So culling is suspended for the duration of an export, with
a `nextTick()` so Vue repaints before serialisation, and restored in the
`finally`. There is a test for the restore specifically: if `exporting` were
only reset on the happy path, one failed export would leave the axis unculled
for the rest of the session.

**The culling fallback matters more than the fast path.** When the viewport
cannot be measured — before mount, or in any headless environment where
`clientWidth` is 0 — the axis renders its FULL range rather than nothing. An
unmeasurable viewport must not read as "nothing is visible": a chart with no
axis is indistinguishable from a chart with no data, which is the same
conflation #14064 records for this view's empty state.

Three smaller decisions:

- `msForX()` is written as the explicit inverse of `xForMs()` and kept
  adjacent to it, so the pair cannot drift about where a millisecond lands.
- Culling snaps its start back onto the step lattice, so a tick sits on the
  same date whether or not culling is active. Without that, scrolling would
  slide the whole axis onto different dates.
- The tick `v-for` was keyed by array index. Under culling, index 0 is no
  longer always `rangeStart`, so ticks now carry and are keyed by their `ms`.

`.gantt-scroll` sits behind `v-else` and does not exist until a timeline has
loaded, so the `ResizeObserver` is attached from a `watch` on the ref rather
than `onMounted` — an `onMounted`-only hookup would observe nothing, leave
`viewWidth` at 0, and permanently take the no-culling fallback while appearing
to work.

## What Changed

**Export (#14767)** — three defects in one function:

| Was | Now |
|---|---|
| Canvas sized in CSS px, i.e. 1x | `devicePixelRatio x 2`, floored at 1x, capped so neither dimension exceeds 8192 |
| `revokeObjectURL` after the `await` — leaked whenever `img.onerror` fired | `finally` |
| `ctx.fillStyle = '#ffffff'` | `--bg-surface` read from the live element, so it follows the active theme |

The scale never drops below 1x: a very wide timeline should export whole and
soft rather than sharp and cropped. Unlike a raster pipeline there is no
source-resolution ceiling to respect — the source is vector SVG — so the only
limit is the canvas cap.

**Axis (#14769)** — viewport state (`scrollEl`, `viewLeft`, `viewWidth`), a
`ResizeObserver` attached via `watch`, `msForX()`, and culling with a 400px
overscan either side. Observer released on unmount as well as on element
change.

**Docs** — `docs/research/canvas-grid-rendering-review.md` plus its `_index`
row. This is the review all ten issues in this series came from, written as an
AutoBot-facing techniques audit. It carries no external product, repository or
author name, per the repo convention.

## Verification

New `GanttTimelineView.rendering.test.ts`:

- **Fallback asserted first**, because it is the dangerous direction — an
  unmeasured viewport renders the full range, not an empty axis.
- Culled tick count is bounded by the window, not the two-year range behind it.
- Scrolling shows a different slice.
- Every visible label also appears in the unculled axis — the lattice-alignment
  check.
- The object URL is released **on the failure path**, driven by stubbing
  `Image` to reject rather than by asserting the happy path.
- Tick culling is restored after a *failed* export.

The tests defeat two ways they could pass for the wrong reason: jsdom reports
`clientWidth` as 0 and its `scrollLeft` setter does not stick, so both are
defined outright — otherwise a culling assertion would pass because the
fallback rendered everything, which is the opposite of what it claims to check.

Not run locally, per the project rule that CI verifies correctness.

## Model Used

Claude Opus 5 (1M context)

## Not in scope

#12707 (no empty state) and #14064 (a load failure rendering as a legitimately
empty board) also live in this file, but they are error/empty-state concerns
spanning board *and* timeline, and #12707 proposes a shared component. They
pair with each other, not with rendering geometry.
