### PR TITLE
fix(ci): break shard ties on bucket count so a thin durations file cannot collapse (#14802)

### DIFF
--- a/repo_tests/stable_shard.py
+++ b/repo_tests/stable_shard.py
@@ -92,11 +92,19 @@ def build_bucket_table(weights: Dict[str, int], splits: int, buckets: int) -> Li
         bucket_weight[bucket_of(module, buckets)] += weight
 
     shard_load = [0] * splits
+    # Bucket counts break the tie that load alone cannot. A zero-weight bucket
+    # adds nothing to `shard_load`, so without this the same lowest-index shard
+    # wins every subsequent tie and every weightless bucket piles onto it — with
+    # an empty durations file all 512 buckets land on shard 0, and the remaining
+    # shards become unreachable by any file that could ever be added, not merely
+    # empty today (#14802).
+    shard_buckets = [0] * splits
     table = [0] * buckets
     for bucket in sorted(range(buckets), key=lambda b: (-bucket_weight[b], b)):
-        target = min(range(splits), key=lambda s: (shard_load[s], s))
+        target = min(range(splits), key=lambda s: (shard_load[s], shard_buckets[s], s))
         table[bucket] = target
         shard_load[target] += bucket_weight[bucket]
+        shard_buckets[target] += 1
     return table
 
 

--- a/repo_tests/stable_shard_test.py
+++ b/repo_tests/stable_shard_test.py
@@ -180,7 +180,42 @@ class TestDurationsFileHandling:
         assert load_module_weights(tmp_path / "nope.json") == {}
         table = build_bucket_table({}, SPLITS, DEFAULT_BUCKETS)
         assert len(table) == DEFAULT_BUCKETS
-        assert set(table) <= set(range(SPLITS))
+        # `<=` was the original assertion and it holds when ONE shard is used,
+        # so the degenerate case read as covered while being untested (#14802).
+        assert set(table) == set(range(SPLITS)), (
+            "every shard must receive buckets even with no durations data; "
+            "otherwise the unused shards collect nothing and the work lands on one"
+        )
+
+    @pytest.mark.parametrize(
+        "weights",
+        [
+            pytest.param({}, id="no-durations"),
+            pytest.param({"autobot-slm-backend/only_test.py": 100}, id="one-module"),
+            pytest.param({f"pkg/m{i}_test.py": 10 * (i + 1) for i in range(5)}, id="five-modules"),
+        ],
+    )
+    def test_every_shard_is_reachable_however_thin_the_durations(self, weights):
+        """A thin durations file must not make most shards unreachable.
+
+        Zero-weight buckets do not move `shard_load`, so a load-only tie-break
+        hands every one of them to the same lowest-index shard. The shards after
+        it then receive nothing — and stay unreachable by any file that could
+        later be added, since the mapping is by hash. #14648 is what activates
+        this algorithm in CI, and the SLM step's exit-5 tolerance would turn the
+        resulting empty shards into green rather than red.
+        """
+        table = build_bucket_table(weights, SPLITS, DEFAULT_BUCKETS)
+        assert set(table) == set(range(SPLITS)), f"only {len(set(table))} of {SPLITS} shards received buckets"
+
+    def test_a_thin_durations_file_does_not_strand_future_modules(self):
+        """The collapse is structural: unused shards can never be reached again."""
+        table = build_bucket_table({"autobot-slm-backend/only_test.py": 100}, SPLITS, DEFAULT_BUCKETS)
+        landed = {shard_of(f"future/mod{i}_test.py", table, DEFAULT_BUCKETS) for i in range(5000)}
+        assert landed == set(range(SPLITS)), (
+            f"5000 hypothetical new modules reached only shards {sorted(landed)} — "
+            "the rest cannot be reached by any file that could be added"
+        )
 
     def test_a_corrupt_durations_file_does_not_raise(self, tmp_path):
         bad = tmp_path / "bad.json"


### PR DESCRIPTION
Closes #14802. Blocks-fix for #14648.

## Thinking Path

`build_bucket_table` assigns buckets to shards by greedy longest-processing-time:

```python
target = min(range(splits), key=lambda s: (shard_load[s], s))
table[bucket] = target
shard_load[target] += bucket_weight[bucket]
```

A **zero-weight** bucket adds nothing to `shard_load`. So once a shard holds the
minimum load it keeps winning the tie, and every weightless bucket after it lands on
that same shard. The shards past it receive nothing.

Reproduced against a standalone reimplementation of the published algorithm, not by
running repo code:

| durations input | shards used, before | after |
|---|---|---|
| empty / missing | **1 of 12** | 12 of 12 |
| one module | **2 of 12** | 12 of 12 |
| five modules | **6 of 12** | 12 of 12 |
| realistic, ~1282 modules | 12 of 12 | 12 of 12 |

The important part is that it is **structural, not transient**. Assignment is by
hash, so a shard that receives no bucket cannot be reached by any file added later
either. Under the one-module case, 5000 hypothetical new modules hashed into shards
`[0, 1]` only.

## Why it was invisible

The committed `.test_durations` describes ~1282 modules, so all twelve shards are
used and the spread is fine. The collapse needs a missing, empty, truncated or very
thin durations file — and those are committed by hand from a workflow artifact, with
no non-degeneracy check before commit.

The existing test looked like it covered this:

```python
assert set(table) <= set(range(SPLITS))
```

`<=` is satisfied when **one** shard of twelve is used. The degenerate case read as
covered while being untested.

## Why it matters now

#14648 is what activates this algorithm in CI. Its SLM step tolerates pytest's
exit 5 (`no tests collected`) and returns 0 — written for the legitimate "fewer
modules than shards" case. Combined with a collapse, eleven of twelve SLM shards
would each exit 0 with a `::notice::`, one shard would silently run the whole suite,
and the aggregator would report that every shard passed.

That is worse than the exit-5 redness this repo has already been bitten by: it turns
the failure green instead of red.

It is also a regression against the old behaviour — `pytest-split` degrades to
equal-count contiguous chunks across all groups when durations are missing.

## What Changed

Tie-break on a per-shard bucket count as well as load, incremented unconditionally,
so weightless buckets round-robin instead of piling up.

## Verification

Each new test run against both algorithms:

```
no-durations   OLD: FAIL (1/12)    NEW: PASS (12/12)
one-module     OLD: FAIL (2/12)    NEW: PASS (12/12)
five-modules   OLD: FAIL (6/12)    NEW: PASS (12/12)
future modules OLD: FAIL (reached [0, 1])   NEW: PASS (reached all 12)
realistic      OLD: spread 1.001x  NEW: spread 1.001x   (unchanged)
```

Every one fails against the old tie-break, so none of them is decorative, and the
realistic distribution is untouched — this fixes the degenerate case without
perturbing the balanced one.

## Model Used

Claude Opus 5
