### PR TITLE
feat(events): multi-client session synchronization, replay, and an ACP agent surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ repeated here; where the two disagree, **this file wins**.
 | Closing an issue | [`CLAUDE_CLOSURE.md`](docs/developer/CLAUDE_CLOSURE.md) |
 | Running parallel agents or a batch | [`CLAUDE_BATCH.md`](docs/developer/CLAUDE_BATCH.md) |
 | Need a service, port, or architecture fact | [`AUTOBOT_REFERENCE.md`](docs/developer/AUTOBOT_REFERENCE.md) |
+| Adding an event type, WebSocket route, bus, or session state | [`EVENT_STATE_DOCTRINE.md`](docs/developer/EVENT_STATE_DOCTRINE.md) |
 | Deviating from a standard pattern on purpose | [`ARCHITECTURE_EXCEPTIONS.md`](docs/developer/ARCHITECTURE_EXCEPTIONS.md) |
 
 ## Engineering Standard

--- a/autobot-backend/acp/__init__.py
+++ b/autobot-backend/acp/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Agent Client Protocol (ACP) server surface for AutoBot (#14825)."""
+
+from acp.protocol import ACP_PROTOCOL_VERSION, AcpError, AcpMethod
+from acp.server import AcpServer
+
+__all__ = ["AcpServer", "AcpError", "AcpMethod", "ACP_PROTOCOL_VERSION"]

--- a/autobot-backend/acp/__main__.py
+++ b/autobot-backend/acp/__main__.py
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP agent entry point (#14825).
+
+Run as an ACP agent from any compatible client:
+
+    python -m acp
+
+The client spawns this as a sub-process and speaks JSON-RPC 2.0 over stdio.
+Nothing may write to stdout except protocol traffic — logging goes to stderr.
+"""
+
+import asyncio
+import sys
+
+from acp.runner import autobot_turn_runner
+from acp.server import AcpServer
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _main() -> int:
+    server = AcpServer(runner=autobot_turn_runner)
+    logger.info("AutoBot ACP agent starting on stdio")
+    try:
+        await server.run()
+    except KeyboardInterrupt:
+        logger.info("AutoBot ACP agent interrupted")
+    logger.info("AutoBot ACP agent stopped")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/autobot-backend/acp/protocol.py
+++ b/autobot-backend/acp/protocol.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Agent Client Protocol wire types (#14825).
+
+ACP is the editor-to-agent standard from Zed Industries and JetBrains
+(https://agentclientprotocol.com).  It is JSON-RPC 2.0, normally over stdio,
+and it standardises the 1:1 conversation between one client and one agent:
+initialize, create session, prompt, stream updates, call tools, ask permission.
+
+This module holds only the vocabulary — method names, capability shapes, error
+codes and the ``session/update`` constructors.  Transport lives in
+``acp/transport.py`` and dispatch in ``acp/server.py``, so the protocol
+definitions stay readable and independently testable.
+
+Conventions ACP requires and this implementation honours:
+
+* absolute file paths only;
+* 1-based line numbers;
+* ``camelCase`` property keys, with ``snake_case`` reserved for discriminators;
+* Markdown as the default format for user-readable text.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List
+
+# The protocol revision this implementation speaks.  ACP negotiates at
+# initialize: the client states what it supports and the agent answers with what
+# it will use.
+ACP_PROTOCOL_VERSION = 1
+
+
+class AcpMethod(str, Enum):
+    """Methods this agent serves, and those it calls back on the client."""
+
+    # Client -> Agent (baseline)
+    INITIALIZE = "initialize"
+    AUTHENTICATE = "authenticate"
+    SESSION_NEW = "session/new"
+    SESSION_PROMPT = "session/prompt"
+
+    # Client -> Agent (optional; advertised via capabilities)
+    SESSION_LOAD = "session/load"
+    SESSION_CANCEL = "session/cancel"  # notification
+
+    # Agent -> Client
+    SESSION_UPDATE = "session/update"  # notification
+    SESSION_REQUEST_PERMISSION = "session/request_permission"
+
+
+class StopReason(str, Enum):
+    """Why a prompt turn ended.  Returned from ``session/prompt``."""
+
+    END_TURN = "end_turn"
+    MAX_TOKENS = "max_tokens"
+    REFUSAL = "refusal"
+    CANCELLED = "cancelled"
+
+
+class AcpErrorCode(int, Enum):
+    """JSON-RPC error codes, standard range plus ACP usage."""
+
+    PARSE_ERROR = -32700
+    INVALID_REQUEST = -32600
+    METHOD_NOT_FOUND = -32601
+    INVALID_PARAMS = -32602
+    INTERNAL_ERROR = -32603
+    AUTH_REQUIRED = -32000
+
+
+class AcpError(Exception):
+    """An error that maps onto a JSON-RPC error object."""
+
+    def __init__(self, code: AcpErrorCode, message: str, data: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Render as a JSON-RPC ``error`` member."""
+        error: Dict[str, Any] = {"code": int(self.code), "message": self.message}
+        if self.data is not None:
+            error["data"] = self.data
+        return error
+
+
+def agent_capabilities() -> Dict[str, Any]:
+    """Declare what this agent actually implements.
+
+    Deliberately conservative: a capability advertised but not implemented is
+    worse than one omitted, because the client will call it.  ``loadSession`` is
+    False until session replay is wired to the chat history store.
+    """
+    return {
+        "loadSession": False,
+        "promptCapabilities": {
+            "image": False,
+            "audio": False,
+            "embeddedContext": True,
+        },
+    }
+
+
+def text_block(text: str) -> Dict[str, Any]:
+    """A ``text`` content block — ACP's default user-readable form."""
+    return {"type": "text", "text": text}
+
+
+def agent_message_chunk(session_id: str, text: str) -> Dict[str, Any]:
+    """``session/update`` carrying a chunk of the agent's reply."""
+    return {
+        "sessionId": session_id,
+        "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": text_block(text),
+        },
+    }
+
+
+def agent_thought_chunk(session_id: str, text: str) -> Dict[str, Any]:
+    """``session/update`` carrying a chunk of the agent's reasoning."""
+    return {
+        "sessionId": session_id,
+        "update": {
+            "sessionUpdate": "agent_thought_chunk",
+            "content": text_block(text),
+        },
+    }
+
+
+def tool_call_update(
+    session_id: str,
+    tool_call_id: str,
+    title: str,
+    status: str,
+    *,
+    kind: str = "other",
+    content: List[Dict[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    """``session/update`` describing a tool call's lifecycle."""
+    update: Dict[str, Any] = {
+        "sessionUpdate": "tool_call",
+        "toolCallId": tool_call_id,
+        "title": title,
+        "kind": kind,
+        "status": status,
+    }
+    if content:
+        update["content"] = content
+    return {"sessionId": session_id, "update": update}
+
+
+def plan_update(session_id: str, entries: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """``session/update`` carrying the agent's plan for this turn."""
+    return {
+        "sessionId": session_id,
+        "update": {"sessionUpdate": "plan", "entries": entries},
+    }

--- a/autobot-backend/acp/protocol_test.py
+++ b/autobot-backend/acp/protocol_test.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP wire vocabulary (#14825).
+
+These are the shapes an external editor parses, so the discriminator strings and
+key casing are contract, not style. ACP requires camelCase property keys with
+snake_case reserved for discriminators; a silent rename here breaks every client
+without failing anything else in this repo.
+"""
+
+import pytest
+
+from acp.protocol import (
+    ACP_PROTOCOL_VERSION,
+    AcpError,
+    AcpErrorCode,
+    AcpMethod,
+    StopReason,
+    agent_capabilities,
+    agent_message_chunk,
+    agent_thought_chunk,
+    plan_update,
+    text_block,
+    tool_call_update,
+)
+
+
+def test_protocol_version_is_an_integer():
+    # ACP negotiates on an integer version; a string would fail min() in the
+    # handshake and silently pin the wrong revision.
+    assert isinstance(ACP_PROTOCOL_VERSION, int)
+
+
+def test_method_names_match_the_acp_specification():
+    # Exact strings — an editor dispatches on these.
+    assert AcpMethod.INITIALIZE == "initialize"
+    assert AcpMethod.SESSION_NEW == "session/new"
+    assert AcpMethod.SESSION_PROMPT == "session/prompt"
+    assert AcpMethod.SESSION_UPDATE == "session/update"
+    assert AcpMethod.SESSION_CANCEL == "session/cancel"
+    assert AcpMethod.SESSION_REQUEST_PERMISSION == "session/request_permission"
+
+
+def test_stop_reasons_match_the_specification():
+    assert StopReason.END_TURN == "end_turn"
+    assert StopReason.CANCELLED == "cancelled"
+    assert StopReason.REFUSAL == "refusal"
+    assert StopReason.MAX_TOKENS == "max_tokens"
+
+
+def test_text_block_shape():
+    assert text_block("hi") == {"type": "text", "text": "hi"}
+
+
+def test_agent_message_chunk_shape():
+    update = agent_message_chunk("s-1", "hello")
+    assert update["sessionId"] == "s-1"
+    assert update["update"]["sessionUpdate"] == "agent_message_chunk"
+    assert update["update"]["content"]["text"] == "hello"
+
+
+def test_agent_thought_chunk_is_distinct_from_a_message_chunk():
+    # Clients render reasoning separately from the reply; collapsing the two
+    # would surface internal thinking as assistant output.
+    thought = agent_thought_chunk("s-1", "considering")
+    message = agent_message_chunk("s-1", "considering")
+    assert thought["update"]["sessionUpdate"] == "agent_thought_chunk"
+    assert thought["update"]["sessionUpdate"] != message["update"]["sessionUpdate"]
+
+
+def test_tool_call_update_carries_lifecycle_fields():
+    update = tool_call_update("s-1", "t-1", "Run tests", "in_progress", kind="execute")
+    inner = update["update"]
+    assert inner["sessionUpdate"] == "tool_call"
+    assert inner["toolCallId"] == "t-1"
+    assert inner["title"] == "Run tests"
+    assert inner["status"] == "in_progress"
+    assert inner["kind"] == "execute"
+
+
+def test_tool_call_update_omits_content_when_none_is_given():
+    # Absent rather than null: an empty content key renders as an empty block
+    # in some clients.
+    assert "content" not in tool_call_update("s-1", "t-1", "x", "pending")["update"]
+
+
+def test_tool_call_update_includes_content_when_given():
+    update = tool_call_update("s-1", "t-1", "x", "completed", content=[text_block("out")])
+    assert update["update"]["content"] == [{"type": "text", "text": "out"}]
+
+
+def test_plan_update_shape():
+    update = plan_update("s-1", [{"content": "step one", "status": "pending"}])
+    assert update["update"]["sessionUpdate"] == "plan"
+    assert update["update"]["entries"][0]["content"] == "step one"
+
+
+def test_capabilities_do_not_claim_unimplemented_features():
+    caps = agent_capabilities()
+    # loadSession is False because session/load is not served; advertising it
+    # would make a client call a method that does not exist.
+    assert caps["loadSession"] is False
+    assert caps["promptCapabilities"]["image"] is False
+    assert caps["promptCapabilities"]["audio"] is False
+
+
+def test_error_renders_as_a_jsonrpc_error_member():
+    err = AcpError(AcpErrorCode.INVALID_PARAMS, "bad cwd")
+    assert err.to_dict() == {"code": -32602, "message": "bad cwd"}
+
+
+def test_error_includes_data_only_when_present():
+    assert "data" not in AcpError(AcpErrorCode.INTERNAL_ERROR, "x").to_dict()
+    assert AcpError(AcpErrorCode.INTERNAL_ERROR, "x", {"k": 1}).to_dict()["data"] == {"k": 1}
+
+
+def test_error_codes_use_the_standard_jsonrpc_range():
+    assert int(AcpErrorCode.METHOD_NOT_FOUND) == -32601
+    assert int(AcpErrorCode.PARSE_ERROR) == -32700
+
+
+def test_error_is_raisable():
+    with pytest.raises(AcpError):
+        raise AcpError(AcpErrorCode.INVALID_REQUEST, "nope")

--- a/autobot-backend/acp/runner.py
+++ b/autobot-backend/acp/runner.py
@@ -1,0 +1,93 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Bridge from an ACP prompt turn to AutoBot's chat workflow (#14825).
+
+``AcpServer`` owns the protocol; this module owns the translation.  Keeping the
+two apart means the protocol layer is testable without an LLM, and the chat
+workflow never learns ACP vocabulary — the same separation AHP describes between
+a coordination layer and the agent beneath it.
+
+``ChatWorkflowManager.process_message_stream`` yields AutoBot's own message
+dicts; this maps each onto the matching ``session/update`` shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict
+
+from acp.protocol import agent_message_chunk, agent_thought_chunk, tool_call_update
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# One manager per agent process, initialised on the first turn.  The ACP entry
+# point is a sub-process serving a single client, so process-wide is the correct
+# scope here — unlike the API layer, which caches on ``app.state``.
+_manager: Any = None
+
+# AutoBot message types that represent the agent's visible reply.
+_REPLY_TYPES = {"llm_response", "agent_llm_chunk", "default", "bot"}
+# Types representing internal reasoning, surfaced separately by ACP clients.
+_THOUGHT_TYPES = {"thought", "agent_step_start", "planning"}
+# Types representing tool activity.
+_TOOL_TYPES = {"tool_code", "tool_output", "agent_tool_call", "agent_tool_result"}
+
+
+def _text_of(message: Dict[str, Any]) -> str:
+    """Extract displayable text from an AutoBot workflow message."""
+    for key in ("text", "content", "message", "chunk"):
+        value = message.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+async def autobot_turn_runner(session_id: str, prompt: str, cwd: str) -> AsyncIterator[Dict[str, Any]]:
+    """Run one turn through AutoBot and yield ACP ``session/update`` payloads.
+
+    Imports are deferred: the ACP entry point must be startable without pulling
+    the whole chat stack at module import time, and a missing dependency should
+    surface as a clear error on the first turn rather than an import crash.
+    """
+    global _manager
+    try:
+        if _manager is None:
+            from chat_workflow import ChatWorkflowManager
+
+            _manager = ChatWorkflowManager()
+            await _manager.initialize()
+    except Exception as exc:
+        logger.error("Chat workflow unavailable for ACP turn: %s", exc)
+        yield agent_message_chunk(session_id, f"AutoBot chat workflow is unavailable: {exc}")
+        return
+
+    manager = _manager
+    context: Dict[str, Any] = {"cwd": cwd, "source": "acp"}
+
+    async for message in manager.process_message_stream(session_id, prompt, context):
+        if not isinstance(message, dict):
+            continue
+        message_type = str(message.get("type") or message.get("message_type") or "default")
+        text = _text_of(message)
+        if not text:
+            continue
+
+        if message_type in _THOUGHT_TYPES:
+            yield agent_thought_chunk(session_id, text)
+        elif message_type in _TOOL_TYPES:
+            yield tool_call_update(
+                session_id,
+                tool_call_id=str(message.get("tool_call_id") or message.get("id") or "tool"),
+                title=str(message.get("tool_name") or message_type),
+                status="completed" if "result" in message_type or "output" in message_type else "in_progress",
+                kind="execute",
+            )
+        elif message_type in _REPLY_TYPES:
+            yield agent_message_chunk(session_id, text)
+        else:
+            # Unknown types still reach the user as reply text rather than
+            # being dropped — silence would be worse than an imperfect label.
+            yield agent_message_chunk(session_id, text)

--- a/autobot-backend/acp/runner_test.py
+++ b/autobot-backend/acp/runner_test.py
@@ -1,0 +1,145 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Translation from AutoBot workflow messages to ACP updates (#14825).
+
+The runner is the seam between AutoBot's own message vocabulary and ACP's, which
+is what keeps the protocol layer testable without an LLM and keeps the chat
+workflow free of ACP vocabulary.
+
+The case worth guarding is the unknown message type: it must still reach the
+user as reply text. Dropping it would make an editor silently show nothing for
+output AutoBot did produce — a failure the user cannot distinguish from the
+agent having no answer.
+"""
+
+from typing import Any, AsyncIterator, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from acp import runner as runner_module
+from acp.runner import _text_of, autobot_turn_runner
+
+
+class _FakeManager:
+    """Yields a scripted message stream in place of the chat workflow."""
+
+    def __init__(self, messages: List[Dict[str, Any]]):
+        self._messages = messages
+        self.seen_context: Dict[str, Any] | None = None
+
+    async def initialize(self) -> None:
+        return None
+
+    async def process_message_stream(
+        self, session_id: str, message: str, context: Dict[str, Any] | None = None
+    ) -> AsyncIterator[Dict[str, Any]]:
+        self.seen_context = context
+        for m in self._messages:
+            yield m
+
+
+async def _collect(messages: List[Dict[str, Any]], cwd: str = "/work") -> List[Dict[str, Any]]:
+    manager = _FakeManager(messages)
+    runner_module._manager = manager
+    return [u async for u in autobot_turn_runner("s-1", "do it", cwd)]
+
+
+@pytest.fixture(autouse=True)
+def reset_manager():
+    yield
+    runner_module._manager = None
+
+
+def test_text_of_prefers_text_then_falls_back():
+    assert _text_of({"text": "a", "content": "b"}) == "a"
+    assert _text_of({"content": "b"}) == "b"
+    assert _text_of({"chunk": "c"}) == "c"
+    assert _text_of({}) == ""
+
+
+def test_text_of_ignores_non_string_values():
+    # A dict under `content` must not be stringified into the prompt.
+    assert _text_of({"content": {"nested": 1}, "text": "real"}) == "real"
+
+
+@pytest.mark.asyncio
+async def test_a_reply_becomes_an_agent_message_chunk():
+    updates = await _collect([{"type": "llm_response", "text": "the answer"}])
+
+    assert len(updates) == 1
+    assert updates[0]["update"]["sessionUpdate"] == "agent_message_chunk"
+    assert updates[0]["update"]["content"]["text"] == "the answer"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_becomes_a_thought_chunk_not_a_reply():
+    updates = await _collect([{"type": "thought", "text": "thinking"}])
+
+    assert updates[0]["update"]["sessionUpdate"] == "agent_thought_chunk"
+
+
+@pytest.mark.asyncio
+async def test_tool_activity_becomes_a_tool_call_update():
+    updates = await _collect([{"type": "agent_tool_call", "text": "ls", "tool_name": "shell"}])
+
+    assert updates[0]["update"]["sessionUpdate"] == "tool_call"
+    assert updates[0]["update"]["title"] == "shell"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_result_is_reported_as_completed():
+    updates = await _collect([{"type": "agent_tool_result", "text": "done", "tool_name": "shell"}])
+
+    assert updates[0]["update"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_type_still_reaches_the_user_as_reply_text():
+    # Silence would be indistinguishable from the agent having no answer.
+    updates = await _collect([{"type": "something_new", "text": "surprise output"}])
+
+    assert len(updates) == 1
+    assert updates[0]["update"]["content"]["text"] == "surprise output"
+
+
+@pytest.mark.asyncio
+async def test_messages_with_no_text_are_skipped():
+    updates = await _collect([{"type": "llm_response"}, {"type": "llm_response", "text": "kept"}])
+
+    assert len(updates) == 1
+    assert updates[0]["update"]["content"]["text"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_non_dict_messages_are_skipped():
+    updates = await _collect(["not a dict", {"type": "llm_response", "text": "kept"}])
+
+    assert len(updates) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_working_directory_reaches_the_workflow_context():
+    manager = _FakeManager([{"type": "llm_response", "text": "x"}])
+    runner_module._manager = manager
+
+    [_ async for _ in autobot_turn_runner("s-1", "do it", "/repo/root")]
+
+    assert manager.seen_context is not None
+    assert manager.seen_context["cwd"] == "/repo/root"
+    assert manager.seen_context["source"] == "acp"
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_workflow_reports_to_the_client_rather_than_crashing():
+    """An editor must be told why nothing happened; a bare exception would
+    surface as a dead session with no explanation."""
+    runner_module._manager = None
+    with patch.dict("sys.modules", {"chat_workflow": None}):
+        updates = [u async for u in autobot_turn_runner("s-1", "hi", "/work")]
+
+    assert len(updates) == 1
+    assert "unavailable" in updates[0]["update"]["content"]["text"].lower()

--- a/autobot-backend/acp/server.py
+++ b/autobot-backend/acp/server.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
+from typing import Any, AsyncIterator, Callable, Dict, Optional
 
 from acp.protocol import (
     ACP_PROTOCOL_VERSION,
@@ -233,9 +233,7 @@ class AcpServer:
         call_id = f"agent-{self._next_call_id}"
         future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending_client_calls[call_id] = future
-        await self._transport.send(
-            {"jsonrpc": "2.0", "id": call_id, "method": method, "params": params}
-        )
+        await self._transport.send({"jsonrpc": "2.0", "id": call_id, "method": method, "params": params})
         try:
             return await future
         finally:
@@ -261,9 +259,7 @@ class AcpServer:
         await self._transport.send({"jsonrpc": "2.0", "method": method, "params": params})
 
     async def _send_error(self, request_id: Any, error: AcpError) -> None:
-        await self._transport.send(
-            {"jsonrpc": "2.0", "id": request_id, "error": error.to_dict()}
-        )
+        await self._transport.send({"jsonrpc": "2.0", "id": request_id, "error": error.to_dict()})
 
     def _require_session(self, session_id: Any) -> AcpSession:
         session = self._sessions.get(str(session_id))
@@ -284,9 +280,5 @@ class AcpServer:
             return prompt
         if not isinstance(prompt, list):
             return ""
-        parts = [
-            block.get("text", "")
-            for block in prompt
-            if isinstance(block, dict) and block.get("type") == "text"
-        ]
+        parts = [block.get("text", "") for block in prompt if isinstance(block, dict) and block.get("type") == "text"]
         return "\n".join(part for part in parts if part)

--- a/autobot-backend/acp/server.py
+++ b/autobot-backend/acp/server.py
@@ -1,0 +1,292 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP agent server (#14825).
+
+Implements the agent half of the Agent Client Protocol so any ACP client — Zed,
+JetBrains IDEs, Neovim, Emacs — can drive an AutoBot agent without a bespoke
+integration.
+
+Lifecycle:
+
+    initialize -> session/new -> session/prompt (repeat) [-> session/cancel]
+
+While a prompt turn runs the agent streams ``session/update`` notifications and
+may call back for ``session/request_permission`` before executing a tool.
+
+The turn itself is delegated to a *runner* — an async callable yielding update
+dicts.  Keeping that a seam means the protocol layer is testable without an LLM,
+and AutoBot's chat workflow stays free of ACP vocabulary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
+
+from acp.protocol import (
+    ACP_PROTOCOL_VERSION,
+    AcpError,
+    AcpErrorCode,
+    AcpMethod,
+    StopReason,
+    agent_capabilities,
+)
+from acp.transport import StdioTransport
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# A runner receives (session_id, prompt_text, cwd) and yields ``session/update``
+# payloads.  ``acp/runner.py`` supplies the AutoBot-backed implementation.
+TurnRunner = Callable[[str, str, str], AsyncIterator[Dict[str, Any]]]
+
+
+class AcpSession:
+    """One ACP conversation."""
+
+    def __init__(self, session_id: str, cwd: str):
+        self.session_id = session_id
+        self.cwd = cwd
+        self.cancelled = False
+        self.task: Optional[asyncio.Task] = None
+
+
+class AcpServer:
+    """JSON-RPC dispatch for the ACP agent surface."""
+
+    def __init__(self, runner: TurnRunner, transport: StdioTransport | None = None):
+        self._runner = runner
+        self._transport = transport or StdioTransport()
+        self._sessions: Dict[str, AcpSession] = {}
+        self._initialized = False
+        self._pending_client_calls: Dict[str, asyncio.Future] = {}
+        self._next_call_id = 0
+
+    # ------------------------------------------------------------------
+    # Run loop
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Serve until stdin closes."""
+        async for message in self._transport.messages():
+            await self._dispatch(message)
+
+    async def _dispatch(self, message: Dict[str, Any]) -> None:
+        """Route one inbound JSON-RPC message."""
+        # A response to something *we* asked the client (permission, fs read).
+        if "method" not in message and "id" in message:
+            self._resolve_client_call(message)
+            return
+
+        method = message.get("method")
+        request_id = message.get("id")
+        params = message.get("params") or {}
+
+        try:
+            result = await self._handle(method, params)
+        except AcpError as exc:
+            if request_id is not None:
+                await self._send_error(request_id, exc)
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unhandled ACP error in %s", method)
+            if request_id is not None:
+                await self._send_error(
+                    request_id,
+                    AcpError(AcpErrorCode.INTERNAL_ERROR, str(exc)),
+                )
+            return
+
+        # Notifications carry no id and MUST NOT be answered.
+        if request_id is not None:
+            await self._transport.send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+    async def _handle(self, method: str | None, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Dispatch one method, enforcing the lifecycle order."""
+        if method == AcpMethod.INITIALIZE:
+            return self._initialize(params)
+
+        # Everything else requires a completed handshake — otherwise a client
+        # could create sessions against un-negotiated capabilities.
+        if not self._initialized:
+            raise AcpError(AcpErrorCode.INVALID_REQUEST, "initialize must be called first")
+
+        if method == AcpMethod.SESSION_NEW:
+            return await self._session_new(params)
+        if method == AcpMethod.SESSION_PROMPT:
+            return await self._session_prompt(params)
+        if method == AcpMethod.SESSION_CANCEL:
+            return await self._session_cancel(params)
+        if method == AcpMethod.AUTHENTICATE:
+            # No auth method is advertised at initialize, so a client should
+            # never reach here; answering emptily is friendlier than an error.
+            return {}
+
+        raise AcpError(AcpErrorCode.METHOD_NOT_FOUND, f"Unknown method: {method}")
+
+    # ------------------------------------------------------------------
+    # Methods
+    # ------------------------------------------------------------------
+
+    def _initialize(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Negotiate the protocol version and advertise capabilities."""
+        requested = params.get("protocolVersion", ACP_PROTOCOL_VERSION)
+        # Answer with the highest version both sides speak: never claim a
+        # version above our own just because the client asked for it.
+        negotiated = min(int(requested), ACP_PROTOCOL_VERSION) if isinstance(requested, int) else ACP_PROTOCOL_VERSION
+        self._initialized = True
+        return {
+            "protocolVersion": negotiated,
+            "agentCapabilities": agent_capabilities(),
+            # Empty: this surface inherits the host's own authentication rather
+            # than defining a second credential path.
+            "authMethods": [],
+        }
+
+    async def _session_new(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a session rooted at an absolute working directory."""
+        cwd = params.get("cwd")
+        if not cwd or not str(cwd).startswith("/"):
+            raise AcpError(AcpErrorCode.INVALID_PARAMS, "cwd must be an absolute path")
+        session_id = f"acp-{uuid.uuid4()}"
+        self._sessions[session_id] = AcpSession(session_id, str(cwd))
+        logger.info("ACP session created: %s", session_id)
+        return {"sessionId": session_id}
+
+    async def _session_prompt(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Run one prompt turn, streaming updates until it ends."""
+        session = self._require_session(params.get("sessionId"))
+        text = self._prompt_text(params.get("prompt"))
+        session.cancelled = False
+
+        try:
+            async for update in self._runner(session.session_id, text, session.cwd):
+                if session.cancelled:
+                    return {"stopReason": StopReason.CANCELLED.value}
+                await self._notify(AcpMethod.SESSION_UPDATE.value, update)
+        except asyncio.CancelledError:
+            return {"stopReason": StopReason.CANCELLED.value}
+        except Exception as exc:
+            logger.exception("ACP turn failed for %s", session.session_id)
+            raise AcpError(AcpErrorCode.INTERNAL_ERROR, f"Turn failed: {exc}")
+
+        if session.cancelled:
+            return {"stopReason": StopReason.CANCELLED.value}
+        return {"stopReason": StopReason.END_TURN.value}
+
+    async def _session_cancel(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Mark the session cancelled; the running turn observes the flag."""
+        session_id = params.get("sessionId")
+        session = self._sessions.get(str(session_id))
+        if session is not None:
+            session.cancelled = True
+            if session.task is not None:
+                session.task.cancel()
+        return {}
+
+    # ------------------------------------------------------------------
+    # Client callbacks
+    # ------------------------------------------------------------------
+
+    async def request_permission(
+        self,
+        session_id: str,
+        tool_call_id: str,
+        title: str,
+        options: list[Dict[str, Any]] | None = None,
+    ) -> bool:
+        """Ask the client to approve a tool call; True only on explicit allow.
+
+        Fails closed: a malformed answer, an unknown option id, or a transport
+        error all deny.  Treating an unreadable response as approval is the
+        failure mode this gate exists to prevent.
+        """
+        options = options or [
+            {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+            {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+        ]
+        try:
+            response = await self._call_client(
+                AcpMethod.SESSION_REQUEST_PERMISSION.value,
+                {
+                    "sessionId": session_id,
+                    "toolCall": {"toolCallId": tool_call_id, "title": title},
+                    "options": options,
+                },
+            )
+        except Exception as exc:
+            logger.warning("Permission request failed, denying: %s", exc)
+            return False
+
+        outcome = (response or {}).get("outcome") or {}
+        if outcome.get("outcome") != "selected":
+            return False
+        return str(outcome.get("optionId", "")).startswith("allow")
+
+    async def _call_client(self, method: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Issue a JSON-RPC request to the client and await its response."""
+        self._next_call_id += 1
+        call_id = f"agent-{self._next_call_id}"
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending_client_calls[call_id] = future
+        await self._transport.send(
+            {"jsonrpc": "2.0", "id": call_id, "method": method, "params": params}
+        )
+        try:
+            return await future
+        finally:
+            self._pending_client_calls.pop(call_id, None)
+
+    def _resolve_client_call(self, message: Dict[str, Any]) -> None:
+        """Complete the future awaiting this response."""
+        call_id = str(message.get("id"))
+        future = self._pending_client_calls.get(call_id)
+        if future is None or future.done():
+            return
+        if "error" in message:
+            future.set_exception(RuntimeError(str(message["error"])))
+        else:
+            future.set_result(message.get("result") or {})
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _notify(self, method: str, params: Dict[str, Any]) -> None:
+        """Send a notification (no id, no response expected)."""
+        await self._transport.send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    async def _send_error(self, request_id: Any, error: AcpError) -> None:
+        await self._transport.send(
+            {"jsonrpc": "2.0", "id": request_id, "error": error.to_dict()}
+        )
+
+    def _require_session(self, session_id: Any) -> AcpSession:
+        session = self._sessions.get(str(session_id))
+        if session is None:
+            raise AcpError(AcpErrorCode.INVALID_PARAMS, f"Unknown session: {session_id}")
+        return session
+
+    @staticmethod
+    def _prompt_text(prompt: Any) -> str:
+        """Flatten ACP prompt content blocks into plain text.
+
+        Non-text blocks are skipped rather than stringified — image and audio
+        input are not advertised in ``agent_capabilities``, so a client should
+        not be sending them, and rendering their raw payload into the prompt
+        would be worse than ignoring them.
+        """
+        if isinstance(prompt, str):
+            return prompt
+        if not isinstance(prompt, list):
+            return ""
+        parts = [
+            block.get("text", "")
+            for block in prompt
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        return "\n".join(part for part in parts if part)

--- a/autobot-backend/acp/server_test.py
+++ b/autobot-backend/acp/server_test.py
@@ -1,0 +1,258 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP agent surface (#14825).
+
+Drives ``AcpServer`` through a fake transport, so the protocol is exercised end
+to end without an LLM or a real editor.  The permission tests deliberately cover
+the *denial* paths — an approval gate that only ever gets tested on the approve
+branch is not a gate.
+"""
+
+from typing import Any, AsyncIterator, Dict, List
+
+import pytest
+
+from acp.protocol import ACP_PROTOCOL_VERSION, AcpErrorCode, StopReason, agent_message_chunk
+from acp.server import AcpServer
+
+
+class FakeTransport:
+    """Captures outbound messages and replays a scripted inbound sequence."""
+
+    def __init__(self, inbound: List[Dict[str, Any]] | None = None):
+        self.sent: List[Dict[str, Any]] = []
+        self._inbound = inbound or []
+
+    async def messages(self) -> AsyncIterator[Dict[str, Any]]:
+        for message in self._inbound:
+            yield message
+
+    async def send(self, message: Dict[str, Any]) -> None:
+        self.sent.append(message)
+
+
+async def _echo_runner(session_id: str, prompt: str, cwd: str) -> AsyncIterator[Dict[str, Any]]:
+    yield agent_message_chunk(session_id, f"echo: {prompt}")
+
+
+def _results(transport: FakeTransport) -> List[Dict[str, Any]]:
+    return [m for m in transport.sent if "result" in m]
+
+
+def _errors(transport: FakeTransport) -> List[Dict[str, Any]]:
+    return [m for m in transport.sent if "error" in m]
+
+
+def _notifications(transport: FakeTransport, method: str) -> List[Dict[str, Any]]:
+    return [m for m in transport.sent if m.get("method") == method]
+
+
+@pytest.mark.asyncio
+async def test_initialize_negotiates_and_advertises_capabilities():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    await server._dispatch(
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}}
+    )
+
+    result = _results(transport)[0]["result"]
+    assert result["protocolVersion"] == ACP_PROTOCOL_VERSION
+    assert "agentCapabilities" in result
+
+
+@pytest.mark.asyncio
+async def test_initialize_never_claims_a_version_above_its_own():
+    """A client asking for v99 must not be told we speak v99."""
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    await server._dispatch(
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 99}}
+    )
+
+    assert _results(transport)[0]["result"]["protocolVersion"] == ACP_PROTOCOL_VERSION
+
+
+@pytest.mark.asyncio
+async def test_capabilities_do_not_advertise_unimplemented_features():
+    """An advertised-but-missing capability is worse than an omitted one."""
+    from acp.protocol import agent_capabilities
+
+    caps = agent_capabilities()
+    assert caps["loadSession"] is False, "loadSession advertised but session/load is not served"
+
+
+@pytest.mark.asyncio
+async def test_methods_before_initialize_are_refused():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    await server._dispatch(
+        {"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/tmp"}}
+    )
+
+    assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.INVALID_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_session_new_requires_an_absolute_cwd():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+    server._initialized = True
+
+    await server._dispatch(
+        {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "relative/path"}}
+    )
+
+    assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.INVALID_PARAMS)
+
+
+@pytest.mark.asyncio
+async def test_full_turn_streams_updates_and_ends():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    await server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+    await server._dispatch(
+        {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "/work"}}
+    )
+    session_id = _results(transport)[-1]["result"]["sessionId"]
+
+    await server._dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "session/prompt",
+            "params": {"sessionId": session_id, "prompt": [{"type": "text", "text": "hi"}]},
+        }
+    )
+
+    updates = _notifications(transport, "session/update")
+    assert len(updates) == 1
+    assert updates[0]["params"]["update"]["content"]["text"] == "echo: hi"
+    assert _results(transport)[-1]["result"]["stopReason"] == StopReason.END_TURN.value
+
+
+@pytest.mark.asyncio
+async def test_prompt_for_unknown_session_is_an_error():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+    server._initialized = True
+
+    await server._dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "session/prompt",
+            "params": {"sessionId": "nope", "prompt": "hi"},
+        }
+    )
+
+    assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.INVALID_PARAMS)
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_returns_method_not_found():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+    server._initialized = True
+
+    await server._dispatch({"jsonrpc": "2.0", "id": 9, "method": "session/teleport", "params": {}})
+
+    assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.METHOD_NOT_FOUND)
+
+
+@pytest.mark.asyncio
+async def test_notification_receives_no_response():
+    """A message without an id MUST NOT be answered."""
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+    server._initialized = True
+
+    await server._dispatch({"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "x"}})
+
+    assert transport.sent == [], "a notification was answered"
+
+
+@pytest.mark.asyncio
+async def test_permission_granted_when_client_selects_allow():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    import asyncio
+
+    task = asyncio.create_task(server.request_permission("s1", "t1", "Run tests"))
+    await asyncio.sleep(0)
+    call = [m for m in transport.sent if m.get("method") == "session/request_permission"][0]
+    server._resolve_client_call(
+        {"id": call["id"], "result": {"outcome": {"outcome": "selected", "optionId": "allow"}}}
+    )
+
+    assert await task is True
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_when_client_selects_reject():
+    """The denial path — the branch an approval gate exists for."""
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    import asyncio
+
+    task = asyncio.create_task(server.request_permission("s1", "t1", "Delete everything"))
+    await asyncio.sleep(0)
+    call = [m for m in transport.sent if m.get("method") == "session/request_permission"][0]
+    server._resolve_client_call(
+        {"id": call["id"], "result": {"outcome": {"outcome": "selected", "optionId": "reject"}}}
+    )
+
+    assert await task is False
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_when_client_cancels():
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    import asyncio
+
+    task = asyncio.create_task(server.request_permission("s1", "t1", "Run"))
+    await asyncio.sleep(0)
+    call = [m for m in transport.sent if m.get("method") == "session/request_permission"][0]
+    server._resolve_client_call({"id": call["id"], "result": {"outcome": {"outcome": "cancelled"}}})
+
+    assert await task is False
+
+
+@pytest.mark.asyncio
+async def test_permission_denied_when_the_client_errors():
+    """An unreadable answer must deny, never fail open."""
+    transport = FakeTransport()
+    server = AcpServer(runner=_echo_runner, transport=transport)
+
+    import asyncio
+
+    task = asyncio.create_task(server.request_permission("s1", "t1", "Run"))
+    await asyncio.sleep(0)
+    call = [m for m in transport.sent if m.get("method") == "session/request_permission"][0]
+    server._resolve_client_call({"id": call["id"], "error": {"code": -32603, "message": "boom"}})
+
+    assert await task is False
+
+
+def test_prompt_text_flattens_blocks_and_skips_non_text():
+    server = AcpServer(runner=_echo_runner, transport=FakeTransport())
+
+    text = server._prompt_text(
+        [
+            {"type": "text", "text": "first"},
+            {"type": "image", "data": "base64..."},
+            {"type": "text", "text": "second"},
+        ]
+    )
+
+    assert text == "first\nsecond", "a non-text block leaked into the prompt"

--- a/autobot-backend/acp/server_test.py
+++ b/autobot-backend/acp/server_test.py
@@ -55,9 +55,7 @@ async def test_initialize_negotiates_and_advertises_capabilities():
     transport = FakeTransport()
     server = AcpServer(runner=_echo_runner, transport=transport)
 
-    await server._dispatch(
-        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}}
-    )
+    await server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 1}})
 
     result = _results(transport)[0]["result"]
     assert result["protocolVersion"] == ACP_PROTOCOL_VERSION
@@ -70,9 +68,7 @@ async def test_initialize_never_claims_a_version_above_its_own():
     transport = FakeTransport()
     server = AcpServer(runner=_echo_runner, transport=transport)
 
-    await server._dispatch(
-        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 99}}
-    )
+    await server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": 99}})
 
     assert _results(transport)[0]["result"]["protocolVersion"] == ACP_PROTOCOL_VERSION
 
@@ -91,9 +87,7 @@ async def test_methods_before_initialize_are_refused():
     transport = FakeTransport()
     server = AcpServer(runner=_echo_runner, transport=transport)
 
-    await server._dispatch(
-        {"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/tmp"}}
-    )
+    await server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/tmp"}})
 
     assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.INVALID_REQUEST)
 
@@ -104,9 +98,7 @@ async def test_session_new_requires_an_absolute_cwd():
     server = AcpServer(runner=_echo_runner, transport=transport)
     server._initialized = True
 
-    await server._dispatch(
-        {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "relative/path"}}
-    )
+    await server._dispatch({"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "relative/path"}})
 
     assert _errors(transport)[0]["error"]["code"] == int(AcpErrorCode.INVALID_PARAMS)
 
@@ -117,9 +109,7 @@ async def test_full_turn_streams_updates_and_ends():
     server = AcpServer(runner=_echo_runner, transport=transport)
 
     await server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
-    await server._dispatch(
-        {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "/work"}}
-    )
+    await server._dispatch({"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {"cwd": "/work"}})
     session_id = _results(transport)[-1]["result"]["sessionId"]
 
     await server._dispatch(
@@ -188,9 +178,7 @@ async def test_permission_granted_when_client_selects_allow():
     task = asyncio.create_task(server.request_permission("s1", "t1", "Run tests"))
     await asyncio.sleep(0)
     call = [m for m in transport.sent if m.get("method") == "session/request_permission"][0]
-    server._resolve_client_call(
-        {"id": call["id"], "result": {"outcome": {"outcome": "selected", "optionId": "allow"}}}
-    )
+    server._resolve_client_call({"id": call["id"], "result": {"outcome": {"outcome": "selected", "optionId": "allow"}}})
 
     assert await task is True
 

--- a/autobot-backend/acp/transport.py
+++ b/autobot-backend/acp/transport.py
@@ -1,0 +1,69 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP stdio transport (#14825).
+
+ACP runs a local agent as a sub-process of the editor and speaks JSON-RPC 2.0
+over stdin/stdout — one complete JSON message per line.  That framing choice is
+what makes an agent installable without any network setup, and it is the reason
+stdout must carry protocol traffic *only*: a stray ``print`` corrupts the
+stream.  AutoBot's logging goes to stderr and the logging manager, so this holds
+as long as nothing in the agent path writes to stdout directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any, AsyncIterator, Dict
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+
+class StdioTransport:
+    """Line-delimited JSON-RPC over stdin/stdout."""
+
+    def __init__(self) -> None:
+        self._writer_lock = asyncio.Lock()
+
+    async def messages(self) -> AsyncIterator[Dict[str, Any]]:
+        """Yield each well-formed JSON message arriving on stdin.
+
+        A malformed line is logged and skipped rather than killing the session:
+        the peer may still send valid traffic, and ACP has no framing-level
+        recovery of its own.  Skipping is safe here precisely because each line
+        is an independent message.
+        """
+        loop = asyncio.get_running_loop()
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+
+        while True:
+            line = await reader.readline()
+            if not line:
+                logger.debug("ACP stdin closed")
+                return
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                yield json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning("Discarding malformed ACP message (%d bytes)", len(stripped))
+
+    async def send(self, message: Dict[str, Any]) -> None:
+        """Write one JSON-RPC message as a single line on stdout.
+
+        Serialised behind a lock: notifications are emitted from streaming
+        tasks, and two interleaved writes would corrupt the framing.
+        """
+        payload = json.dumps(message, ensure_ascii=False, default=str)
+        async with self._writer_lock:
+            sys.stdout.write(payload + "\n")
+            sys.stdout.flush()

--- a/autobot-backend/acp/transport_test.py
+++ b/autobot-backend/acp/transport_test.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+ACP stdio framing (#14825).
+
+One complete JSON message per line, on stdout, and nothing else. Two properties
+carry the whole transport:
+
+* a malformed line must be skipped rather than killing the session — each line
+  is an independent message, and the peer may still send valid traffic;
+* concurrent writes must not interleave, because notifications are emitted from
+  streaming tasks while a response may be written at the same time. A torn line
+  corrupts the stream for good.
+"""
+
+import asyncio
+import io
+import json
+
+import pytest
+
+from acp.transport import StdioTransport
+
+
+@pytest.mark.asyncio
+async def test_send_writes_one_json_line(monkeypatch):
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    transport = StdioTransport()
+
+    await transport.send({"jsonrpc": "2.0", "id": 1, "result": {}})
+
+    written = out.getvalue()
+    assert written.endswith("\n")
+    assert written.count("\n") == 1
+    assert json.loads(written)["id"] == 1
+
+
+@pytest.mark.asyncio
+async def test_send_does_not_embed_raw_newlines(monkeypatch):
+    """A newline inside a value would otherwise split one message into two."""
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    transport = StdioTransport()
+
+    await transport.send({"text": "line one\nline two"})
+
+    assert out.getvalue().count("\n") == 1
+    assert json.loads(out.getvalue())["text"] == "line one\nline two"
+
+
+@pytest.mark.asyncio
+async def test_send_preserves_non_ascii(monkeypatch):
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    transport = StdioTransport()
+
+    await transport.send({"text": "café — 日本語"})
+
+    assert json.loads(out.getvalue())["text"] == "café — 日本語"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sends_do_not_interleave(monkeypatch):
+    """Every line must parse; a torn write corrupts the stream permanently."""
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    transport = StdioTransport()
+
+    await asyncio.gather(*(transport.send({"n": i, "pad": "x" * 200}) for i in range(30)))
+
+    lines = [ln for ln in out.getvalue().split("\n") if ln]
+    assert len(lines) == 30
+    assert sorted(json.loads(ln)["n"] for ln in lines) == list(range(30))
+
+
+@pytest.mark.asyncio
+async def test_send_serialises_unknown_types_rather_than_raising(monkeypatch):
+    """`default=str` keeps one odd value from killing the whole session."""
+    out = io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    transport = StdioTransport()
+
+    class Odd:
+        def __str__(self) -> str:
+            return "odd-value"
+
+    await transport.send({"v": Odd()})
+
+    assert json.loads(out.getvalue())["v"] == "odd-value"

--- a/autobot-backend/api/chat_llm_context_test.py
+++ b/autobot-backend/api/chat_llm_context_test.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from api.chat import _build_llm_context, _generate_ai_stack_chat_response, _to_persisted_message
-from api.websockets import NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES, _create_broadcast_event_handler
+from api.websockets import NON_CONVERSATIONAL_WEBSOCKET_MESSAGE_TYPES, _persist_event_to_chat_history
 from chat_history.messages import MessagesMixin
 
 
@@ -208,11 +208,6 @@ class _RecordingHistory(MessagesMixin):
         return True
 
 
-class _FakeWebSocket:
-    async def send_json(self, data: dict) -> None:
-        pass
-
-
 class TestWebsocketTelemetryPinnedDecision:
     """#14342 review follow-up: #14342 fixed *where* websocket-broadcast UI
     telemetry is stored (its own session, not a bucket no reader touched).
@@ -221,20 +216,26 @@ class TestWebsocketTelemetryPinnedDecision:
     `llm_context` — it is UI telemetry, not something the user or the
     assistant said.
 
-    Built through the real #14342 producer (`broadcast_event`, the callback
-    `events/bus.py` invokes) into a real session store, not a hand-fed dict
-    already carrying the key the filter checks — the same trap that let
-    #14340/#14341 hide.
+    Built through the real #14342 producer into a real session store, not a
+    hand-fed dict already carrying the key the filter checks — the same trap
+    that let #14340/#14341 hide.
+
+    #14814 moved that producer: persistence used to run inside the WebSocket
+    broadcast callback (so nothing was written with no client attached) and now
+    runs on the event manager's publish-time hook. The seeding below follows it.
     """
 
     def test_a_real_tool_output_event_does_not_enter_llm_context(self):
         manager = _RecordingHistory()
 
         async def seed_and_read() -> list:
-            broadcast_event = await _create_broadcast_event_handler(_FakeWebSocket(), manager)
-            await broadcast_event(
-                {"type": "tool_output", "payload": {"output": "rm -rf leftover", "session_id": "s-1"}}
-            )
+            with patch(
+                "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+                return_value=manager,
+            ):
+                await _persist_event_to_chat_history(
+                    {"type": "tool_output", "payload": {"output": "rm -rf leftover", "session_id": "s-1"}}
+                )
             await manager.add_message(sender="user", text="clean up the workspace", session_id="s-1")
             return await manager.get_session_messages("s-1", limit=500)
 
@@ -280,8 +281,15 @@ class TestWebsocketTelemetryPinnedDecision:
     @pytest.mark.asyncio
     async def test_a_real_tool_output_event_does_not_enter_the_ai_stack_history(self):
         manager = _RecordingHistory()
-        broadcast_event = await _create_broadcast_event_handler(_FakeWebSocket(), manager)
-        await broadcast_event({"type": "tool_output", "payload": {"output": "secret command", "session_id": "s-2"}})
+        # #14814: seeded through the publish-time persistence hook, which is
+        # where websocket telemetry is written now.
+        with patch(
+            "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+            return_value=manager,
+        ):
+            await _persist_event_to_chat_history(
+                {"type": "tool_output", "payload": {"output": "secret command", "session_id": "s-2"}}
+            )
         await manager.add_message(sender="user", text="deploy it", session_id="s-2")
         chat_context = await manager.get_session_messages("s-2", limit=500)
 

--- a/autobot-backend/api/chat_sessions.py
+++ b/autobot-backend/api/chat_sessions.py
@@ -37,6 +37,11 @@ from api.schemas_chat import (
     SessionUpdateData,
 )
 from api.schemas_common import DataResponse
+from api.session_events import (
+    publish_session_created,
+    publish_session_deleted,
+    publish_session_updated,
+)
 from auth_middleware import get_auth_middleware, get_current_user
 from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
@@ -896,6 +901,10 @@ async def create_session(session_data: SessionCreate, request: Request):
         outcome="success",
     )
 
+    # #14820: tell every other client this session now exists.  The backend is
+    # the authority for session state; observers render from what it publishes.
+    await publish_session_created(session_id, session if isinstance(session, dict) else {})
+
     return create_chat_response(
         data=session,
         message="Session created successfully",
@@ -956,6 +965,9 @@ async def update_session(
         session_id,
         {"title": session_data.title, "request_id": request_id},
     )
+
+    # #14820: a title change made in one client must show up in the others.
+    await publish_session_updated(session_id, {"title": session_data.title})
 
     return create_chat_response(
         data=updated_session,
@@ -1442,6 +1454,10 @@ async def delete_session(
         },
         outcome="success",
     )
+
+    # #14820: other clients must drop this session from their list rather than
+    # holding a reference to something the backend no longer has.
+    await publish_session_deleted(session_id)
 
     return _build_delete_session_response(
         session_id,

--- a/autobot-backend/api/frontend_config.py
+++ b/autobot-backend/api/frontend_config.py
@@ -171,7 +171,10 @@ def _build_fallback_config() -> Dict[str, Any]:
             "timeouts": _build_timeouts_config(api_config.get("timeouts", {})),
         },
         "websocket": {
-            "url": f"ws://{backend_config.get('host')}:{backend_config.get('port')}/api/ws",
+            # #14822: advertise the channel socket. Telling clients to use the
+            # legacy broadcast endpoint would undo the migration for anyone who
+            # reads their WebSocket URL from this config rather than hard-coding it.
+            "url": f"ws://{backend_config.get('host')}:{backend_config.get('port')}/api/ws/live",
             "reconnect_attempts": websocket_config.get("reconnect_attempts", 5),
             "reconnect_delay": websocket_config.get("reconnect_delay", 1000),
         },

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -229,11 +229,7 @@ async def _authorize_channel(channel: str, user_payload: dict | None) -> bool:
         return await _authorize_llc_channel(channel, user_payload)
     if channel.startswith("session:") or channel.startswith("chat:"):
         return await _authorize_conversation_channel(channel, user_payload)
-    if (
-        channel.startswith("workflow:")
-        or channel.startswith("heartbeat:")
-        or channel.startswith("task:")
-    ):
+    if channel.startswith("workflow:") or channel.startswith("heartbeat:") or channel.startswith("task:"):
         return await _authorize_resource_channel(channel, user_payload)
     return True
 

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -12,10 +12,13 @@ Protocol:
   Subscribe:   {"action": "subscribe",   "channel": "task:abc123"}
                {"action": "subscribe",   "channel": "chat:c1", "last_event_id": 42}
   Unsubscribe: {"action": "unsubscribe", "channel": "task:abc123"}
+  Command:     {"action": "command", "channel": "operation:x", "command": "pause",
+                "payload": {...}}
   Ping:        {"action": "ping"}
   Server ack:  {"type": "subscribed",   "channel": "...", "replayed": <int>}
                {"type": "unsubscribed", "channel": "..."}
                {"type": "resync",       "channel": "...", "reason": "..."}
+               {"type": "command_result","channel": "...", "command": "...", "result": {...}}
                {"type": "pong"}
                {"type": "error",        "message": "..."}
   Live event:  {"type": "live_event", "channel": "...", "event_type": "...",
@@ -40,6 +43,7 @@ from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from events.bus import get_event_bus
+from events.channel_commands import CommandRefused, dispatch_command
 from events.channel_stream import get_channel_event_stream
 from services.workflow_permission_service import WorkflowPermissionService
 
@@ -205,6 +209,58 @@ async def _authorize_resource_channel(channel: str, user_payload: dict) -> bool:
     return False
 
 
+async def _authorize_channel(channel: str, user_payload: dict | None) -> bool:
+    """Single authorization rule for a channel, shared by subscribe and command.
+
+    #14824: commands must not be able to reach a channel the caller could not
+    subscribe to. Deriving both from this one function is what keeps the two
+    paths from drifting — a second copy of the rules is how one of them ends up
+    weaker than the other.
+    """
+    if not user_payload:
+        return True
+    if channel.startswith("agent:"):
+        claimed_id = channel.split(":", 1)[1]
+        user_id = str(user_payload.get("user_id", ""))
+        username = user_payload.get("username", "")
+        is_admin = "admin" in user_payload.get("roles", [])
+        return is_admin or claimed_id in (user_id, username)
+    if channel.startswith("company:") or channel.startswith("board:"):
+        return await _authorize_llc_channel(channel, user_payload)
+    if channel.startswith("session:") or channel.startswith("chat:"):
+        return await _authorize_conversation_channel(channel, user_payload)
+    if (
+        channel.startswith("workflow:")
+        or channel.startswith("heartbeat:")
+        or channel.startswith("task:")
+    ):
+        return await _authorize_resource_channel(channel, user_payload)
+    return True
+
+
+async def _handle_command(
+    ws: WebSocket,
+    channel: str,
+    command: str,
+    payload: dict,
+    user_payload: dict | None,
+) -> None:
+    """Route one client command to the handler registered for its channel (#14824)."""
+    try:
+        result = await dispatch_command(channel, command, payload, user_payload, _authorize_channel)
+    except CommandRefused as refusal:
+        await _send_error(ws, refusal.reason)
+        return
+    await ws.send_json(
+        {
+            "type": "command_result",
+            "channel": channel,
+            "command": command,
+            "result": result or {},
+        }
+    )
+
+
 async def _handle_subscribe(
     ws: WebSocket,
     channel: str,
@@ -288,6 +344,14 @@ async def _handle_message(ws: WebSocket, raw: str, user_payload: dict | None) ->
         )
     elif action == "unsubscribe":
         await _handle_unsubscribe(ws, data.get("channel", ""))
+    elif action == "command":
+        await _handle_command(
+            ws,
+            data.get("channel", ""),
+            data.get("command", ""),
+            data.get("payload") or {},
+            user_payload,
+        )
     elif action == "ping":
         await ws.send_json({"type": "pong"})
     else:

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -10,14 +10,24 @@ Scoped real-time event streaming with entity-level channel subscriptions.
 Protocol:
   Connect:     wss://host/ws/live?token=<jwt>
   Subscribe:   {"action": "subscribe",   "channel": "task:abc123"}
+               {"action": "subscribe",   "channel": "chat:c1", "last_event_id": 42}
   Unsubscribe: {"action": "unsubscribe", "channel": "task:abc123"}
   Ping:        {"action": "ping"}
-  Server ack:  {"type": "subscribed",   "channel": "..."}
+  Server ack:  {"type": "subscribed",   "channel": "...", "replayed": <int>}
                {"type": "unsubscribed", "channel": "..."}
+               {"type": "resync",       "channel": "...", "reason": "..."}
                {"type": "pong"}
                {"type": "error",        "message": "..."}
   Live event:  {"type": "live_event", "channel": "...", "event_type": "...",
                 "event_id": <int>, "payload": {...}}
+
+Reconnect with replay (#14818): a client that tracks the highest ``event_id``
+it has seen per channel may pass it back as ``last_event_id`` on subscribe.
+The server replays what was missed before resuming live delivery.  When it
+cannot produce a *complete* history — the marker has aged out of the retention
+window, or the durable stream is unavailable — it sends ``resync`` instead of a
+partial replay.  A partial history delivered as if it were whole is precisely
+the silent data loss this protocol addition exists to prevent.
 """
 
 import asyncio
@@ -30,6 +40,7 @@ from api.ws_security import enforce_ws_origin
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from events.bus import get_event_bus
+from events.channel_stream import get_channel_event_stream
 from services.workflow_permission_service import WorkflowPermissionService
 
 logger = get_logger(__name__)
@@ -46,6 +57,64 @@ def _auth_required() -> bool:
         return get_auth_middleware().enable_auth
     except Exception:
         return True
+
+
+def _coerce_last_event_id(raw: object) -> int:
+    """Return a usable ``last_event_id``, or 0 when absent or unusable.
+
+    #14818: an unparseable marker must mean "replay nothing and start fresh",
+    never a crash and never a silently trusted partial value.
+    """
+    if raw is None:
+        return 0
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.debug("Ignoring non-integer last_event_id: %r", raw)
+        return 0
+    return value if value > 0 else 0
+
+
+async def _authorize_conversation_channel(channel: str, user_payload: dict) -> bool:
+    """Authorize ``session:``/``chat:`` subscriptions (#14819).
+
+    Conversation channels carry a user's own messages, so this fails closed:
+    admins bypass, the owner is allowed, everyone else is denied.  Ownership is
+    resolved through the chat history manager, which is the store that knows
+    which user a session belongs to.
+    """
+    if "admin" in user_payload.get("roles", []):
+        return True
+    # ``get_session_owner`` returns the *username* it stored in session
+    # metadata, but a JWT may identify the caller by either field — compare
+    # against both rather than guessing which one this deployment uses.
+    identities = {
+        str(value)
+        for value in (user_payload.get("user_id"), user_payload.get("username"))
+        if value
+    }
+    if not identities:
+        return False
+    _prefix, _, ident = channel.partition(":")
+    if not ident:
+        return False
+    try:
+        from utils.resource_factory import ResourceFactory
+
+        manager = ResourceFactory.get_initialized_chat_history_manager()
+        if manager is None:
+            # No store to check against — deny rather than assume ownership.
+            logger.warning("Conversation channel authz denied: chat history manager unavailable")
+            return False
+        owner = await manager.get_session_owner(ident)
+        if owner is None:
+            # Unknown or unowned conversation: deny non-admins rather than
+            # treating "no record" as "no restriction" (#14819 fails closed).
+            return False
+        return str(owner) in identities
+    except Exception:
+        logger.exception("Conversation channel authorization failed for %s", channel)
+        return False
 
 
 async def _send_error(ws: WebSocket, message: str) -> None:
@@ -140,8 +209,13 @@ async def _authorize_resource_channel(channel: str, user_payload: dict) -> bool:
     return False
 
 
-async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | None) -> None:
-    """Process a subscribe action from the client."""
+async def _handle_subscribe(
+    ws: WebSocket,
+    channel: str,
+    user_payload: dict | None,
+    last_event_id: int = 0,
+) -> None:
+    """Process a subscribe action, optionally replaying from ``last_event_id`` (#14818)."""
     if user_payload and channel.startswith("agent:"):
         claimed_id = channel.split(":", 1)[1]
         user_id = str(user_payload.get("user_id", ""))
@@ -155,6 +229,12 @@ async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | No
         if not await _authorize_llc_channel(channel, user_payload):
             await _send_error(ws, f"Not authorized to subscribe to {channel}")
             return
+    elif user_payload and (channel.startswith("session:") or channel.startswith("chat:")):
+        # #14819: conversation channels are per-user; without this branch any
+        # authenticated caller could subscribe to anyone's conversation.
+        if not await _authorize_conversation_channel(channel, user_payload):
+            await _send_error(ws, f"Not authorized to subscribe to {channel}")
+            return
     elif user_payload and (
         channel.startswith("workflow:") or channel.startswith("heartbeat:") or channel.startswith("task:")
     ):
@@ -163,10 +243,30 @@ async def _handle_subscribe(ws: WebSocket, channel: str, user_payload: dict | No
             await _send_error(ws, f"Not authorized to subscribe to {channel}")
             return
     ok = await get_event_bus().subscribe_ws(ws, channel)
-    if ok:
-        await ws.send_json({"type": "subscribed", "channel": channel})
-    else:
+    if not ok:
         await _send_error(ws, f"Invalid channel: {channel}")
+        return
+
+    # #14818: subscribe first, then replay.  Doing it in this order means events
+    # published *during* the replay are delivered live rather than falling into
+    # a second gap between the replay read and the subscription taking effect.
+    replayed = 0
+    if last_event_id > 0:
+        result = await get_channel_event_stream().replay_since(channel, last_event_id)
+        if result.resync_required:
+            await ws.send_json(
+                {
+                    "type": "resync",
+                    "channel": channel,
+                    "reason": result.reason or "unknown",
+                }
+            )
+        else:
+            for message in result.events:
+                await ws.send_json(message)
+            replayed = len(result.events)
+
+    await ws.send_json({"type": "subscribed", "channel": channel, "replayed": replayed})
 
 
 async def _handle_unsubscribe(ws: WebSocket, channel: str) -> None:
@@ -184,7 +284,12 @@ async def _handle_message(ws: WebSocket, raw: str, user_payload: dict | None) ->
         return
     action = data.get("action")
     if action == "subscribe":
-        await _handle_subscribe(ws, data.get("channel", ""), user_payload)
+        await _handle_subscribe(
+            ws,
+            data.get("channel", ""),
+            user_payload,
+            _coerce_last_event_id(data.get("last_event_id")),
+        )
     elif action == "unsubscribe":
         await _handle_unsubscribe(ws, data.get("channel", ""))
     elif action == "ping":

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -231,7 +231,21 @@ async def _authorize_channel(channel: str, user_payload: dict | None) -> bool:
         return await _authorize_conversation_channel(channel, user_payload)
     if channel.startswith("workflow:") or channel.startswith("heartbeat:") or channel.startswith("task:"):
         return await _authorize_resource_channel(channel, user_payload)
-    return True
+    # ``global`` is the shared broadcast channel: every authenticated client is
+    # meant to see it, and it carries no per-tenant payload of its own.
+    if channel == "global":
+        return True
+    # Everything else is DENIED.  This used to `return True`, which was
+    # survivable while the socket was subscribe-only — every valid prefix above
+    # has an explicit rule, so nothing reached data unchecked. It stopped being
+    # survivable when ``dispatch_command`` started using this same function as
+    # the only gate on a *write* path: a handler registered for a new prefix
+    # (``research:``, ``operation:``, ...) would have been reachable by any
+    # connected client with no check at all. Defaulting to deny means a new
+    # channel type is inert until someone writes its rule, which is the failure
+    # direction we want.
+    logger.warning("Denying unrecognised channel prefix: %s", channel)
+    return False
 
 
 async def _handle_command(

--- a/autobot-backend/api/live_events.py
+++ b/autobot-backend/api/live_events.py
@@ -88,11 +88,7 @@ async def _authorize_conversation_channel(channel: str, user_payload: dict) -> b
     # ``get_session_owner`` returns the *username* it stored in session
     # metadata, but a JWT may identify the caller by either field — compare
     # against both rather than guessing which one this deployment uses.
-    identities = {
-        str(value)
-        for value in (user_payload.get("user_id"), user_payload.get("username"))
-        if value
-    }
+    identities = {str(value) for value in (user_payload.get("user_id"), user_payload.get("username")) if value}
     if not identities:
         return False
     _prefix, _, ident = channel.partition(":")

--- a/autobot-backend/api/live_events_authz_review_test.py
+++ b/autobot-backend/api/live_events_authz_review_test.py
@@ -1,0 +1,71 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Channel authorization defaults (review finding, #14819/#14824).
+
+``_authorize_channel`` used to end in ``return True``. That was survivable while
+the socket was subscribe-only — every valid prefix has an explicit rule, so
+nothing reached data unchecked — but it stopped being survivable once
+``dispatch_command`` adopted the same function as the only gate on a *write*
+path. A handler registered for a new prefix would have been reachable by any
+connected client with no check at all.
+
+The invariant these pin: an unrecognised channel is DENIED, so a new channel
+type is inert until someone writes its rule.
+"""
+
+import pytest
+
+from api.live_events import _authorize_channel
+
+_USER = {"user_id": "u1", "username": "alice", "roles": []}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "channel",
+    [
+        "research:abc",
+        "operation:1",
+        "metrics:cpu",
+        "admin:secrets",
+        "x-custom:1",
+        "nocolon",
+        "",
+    ],
+)
+async def test_an_unrecognised_channel_is_denied(channel):
+    assert await _authorize_channel(channel, _USER) is False
+
+
+@pytest.mark.asyncio
+async def test_global_remains_readable_by_an_authenticated_client():
+    # The shared broadcast channel carries no per-tenant payload and every
+    # authenticated client is meant to see it. Default-deny must not break it.
+    assert await _authorize_channel("global", _USER) is True
+
+
+@pytest.mark.asyncio
+async def test_a_users_own_agent_channel_is_allowed():
+    assert await _authorize_channel("agent:u1", _USER) is True
+
+
+@pytest.mark.asyncio
+async def test_another_users_agent_channel_is_denied():
+    assert await _authorize_channel("agent:someone-else", _USER) is False
+
+
+@pytest.mark.asyncio
+async def test_an_admin_may_reach_another_users_agent_channel():
+    admin = {"user_id": "u2", "username": "root", "roles": ["admin"]}
+    assert await _authorize_channel("agent:u1", admin) is True
+
+
+@pytest.mark.asyncio
+async def test_an_admin_is_still_denied_an_unrecognised_prefix():
+    # Admin bypass lives inside each prefix's rule, not in the default arm —
+    # an unknown channel has no rule to bypass.
+    admin = {"user_id": "u2", "username": "root", "roles": ["admin"]}
+    assert await _authorize_channel("research:abc", admin) is False

--- a/autobot-backend/api/session_events.py
+++ b/autobot-backend/api/session_events.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Session and chat channel publishing (#14820).
+
+Session state used to live in the browser: the frontend minted session ids,
+appended messages locally and persisted to ``localStorage``.  Two clients on one
+account therefore held two independent truths that could never converge — no
+amount of reliable event delivery fixes that, because each client *is* its own
+source of truth.
+
+The fix is to make the backend authoritative and let clients render from it.
+The REST surface in ``api/chat_sessions.py`` already serves the snapshot; what
+was missing was telling everyone *else* when it changed.  Every mutation
+published here goes out durably, so a client that was disconnected can replay it
+rather than silently diverging (#14818).
+
+Channels:
+    ``session:{session_id}``  — session lifecycle (created, updated, deleted)
+    ``chat:{session_id}``     — conversation contents (messages appended)
+
+Publishing must never break the request that triggered it: a failure to notify
+observers is not a reason to fail the write that already succeeded.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from autobot_shared.logging_manager import get_logger
+from events.bus import PersistStrategy, publish_event
+
+logger = get_logger(__name__)
+
+# Event type names carried on the session/chat channels.  Kept display-oriented
+# and backend-agnostic: a client renders from these without knowing which store
+# produced them.
+SESSION_CREATED = "session.created"
+SESSION_UPDATED = "session.updated"
+SESSION_DELETED = "session.deleted"
+CHAT_MESSAGE_ADDED = "chat.message_added"
+CHAT_CLEARED = "chat.cleared"
+
+
+def session_channel(session_id: str) -> str:
+    """Channel carrying lifecycle events for one session."""
+    return f"session:{session_id}"
+
+
+def chat_channel(session_id: str) -> str:
+    """Channel carrying conversation contents for one session."""
+    return f"chat:{session_id}"
+
+
+async def _publish(channel: str, event_type: str, payload: Dict[str, Any]) -> None:
+    """Publish durably, swallowing failures.
+
+    Durable because a client that reconnects must be able to replay what it
+    missed; swallowing because the caller's write has already committed and
+    failing it now would be worse than a missed notification.
+    """
+    try:
+        await publish_event(channel, event_type, payload, persist=PersistStrategy.REDIS)
+    except Exception as exc:
+        logger.warning("Failed to publish %s on %s: %s", event_type, channel, exc)
+
+
+async def publish_session_created(session_id: str, session: Dict[str, Any]) -> None:
+    """Announce a new session so other clients can add it to their list."""
+    await _publish(
+        session_channel(session_id),
+        SESSION_CREATED,
+        {"session_id": session_id, "session": session},
+    )
+
+
+async def publish_session_updated(session_id: str, changes: Dict[str, Any]) -> None:
+    """Announce changed session fields (title, metadata, ...)."""
+    await _publish(
+        session_channel(session_id),
+        SESSION_UPDATED,
+        {"session_id": session_id, "changes": changes},
+    )
+
+
+async def publish_session_deleted(session_id: str) -> None:
+    """Announce a deleted session so other clients drop it from their list."""
+    await _publish(
+        session_channel(session_id),
+        SESSION_DELETED,
+        {"session_id": session_id},
+    )
+
+
+async def publish_chat_message(session_id: str, message: Dict[str, Any]) -> None:
+    """Announce one appended message to everyone watching the conversation."""
+    await _publish(
+        chat_channel(session_id),
+        CHAT_MESSAGE_ADDED,
+        {"session_id": session_id, "message": message},
+    )
+
+
+async def publish_chat_cleared(session_id: str) -> None:
+    """Announce that a conversation's contents were reset."""
+    await _publish(
+        chat_channel(session_id),
+        CHAT_CLEARED,
+        {"session_id": session_id},
+    )

--- a/autobot-backend/api/session_events_test.py
+++ b/autobot-backend/api/session_events_test.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Session and chat channel publishing (#14820).
+
+The property that matters most here is not that a publish happens — it is that a
+publish failure never breaks the request that triggered it. These helpers run
+*after* a write has already committed, so raising would turn "we could not tell
+the other tabs" into "your message failed", which is strictly worse.
+
+Every publish is also asserted to be durable: a client that reconnects has to be
+able to replay session changes it missed (#14818), which only works if they were
+written to the replay window in the first place.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.session_events import (
+    CHAT_CLEARED,
+    CHAT_MESSAGE_ADDED,
+    SESSION_CREATED,
+    SESSION_DELETED,
+    SESSION_UPDATED,
+    chat_channel,
+    publish_chat_cleared,
+    publish_chat_message,
+    publish_session_created,
+    publish_session_deleted,
+    publish_session_updated,
+    session_channel,
+)
+from events.bus import PersistStrategy
+
+
+def test_session_channel_is_prefixed_by_session():
+    assert session_channel("s-1") == "session:s-1"
+
+
+def test_chat_channel_is_prefixed_by_chat():
+    assert chat_channel("s-1") == "chat:s-1"
+
+
+def test_the_two_channels_are_distinct_for_one_session():
+    # Lifecycle and conversation contents are separately subscribable, so a
+    # client can watch a session list without paying for message traffic.
+    assert session_channel("s-1") != chat_channel("s-1")
+
+
+@pytest.fixture
+def publisher():
+    with patch("api.session_events.publish_event", new=AsyncMock()) as mock:
+        yield mock
+
+
+@pytest.mark.asyncio
+async def test_session_created_publishes_durably_on_the_session_channel(publisher):
+    await publish_session_created("s-1", {"title": "New"})
+
+    channel, event_type, payload = publisher.await_args.args
+    assert channel == "session:s-1"
+    assert event_type == SESSION_CREATED
+    assert payload["session_id"] == "s-1"
+    assert payload["session"] == {"title": "New"}
+    assert publisher.await_args.kwargs["persist"] is PersistStrategy.REDIS
+
+
+@pytest.mark.asyncio
+async def test_session_updated_carries_only_the_changed_fields(publisher):
+    await publish_session_updated("s-1", {"title": "Renamed"})
+
+    channel, event_type, payload = publisher.await_args.args
+    assert channel == "session:s-1"
+    assert event_type == SESSION_UPDATED
+    assert payload["changes"] == {"title": "Renamed"}
+
+
+@pytest.mark.asyncio
+async def test_session_deleted_publishes_on_the_session_channel(publisher):
+    await publish_session_deleted("s-1")
+
+    channel, event_type, payload = publisher.await_args.args
+    assert channel == "session:s-1"
+    assert event_type == SESSION_DELETED
+    assert payload == {"session_id": "s-1"}
+
+
+@pytest.mark.asyncio
+async def test_chat_message_publishes_on_the_chat_channel(publisher):
+    message = {"id": "m-1", "text": "hello"}
+    await publish_chat_message("s-1", message)
+
+    channel, event_type, payload = publisher.await_args.args
+    assert channel == "chat:s-1"
+    assert event_type == CHAT_MESSAGE_ADDED
+    assert payload["message"] == message
+
+
+@pytest.mark.asyncio
+async def test_chat_cleared_publishes_on_the_chat_channel(publisher):
+    await publish_chat_cleared("s-1")
+
+    channel, event_type, _payload = publisher.await_args.args
+    assert channel == "chat:s-1"
+    assert event_type == CHAT_CLEARED
+
+
+@pytest.mark.asyncio
+async def test_every_publisher_requests_durable_persistence(publisher):
+    """Replay only works for events that reached the replay window (#14818)."""
+    await publish_session_created("s-1", {})
+    await publish_session_updated("s-1", {})
+    await publish_session_deleted("s-1")
+    await publish_chat_message("s-1", {})
+    await publish_chat_cleared("s-1")
+
+    assert publisher.await_count == 5
+    for call in publisher.await_args_list:
+        assert call.kwargs["persist"] is PersistStrategy.REDIS
+
+
+@pytest.mark.asyncio
+async def test_a_publish_failure_does_not_raise_into_the_caller():
+    """The write already committed; failing the request now would be worse than
+    a missed notification."""
+    with patch("api.session_events.publish_event", new=AsyncMock(side_effect=RuntimeError("bus down"))):
+        # Each of these must return normally rather than propagate.
+        await publish_session_created("s-1", {})
+        await publish_session_updated("s-1", {"title": "x"})
+        await publish_session_deleted("s-1")
+        await publish_chat_message("s-1", {"id": "m"})
+        await publish_chat_cleared("s-1")

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -736,8 +736,16 @@ async def websocket_endpoint(websocket: WebSocket):
     """
     WebSocket endpoint for real-time event stream between backend and frontend.
 
+    DEPRECATED (#14822): ``/api/ws/live`` is the canonical event socket. It
+    subscribes per channel and fans out per client, where this endpoint
+    broadcasts every event to every connected client with no scoping. The
+    AutoBot frontend moved to ``/ws/live``; this route remains for external or
+    pinned clients and is no longer the model new work should target.
+
     Issue #665: Refactored to use extracted helper methods.
     Issue #2818: Authenticate before accepting connection.
+    Issue #14814: broadcast registration is per-connection, so several clients
+    can be attached at once.
     """
     if not await enforce_ws_origin(websocket):
         return

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -516,7 +516,59 @@ def register_chat_history_persistence() -> None:
         logger.error("Failed to register chat-history persistence hook: %s", e)
 
 
-async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_manager):
+async def _event_is_for_user(event_data: dict, current_user_id: str, owner_cache: dict) -> bool:
+    """Decide whether one broadcast event may be shown to this connection.
+
+    Issue #14814 made ``/ws`` delivery additive so several clients could receive
+    events. That fixed delivery but widened an existing leak: this endpoint has
+    no channel scoping, so every connected client would otherwise see every
+    ``PersistStrategy.NONE`` event, including other users' sessions.
+
+    Scoping rules, in order:
+
+    * an explicit ``user_id`` in the payload must match this connection;
+    * a ``session_id`` must resolve to a session this user owns;
+    * anything else is a system-wide event (worker health, NPU status,
+      diagnostics) and stays visible to everyone, as before.
+
+    Fails **closed** for session-scoped events: if ownership cannot be
+    resolved, the event is withheld rather than shown to the wrong user.
+    """
+    payload = event_data.get("payload") or {}
+    if not isinstance(payload, dict):
+        return True
+
+    claimed_user = payload.get("user_id")
+    if claimed_user is not None:
+        return str(claimed_user) == current_user_id
+
+    session_id = payload.get("session_id")
+    if not session_id:
+        return True
+
+    session_id = str(session_id)
+    if session_id in owner_cache:
+        return owner_cache[session_id]
+
+    allowed = False
+    try:
+        from utils.resource_factory import ResourceFactory
+
+        manager = ResourceFactory.get_initialized_chat_history_manager()
+        if manager is not None:
+            owner = await manager.get_session_owner(session_id)
+            # An unowned session predates ownership tracking and stays visible;
+            # an owned one is visible only to its owner.
+            allowed = owner is None or str(owner) == current_user_id
+    except Exception as exc:
+        logger.warning("Could not resolve session owner for %s, withholding: %s", session_id, exc)
+        allowed = False
+
+    owner_cache[session_id] = allowed
+    return allowed
+
+
+async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_manager, current_user_id: str = ""):
     """Create broadcast event handler function (Issue #315 - extracted).
 
     Args:
@@ -526,6 +578,8 @@ async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_man
     Returns:
         Async function that broadcasts events
     """
+    # Per-connection memo so a burst on one session costs a single lookup.
+    owner_cache: dict[str, bool] = {}
 
     async def broadcast_event(event_data: dict):
         """Send one event to this WebSocket client.
@@ -536,6 +590,10 @@ async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_man
         History is now written once at publish time, independently of delivery.
         """
         try:
+            # #14814 follow-up: this endpoint has no channel scoping, so filter
+            # per event rather than shipping every user's traffic to everyone.
+            if not await _event_is_for_user(event_data, current_user_id, owner_cache):
+                return
             await websocket.send_json(event_data)
         except RuntimeError as e:
             if "websocket" in str(e).lower() or "connection" in str(e).lower():
@@ -779,7 +837,7 @@ async def websocket_endpoint(websocket: WebSocket):
     # Issue #665: Use helper for chat history manager access
     chat_history_manager = _get_chat_history_manager(websocket)
 
-    broadcast_event = await _create_broadcast_event_handler(websocket, chat_history_manager)
+    broadcast_event = await _create_broadcast_event_handler(websocket, chat_history_manager, current_user_id)
 
     # Issue #665: Use helper for event manager registration
     _register_event_manager_broadcast(broadcast_event)

--- a/autobot-backend/api/websockets.py
+++ b/autobot-backend/api/websockets.py
@@ -487,6 +487,35 @@ async def _add_to_chat_history(chat_history_manager, message_type: str, raw_data
             logger.error("Failed to add message to chat history: %s", e)
 
 
+async def _persist_event_to_chat_history(event_data: dict) -> None:
+    """Persist one published event to chat history, independent of delivery.
+
+    Issue #14814: registered once as the event manager's persistence hook, so
+    history is written even when no WebSocket client is connected.  Resolves the
+    manager lazily — it does not exist yet at import time.
+    """
+    from utils.resource_factory import ResourceFactory
+
+    manager = ResourceFactory.get_initialized_chat_history_manager()
+    if manager is None:
+        return
+    payload = event_data.get("payload") or {}
+    await _add_to_chat_history(manager, event_data.get("type", "default"), payload)
+
+
+def register_chat_history_persistence() -> None:
+    """Wire event persistence into the event manager (Issue #14814).
+
+    Called once during application startup.  Idempotent — re-registering
+    replaces the same hook.
+    """
+    try:
+        get_event_bus().register_persistence_hook(_persist_event_to_chat_history)
+        logger.info("Chat-history persistence hook registered with event manager")
+    except Exception as e:
+        logger.error("Failed to register chat-history persistence hook: %s", e)
+
+
 async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_manager):
     """Create broadcast event handler function (Issue #315 - extracted).
 
@@ -499,16 +528,15 @@ async def _create_broadcast_event_handler(websocket: WebSocket, chat_history_man
     """
 
     async def broadcast_event(event_data: dict):
-        """Broadcast event to WebSocket client and add to chat history."""
+        """Send one event to this WebSocket client.
+
+        #14814: persistence deliberately does NOT happen here.  It used to,
+        which meant chat history was only written as a side effect of a client
+        being attached — with no client, events were never persisted at all.
+        History is now written once at publish time, independently of delivery.
+        """
         try:
             await websocket.send_json(event_data)
-
-            # Add event to chat history manager
-            message_type = event_data.get("type", "default")
-            raw_data = event_data.get("payload", {})
-
-            await _add_to_chat_history(chat_history_manager, message_type, raw_data)
-
         except RuntimeError as e:
             if "websocket" in str(e).lower() or "connection" in str(e).lower():
                 logger.info("WebSocket connection lost during broadcast: %s", e)
@@ -670,28 +698,29 @@ def _get_chat_history_manager(websocket: WebSocket):
 
 def _register_event_manager_broadcast(broadcast_event: Callable) -> None:
     """
-    Register broadcast function with event manager.
+    Register this connection's broadcast callback with the event manager.
 
     Issue #665: Extracted from websocket_endpoint to reduce function length.
-
-    Args:
-        broadcast_event: Broadcast callback function
+    Issue #14814: additive registration — registering a second client no longer
+    displaces the first.
     """
     try:
         get_event_bus().register_ws_broadcast(broadcast_event)
-        logger.info("Successfully registered WebSocket broadcast with event manager")
+        logger.info("Registered WebSocket broadcast with event manager")
     except Exception as e:
         logger.warning("Failed to register WebSocket broadcast, continuing: %s", e)
 
 
-def _unregister_event_manager_broadcast() -> None:
+def _unregister_event_manager_broadcast(broadcast_event: Callable) -> None:
     """
-    Unregister broadcast function from event manager.
+    Unregister only *this* connection's broadcast callback.
 
     Issue #665: Extracted from websocket_endpoint to reduce function length.
+    Issue #14814: this used to clear the single global callback, so one client
+    disconnecting silenced every other client that was still connected.
     """
     try:
-        get_event_bus().register_ws_broadcast(None)
+        get_event_bus().unregister_ws_broadcast(broadcast_event)
         logger.info("WebSocket broadcast unregistered from event manager")
     except Exception as e:
         logger.error("Error during event manager cleanup: %s", e)
@@ -755,7 +784,8 @@ async def websocket_endpoint(websocket: WebSocket):
         logger.error("WebSocket error: %s", e, exc_info=True)
     finally:
         # Issue #665: Use helper for cleanup
-        _unregister_event_manager_broadcast()
+        # Issue #14814: unregister this connection only, never the global slot.
+        _unregister_event_manager_broadcast(broadcast_event)
         logger.info("WebSocket connection cleanup completed")
 
 

--- a/autobot-backend/api/websockets_chat_history_routing_test.py
+++ b/autobot-backend/api/websockets_chat_history_routing_test.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 from api.websockets import _persist_event_to_chat_history
+from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES
 from chat_history.messages import MessagesMixin
 
 
@@ -128,19 +129,55 @@ def test_event_is_persisted_with_no_websocket_client_attached() -> None:
     ``broadcast_event``: with no client connected there was no callback, so no
     broadcast, so nothing was ever written. No WebSocket exists in this test at
     all — the event must still land.
+
+    ``tool_output`` is used deliberately. Types in
+    ``SKIP_WEBSOCKET_PERSISTENCE_TYPES`` (``llm_response`` among them) are
+    persisted by their own handlers and this path is *supposed* to skip them, so
+    picking one would assert the opposite of the intended behaviour while
+    looking like a delivery bug.
     """
+    # Guard the premise rather than assuming it: if this type is ever added to
+    # the skip set, fail here with the real reason instead of further down with
+    # a misleading "nothing was persisted" message.
+    assert "tool_output" not in SKIP_WEBSOCKET_PERSISTENCE_TYPES, (
+        "tool_output joined the skip set — this test now proves nothing; pick another persisted type"
+    )
+
     manager = _RecordingHistory()
 
     asyncio.run(
         _persist_with(
             manager,
             {
-                "type": "llm_response",
-                "payload": {"response": "answered offline", "session_id": "session-z"},
+                "type": "tool_output",
+                "payload": {"output": "ran while nobody watched", "session_id": "session-z"},
             },
         )
     )
 
     stored = asyncio.run(manager.get_session_messages("session-z", limit=500))
     assert len(stored) == 1, "nothing was persisted while no client was connected"
-    assert "answered offline" in stored[0]["text"]
+    assert "ran while nobody watched" in stored[0]["text"]
+
+
+def test_a_skipped_type_is_still_skipped_through_the_new_hook() -> None:
+    """The other half of the contract: moving persistence must not start writing
+    types that are deliberately persisted elsewhere (#350).
+
+    Without this, a future change that dropped the skip check would look like an
+    improvement — more events recorded — while silently double-writing every
+    streaming LLM response.
+    """
+    skipped_type = next(iter(SKIP_WEBSOCKET_PERSISTENCE_TYPES))
+    manager = _RecordingHistory()
+
+    asyncio.run(
+        _persist_with(
+            manager,
+            {"type": skipped_type, "payload": {"response": "handled elsewhere", "session_id": "session-y"}},
+        )
+    )
+
+    stored = asyncio.run(manager.get_session_messages("session-y", limit=500))
+    assert stored == [], f"{skipped_type} is persisted by its own handler and must not be double-written here"
+    assert manager.history == []

--- a/autobot-backend/api/websockets_chat_history_routing_test.py
+++ b/autobot-backend/api/websockets_chat_history_routing_test.py
@@ -10,16 +10,23 @@ Nothing that serves a session (``get_session_messages``, ``load_session``)
 ever reads that bucket, so every agent-step, tool-output, workflow and
 thought event the websocket layer formatted was silently unreadable.
 
-These tests exercise the *real* producer path — ``broadcast_event``, the
-exact callback ``events/bus.py`` invokes for every published event — through
-to a real ``MessagesMixin``-backed session store, not a hand-fed dict shaped
-to match what the fix happens to check.
+These tests exercise the *real* producer path through to a real
+``MessagesMixin``-backed session store, not a hand-fed dict shaped to match
+what the fix happens to check.
+
+Issue #14814 moved that path: chat history used to be written from inside the
+WebSocket broadcast callback, which meant nothing was persisted at all when no
+client was attached. Persistence now hangs off the event manager's publish-time
+hook (``_persist_event_to_chat_history``), so these tests drive *that* — the
+#14342 session-routing guarantee is unchanged, only its location moved.
 """
 
 import asyncio
 from typing import Any, Dict, List
 
-from api.websockets import _create_broadcast_event_handler
+from unittest.mock import patch
+
+from api.websockets import _persist_event_to_chat_history
 from chat_history.messages import MessagesMixin
 
 
@@ -40,14 +47,18 @@ class _RecordingHistory(MessagesMixin):
         return True
 
 
-class _FakeWebSocket:
-    """Minimal stand-in for the real FastAPI WebSocket send path."""
+async def _persist_with(manager: "_RecordingHistory", event: dict) -> None:
+    """Run the production persistence hook against ``manager``.
 
-    def __init__(self) -> None:
-        self.sent: List[dict] = []
-
-    async def send_json(self, data: dict) -> None:
-        self.sent.append(data)
+    The hook resolves the process-wide manager itself, so the seam under test is
+    that resolution plus the routing below it — the same code path a published
+    event takes in production.
+    """
+    with patch(
+        "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+        return_value=manager,
+    ):
+        await _persist_event_to_chat_history(event)
 
 
 def test_tool_output_event_round_trips_through_its_own_session() -> None:
@@ -55,18 +66,16 @@ def test_tool_output_event_round_trips_through_its_own_session() -> None:
     get_session_messages for that session — the real websocket entry point,
     not the internal dispatch helper."""
     manager = _RecordingHistory()
-    websocket = _FakeWebSocket()
 
-    async def run() -> None:
-        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
-        await broadcast_event(
+    asyncio.run(
+        _persist_with(
+            manager,
             {
                 "type": "tool_output",
                 "payload": {"output": "command finished", "session_id": "session-a"},
-            }
+            },
         )
-
-    asyncio.run(run())
+    )
 
     stored = asyncio.run(manager.get_session_messages("session-a", limit=500))
     assert len(stored) == 1
@@ -79,18 +88,16 @@ def test_tool_output_event_round_trips_through_its_own_session() -> None:
 def test_tool_output_event_not_visible_from_a_different_session() -> None:
     """An event raised on session-a must not leak into session-b's history."""
     manager = _RecordingHistory()
-    websocket = _FakeWebSocket()
 
-    async def run() -> None:
-        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
-        await broadcast_event(
+    asyncio.run(
+        _persist_with(
+            manager,
             {
                 "type": "tool_output",
                 "payload": {"output": "secret result", "session_id": "session-a"},
-            }
+            },
         )
-
-    asyncio.run(run())
+    )
 
     other_session = asyncio.run(manager.get_session_messages("session-b", limit=500))
     assert other_session == []
@@ -100,18 +107,41 @@ def test_workflow_error_event_without_session_id_falls_back_to_default_bucket() 
     """A genuinely session-less event (no session_id in its payload) keeps its
     prior behaviour instead of raising — the fallback the fix must preserve."""
     manager = _RecordingHistory()
-    websocket = _FakeWebSocket()
 
-    async def run() -> None:
-        broadcast_event = await _create_broadcast_event_handler(websocket, manager)
-        await broadcast_event(
+    asyncio.run(
+        _persist_with(
+            manager,
             {
                 "type": "workflow_failed",
                 "payload": {"workflow_id": "wf-1", "error": "boom"},
-            }
+            },
         )
-
-    asyncio.run(run())
+    )
 
     assert len(manager.history) == 1
     assert manager.history[0]["sender"] == "workflow-error"
+
+
+def test_event_is_persisted_with_no_websocket_client_attached() -> None:
+    """#14814: persistence must not be a side effect of delivery.
+
+    This is the regression that motivated moving the write out of
+    ``broadcast_event``: with no client connected there was no callback, so no
+    broadcast, so nothing was ever written. No WebSocket exists in this test at
+    all — the event must still land.
+    """
+    manager = _RecordingHistory()
+
+    asyncio.run(
+        _persist_with(
+            manager,
+            {
+                "type": "llm_response",
+                "payload": {"response": "answered offline", "session_id": "session-z"},
+            },
+        )
+    )
+
+    stored = asyncio.run(manager.get_session_messages("session-z", limit=500))
+    assert len(stored) == 1, "nothing was persisted while no client was connected"
+    assert "answered offline" in stored[0]["text"]

--- a/autobot-backend/api/websockets_chat_history_routing_test.py
+++ b/autobot-backend/api/websockets_chat_history_routing_test.py
@@ -23,7 +23,6 @@ hook (``_persist_event_to_chat_history``), so these tests drive *that* — the
 
 import asyncio
 from typing import Any, Dict, List
-
 from unittest.mock import patch
 
 from api.websockets import _persist_event_to_chat_history

--- a/autobot-backend/api/websockets_chat_history_routing_test.py
+++ b/autobot-backend/api/websockets_chat_history_routing_test.py
@@ -26,8 +26,8 @@ from typing import Any, Dict, List
 from unittest.mock import patch
 
 from api.websockets import _persist_event_to_chat_history
-from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES
 from chat_history.messages import MessagesMixin
+from type_defs.common import SKIP_WEBSOCKET_PERSISTENCE_TYPES
 
 
 class _RecordingHistory(MessagesMixin):
@@ -139,9 +139,9 @@ def test_event_is_persisted_with_no_websocket_client_attached() -> None:
     # Guard the premise rather than assuming it: if this type is ever added to
     # the skip set, fail here with the real reason instead of further down with
     # a misleading "nothing was persisted" message.
-    assert "tool_output" not in SKIP_WEBSOCKET_PERSISTENCE_TYPES, (
-        "tool_output joined the skip set — this test now proves nothing; pick another persisted type"
-    )
+    assert (
+        "tool_output" not in SKIP_WEBSOCKET_PERSISTENCE_TYPES
+    ), "tool_output joined the skip set — this test now proves nothing; pick another persisted type"
 
     manager = _RecordingHistory()
 

--- a/autobot-backend/api/websockets_scoping_review_test.py
+++ b/autobot-backend/api/websockets_scoping_review_test.py
@@ -1,0 +1,118 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Per-user scoping on the legacy broadcast endpoint (review finding, #14814).
+
+Making delivery additive so several clients could receive events fixed the
+delivery bug but widened an existing leak: ``/ws`` has no channel scoping, so
+every connected client would have seen every ``PersistStrategy.NONE`` event —
+including other users' sessions. Previously only the single most-recently
+connected client had that view; now it would have been all of them.
+
+These pin the scoping rules, including the one that matters most: an event whose
+ownership cannot be resolved is WITHHELD, not shown to whoever happens to ask.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from api.websockets import _event_is_for_user
+
+
+class _Manager:
+    def __init__(self, owners: dict):
+        self._owners = owners
+
+    async def get_session_owner(self, session_id: str):
+        return self._owners.get(session_id)
+
+
+def _with_manager(manager):
+    return patch(
+        "utils.resource_factory.ResourceFactory.get_initialized_chat_history_manager",
+        return_value=manager,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_system_event_with_no_owner_fields_is_visible_to_everyone():
+    # Worker health, NPU status and diagnostics carry no tenant, and hiding
+    # them would break the operator dashboards that consume this endpoint.
+    event = {"type": "npu_worker_status_change", "payload": {"worker": "w1"}}
+    assert await _event_is_for_user(event, "u1", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_an_event_addressed_to_another_user_is_withheld():
+    event = {"type": "llm_response", "payload": {"user_id": "u2", "text": "private"}}
+    assert await _event_is_for_user(event, "u1", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_an_event_addressed_to_this_user_is_delivered():
+    event = {"type": "llm_response", "payload": {"user_id": "u1"}}
+    assert await _event_is_for_user(event, "u1", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_another_users_session_event_is_withheld():
+    event = {"type": "tool_output", "payload": {"session_id": "s-bob"}}
+    with _with_manager(_Manager({"s-bob": "bob"})):
+        assert await _event_is_for_user(event, "alice", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_your_own_session_event_is_delivered():
+    event = {"type": "tool_output", "payload": {"session_id": "s-alice"}}
+    with _with_manager(_Manager({"s-alice": "alice"})):
+        assert await _event_is_for_user(event, "alice", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_an_unowned_session_stays_visible():
+    # Sessions created before ownership tracking have no owner recorded;
+    # hiding them would silently blank existing users' history.
+    event = {"type": "tool_output", "payload": {"session_id": "s-legacy"}}
+    with _with_manager(_Manager({})):
+        assert await _event_is_for_user(event, "alice", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_owner_withholds_rather_than_leaks():
+    """The load-bearing case: failure must not default to 'show it'."""
+    event = {"type": "tool_output", "payload": {"session_id": "s-1"}}
+    broken = AsyncMock()
+    broken.get_session_owner.side_effect = RuntimeError("store unavailable")
+    with _with_manager(broken):
+        assert await _event_is_for_user(event, "alice", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_no_history_manager_withholds_session_scoped_events():
+    event = {"type": "tool_output", "payload": {"session_id": "s-1"}}
+    with _with_manager(None):
+        assert await _event_is_for_user(event, "alice", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_the_owner_lookup_is_memoised_per_connection():
+    manager = AsyncMock()
+    manager.get_session_owner.return_value = "alice"
+    cache: dict = {}
+    event = {"type": "tool_output", "payload": {"session_id": "s-1"}}
+
+    with _with_manager(manager):
+        await _event_is_for_user(event, "alice", cache)
+        await _event_is_for_user(event, "alice", cache)
+        await _event_is_for_user(event, "alice", cache)
+
+    assert manager.get_session_owner.await_count == 1, "a burst re-queried ownership per event"
+
+
+@pytest.mark.asyncio
+async def test_a_non_dict_payload_is_not_treated_as_owned():
+    event = {"type": "raw", "payload": "just a string"}
+    assert await _event_is_for_user(event, "u1", {}) is True

--- a/autobot-backend/chat_history/messages.py
+++ b/autobot-backend/chat_history/messages.py
@@ -175,6 +175,10 @@ class MessagesMixin:
         # If session_id provided, add to that session
         if session_id:
             if await self._add_message_to_session(session_id, message):
+                # #14820: the message is committed — now tell every other client
+                # watching this conversation, so a second tab or device does not
+                # silently diverge from the first.
+                await self._announce_message(session_id, message)
                 return
             # Fall through to add to default history on failure
 
@@ -183,6 +187,21 @@ class MessagesMixin:
         self._periodic_memory_check()
         await self._save_history()
         logger.debug("Added message from %s with type %s", sender, message_type)
+
+    @staticmethod
+    async def _announce_message(session_id: str, message: Dict[str, Any]) -> None:
+        """Publish an appended message on the conversation channel (#14820).
+
+        Import is deferred and failures are swallowed: notifying observers must
+        never fail a write that already succeeded, and ``chat_history`` must not
+        take a hard dependency on the API layer at import time.
+        """
+        try:
+            from api.session_events import publish_chat_message
+
+            await publish_chat_message(session_id, message)
+        except Exception as exc:
+            logger.debug("Could not announce message on chat channel: %s", exc)
 
     def get_all_messages(self) -> List[Dict[str, Any]]:
         """Returns the entire chat history."""

--- a/autobot-backend/constants/event_stream_constants.py
+++ b/autobot-backend/constants/event_stream_constants.py
@@ -1,0 +1,25 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Durable channel-event-stream tuning constants (#14817, #14818).
+
+Every value is env-var backed at module import so nothing here is hard-coded at
+a call site, per the project's TTL/config rule.
+"""
+
+import os
+
+# Redis key prefixes for per-channel sequence allocation and replay storage.
+CHANNEL_SEQ_KEY_PREFIX: str = os.getenv("AUTOBOT_CHANNEL_SEQ_KEY_PREFIX", "autobot:events:seq:")
+CHANNEL_STREAM_KEY_PREFIX: str = os.getenv("AUTOBOT_CHANNEL_STREAM_KEY_PREFIX", "autobot:events:channel:")
+
+# How many events are retained per channel for replay.  A client whose
+# last_event_id has fallen out of this window is told to resync rather than
+# handed a partial history.
+CHANNEL_STREAM_MAX_ENTRIES: int = int(os.getenv("AUTOBOT_CHANNEL_STREAM_MAX_ENTRIES", "1000"))
+
+# Idle channel streams expire so per-session and per-chat channels do not
+# accumulate in Redis forever.
+CHANNEL_STREAM_TTL_SECONDS: int = int(os.getenv("AUTOBOT_CHANNEL_STREAM_TTL_SECONDS", "86400"))

--- a/autobot-backend/event_manager.py
+++ b/autobot-backend/event_manager.py
@@ -11,7 +11,7 @@ both fire-and-forget and awaitable delivery patterns.
 """
 
 import asyncio  # Added back asyncio import
-from typing import Any, Awaitable, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict, Set
 
 import yaml
 
@@ -27,9 +27,16 @@ class EventManager:
     """Manages event publishing and subscription with WebSocket support."""
 
     def __init__(self):
-        """Initialize event manager with empty listeners and no WebSocket callback."""
+        """Initialize event manager with empty listeners and no WebSocket callbacks."""
         self._listeners: Dict[str, list[Callable[[Dict[str, Any]], Awaitable[None]]]] = {}
-        self._websocket_broadcast_callback: Callable[[Dict[str, Any]], Awaitable[None]] | None = None
+        # #14814: a set, not a scalar.  This was a single callback, so each new
+        # WebSocket connection overwrote the previous one and the first
+        # disconnect cleared delivery for everyone still connected.
+        self._websocket_broadcast_callbacks: Set[Callable[[Dict[str, Any]], Awaitable[None]]] = set()
+        # #14814: persistence must not be a side effect of delivery.  This hook
+        # fires exactly once per publish, whether zero clients or ten are
+        # connected.
+        self._persistence_hook: Callable[[Dict[str, Any]], Awaitable[None]] | None = None
         self._config = self._load_config()  # Load config on init
 
     def _load_config(self):
@@ -50,9 +57,34 @@ class EventManager:
         """Check if debug mode is enabled in configuration."""
         return self._config.get("agent_behavior", {}).get("debug_mode", False)
 
-    def register_websocket_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]] | None):
-        """Registers a callback function to broadcast events via WebSocket."""
-        self._websocket_broadcast_callback = callback
+    def register_websocket_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
+        """Register one connection's broadcast callback.
+
+        #14814: additive.  Every connected client keeps receiving events when
+        another connects or drops; pair each call with
+        :meth:`unregister_websocket_broadcast`.
+        """
+        if callback is None:
+            raise ValueError("callback must not be None — use unregister_websocket_broadcast()")
+        self._websocket_broadcast_callbacks.add(callback)
+
+    def unregister_websocket_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
+        """Remove one connection's broadcast callback, leaving the others intact."""
+        self._websocket_broadcast_callbacks.discard(callback)
+
+    def register_persistence_hook(self, hook: Callable[[Dict[str, Any]], Awaitable[None]] | None) -> None:
+        """Register the single hook that durably records published events.
+
+        #14814: chat history used to be written from inside the WebSocket
+        broadcast callback, so with no client attached nothing was persisted at
+        all.  Persistence now hangs here instead, decoupled from delivery.
+        """
+        self._persistence_hook = hook
+
+    @property
+    def websocket_broadcast_count(self) -> int:
+        """Number of registered broadcast callbacks (used by tests and diagnostics)."""
+        return len(self._websocket_broadcast_callbacks)
 
     async def publish(self, event_type: str, payload: Dict[str, Any]):
         """Publishes an event to all registered listeners and broadcasts
@@ -60,9 +92,23 @@ class EventManager:
         """
         event_data = {"type": event_type, "payload": payload}
 
-        # Broadcast via WebSocket if registered
-        if self._websocket_broadcast_callback:
-            await self._websocket_broadcast_callback(event_data)
+        # #14814: persist first and exactly once, independent of how many
+        # clients are attached.  A persistence failure must not stop delivery.
+        if self._persistence_hook is not None:
+            try:
+                await self._persistence_hook(event_data)
+            except Exception as exc:
+                logger.error("Event persistence hook failed: %s", exc)
+
+        # #14814: fan out to every registered connection.  Iterate a copy — a
+        # failing callback is removed mid-loop.  One dead socket must not stop
+        # delivery to the others, so each is isolated.
+        for callback in list(self._websocket_broadcast_callbacks):
+            try:
+                await callback(event_data)
+            except Exception as exc:
+                logger.warning("WebSocket broadcast callback failed, unregistering: %s", exc)
+                self._websocket_broadcast_callbacks.discard(callback)
 
         # Notify local listeners (if any)
         if event_type in self._listeners:

--- a/autobot-backend/event_manager_multiclient_14814_test.py
+++ b/autobot-backend/event_manager_multiclient_14814_test.py
@@ -1,0 +1,150 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Multi-client event delivery and delivery-independent persistence (#14814).
+
+The defect: ``EventManager`` held its WebSocket broadcast callback as a single
+scalar.  Registering a second client silently displaced the first, the first
+disconnect cleared delivery for everyone still connected, and — because chat
+history was written from inside the broadcast callback — persistence stopped
+entirely once no client was attached.
+
+These tests drive ``EventManager.publish`` (the production entry point) and
+assert at the far boundary: what each registered client actually received, and
+what the persistence hook actually recorded.  Mutating the fan-out back to a
+single callback must fail them.
+"""
+
+import pytest
+
+from event_manager import EventManager
+
+
+def _collector():
+    """Return (received_list, async callback appending to it)."""
+    received: list = []
+
+    async def callback(event):
+        received.append(event)
+
+    return received, callback
+
+
+@pytest.mark.asyncio
+async def test_two_clients_both_receive_every_event():
+    """Both registered clients receive the event — not just the last registered."""
+    manager = EventManager()
+    a_received, a_cb = _collector()
+    b_received, b_cb = _collector()
+
+    manager.register_websocket_broadcast(a_cb)
+    manager.register_websocket_broadcast(b_cb)
+
+    await manager.publish("task_update", {"task_id": "t1"})
+
+    assert len(a_received) == 1, "first client stopped receiving when the second connected"
+    assert len(b_received) == 1
+    assert a_received[0]["type"] == "task_update"
+    assert a_received[0] == b_received[0]
+
+
+@pytest.mark.asyncio
+async def test_one_client_disconnecting_does_not_silence_the_others():
+    """Unregistering one connection leaves the remaining connections delivering."""
+    manager = EventManager()
+    a_received, a_cb = _collector()
+    b_received, b_cb = _collector()
+
+    manager.register_websocket_broadcast(a_cb)
+    manager.register_websocket_broadcast(b_cb)
+
+    manager.unregister_websocket_broadcast(b_cb)
+    await manager.publish("task_update", {"task_id": "t2"})
+
+    assert len(a_received) == 1, "surviving client went silent when another disconnected"
+    assert len(b_received) == 0, "unregistered client still received events"
+
+
+@pytest.mark.asyncio
+async def test_persistence_runs_with_zero_clients_connected():
+    """History is written when nobody is attached — persistence is not a delivery side effect."""
+    manager = EventManager()
+    persisted: list = []
+
+    async def hook(event):
+        persisted.append(event)
+
+    manager.register_persistence_hook(hook)
+    assert manager.websocket_broadcast_count == 0
+
+    await manager.publish("llm_response", {"text": "hello", "session_id": "s1"})
+
+    assert len(persisted) == 1, "nothing was persisted while no client was connected"
+    assert persisted[0]["payload"]["session_id"] == "s1"
+
+
+@pytest.mark.asyncio
+async def test_persistence_runs_exactly_once_regardless_of_client_count():
+    """Two clients must not produce two history writes."""
+    manager = EventManager()
+    persisted: list = []
+
+    async def hook(event):
+        persisted.append(event)
+
+    manager.register_persistence_hook(hook)
+    _, a_cb = _collector()
+    _, b_cb = _collector()
+    manager.register_websocket_broadcast(a_cb)
+    manager.register_websocket_broadcast(b_cb)
+
+    await manager.publish("llm_response", {"text": "hi"})
+
+    assert len(persisted) == 1, f"expected one write, got {len(persisted)}"
+
+
+@pytest.mark.asyncio
+async def test_failing_client_is_dropped_without_blocking_the_others():
+    """A dead socket must not stop delivery to healthy ones."""
+    manager = EventManager()
+    good_received, good_cb = _collector()
+
+    async def exploding_cb(event):
+        raise RuntimeError("websocket connection closed")
+
+    manager.register_websocket_broadcast(exploding_cb)
+    manager.register_websocket_broadcast(good_cb)
+
+    await manager.publish("progress", {"pct": 10})
+
+    assert len(good_received) == 1, "healthy client lost delivery because a peer failed"
+    assert manager.websocket_broadcast_count == 1, "failed callback was not unregistered"
+
+    await manager.publish("progress", {"pct": 20})
+    assert len(good_received) == 2
+
+
+@pytest.mark.asyncio
+async def test_persistence_failure_does_not_stop_delivery():
+    """A broken persistence hook must not cost connected clients their events."""
+    manager = EventManager()
+    received, cb = _collector()
+
+    async def bad_hook(event):
+        raise RuntimeError("database unavailable")
+
+    manager.register_persistence_hook(bad_hook)
+    manager.register_websocket_broadcast(cb)
+
+    await manager.publish("progress", {"pct": 50})
+
+    assert len(received) == 1, "delivery was lost because persistence failed"
+
+
+def test_register_rejects_none_instead_of_silently_clearing():
+    """The old API cleared the global slot with None; that must now be an error."""
+    manager = EventManager()
+    with pytest.raises(ValueError):
+        manager.register_websocket_broadcast(None)

--- a/autobot-backend/events/bus.py
+++ b/autobot-backend/events/bus.py
@@ -39,7 +39,9 @@ logger = get_logger(__name__)
 class PersistStrategy(Enum):
     """Controls which storage backend(s) receive the event."""
 
-    NONE = "none"  # In-memory EventManager only (fire-and-forget signals)
+    # In-process listeners plus channel fan-out.  Historically "EventManager
+    # only", but its WebSocket delivery was a single global slot; see #14822.
+    NONE = "none"
     MEMORY = "memory"  # LiveEventManager (WebSocket fan-out, channel-scoped)
     BOTH = "both"  # EventManager + LiveEventManager (old workaround, now explicit)
     REDIS = "redis"  # RedisEventStreamManager (durable, task-scoped history)
@@ -82,7 +84,13 @@ class EventBus:
             return
         if persist in (PersistStrategy.NONE, PersistStrategy.BOTH):
             await get_event_manager().publish(event_type, {"channel": channel, **payload})
-        if persist in (PersistStrategy.MEMORY, PersistStrategy.BOTH):
+        if persist in (PersistStrategy.NONE, PersistStrategy.MEMORY, PersistStrategy.BOTH):
+            # #14822: NONE now fans out to the channel too.  This is
+            # behaviour-preserving, not a widening: NONE events already reached
+            # WebSocket clients, via the single global broadcast slot inside
+            # EventManager.  That slot only ever served one client (#14814), so
+            # routing the same events through the channel model is what lets the
+            # frontend converge on one socket without losing anything.
             await get_live_event_manager().publish(channel, event_type, payload)
 
     async def subscribe_ws(self, ws: WebSocket, channel: str) -> bool:

--- a/autobot-backend/events/bus.py
+++ b/autobot-backend/events/bus.py
@@ -15,11 +15,10 @@ out to the appropriate backend(s) based on ``persist``.  The three underlying
 managers are preserved; this layer simply removes the need for callers to know
 which combination to invoke.
 
-Migration plan:
-  Phase 1 (this PR):   events/bus.py lands; agent_loop dual-publish fixed.
-  Phase 2 (follow-up): Migrate api/workflow.py and top ~10 callers.
-  Phase 3 (follow-up): Migrate remaining ~17 files, remove direct imports of
-                        EventManager/LiveEventManager outside their modules.
+The governing rules for this layer — principles, design tests and anti-goals —
+live in ``docs/developer/EVENT_STATE_DOCTRINE.md`` (#14823).  Read that before
+adding a fourth bus, a new WebSocket route, or an event type that is only ever
+delivered as an ephemeral notification.
 """
 
 from __future__ import annotations
@@ -51,8 +50,9 @@ class EventBus:
 
     RedisEventStreamManager is intentionally NOT wrapped here — it has a
     richer typed API (AgentEvent dataclasses, task-scoped streams) that callers
-    should use directly.  The bus handles the two lightweight in-memory managers
-    whose split was causing the dual-publish workaround.
+    should use directly.  ``PersistStrategy.REDIS`` instead durably records the
+    *channel* event stream via ``ChannelEventStream`` (#14816), which is what
+    reconnect-with-replay reads back (#14818).
     """
 
     async def publish(
@@ -73,15 +73,12 @@ class EventBus:
             persist: Which backend(s) receive the event.
         """
         if persist is PersistStrategy.REDIS:
-            # #8304: REDIS strategy has no implementation in this facade.
-            # Callers needing durable Redis events must use RedisEventStreamManager
-            # directly.  Log a critical error instead of silently dropping.
-            logger.critical(
-                "PersistStrategy.REDIS is not implemented in EventBus — event dropped "
-                "(channel=%s, event_type=%s). Use RedisEventStreamManager directly.",
-                channel,
-                event_type,
-            )
+            # #14816: previously this logged critical and dropped the event.
+            # A durable publish now goes through the same channel fan-out as
+            # MEMORY — a persisted event no connected client sees would be a
+            # regression on the old behaviour — and additionally lands in the
+            # channel's Redis replay window.
+            await get_live_event_manager().publish(channel, event_type, payload, durable=True)
             return
         if persist in (PersistStrategy.NONE, PersistStrategy.BOTH):
             await get_event_manager().publish(event_type, {"channel": channel, **payload})
@@ -108,9 +105,17 @@ class EventBus:
         """Unsubscribe a listener from EventManager events."""
         get_event_manager().unsubscribe(event_type, listener)
 
-    def register_ws_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]] | None) -> None:
-        """Register (or clear) the EventManager WebSocket broadcast callback."""
+    def register_ws_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
+        """Register one connection's EventManager WebSocket broadcast callback (#14814)."""
         get_event_manager().register_websocket_broadcast(callback)
+
+    def unregister_ws_broadcast(self, callback: Callable[[Dict[str, Any]], Awaitable[None]]) -> None:
+        """Unregister one connection's broadcast callback, leaving others intact (#14814)."""
+        get_event_manager().unregister_websocket_broadcast(callback)
+
+    def register_persistence_hook(self, hook: Callable[[Dict[str, Any]], Awaitable[None]] | None) -> None:
+        """Register the hook that durably records every published event (#14814)."""
+        get_event_manager().register_persistence_hook(hook)
 
 
 get_event_bus = lazy_singleton(EventBus)

--- a/autobot-backend/events/bus_channel_fanout_14822_test.py
+++ b/autobot-backend/events/bus_channel_fanout_14822_test.py
@@ -1,0 +1,80 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+EventBus routing after the socket consolidation (#14816, #14822).
+
+Two properties are load-bearing for the frontend's move onto a single socket:
+
+* ``PersistStrategy.NONE`` must still reach WebSocket clients.  It did before —
+  through the single global broadcast slot inside ``EventManager`` — so if it
+  did not also reach the channel, migrating the frontend to ``/ws/live`` would
+  silently drop workflow, chain-of-thought and approval events.
+* ``PersistStrategy.REDIS`` must publish rather than drop.  It previously logged
+  critical and returned.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from events.bus import EventBus, PersistStrategy
+
+
+@pytest.fixture
+def buses():
+    """Patch both managers and yield (event_manager, live_event_manager)."""
+    event_manager = AsyncMock()
+    live_manager = AsyncMock()
+    with (
+        patch("events.bus.get_event_manager", return_value=event_manager),
+        patch("events.bus.get_live_event_manager", return_value=live_manager),
+    ):
+        yield event_manager, live_manager
+
+
+@pytest.mark.asyncio
+async def test_none_reaches_the_channel_so_the_single_socket_still_sees_it(buses):
+    """#14822: without this the frontend migration loses every NONE event."""
+    event_manager, live_manager = buses
+
+    await EventBus().publish("global", "workflow_step_started", {"step": 1}, persist=PersistStrategy.NONE)
+
+    live_manager.publish.assert_awaited_once()
+    assert live_manager.publish.await_args.args[0] == "global"
+    # In-process listeners must keep working too.
+    event_manager.publish.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_memory_does_not_notify_in_process_listeners(buses):
+    event_manager, live_manager = buses
+
+    await EventBus().publish("task:1", "progress", {}, persist=PersistStrategy.MEMORY)
+
+    live_manager.publish.assert_awaited_once()
+    event_manager.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_redis_publishes_durably_instead_of_dropping(buses):
+    """#14816: this path used to log critical and return."""
+    _event_manager, live_manager = buses
+
+    await EventBus().publish("chat:c1", "chat.message_added", {"m": 1}, persist=PersistStrategy.REDIS)
+
+    live_manager.publish.assert_awaited_once()
+    assert live_manager.publish.await_args.kwargs.get("durable") is True, (
+        "REDIS published without requesting durable storage — nothing to replay from"
+    )
+
+
+@pytest.mark.asyncio
+async def test_both_reaches_listeners_and_channel(buses):
+    event_manager, live_manager = buses
+
+    await EventBus().publish("global", "evt", {}, persist=PersistStrategy.BOTH)
+
+    event_manager.publish.assert_awaited_once()
+    live_manager.publish.assert_awaited_once()

--- a/autobot-backend/events/bus_channel_fanout_14822_test.py
+++ b/autobot-backend/events/bus_channel_fanout_14822_test.py
@@ -65,9 +65,9 @@ async def test_redis_publishes_durably_instead_of_dropping(buses):
     await EventBus().publish("chat:c1", "chat.message_added", {"m": 1}, persist=PersistStrategy.REDIS)
 
     live_manager.publish.assert_awaited_once()
-    assert live_manager.publish.await_args.kwargs.get("durable") is True, (
-        "REDIS published without requesting durable storage — nothing to replay from"
-    )
+    assert (
+        live_manager.publish.await_args.kwargs.get("durable") is True
+    ), "REDIS published without requesting durable storage — nothing to replay from"
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/events/channel_commands.py
+++ b/autobot-backend/events/channel_commands.py
@@ -1,0 +1,112 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Client-to-server command dispatch on the channel socket (#14824).
+
+Consolidating the bespoke WebSocket routes onto channel subscriptions ran into a
+gap: ``/ws/live`` only ever accepted ``subscribe``, ``unsubscribe`` and
+``ping``.  Eight of the nine routes queued for migration are **bidirectional** —
+the client sends commands (start a research run, pause an operation, change a
+metrics interval) — and there was nowhere for those to go.  Without this, a
+migrated route would lose half its behaviour.
+
+The design mirrors subscription: a command is addressed to a ``channel``, and
+the handler registered for that channel's prefix serves it.  That keeps one
+routing rule for the whole socket — dispatch on ``(action, channel)`` — instead
+of reintroducing per-route knowledge in the endpoint.
+
+Authorization is deliberately **not** re-implemented here.  The caller passes an
+``authorize`` callable and dispatch refuses to run a handler without it, so a
+command can never reach a channel the caller could not subscribe to.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.singleton_factory import lazy_singleton
+
+logger = get_logger(__name__)
+
+# A handler receives (channel, command, payload, user_payload) and returns an
+# optional result dict sent back to the caller.
+CommandHandler = Callable[[str, str, Dict[str, Any], Optional[Dict[str, Any]]], Awaitable[Optional[Dict[str, Any]]]]
+
+
+class ChannelCommandRegistry:
+    """Maps a channel prefix to the handler that serves its commands."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, CommandHandler] = {}
+
+    def register(self, prefix: str, handler: CommandHandler) -> None:
+        """Register the handler for one channel prefix (``research``, ``operation``, ...)."""
+        if prefix in self._handlers:
+            # Replacing silently would make two features fight over a prefix
+            # with the winner decided by import order.
+            logger.warning("Replacing existing command handler for prefix: %s", prefix)
+        self._handlers[prefix] = handler
+        logger.debug("Registered channel command handler for prefix: %s", prefix)
+
+    def unregister(self, prefix: str) -> None:
+        """Remove a prefix's handler."""
+        self._handlers.pop(prefix, None)
+
+    def handler_for(self, channel: str) -> CommandHandler | None:
+        """Return the handler serving ``channel``, or None."""
+        prefix, _, _ident = channel.partition(":")
+        return self._handlers.get(prefix or channel)
+
+    @property
+    def prefixes(self) -> set[str]:
+        """Prefixes with a registered handler (used by tests and diagnostics)."""
+        return set(self._handlers)
+
+
+get_channel_command_registry = lazy_singleton(ChannelCommandRegistry)
+
+
+class CommandRefused(Exception):
+    """A command could not be served.  Carries a client-safe reason."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+async def dispatch_command(
+    channel: str,
+    command: str,
+    payload: Dict[str, Any],
+    user_payload: Optional[Dict[str, Any]],
+    authorize: Callable[[str, Optional[Dict[str, Any]]], Awaitable[bool]],
+) -> Optional[Dict[str, Any]]:
+    """Authorize and run one channel command.
+
+    Raises :class:`CommandRefused` for every rejection path — unknown channel,
+    unauthorized caller, missing handler — so the endpoint has one place to
+    translate a refusal into an error frame, and no refusal can be mistaken for
+    a successful no-op.
+    """
+    if not channel or not command:
+        raise CommandRefused("channel and command are required")
+
+    # Authorize before looking up the handler: whether a handler exists is
+    # itself information about what the deployment runs.
+    if not await authorize(channel, user_payload):
+        raise CommandRefused(f"Not authorized for {channel}")
+
+    handler = get_channel_command_registry().handler_for(channel)
+    if handler is None:
+        raise CommandRefused(f"No command handler for {channel}")
+
+    try:
+        return await handler(channel, command, payload or {}, user_payload)
+    except CommandRefused:
+        raise
+    except Exception as exc:
+        logger.exception("Channel command %s failed on %s", command, channel)
+        raise CommandRefused(f"Command failed: {exc}")

--- a/autobot-backend/events/channel_commands_14824_test.py
+++ b/autobot-backend/events/channel_commands_14824_test.py
@@ -1,0 +1,143 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Channel command dispatch (#14824).
+
+Route consolidation needs a client-to-server path on the channel socket, and the
+property that matters most is that it cannot become a weaker door than
+``subscribe``.  These tests pin the refusal branches — unauthorized, unknown
+handler, malformed, handler raising — because a dispatch that silently no-ops on
+refusal reads to the caller exactly like success.
+"""
+
+import pytest
+
+from events.channel_commands import (
+    ChannelCommandRegistry,
+    CommandRefused,
+    dispatch_command,
+    get_channel_command_registry,
+)
+
+
+async def _allow(_channel, _user):
+    return True
+
+
+async def _deny(_channel, _user):
+    return False
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Keep the process-wide registry from leaking between tests."""
+    registry = get_channel_command_registry()
+    saved = dict(registry._handlers)
+    registry._handlers.clear()
+    yield registry
+    registry._handlers.clear()
+    registry._handlers.update(saved)
+
+
+@pytest.mark.asyncio
+async def test_command_reaches_the_handler_for_its_prefix(clean_registry):
+    seen = {}
+
+    async def handler(channel, command, payload, user):
+        seen.update({"channel": channel, "command": command, "payload": payload})
+        return {"ok": True}
+
+    clean_registry.register("operation", handler)
+
+    result = await dispatch_command("operation:42", "pause", {"why": "test"}, None, _allow)
+
+    assert result == {"ok": True}
+    assert seen["channel"] == "operation:42"
+    assert seen["command"] == "pause"
+    assert seen["payload"] == {"why": "test"}
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_caller_is_refused(clean_registry):
+    """The load-bearing case: commands must not bypass channel authorization."""
+    called = False
+
+    async def handler(channel, command, payload, user):
+        nonlocal called
+        called = True
+        return {}
+
+    clean_registry.register("operation", handler)
+
+    with pytest.raises(CommandRefused):
+        await dispatch_command("operation:42", "pause", {}, {"user_id": "u1"}, _deny)
+
+    assert called is False, "handler ran despite authorization failing"
+
+
+@pytest.mark.asyncio
+async def test_authorization_is_checked_before_handler_lookup(clean_registry):
+    """Whether a handler exists is itself information; deny first."""
+    with pytest.raises(CommandRefused) as exc:
+        await dispatch_command("secret:1", "peek", {}, {"user_id": "u1"}, _deny)
+
+    assert "Not authorized" in exc.value.reason
+    assert "No command handler" not in exc.value.reason
+
+
+@pytest.mark.asyncio
+async def test_unknown_prefix_is_refused(clean_registry):
+    with pytest.raises(CommandRefused) as exc:
+        await dispatch_command("nosuch:1", "go", {}, None, _allow)
+
+    assert "No command handler" in exc.value.reason
+
+
+@pytest.mark.asyncio
+async def test_missing_channel_or_command_is_refused(clean_registry):
+    with pytest.raises(CommandRefused):
+        await dispatch_command("", "go", {}, None, _allow)
+    with pytest.raises(CommandRefused):
+        await dispatch_command("operation:1", "", {}, None, _allow)
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_becomes_a_refusal_not_a_crash(clean_registry):
+    async def boom(channel, command, payload, user):
+        raise RuntimeError("handler exploded")
+
+    clean_registry.register("operation", boom)
+
+    with pytest.raises(CommandRefused) as exc:
+        await dispatch_command("operation:1", "go", {}, None, _allow)
+
+    assert "Command failed" in exc.value.reason
+
+
+@pytest.mark.asyncio
+async def test_handler_may_refuse_explicitly(clean_registry):
+    async def picky(channel, command, payload, user):
+        raise CommandRefused("operation already finished")
+
+    clean_registry.register("operation", picky)
+
+    with pytest.raises(CommandRefused) as exc:
+        await dispatch_command("operation:1", "pause", {}, None, _allow)
+
+    # The handler's own reason must survive, not be flattened into a generic one.
+    assert exc.value.reason == "operation already finished"
+
+
+def test_registry_resolves_by_prefix_only():
+    registry = ChannelCommandRegistry()
+
+    async def handler(channel, command, payload, user):
+        return None
+
+    registry.register("process", handler)
+
+    assert registry.handler_for("process:abc") is handler
+    assert registry.handler_for("process:other") is handler
+    assert registry.handler_for("processx:abc") is None

--- a/autobot-backend/events/channel_stream.py
+++ b/autobot-backend/events/channel_stream.py
@@ -1,0 +1,201 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Durable channel-scoped event stream (#14816, #14817, #14818).
+
+``LiveEventManager`` fans events out to connected WebSocket subscribers, but it
+held its sequence numbers in a process-local dict.  That id reset on every
+restart and diverged between workers, so it could not anchor a replay request —
+and an id a consumer trusts but which silently restarts is worse than no id.
+
+This module backs both concerns with Redis:
+
+* :meth:`next_event_id` allocates the sequence with ``INCR``, so it is monotonic
+  per channel across restarts and shared across workers.
+* :meth:`append` writes the event into a per-channel Redis Stream trimmed to
+  ``CHANNEL_STREAM_MAX_ENTRIES``, giving reconnecting clients something to
+  replay from.
+* :meth:`replay_since` returns the events a client missed, or reports that the
+  gap is wider than the retained window so the caller resyncs instead of
+  delivering a silent partial.
+
+Redis is not required.  When it is unreachable the stream degrades to an
+in-process counter and reports replay as *unavailable* — the client is told to
+resync rather than handed an incomplete history.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.singleton_factory import lazy_singleton
+from constants.event_stream_constants import (
+    CHANNEL_SEQ_KEY_PREFIX,
+    CHANNEL_STREAM_KEY_PREFIX,
+    CHANNEL_STREAM_MAX_ENTRIES,
+    CHANNEL_STREAM_TTL_SECONDS,
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class ReplayResult:
+    """Outcome of a replay request.
+
+    ``resync_required`` carries the weight here: it keeps "you missed nothing"
+    and "we cannot tell you what you missed" from collapsing into the same empty
+    list, which is the failure mode that makes lost events invisible.
+    """
+
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    resync_required: bool = False
+    reason: str | None = None
+
+
+class ChannelEventStream:
+    """Redis-backed sequence allocation and replay for live-event channels."""
+
+    def __init__(self) -> None:
+        self._redis: Any = None
+        self._redis_unavailable = False
+        # Fallback only.  Never the primary source of ids — it resets on
+        # restart, which is the defect this module exists to fix (#14817).
+        self._memory_counters: Dict[str, int] = {}
+
+    async def _get_redis(self) -> Any:
+        """Return the async Redis client, or ``None`` when unreachable."""
+        if self._redis is not None:
+            return self._redis
+        if self._redis_unavailable:
+            return None
+        try:
+            self._redis = await get_async_redis_client(database="main")
+            return self._redis
+        except Exception as exc:
+            # Log once, then stay quiet: a Redis-less dev run should not spam.
+            self._redis_unavailable = True
+            logger.warning(
+                "Channel event stream falling back to in-process ids — Redis unavailable: %s",
+                exc,
+            )
+            return None
+
+    @property
+    def durable(self) -> bool:
+        """True when ids and replay are Redis-backed rather than in-process."""
+        return self._redis is not None and not self._redis_unavailable
+
+    @staticmethod
+    def _seq_key(channel: str) -> str:
+        return f"{CHANNEL_SEQ_KEY_PREFIX}{channel}"
+
+    @staticmethod
+    def _stream_key(channel: str) -> str:
+        return f"{CHANNEL_STREAM_KEY_PREFIX}{channel}"
+
+    async def next_event_id(self, channel: str) -> int:
+        """Allocate the next sequence number for ``channel``.
+
+        Redis ``INCR`` is atomic, so this is monotonic across restarts and safe
+        across worker processes.  Without Redis it degrades to a process-local
+        counter, and :attr:`durable` reports False so callers can tell clients
+        that replay is not available.
+        """
+        redis_client = await self._get_redis()
+        if redis_client is not None:
+            try:
+                return int(await redis_client.incr(self._seq_key(channel)))
+            except Exception as exc:
+                logger.warning("Sequence allocation failed for %s, using memory: %s", channel, exc)
+        self._memory_counters[channel] = self._memory_counters.get(channel, 0) + 1
+        return self._memory_counters[channel]
+
+    async def append(self, channel: str, message: Dict[str, Any]) -> None:
+        """Persist ``message`` into the channel's replay window.
+
+        A failure here must not stop live delivery — the event still reaches
+        connected clients; only the ability to replay it later is lost.
+        """
+        redis_client = await self._get_redis()
+        if redis_client is None:
+            return
+        try:
+            stream_key = self._stream_key(channel)
+            await redis_client.xadd(
+                stream_key,
+                {
+                    "event_id": str(message.get("event_id", 0)),
+                    "data": json.dumps(message, ensure_ascii=False, default=str),
+                },
+                maxlen=CHANNEL_STREAM_MAX_ENTRIES,
+                approximate=True,
+            )
+            await redis_client.expire(stream_key, CHANNEL_STREAM_TTL_SECONDS)
+        except Exception as exc:
+            logger.warning("Failed to persist event for replay on %s: %s", channel, exc)
+
+    async def replay_since(self, channel: str, last_event_id: int) -> ReplayResult:
+        """Return the events on ``channel`` newer than ``last_event_id``.
+
+        Sets ``resync_required`` when a complete history cannot be produced —
+        Redis unavailable, or the client's marker already trimmed out of the
+        retained window.  Never returns a partial history as if it were whole.
+        """
+        redis_client = await self._get_redis()
+        if redis_client is None:
+            return ReplayResult(resync_required=True, reason="replay_unavailable")
+
+        try:
+            entries = await redis_client.xrange(self._stream_key(channel))
+        except Exception as exc:
+            logger.warning("Replay read failed on %s: %s", channel, exc)
+            return ReplayResult(resync_required=True, reason="replay_unavailable")
+
+        decoded: List[Dict[str, Any]] = []
+        lowest_retained: int | None = None
+        for _entry_id, fields in entries or []:
+            raw = self._field(fields, "data")
+            if raw is None:
+                continue
+            try:
+                message = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                # An unparseable entry means the window is not trustworthy.
+                # Treat that as a gap, never as "nothing to replay".
+                return ReplayResult(resync_required=True, reason="replay_corrupt")
+            event_id = int(message.get("event_id", 0))
+            if lowest_retained is None or event_id < lowest_retained:
+                lowest_retained = event_id
+            if event_id > last_event_id:
+                decoded.append(message)
+
+        # The client's marker predates everything we still hold, so events
+        # between its marker and our oldest entry are gone.  A first-ever
+        # subscribe (last_event_id == 0) is not a gap.
+        if lowest_retained is not None and last_event_id > 0 and lowest_retained > last_event_id + 1:
+            return ReplayResult(resync_required=True, reason="gap_exceeds_retention")
+
+        return ReplayResult(events=decoded)
+
+    @staticmethod
+    def _field(fields: Any, name: str) -> str | None:
+        """Read one field from a stream entry, tolerating bytes or str keys."""
+        if not isinstance(fields, dict):
+            return None
+        if name in fields:
+            value = fields[name]
+        elif name.encode() in fields:
+            value = fields[name.encode()]
+        else:
+            return None
+        return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+get_channel_event_stream = lazy_singleton(ChannelEventStream)

--- a/autobot-backend/events/channel_stream.py
+++ b/autobot-backend/events/channel_stream.py
@@ -100,6 +100,11 @@ class ChannelEventStream:
     def _stream_key(channel: str) -> str:
         return f"{CHANNEL_STREAM_KEY_PREFIX}{channel}"
 
+    @staticmethod
+    def _broken_key(channel: str) -> str:
+        """Key marking that a durable write was lost, so replay is untrustworthy."""
+        return f"{CHANNEL_STREAM_KEY_PREFIX}{channel}:broken-from"
+
     async def next_event_id(self, channel: str) -> int:
         """Allocate the next sequence number for ``channel``.
 
@@ -139,7 +144,53 @@ class ChannelEventStream:
             )
             await redis_client.expire(stream_key, CHANNEL_STREAM_TTL_SECONDS)
         except Exception as exc:
+            # The event still reached connected clients; only its replayability
+            # is lost. But a swallowed failure here punches a hole in the replay
+            # window that `replay_since` cannot otherwise see: it checks only the
+            # lower boundary of the retained range, so a client whose marker sits
+            # *below* the hole would be handed a partial history as if it were
+            # whole — the exact silent loss this module exists to prevent.
+            #
+            # Contiguity checking is NOT a workable substitute: only
+            # PersistStrategy.REDIS publishes durably, so non-durable events
+            # legitimately consume sequence numbers without ever being appended
+            # and the stream is full of by-design gaps. Recording the failure is
+            # what distinguishes "never meant to be replayable" from "should
+            # have been, and is missing".
             logger.warning("Failed to persist event for replay on %s: %s", channel, exc)
+            await self._mark_broken(channel, int(message.get("event_id", 0)))
+
+    async def _mark_broken(self, channel: str, event_id: int) -> None:
+        """Record the lowest event id whose durable write was lost."""
+        redis_client = await self._get_redis()
+        if redis_client is None:
+            return
+        try:
+            key = self._broken_key(channel)
+            # SETNX keeps the *lowest* failed id: a client below it cannot be
+            # served a complete history, one above it is unaffected.
+            await redis_client.setnx(key, str(event_id))
+            await redis_client.expire(key, CHANNEL_STREAM_TTL_SECONDS)
+        except Exception as exc:
+            # Cannot record the hole. Fail loud rather than leave a silent gap.
+            logger.error("Could not mark replay broken on %s: %s", channel, exc)
+
+    async def _broken_from(self, channel: str) -> int | None:
+        """Lowest event id known to be missing from the replay window, if any."""
+        redis_client = await self._get_redis()
+        if redis_client is None:
+            return None
+        try:
+            raw = await redis_client.get(self._broken_key(channel))
+        except Exception:
+            return None
+        if raw is None:
+            return None
+        try:
+            return int(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+        except (TypeError, ValueError):
+            # An unreadable marker means we cannot prove the window is whole.
+            return 0
 
     async def replay_since(self, channel: str, last_event_id: int) -> ReplayResult:
         """Return the events on ``channel`` newer than ``last_event_id``.
@@ -151,6 +202,12 @@ class ChannelEventStream:
         redis_client = await self._get_redis()
         if redis_client is None:
             return ReplayResult(resync_required=True, reason="replay_unavailable")
+
+        # A recorded durable-write failure below the caller's position means we
+        # cannot hand them a complete history, however healthy the range looks.
+        broken_from = await self._broken_from(channel)
+        if broken_from is not None and broken_from > last_event_id:
+            return ReplayResult(resync_required=True, reason="durable_write_lost")
 
         try:
             entries = await redis_client.xrange(self._stream_key(channel))

--- a/autobot-backend/events/channel_stream_replay_14818_test.py
+++ b/autobot-backend/events/channel_stream_replay_14818_test.py
@@ -18,7 +18,6 @@ The fake Redis below implements only INCR/XADD/XRANGE/EXPIRE semantics, so the
 tests exercise the real ``ChannelEventStream`` logic rather than a mock of it.
 """
 
-import json
 
 import pytest
 

--- a/autobot-backend/events/channel_stream_replay_14818_test.py
+++ b/autobot-backend/events/channel_stream_replay_14818_test.py
@@ -18,7 +18,6 @@ The fake Redis below implements only INCR/XADD/XRANGE/EXPIRE semantics, so the
 tests exercise the real ``ChannelEventStream`` logic rather than a mock of it.
 """
 
-
 import pytest
 
 from events.channel_stream import ChannelEventStream

--- a/autobot-backend/events/channel_stream_replay_14818_test.py
+++ b/autobot-backend/events/channel_stream_replay_14818_test.py
@@ -29,6 +29,7 @@ class FakeRedis:
     def __init__(self):
         self.counters: dict[str, int] = {}
         self.streams: dict[str, list] = {}
+        self.plain: dict[str, str] = {}
         self._seq = 0
 
     async def incr(self, key: str) -> int:
@@ -49,6 +50,15 @@ class FakeRedis:
 
     async def expire(self, key, ttl):
         return True
+
+    async def setnx(self, key, value):
+        if key in self.counters or key in self.plain:
+            return False
+        self.plain[key] = value
+        return True
+
+    async def get(self, key):
+        return self.plain.get(key)
 
 
 @pytest.fixture
@@ -182,3 +192,72 @@ async def test_append_failure_does_not_raise(stream):
 
     stream._redis.xadd = boom
     await stream.append("chat:c1", {"event_id": 1})  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_a_lost_durable_write_forces_resync_for_earlier_clients(stream):
+    """Review finding: a swallowed append failure punched an invisible hole.
+
+    ``replay_since`` only checks the LOWER boundary of the retained range, so a
+    client whose marker sits below a mid-stream hole was handed a partial
+    history as if it were whole.
+    """
+    await _publish(stream, "chat:c1", 3)
+
+    # Event 4's durable write fails and is swallowed, as it must be — the event
+    # still reached live subscribers, only its replayability is lost.
+    async def boom(*_a, **_kw):
+        raise RuntimeError("redis rejected the write")
+
+    original_xadd = stream._redis.xadd
+    stream._redis.xadd = boom
+    event_id = await stream.next_event_id("chat:c1")
+    await stream.append("chat:c1", {"event_id": event_id, "payload": {}})
+    stream._redis.xadd = original_xadd
+
+    await _publish(stream, "chat:c1", 2)  # ids 5, 6 land normally
+
+    result = await stream.replay_since("chat:c1", 2)
+
+    assert result.resync_required, "partial history returned as if it were whole"
+    assert result.reason == "durable_write_lost"
+
+
+@pytest.mark.asyncio
+async def test_a_client_past_the_hole_is_unaffected(stream):
+    """The marker records the LOWEST lost id, so later clients still replay."""
+    await _publish(stream, "chat:c1", 3)
+
+    async def boom(*_a, **_kw):
+        raise RuntimeError("redis rejected the write")
+
+    original_xadd = stream._redis.xadd
+    stream._redis.xadd = boom
+    event_id = await stream.next_event_id("chat:c1")
+    await stream.append("chat:c1", {"event_id": event_id, "payload": {}})
+    stream._redis.xadd = original_xadd
+
+    await _publish(stream, "chat:c1", 2)
+
+    # Marker is at 4; a client that already saw 4 lost nothing.
+    result = await stream.replay_since("chat:c1", 4)
+
+    assert not result.resync_required
+    assert [e["event_id"] for e in result.events] == [5, 6]
+
+
+@pytest.mark.asyncio
+async def test_by_design_gaps_do_not_trigger_a_resync(stream):
+    """Non-durable events consume ids without being appended.
+
+    Only PersistStrategy.REDIS publishes durably, so the stream is legitimately
+    full of holes. A naive contiguity check would fire on every one of them and
+    resync clients constantly for no reason.
+    """
+    await _publish(stream, "chat:c1", 2)
+    await stream.next_event_id("chat:c1")  # id 3, never appended (non-durable)
+    await _publish(stream, "chat:c1", 1)  # id 4 appended
+
+    result = await stream.replay_since("chat:c1", 1)
+
+    assert not result.resync_required, "a by-design gap was mistaken for data loss"

--- a/autobot-backend/events/channel_stream_replay_14818_test.py
+++ b/autobot-backend/events/channel_stream_replay_14818_test.py
@@ -1,0 +1,186 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""
+Durable channel sequencing and reconnect replay (#14817, #14818).
+
+Two properties matter here and neither is covered by "the happy path returns
+events":
+
+* an id that resets on restart is worse than no id, because a consumer trusts
+  it and silently skips or re-applies events (#14817);
+* a replay that cannot be completed must say so.  Returning an empty list for
+  both "you missed nothing" and "we cannot tell you what you missed" is exactly
+  how lost events become invisible (#14818).
+
+The fake Redis below implements only INCR/XADD/XRANGE/EXPIRE semantics, so the
+tests exercise the real ``ChannelEventStream`` logic rather than a mock of it.
+"""
+
+import json
+
+import pytest
+
+from events.channel_stream import ChannelEventStream
+
+
+class FakeRedis:
+    """Minimal INCR/XADD/XRANGE stand-in with a real trimming rule."""
+
+    def __init__(self):
+        self.counters: dict[str, int] = {}
+        self.streams: dict[str, list] = {}
+        self._seq = 0
+
+    async def incr(self, key: str) -> int:
+        self.counters[key] = self.counters.get(key, 0) + 1
+        return self.counters[key]
+
+    async def xadd(self, key, fields, maxlen=None, approximate=True):
+        self._seq += 1
+        entry_id = f"{self._seq}-0"
+        self.streams.setdefault(key, []).append((entry_id, dict(fields)))
+        if maxlen is not None and len(self.streams[key]) > maxlen:
+            # Trim oldest first, as Redis does.
+            self.streams[key] = self.streams[key][-maxlen:]
+        return entry_id
+
+    async def xrange(self, key):
+        return list(self.streams.get(key, []))
+
+    async def expire(self, key, ttl):
+        return True
+
+
+@pytest.fixture
+def stream():
+    s = ChannelEventStream()
+    s._redis = FakeRedis()
+    return s
+
+
+async def _publish(stream: ChannelEventStream, channel: str, n: int) -> list[int]:
+    ids = []
+    for i in range(n):
+        event_id = await stream.next_event_id(channel)
+        ids.append(event_id)
+        await stream.append(channel, {"event_id": event_id, "payload": {"i": i}})
+    return ids
+
+
+@pytest.mark.asyncio
+async def test_ids_are_monotonic_per_channel(stream):
+    ids = await _publish(stream, "chat:c1", 5)
+    assert ids == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_ids_survive_a_restart(stream):
+    """#14817: the defect was a process-local counter restarting at 1."""
+    await _publish(stream, "chat:c1", 3)
+    shared_redis = stream._redis
+
+    # A "restarted" process: brand-new object, same Redis.
+    restarted = ChannelEventStream()
+    restarted._redis = shared_redis
+
+    next_id = await restarted.next_event_id("chat:c1")
+    assert next_id == 4, f"id restarted at {next_id} — a client's marker would now be wrong"
+
+
+@pytest.mark.asyncio
+async def test_two_workers_never_allocate_the_same_id(stream):
+    """Independent instances sharing one Redis must not collide."""
+    shared_redis = stream._redis
+    worker_b = ChannelEventStream()
+    worker_b._redis = shared_redis
+
+    a_ids = [await stream.next_event_id("chat:c1") for _ in range(3)]
+    b_ids = [await worker_b.next_event_id("chat:c1") for _ in range(3)]
+
+    assert len(set(a_ids) | set(b_ids)) == 6, "workers allocated overlapping ids"
+
+
+@pytest.mark.asyncio
+async def test_channels_have_independent_sequences(stream):
+    await _publish(stream, "chat:c1", 3)
+    other = await stream.next_event_id("chat:c2")
+    assert other == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_only_events_after_the_marker(stream):
+    await _publish(stream, "chat:c1", 5)
+    result = await stream.replay_since("chat:c1", 2)
+    assert not result.resync_required
+    assert [e["event_id"] for e in result.events] == [3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_replay_of_a_current_client_returns_nothing_and_no_resync(stream):
+    await _publish(stream, "chat:c1", 3)
+    result = await stream.replay_since("chat:c1", 3)
+    assert result.events == []
+    assert not result.resync_required, "an up-to-date client was told to resync"
+
+
+@pytest.mark.asyncio
+async def test_gap_wider_than_retention_demands_resync(stream):
+    """The distinguishing case: a partial history must never look complete."""
+    from events import channel_stream as cs
+
+    original = cs.CHANNEL_STREAM_MAX_ENTRIES
+    cs.CHANNEL_STREAM_MAX_ENTRIES = 3
+    try:
+        await _publish(stream, "chat:c1", 10)
+        # Retained window is ids 8,9,10. A client last saw 2 — ids 3..7 are gone.
+        result = await stream.replay_since("chat:c1", 2)
+    finally:
+        cs.CHANNEL_STREAM_MAX_ENTRIES = original
+
+    assert result.resync_required, "silently returned a partial history as if it were whole"
+    assert result.reason == "gap_exceeds_retention"
+
+
+@pytest.mark.asyncio
+async def test_replay_without_redis_demands_resync():
+    """No durable stream means we cannot prove completeness — say so."""
+    s = ChannelEventStream()
+    s._redis_unavailable = True
+
+    result = await s.replay_since("chat:c1", 5)
+    assert result.resync_required
+    assert result.reason == "replay_unavailable"
+    assert result.events == []
+
+
+@pytest.mark.asyncio
+async def test_corrupt_entry_demands_resync_rather_than_skipping(stream):
+    await _publish(stream, "chat:c1", 3)
+    key = stream._stream_key("chat:c1")
+    stream._redis.streams[key][1] = ("2-0", {"event_id": "2", "data": "{not json"})
+
+    result = await stream.replay_since("chat:c1", 0)
+    assert result.resync_required, "an unreadable entry was skipped instead of forcing a resync"
+    assert result.reason == "replay_corrupt"
+
+
+@pytest.mark.asyncio
+async def test_first_subscribe_is_not_treated_as_a_gap(stream):
+    """last_event_id == 0 means 'never seen anything', not 'I lost events'."""
+    await _publish(stream, "chat:c1", 3)
+    result = await stream.replay_since("chat:c1", 0)
+    assert not result.resync_required
+    assert [e["event_id"] for e in result.events] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_append_failure_does_not_raise(stream):
+    """Losing replay-ability must never break live delivery."""
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("redis down")
+
+    stream._redis.xadd = boom
+    await stream.append("chat:c1", {"event_id": 1})  # must not raise

--- a/autobot-backend/initialization/lifespan.py
+++ b/autobot-backend/initialization/lifespan.py
@@ -159,6 +159,11 @@ async def _init_chat_history_manager(app: FastAPI) -> None:
         await chat_history_manager.initialize()
         app.state.chat_history_manager = chat_history_manager
         await update_app_state("chat_history_manager", chat_history_manager)
+        # Issue #14814: persistence must not depend on a WebSocket client being
+        # attached.  Register the publish-time hook now that the manager exists.
+        from api.websockets import register_chat_history_persistence
+
+        register_chat_history_persistence()
         logger.info("✅ [ 30%] Chat History: Manager initialized successfully")
     except Exception as chat_history_error:
         logger.error(f"❌ CRITICAL: Chat history manager initialization failed: {chat_history_error}")

--- a/autobot-backend/live_event_manager.py
+++ b/autobot-backend/live_event_manager.py
@@ -17,15 +17,27 @@ from starlette.websockets import WebSocketState
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from events.channel_stream import get_channel_event_stream
 
 logger = get_logger(__name__)
 
-_VALID_PREFIXES = {"agent", "task", "workflow", "heartbeat", "company", "board"}
+# #14819: session and chat make a conversation addressable, which is what lets
+# several clients subscribe to the same conversation instead of falling back to
+# ``global`` (everything) or the legacy single-client endpoint.
+_VALID_PREFIXES = {
+    "agent",
+    "task",
+    "workflow",
+    "heartbeat",
+    "company",
+    "board",
+    "session",
+    "chat",
+}
 
 
 def _is_valid_channel(channel: str) -> bool:
-    """Return True for a valid channel — an agent/task/workflow/heartbeat/company/board
-    ``:{id}`` prefix, or ``global``."""
+    """Return True for a valid channel — a known ``{prefix}:{id}`` form, or ``global``."""
     if channel == "global":
         return True
     parts = channel.split(":", 1)
@@ -39,7 +51,6 @@ class LiveEventManager:
         self._subscriptions: Dict[str, Set[WebSocket]] = {}
         self._client_channels: Dict[int, Set[str]] = {}
         self._lock = asyncio.Lock()
-        self._event_counters: Dict[str, int] = {}
 
     def _ws_key(self, ws: WebSocket) -> int:
         return id(ws)
@@ -84,17 +95,22 @@ class LiveEventManager:
                         del self._subscriptions[channel]
         logger.debug("Client removed from all channel subscriptions")
 
-    def _next_event_id(self, channel: str) -> int:
-        """Return next auto-incrementing event ID for channel."""
-        self._event_counters[channel] = self._event_counters.get(channel, 0) + 1
-        return self._event_counters[channel]
+    async def publish(self, channel: str, event_type: str, payload: dict, *, durable: bool = False) -> int:
+        """Publish event to channel subscribers and global subscribers.
 
-    async def publish(self, channel: str, event_type: str, payload: dict) -> int:
-        """Publish event to channel subscribers and global subscribers."""
+        #14817: the sequence number comes from :class:`ChannelEventStream`
+        (Redis ``INCR``), so it is monotonic across restarts and shared between
+        workers.  It previously came from a process-local dict, which reset on
+        restart and diverged across processes — an id a client trusts but which
+        silently restarts is worse than no id at all.
+
+        ``durable`` additionally records the event in the channel's replay
+        window so a reconnecting client can ask for what it missed (#14818).
+        """
         if not _is_valid_channel(channel):
             logger.warning("Publish to invalid channel ignored: %s", channel)
             return 0
-        event_id = self._next_event_id(channel)
+        event_id = await get_channel_event_stream().next_event_id(channel)
         message = {
             "type": "live_event",
             "channel": channel,
@@ -102,6 +118,8 @@ class LiveEventManager:
             "event_id": event_id,
             "payload": payload,
         }
+        if durable:
+            await get_channel_event_stream().append(channel, message)
         async with self._lock:
             recipients: Set[WebSocket] = set()
             recipients.update(self._subscriptions.get(channel, set()))

--- a/autobot-backend/middleware/service_auth_enforcement.py
+++ b/autobot-backend/middleware/service_auth_enforcement.py
@@ -78,7 +78,10 @@ EXEMPT_PATHS: List[str] = [
     "/api/monitoring",
     "/api/metrics",
     "/api/analytics",
-    # WebSocket connections (api.websockets router mounted at /api prefix)
+    # WebSocket connections (api.websockets router mounted at /api prefix).
+    # #14822: prefix match, so this one entry covers both the legacy /api/ws
+    # and the canonical /api/ws/live. Narrowing it to /api/ws/live would
+    # silently start rejecting the legacy endpoint.
     "/api/ws",
     # API documentation
     "/docs",

--- a/autobot-backend/project_state_manager.py
+++ b/autobot-backend/project_state_manager.py
@@ -274,7 +274,9 @@ class ProjectStateManager:
 
     def _get_phase4_capabilities(self) -> List[PhaseCapability]:
         """Get Phase 4 System Integration capabilities."""
-        ws_url = get_service_url("backend", "/ws").replace("http://", "ws://").replace("https://", "wss://")
+        # #14822: probe the canonical channel socket, not the legacy broadcast
+        # endpoint — a capability report should describe what clients use.
+        ws_url = get_service_url("backend", "/api/ws/live").replace("http://", "ws://").replace("https://", "wss://")
         return [
             PhaseCapability(
                 "terminal_integration",

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
@@ -45,10 +45,17 @@ function step(id: string, x: number, y: number, connections: string[] = []): Can
   }
 }
 
+// #14854: built once, not per mount. This file mounts many times and the `en`
+// bundle is ~400KB, so constructing a fresh i18n instance inside mountCanvas
+// re-ingested the whole message tree on every single mount. The instance is
+// read-only here — no test mutates locale or messages — so sharing it is safe
+// and removes work that was never the thing under test.
+const i18nForTests = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(nodes: CanvasNode[]) {
   return mount(WorkflowCanvas, {
     props: { nodes, selectedNodeId: null },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+    global: { plugins: [i18nForTests] },
   })
 }
 
@@ -113,22 +120,35 @@ describe('the node count this canvas is known to carry (#14766)', () => {
   // handful. This states the number rather than leaving it to be discovered by
   // a real org graph. It is a floor on what we support, not a performance
   // budget: raise it when a surface needs more.
-  // 200 leaves headroom under the suite's 10s `testTimeout` while still being
-  // an order of magnitude past anything the suite mounted before.
+  // 200 is an order of magnitude past anything else the suite mounts.
   const SUPPORTED_NODES = 200
 
-  it(`renders ${SUPPORTED_NODES} nodes and their edges without dropping any`, () => {
-    const nodes = Array.from({ length: SUPPORTED_NODES }, (_, i) =>
-      step(`n${i}`, (i % 20) * 300, Math.floor(i / 20) * 200, i > 0 ? [`n${i - 1}`] : []),
-    )
+  // #14854: this case previously ran at 11-15s against the suite's 10s
+  // `testTimeout` and flaked on runner load. Mounting 200 live DOM nodes with no
+  // virtualisation is genuinely slow, and the node count *is* the assertion — so
+  // the honest fix is an explicit budget for this one test, not a smaller graph
+  // (which would delete the coverage #14766 exists for) and not a global timeout
+  // bump (which would hide every other slow test too).
+  const MOUNT_BUDGET_MS = 30_000
 
-    const w = mountCanvas(nodes)
+  it(
+    `renders ${SUPPORTED_NODES} nodes and their edges without dropping any`,
+    () => {
+      const nodes = Array.from({ length: SUPPORTED_NODES }, (_, i) =>
+        step(`n${i}`, (i % 20) * 300, Math.floor(i / 20) * 200, i > 0 ? [`n${i - 1}`] : []),
+      )
 
-    expect(w.findAll('.workflow-node')).toHaveLength(SUPPORTED_NODES)
-    // Every node but the first carries exactly one outgoing edge.
-    expect(paths(w)).toHaveLength(SUPPORTED_NODES - 1)
-    expect(paths(w).every((d) => d.startsWith('M'))).toBe(true)
-  })
+      const w = mountCanvas(nodes)
+
+      expect(w.findAll('.workflow-node')).toHaveLength(SUPPORTED_NODES)
+      // Collected once: each call re-queries all 199 edges.
+      const rendered = paths(w)
+      // Every node but the first carries exactly one outgoing edge.
+      expect(rendered).toHaveLength(SUPPORTED_NODES - 1)
+      expect(rendered.every((d) => d.startsWith('M'))).toBe(true)
+    },
+    MOUNT_BUDGET_MS,
+  )
 })
 
 describe('the edge-target index cannot go stale (#14792)', () => {

--- a/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
@@ -311,4 +311,91 @@ describe('useSessionSync (#14820)', () => {
     // Reached the new session despite the failure above.
     expect(harness.__channelHandlers.has('chat:s2')).toBe(true)
   })
+
+  it('accepts message_id when the record carries no id', async () => {
+    // Backend records surface their identity on either field depending on the
+    // path that produced them.
+    vi.mocked(apiClient.get).mockResolvedValue(
+      snapshot([{ message_id: 'via-message-id', text: 'hi', sender: 'bot' }])
+    )
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    useSessionSync(ref('s1'))
+    await settle()
+
+    expect(store.currentMessages[0].id).toBe('via-message-id')
+  })
+
+  it('defaults a message with no sender to the assistant', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([{ id: 'm1', text: 'hi' }]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    useSessionSync(ref('s1'))
+    await settle()
+
+    expect(store.currentMessages[0].sender).toBe('bot')
+  })
+
+  it('defaults missing text to an empty string rather than undefined', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([{ id: 'm1', sender: 'bot' }]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    useSessionSync(ref('s1'))
+    await settle()
+
+    expect(store.currentMessages[0].content).toBe('')
+  })
+
+  it('reports a non-Error rejection as a string', async () => {
+    // A thrown string would otherwise surface as "undefined" in syncError,
+    // which tells the user nothing about why their view is stale.
+    vi.mocked(apiClient.get).mockRejectedValue('plain string failure')
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    const { syncError } = useSessionSync(ref('s1'))
+    await settle()
+
+    expect(syncError.value).toBe('plain string failure')
+  })
+
+  it('an event arriving after the session is cleared is a no-op', async () => {
+    // Handlers are captured by the subscription, so one can still fire between
+    // the session going null and teardown completing.
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    const sessionId = ref<string | null>('s1')
+    useSessionSync(sessionId)
+    await settle()
+
+    const chatHandler = harness.__channelHandlers.get('chat:s1')!
+    const sessionHandler = harness.__channelHandlers.get('session:s1')!
+    sessionId.value = null
+    await settle()
+
+    chatHandler({
+      event_type: 'chat.message_added',
+      payload: { message: backendMessage('late', 'too late') },
+    })
+    sessionHandler({ event_type: 'session.deleted', payload: {} })
+
+    expect(store.sessions.find((s) => s.id === 's1')).toBeDefined()
+  })
+
+  it('exposes resync for a caller to trigger a manual rebuild', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    const { resync } = useSessionSync(ref('s1'))
+    await settle()
+
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([backendMessage('m9', 'manual')]))
+    await resync('s1')
+
+    expect(store.currentMessages[0].content).toBe('manual')
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Client-side session synchronization (#14820, #14818).
+ *
+ * This composable is the seam that makes the backend authoritative for a
+ * conversation: subscribe to its channels, apply what the server publishes,
+ * recognise our own echoes, and rebuild from the REST snapshot when the server
+ * says our view cannot be trusted.
+ *
+ * The cases that carry real risk are the negative ones — a failed resync must
+ * not look like an empty conversation, and our own echo must not render twice.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useSessionSync } from '@/composables/useSessionSync'
+import { useChatStore } from '@/stores/useChatStore'
+import apiClient from '@/utils/ApiClient'
+import liveEventService from '@/services/LiveEventService'
+
+vi.mock('@/utils/ApiClient', () => ({ default: { get: vi.fn(), post: vi.fn() } }))
+
+vi.mock('@/services/LiveEventService', () => {
+  const channelHandlers = new Map<string, (e: unknown) => void>()
+  const resyncHandlers = new Map<string, (e: unknown) => void>()
+  return {
+    default: {
+      subscribe: vi.fn((channel: string, cb: (e: unknown) => void) => {
+        channelHandlers.set(channel, cb)
+        return () => channelHandlers.delete(channel)
+      }),
+      onResync: vi.fn((channel: string, cb: (e: unknown) => void) => {
+        resyncHandlers.set(channel, cb)
+        return () => resyncHandlers.delete(channel)
+      }),
+      __channelHandlers: channelHandlers,
+      __resyncHandlers: resyncHandlers,
+    },
+  }
+})
+
+type Harness = {
+  __channelHandlers: Map<string, (e: unknown) => void>
+  __resyncHandlers: Map<string, (e: unknown) => void>
+}
+
+const harness = liveEventService as unknown as Harness
+
+function snapshot(messages: Array<Record<string, unknown>>) {
+  return { data: { messages } }
+}
+
+function backendMessage(id: string, text: string, sender = 'bot') {
+  return { id, text, sender, timestamp: '2026-08-23T10:00:00Z', message_type: 'llm_response' }
+}
+
+/** Let the immediate watcher + its awaited resync settle. */
+async function settle() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await new Promise((r) => setTimeout(r, 0))
+}
+
+describe('useSessionSync (#14820)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    harness.__channelHandlers.clear()
+    harness.__resyncHandlers.clear()
+  })
+
+  it('subscribes to both the session and chat channels', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    useSessionSync(ref('s1'))
+    await settle()
+
+    expect(harness.__channelHandlers.has('session:s1')).toBe(true)
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(true)
+  })
+
+  it('applies the server snapshot on attach', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([backendMessage('m1', 'from server')]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    const { synchronized } = useSessionSync(ref('s1'))
+    await settle()
+
+    expect(synchronized.value).toBe(true)
+    expect(store.currentMessages).toHaveLength(1)
+    // Backend `text` maps onto the store's canonical `content` field.
+    expect(store.currentMessages[0].content).toBe('from server')
+  })
+
+  it('reports a failed resync instead of leaving a stale view looking authoritative', async () => {
+    // The distinguishing case: a fetch failure and an empty conversation must
+    // not be indistinguishable.
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('backend down'))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    const { synchronized, syncError } = useSessionSync(ref('s1'))
+    await settle()
+
+    expect(synchronized.value).toBe(false)
+    expect(syncError.value).toContain('backend down')
+  })
+
+  it('reports an unexpected snapshot shape rather than treating it as empty', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: {} })
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    const { synchronized, syncError } = useSessionSync(ref('s1'))
+    await settle()
+
+    expect(synchronized.value).toBe(false)
+    expect(syncError.value).toBeTruthy()
+  })
+
+  it('drops a remote message that carries no usable id', async () => {
+    // Without an id it cannot be deduplicated, and appending it blindly is how
+    // duplicate bubbles appear.
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([{ text: 'no id here', sender: 'bot' }]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    useSessionSync(ref('s1'))
+    await settle()
+
+    expect(store.currentMessages).toHaveLength(0)
+  })
+
+  it('applies a message published by another client', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    harness.__channelHandlers.get('chat:s1')!({
+      event_type: 'chat.message_added',
+      payload: { message: backendMessage('remote-1', 'from another tab') },
+    })
+
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.currentMessages[0].content).toBe('from another tab')
+  })
+
+  it('clears the conversation on chat.cleared', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([backendMessage('m1', 'existing')]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+    expect(store.currentMessages).toHaveLength(1)
+
+    harness.__channelHandlers.get('chat:s1')!({ event_type: 'chat.cleared', payload: {} })
+
+    expect(store.currentMessages).toHaveLength(0)
+  })
+
+  it('renames the session on session.updated', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('Old name', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    harness.__channelHandlers.get('session:s1')!({
+      event_type: 'session.updated',
+      payload: { changes: { title: 'Renamed elsewhere' } },
+    })
+
+    expect(store.sessions.find((s) => s.id === 's1')?.title).toBe('Renamed elsewhere')
+  })
+
+  it('rebuilds from the snapshot when the server sends a resync directive', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([backendMessage('after', 'rebuilt')]))
+    harness.__resyncHandlers.get('chat:s1')!({ channel: 'chat:s1', reason: 'gap_exceeds_retention' })
+    await settle()
+
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.currentMessages[0].content).toBe('rebuilt')
+  })
+
+  it('tears down subscriptions when the session id becomes null', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    const sessionId = ref<string | null>('s1')
+    useSessionSync(sessionId)
+    await settle()
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(true)
+
+    sessionId.value = null
+    await settle()
+
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(false)
+  })
+
+  it('re-subscribes to the new channels when the session changes', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('A', 's1')
+    store.createNewSession('B', 's2')
+    const sessionId = ref<string | null>('s1')
+    useSessionSync(sessionId)
+    await settle()
+
+    sessionId.value = 's2'
+    await settle()
+
+    expect(harness.__channelHandlers.has('chat:s2')).toBe(true)
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(false)
+  })
+})

--- a/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
@@ -231,4 +231,84 @@ describe('useSessionSync (#14820)', () => {
     expect(harness.__channelHandlers.has('chat:s2')).toBe(true)
     expect(harness.__channelHandlers.has('chat:s1')).toBe(false)
   })
+
+  it('removes the session when another client deletes it', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+    expect(store.sessionCount).toBe(1)
+
+    harness.__channelHandlers.get('session:s1')!({
+      event_type: 'session.deleted',
+      payload: { session_id: 's1' },
+    })
+
+    expect(store.sessions.find((s) => s.id === 's1')).toBeUndefined()
+  })
+
+  it('ignores a session.updated with no title change', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('Original', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    harness.__channelHandlers.get('session:s1')!({
+      event_type: 'session.updated',
+      payload: { changes: {} },
+    })
+
+    expect(store.sessions.find((s) => s.id === 's1')?.title).toBe('Original')
+  })
+
+  it('ignores an unrecognised event type', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    harness.__channelHandlers.get('chat:s1')!({ event_type: 'chat.something_new', payload: {} })
+
+    expect(store.currentMessages).toHaveLength(0)
+  })
+
+  it('ignores a chat.message_added carrying no message', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    harness.__channelHandlers.get('chat:s1')!({ event_type: 'chat.message_added', payload: {} })
+
+    expect(store.currentMessages).toHaveLength(0)
+  })
+
+  it('a throwing disposer does not prevent the rest of teardown', async () => {
+    // Teardown runs on session switch and unmount; one bad disposer must not
+    // strand the remaining subscriptions.
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    store.createNewSession('T2', 's2')
+    const sessionId = ref<string | null>('s1')
+
+    vi.mocked(liveEventService.subscribe).mockImplementationOnce(() => {
+      return () => {
+        throw new Error('disposer exploded')
+      }
+    })
+
+    useSessionSync(sessionId)
+    await settle()
+
+    sessionId.value = 's2'
+    await settle()
+
+    // Reached the new session despite the failure above.
+    expect(harness.__channelHandlers.has('chat:s2')).toBe(true)
+  })
 })

--- a/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
@@ -12,7 +12,8 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { ref, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { ref, nextTick, defineComponent, h } from 'vue'
 import { useSessionSync } from '@/composables/useSessionSync'
 import { useChatStore } from '@/stores/useChatStore'
 import apiClient from '@/utils/ApiClient'
@@ -397,5 +398,51 @@ describe('useSessionSync (#14820)', () => {
     await resync('s1')
 
     expect(store.currentMessages[0].content).toBe('manual')
+  })
+
+  it('rebuilds when the resync directive arrives on the session channel', async () => {
+    // Both channels register a resync handler. Exercising only the chat one
+    // left the session path unproven — and a session-level resync is exactly
+    // what fires when the session list itself falls out of the replay window.
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+    useSessionSync(ref('s1'))
+    await settle()
+
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([backendMessage('s-after', 'session rebuild')]))
+    harness.__resyncHandlers.get('session:s1')!({
+      channel: 'session:s1',
+      reason: 'replay_unavailable',
+    })
+    await settle()
+
+    expect(store.currentMessages[0].content).toBe('session rebuild')
+  })
+
+  it('tears down its subscriptions when the owning component unmounts', async () => {
+    // Called bare, the composable's onUnmounted hook never registers, so the
+    // teardown-on-unmount path went unproven. Mounting a real component is the
+    // only way to exercise it — and a composable that leaks subscriptions past
+    // unmount would keep writing into a store the view no longer shows.
+    vi.mocked(apiClient.get).mockResolvedValue(snapshot([]))
+    const store = useChatStore()
+    store.createNewSession('T', 's1')
+
+    const Host = defineComponent({
+      setup() {
+        useSessionSync(ref('s1'))
+        return () => h('div')
+      },
+    })
+
+    const wrapper = mount(Host)
+    await settle()
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(true)
+
+    wrapper.unmount()
+
+    expect(harness.__channelHandlers.has('chat:s1')).toBe(false)
+    expect(harness.__channelHandlers.has('session:s1')).toBe(false)
   })
 })

--- a/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
+++ b/autobot-frontend/src/composables/__tests__/useSessionSync.test.ts
@@ -12,7 +12,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { ref } from 'vue'
+import { ref, nextTick } from 'vue'
 import { useSessionSync } from '@/composables/useSessionSync'
 import { useChatStore } from '@/stores/useChatStore'
 import apiClient from '@/utils/ApiClient'
@@ -54,11 +54,19 @@ function backendMessage(id: string, text: string, sender = 'bot') {
   return { id, text, sender, timestamp: '2026-08-23T10:00:00Z', message_type: 'llm_response' }
 }
 
-/** Let the immediate watcher + its awaited resync settle. */
+/**
+ * Let the watcher and its awaited resync settle.
+ *
+ * `watch(..., { immediate: true })` runs its callback through Vue's scheduler,
+ * and the callback then awaits a mocked HTTP round trip. `nextTick` flushes the
+ * scheduler; the macrotask turn drains the promise chain behind it. Hand-rolled
+ * microtask counting would work by accident today and break the moment the
+ * composable gains another await.
+ */
 async function settle() {
-  await Promise.resolve()
-  await Promise.resolve()
+  await nextTick()
   await new Promise((r) => setTimeout(r, 0))
+  await nextTick()
 }
 
 describe('useSessionSync (#14820)', () => {

--- a/autobot-frontend/src/composables/useSessionSync.ts
+++ b/autobot-frontend/src/composables/useSessionSync.ts
@@ -88,9 +88,12 @@ export function useSessionSync(sessionId: Ref<string | null>) {
    */
   async function resync(id: string): Promise<void> {
     try {
-      const response = await apiClient.get(`/api/chat/sessions/${encodeURIComponent(id)}`)
-      const payload = response?.data as { data?: { messages?: BackendMessage[] } } | undefined
-      const rawMessages = payload?.data?.messages
+      // ApiClient resolves to the parsed body itself, so the backend's
+      // DataResponse wrapper is the only `data` level to unwrap.
+      const body = await apiClient.get<{ data?: { messages?: BackendMessage[] } }>(
+        `/api/chat/sessions/${encodeURIComponent(id)}`
+      )
+      const rawMessages = body?.data?.messages
       if (!Array.isArray(rawMessages)) {
         syncError.value = 'Server snapshot contained no messages array'
         synchronized.value = false

--- a/autobot-frontend/src/composables/useSessionSync.ts
+++ b/autobot-frontend/src/composables/useSessionSync.ts
@@ -131,10 +131,9 @@ export function useSessionSync(sessionId: Ref<string | null>) {
       if (!raw) return
       const message = toChatMessage(raw)
       if (!message) return
-      // #14821: our own message coming back is a confirmation, not new content.
-      if (!chatStore.confirmMessage(message.id, message.id)) {
-        chatStore.applyRemoteMessage(id, message)
-      }
+      // #14821: applyRemoteMessage correlates the echo of our own pending
+      // message and confirms it, rather than rendering a second bubble.
+      chatStore.applyRemoteMessage(id, message)
     } else if (event.event_type === CHAT_CLEARED) {
       chatStore.applyServerSnapshot(id, [])
     }

--- a/autobot-frontend/src/composables/useSessionSync.ts
+++ b/autobot-frontend/src/composables/useSessionSync.ts
@@ -1,0 +1,197 @@
+/**
+ * Session synchronization across clients (#14820, #14821).
+ *
+ * AutoBot is one host with many clients. Session state used to live in the
+ * browser — ids minted locally, messages appended locally, `localStorage` as
+ * the source of truth — so two tabs on one account held two independent truths
+ * that could never converge.
+ *
+ * This composable makes the backend authoritative for one conversation:
+ * subscribe to its `session:` and `chat:` channels, apply what the server
+ * publishes, and rebuild from the REST snapshot whenever the server says our
+ * view cannot be trusted.
+ *
+ * `localStorage` remains, demoted to a cache: useful for an instant first
+ * paint and for offline reads, never the authority.
+ */
+
+import { onUnmounted, ref, watch, type Ref } from 'vue'
+import liveEventService, { type LiveEvent } from '@/services/LiveEventService'
+import { useChatStore } from '@/stores/useChatStore'
+import { createLogger } from '@/utils/debugUtils'
+import type { ChatMessage, MessageSender } from '@/types/api'
+import apiClient from '@/utils/ApiClient'
+
+const logger = createLogger('SessionSync')
+
+/** Event types published on the session/chat channels by the backend. */
+const SESSION_UPDATED = 'session.updated'
+const SESSION_DELETED = 'session.deleted'
+const CHAT_MESSAGE_ADDED = 'chat.message_added'
+const CHAT_CLEARED = 'chat.cleared'
+
+interface BackendMessage {
+  id?: string
+  message_id?: string
+  sender?: string
+  text?: string
+  message_type?: string
+  timestamp?: string
+}
+
+/**
+ * Convert one backend message record into the store's shape.
+ *
+ * Returns null when the record carries no usable identity — a message we
+ * cannot identify cannot be deduplicated, and appending it blindly is how
+ * duplicate bubbles appear.
+ */
+function toChatMessage(raw: BackendMessage): ChatMessage | null {
+  const id = raw.id ?? raw.message_id
+  if (!id) {
+    logger.warn('Dropping remote message with no id', raw)
+    return null
+  }
+  // The backend stores the body as `text`; the canonical frontend field is
+  // `content` (see types/api.ts). Mapping it here keeps the rest of the store
+  // working in one vocabulary.
+  return {
+    id,
+    content: raw.text ?? '',
+    sender: (raw.sender ?? 'bot') as MessageSender,
+    timestamp: raw.timestamp ? new Date(raw.timestamp) : new Date(),
+    message_type: raw.message_type,
+  }
+}
+
+/**
+ * Keep `sessionId` synchronized with the backend for as long as the caller is
+ * mounted. Pass a ref to follow the active session as the user switches.
+ */
+export function useSessionSync(sessionId: Ref<string | null>) {
+  const chatStore = useChatStore()
+
+  /** True once a server snapshot has been applied for the current session. */
+  const synchronized = ref(false)
+  /** Set when the last resync attempt failed — the view may be stale. */
+  const syncError = ref<string | null>(null)
+
+  let disposers: Array<() => void> = []
+
+  /**
+   * Rebuild this session's contents from the server.
+   *
+   * Called on subscribe and whenever the server sends a resync directive. On
+   * failure it records the error rather than leaving a stale view looking
+   * authoritative — an empty result and a failed fetch must not be
+   * indistinguishable.
+   */
+  async function resync(id: string): Promise<void> {
+    try {
+      const response = await apiClient.get(`/api/chat/sessions/${encodeURIComponent(id)}`)
+      const payload = response?.data as { data?: { messages?: BackendMessage[] } } | undefined
+      const rawMessages = payload?.data?.messages
+      if (!Array.isArray(rawMessages)) {
+        syncError.value = 'Server snapshot contained no messages array'
+        synchronized.value = false
+        logger.warn('Resync returned an unexpected shape for session', id)
+        return
+      }
+      const messages = rawMessages
+        .map(toChatMessage)
+        .filter((m): m is ChatMessage => m !== null)
+      chatStore.applyServerSnapshot(id, messages)
+      synchronized.value = true
+      syncError.value = null
+      logger.debug(`Resynchronized session ${id} with ${messages.length} messages`)
+    } catch (error: unknown) {
+      synchronized.value = false
+      syncError.value = error instanceof Error ? error.message : String(error)
+      logger.error(`Failed to resync session ${id}:`, error)
+    }
+  }
+
+  function handleSessionEvent(event: LiveEvent): void {
+    const id = sessionId.value
+    if (!id) return
+    if (event.event_type === SESSION_UPDATED) {
+      const changes = event.payload?.changes as { title?: string } | undefined
+      if (changes?.title) chatStore.updateSessionTitle(id, changes.title)
+    } else if (event.event_type === SESSION_DELETED) {
+      logger.debug(`Session ${id} deleted on another client`)
+      chatStore.deleteSession(id)
+    }
+  }
+
+  function handleChatEvent(event: LiveEvent): void {
+    const id = sessionId.value
+    if (!id) return
+    if (event.event_type === CHAT_MESSAGE_ADDED) {
+      const raw = event.payload?.message as BackendMessage | undefined
+      if (!raw) return
+      const message = toChatMessage(raw)
+      if (!message) return
+      // #14821: our own message coming back is a confirmation, not new content.
+      if (!chatStore.confirmMessage(message.id, message.id)) {
+        chatStore.applyRemoteMessage(id, message)
+      }
+    } else if (event.event_type === CHAT_CLEARED) {
+      chatStore.applyServerSnapshot(id, [])
+    }
+  }
+
+  function teardown(): void {
+    disposers.forEach((dispose) => {
+      try {
+        dispose()
+      } catch (error: unknown) {
+        logger.debug('Error disposing session subscription:', error)
+      }
+    })
+    disposers = []
+  }
+
+  async function attach(id: string): Promise<void> {
+    teardown()
+    synchronized.value = false
+
+    const sessionChannel = `session:${id}`
+    const chatChannel = `chat:${id}`
+
+    disposers.push(liveEventService.subscribe(sessionChannel, handleSessionEvent))
+    disposers.push(liveEventService.subscribe(chatChannel, handleChatEvent))
+
+    // #14818: when the server cannot replay what we missed, the local view is
+    // untrustworthy — rebuild from the snapshot rather than carrying on.
+    disposers.push(
+      liveEventService.onResync(chatChannel, () => {
+        logger.debug(`Resync directive for ${chatChannel}`)
+        void resync(id)
+      })
+    )
+    disposers.push(
+      liveEventService.onResync(sessionChannel, () => {
+        void resync(id)
+      })
+    )
+
+    await resync(id)
+  }
+
+  watch(
+    sessionId,
+    (id) => {
+      if (id) {
+        void attach(id)
+      } else {
+        teardown()
+        synchronized.value = false
+      }
+    },
+    { immediate: true }
+  )
+
+  onUnmounted(teardown)
+
+  return { synchronized, syncError, resync }
+}

--- a/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { reloadConfig, runtimeHttpProto, getBackendUrl } from '../ssot-config';
+import { reloadConfig, runtimeHttpProto, getBackendUrl, getConfig } from '../ssot-config';
 
 // Note: In a real test environment, we would need to mock import.meta.env
 // For now, these tests validate the TypeScript structure and default values
@@ -619,5 +619,28 @@ describe('getBackendUrl() — proxy-mode default (#12339)', () => {
 
   it('returns "" (proxy mode) when neither host nor base URL is set', () => {
     expect(getBackendUrl()).toBe('');
+  });
+});
+
+describe('liveEventsUrl (#14822)', () => {
+  it('points at the channel socket, not the legacy broadcast endpoint', () => {
+    // The migration is only real if the canonical getter actually resolves to
+    // /api/ws/live — the deprecated websocketUrl still ends at /api/ws.
+    expect(getConfig().liveEventsUrl.endsWith('/api/ws/live')).toBe(true);
+  });
+
+  it('stays exactly websocketUrl plus /live', () => {
+    // liveEventsUrl duplicates websocketUrl's host/protocol resolution rather
+    // than reading `this` (a getter on a contextually-typed object literal makes
+    // `this` awkward to type). Duplication is only safe while the two agree, so
+    // this is the assertion that keeps them from drifting apart.
+    const config = getConfig();
+    expect(config.liveEventsUrl).toBe(`${config.websocketUrl}/live`);
+  });
+
+  it('uses the same ws/wss scheme as websocketUrl', () => {
+    const config = getConfig();
+    const scheme = (url: string) => url.split('://')[0];
+    expect(scheme(config.liveEventsUrl)).toBe(scheme(config.websocketUrl));
   });
 });

--- a/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
+++ b/autobot-frontend/src/config/__tests__/ssot-config.spec.ts
@@ -643,4 +643,37 @@ describe('liveEventsUrl (#14822)', () => {
     const scheme = (url: string) => url.split('://')[0];
     expect(scheme(config.liveEventsUrl)).toBe(scheme(config.websocketUrl));
   });
+
+  describe('under https', () => {
+    const realLocation = window.location;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', { value: realLocation, writable: true });
+      reloadConfig();
+    });
+
+    it('upgrades to wss and uses the page host', () => {
+      // The https branch is unreachable under the default jsdom origin, so it
+      // needs an explicit stub — otherwise a mixed-content bug (ws:// on an
+      // https page, which browsers block outright) would ship untested.
+      Object.defineProperty(window, 'location', {
+        value: { protocol: 'https:', host: 'autobot.example' },
+        writable: true,
+      });
+      reloadConfig();
+
+      expect(getConfig().liveEventsUrl).toBe('wss://autobot.example/api/ws/live');
+    });
+
+    it('still equals websocketUrl plus /live under https', () => {
+      Object.defineProperty(window, 'location', {
+        value: { protocol: 'https:', host: 'autobot.example' },
+        writable: true,
+      });
+      reloadConfig();
+
+      const config = getConfig();
+      expect(config.liveEventsUrl).toBe(`${config.websocketUrl}/live`);
+    });
+  });
 });

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -520,6 +520,13 @@ function buildConfig(): AutoBotConfig {
       return `${runtimeHttpProto()}://${vm.ollama}:${port.ollama}`;
     },
 
+    /**
+     * @deprecated #14822 — this is the base of the legacy `/api/ws` endpoint,
+     * which broadcasts every event to every client with no channel scoping.
+     * Use {@link liveEventsUrl} instead. Retained because it is still the base
+     * other callers append to, and because removing it would silently change
+     * every URL derived from it.
+     */
     get websocketUrl(): string {
       if (runtimeHttpProto() === 'https') {
         const host =
@@ -527,6 +534,18 @@ function buildConfig(): AutoBotConfig {
         return `wss://${host}/api/ws`;
       }
       return `ws://${vm.main}:${port.backend}/api/ws`;
+    },
+
+    /**
+     * Canonical event socket (#14822): `/api/ws/live`.
+     *
+     * Channel-scoped and fanned out per subscriber, unlike {@link websocketUrl}.
+     * Derived from the same base so protocol and host resolution stay in one
+     * place — a second hand-built URL is how the two sockets drifted apart in
+     * the first place.
+     */
+    get liveEventsUrl(): string {
+      return `${this.websocketUrl}/live`;
     },
 
     get aistackUrl(): string {

--- a/autobot-frontend/src/config/ssot-config.ts
+++ b/autobot-frontend/src/config/ssot-config.ts
@@ -290,7 +290,10 @@ export interface AutoBotConfig {
   readonly frontendUrl: string;
   readonly redisUrl: string;
   readonly ollamaUrl: string;
+  /** @deprecated #14822 — legacy broadcast socket base; use `liveEventsUrl`. */
   readonly websocketUrl: string;
+  /** Canonical channel event socket (#14822): `/api/ws/live`. */
+  readonly liveEventsUrl: string;
   readonly aistackUrl: string;
   readonly npuWorkerUrl: string;
   readonly browserServiceUrl: string;
@@ -545,7 +548,16 @@ function buildConfig(): AutoBotConfig {
      * the first place.
      */
     get liveEventsUrl(): string {
-      return `${this.websocketUrl}/live`;
+      // Host/protocol resolution is duplicated from `websocketUrl` rather than
+      // read through `this`: a getter on a contextually-typed object literal
+      // makes `this` awkward to type, and the two must not silently disagree —
+      // so they are kept adjacent and identical apart from the `/live` suffix.
+      if (runtimeHttpProto() === 'https') {
+        const host =
+          typeof window !== 'undefined' ? window.location.host : vm.main;
+        return `wss://${host}/api/ws/live`;
+      }
+      return `ws://${vm.main}:${port.backend}/api/ws/live`;
     },
 
     get aistackUrl(): string {

--- a/autobot-frontend/src/constants/network.ts
+++ b/autobot-frontend/src/constants/network.ts
@@ -105,7 +105,8 @@ export const ServiceURLs = Object.freeze({
 
   // WebSocket URLs
   WEBSOCKET_API: config.websocketUrl,
-  WEBSOCKET_LOCAL: `ws://${NetworkConstants.LOCALHOST_NAME}:${config.port.backend}/api/ws`
+  // #14822: the channel socket is the canonical event endpoint.
+  WEBSOCKET_LOCAL: `ws://${NetworkConstants.LOCALHOST_NAME}:${config.port.backend}/api/ws/live`
 })
 
 /**

--- a/autobot-frontend/src/i18n/__tests__/rtl.spec.ts
+++ b/autobot-frontend/src/i18n/__tests__/rtl.spec.ts
@@ -14,7 +14,7 @@
  * Issue #1510: Add automated RTL layout tests
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 
 // Mock only loadLocaleMessages so tests exercise the real setLocale(). (#1598)
 // The real setLocale() calls loadLocaleMessages() via an internal reference that
@@ -31,6 +31,43 @@ vi.mock('@/i18n', async (importOriginal) => {
 })
 
 import { setLocale } from '@/i18n'
+
+// Every locale this file exercises. Each locale JSON is ~400KB, and
+// loadLocaleMessages() caches on i18n.global.availableLocales — so the *first*
+// setLocale() for a locale pays a real dynamic import and every later one is
+// free.
+//
+// #14854: with nothing warmed, whichever test happened to touch a locale first
+// paid ~10s inside its own 10s per-test budget, so this file flaked purely on
+// ordering and runner load. Warming here moves that one-off cost into a hook
+// with its own budget. The tests still assert against the REAL `_meta.dir` from
+// the real locale files — nothing is stubbed, so coverage is unchanged.
+const EXERCISED_LOCALES = ['ar', 'he', 'fa', 'ur', 'en', 'de', 'fr'] as const
+
+beforeAll(async () => {
+  for (const locale of EXERCISED_LOCALES) {
+    await setLocale(locale)
+  }
+}, 120_000)
+
+describe('locale warm-up (#14854)', () => {
+  it('every exercised locale is cached, so no test pays a real import', async () => {
+    // Guards the mechanism above rather than the outcome of one test: if the
+    // warm loop silently stops working, this fails with the reason instead of
+    // the file going flaky again on whichever test drew the slow straw.
+    // i18n is the module's default export.
+    const i18n = (await import('@/i18n')).default
+    for (const locale of EXERCISED_LOCALES) {
+      expect(i18n.global.availableLocales).toContain(locale)
+    }
+  })
+
+  it('a locale used by this file but missing from the warm list is a bug', () => {
+    // A new setLocale('xx') case added without extending EXERCISED_LOCALES
+    // would reintroduce the flake. Keep this list in step with the cases below.
+    expect(EXERCISED_LOCALES.length).toBe(7)
+  })
+})
 
 describe('setLocale() RTL dir attribute', () => {
   beforeEach(() => {

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -143,14 +143,18 @@ class GlobalWebSocketService {
         window.location.hostname === 'localhost'
 
       if (isViteDevServer) {
-        const wsUrl = `${wsProtocol}//${window.location.host}${getApiBase()}/ws`
+        // #14822: the channel socket is now the single event endpoint. The
+        // legacy `/ws` used a global broadcast slot that could only ever serve
+        // one client (#14814); `/ws/live` fans out per subscriber.
+        const wsUrl = `${wsProtocol}//${window.location.host}${getApiBase()}/ws/live`
         logger.debug('Development WebSocket URL (via Vite proxy):', wsUrl)
         return wsUrl
       }
 
       // Issue #916: Use window.location.host so WebSocket goes through nginx proxy at .21
       // Nginx proxies /api/ws to backend with proxy_ssl_verify off (handles self-signed cert)
-      const wsUrl = `${wsProtocol}//${window.location.host}${getApiBase()}/ws`
+      // #14822: single event endpoint — see the development branch above.
+      const wsUrl = `${wsProtocol}//${window.location.host}${getApiBase()}/ws/live`
       logger.debug('Production WebSocket URL (via nginx proxy):', wsUrl)
       return wsUrl
     } catch (error: unknown) {
@@ -331,6 +335,15 @@ class GlobalWebSocketService {
     this.saveConnectionState()
     this.startHeartbeat()
 
+    // #14822: `/ws/live` delivers nothing until a channel is subscribed.
+    // #14818: resume from the last event we saw so the reconnect window is
+    // replayed instead of silently lost.
+    this.send(
+      this.lastGlobalEventId === null
+        ? { action: 'subscribe', channel: 'global' }
+        : { action: 'subscribe', channel: 'global', last_event_id: this.lastGlobalEventId }
+    )
+
     this.trackEvent('connection_opened', { url: this.state.url })
     this.emit('connected', { url: this.state.url })
 
@@ -347,16 +360,39 @@ class GlobalWebSocketService {
       this.state.lastMessage = data
 
       if (data.type === 'ping') {
-        this.send({ type: 'pong', timestamp: Date.now() })
+        // Server-initiated keepalive; the channel socket expects `action`.
+        this.send({ action: 'ping', timestamp: Date.now() })
         return
       }
       if (data.type === 'pong') {
         return
       }
+      // #14822: channel-socket control frames carry no listener payload.
+      if (
+        data.type === 'subscribed' ||
+        data.type === 'unsubscribed' ||
+        data.type === 'connection_established'
+      ) {
+        return
+      }
+      // #14818: the server could not replay what we missed — drop the marker
+      // and tell listeners their view must be rebuilt.
+      if (data.type === 'resync') {
+        logger.warn('Global channel resync required:', data.reason)
+        this.lastGlobalEventId = null
+        this.emit('resync', data)
+        return
+      }
 
-      this.emit('message', data)
-      if (data.type) {
-        this.emit(data.type as string, data)
+      // #14822: `/ws/live` wraps events as
+      // {type:'live_event', channel, event_type, event_id, payload}.
+      // Listeners registered against the legacy flat {type, payload} shape must
+      // keep working, so unwrap rather than forcing every consumer to change.
+      const unwrapped = this._unwrapChannelEvent(data)
+
+      this.emit('message', unwrapped)
+      if (unwrapped.type) {
+        this.emit(unwrapped.type as string, unwrapped)
       }
 
       this.trackEvent('message_received', {
@@ -372,6 +408,33 @@ class GlobalWebSocketService {
         rawDataLength:
           typeof event.data === 'string' ? event.data.length : 0
       })
+    }
+  }
+
+  /**
+   * Translate a channel frame into the legacy flat event shape (#14822).
+   *
+   * Also advances the global high-water mark so a reconnect can ask for a
+   * replay (#14818). Anything that is not a `live_event` passes through
+   * untouched.
+   */
+  private _unwrapChannelEvent(
+    data: Record<string, unknown>
+  ): Record<string, unknown> {
+    if (data.type !== 'live_event') return data
+
+    const eventId = data.event_id
+    if (typeof eventId === 'number') {
+      if (this.lastGlobalEventId === null || eventId > this.lastGlobalEventId) {
+        this.lastGlobalEventId = eventId
+      }
+    }
+
+    return {
+      type: data.event_type,
+      payload: data.payload ?? {},
+      channel: data.channel,
+      event_id: data.event_id
     }
   }
 
@@ -563,7 +626,9 @@ class GlobalWebSocketService {
 
     this.heartbeatInterval = setInterval(() => {
       if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-        this.send({ type: 'ping', timestamp: Date.now() })
+        // #14822: the channel socket dispatches on `action`, not `type`.
+        // Sending the legacy shape here left the heartbeat silently inert.
+        this.send({ action: 'ping', timestamp: Date.now() })
       } else {
         this.stopHeartbeat()
       }
@@ -743,7 +808,7 @@ class GlobalWebSocketService {
         }
 
         this.on('pong', handlePong)
-        this.send({ type: 'ping', timestamp: Date.now(), test: true })
+        this.send({ action: 'ping', timestamp: Date.now(), test: true })
       })
     }
 

--- a/autobot-frontend/src/services/GlobalWebSocketService.ts
+++ b/autobot-frontend/src/services/GlobalWebSocketService.ts
@@ -89,6 +89,8 @@ class GlobalWebSocketService {
   heartbeatTimeout: number
   listeners: Map<string, Set<EventCallback>>
   state: WebSocketReactiveState
+  /** #14818: highest global-channel event_id seen; replayed from on reconnect. */
+  private lastGlobalEventId: number | null
   private _backendWaitTimer: ReturnType<typeof setInterval> | null
 
   constructor() {
@@ -102,6 +104,7 @@ class GlobalWebSocketService {
     this.connectionTimeout = 5000
     this.heartbeatInterval = null
     this.heartbeatTimeout = 30000
+    this.lastGlobalEventId = null
     this._backendWaitTimer = null
     this.listeners = new Map()
 

--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -96,12 +96,13 @@ class LiveEventService {
   // explicitly (e.g., test override). Returns null when no token is available
   // so connect() can defer instead of producing a guaranteed-403 handshake.
   //
-  // Path is `/live` not `/ws/live` — `config.websocketUrl` already ends in
-  // `/api/ws` (see ssot-config.ts websocketUrl getter, baked in by #6271).
-  // Backend WS handler is `/api/ws/live`. Prepending `/ws/` here would build
-  // `wss://host/api/ws/ws/live` and 404 every connection.
+  // #14822: the `/live` suffix now lives in `config.liveEventsUrl` rather than
+  // being appended here. The old comment warned that `config.websocketUrl`
+  // already ends in `/api/ws`, so prepending `/ws/` would build
+  // `wss://host/api/ws/ws/live` and 404 — the named getter removes the chance
+  // of getting that wrong at each call site.
   private getUrl(token?: string): string | null {
-    const base = `${config.websocketUrl}/live`
+    const base = config.liveEventsUrl
     if (token) {
       const sep = base.includes('?') ? '&' : '?'
       return `${base}${sep}token=${encodeURIComponent(token)}`

--- a/autobot-frontend/src/services/LiveEventService.ts
+++ b/autobot-frontend/src/services/LiveEventService.ts
@@ -48,10 +48,21 @@ export interface SteeringMessage {
   guidance: string
 }
 
+/** Server could not produce a complete history for a channel (#14818). */
+export interface LiveEventResync {
+  type: 'resync'
+  channel: string
+  reason: string
+}
+
+/** Callback invoked when a channel's local view must be rebuilt from scratch. */
+export type LiveEventResyncCallback = (resync: LiveEventResync) => void
+
 type ServerMessage =
   | LiveEvent
+  | LiveEventResync
   | { type: 'connection_established'; message: string }
-  | { type: 'subscribed'; channel: string }
+  | { type: 'subscribed'; channel: string; replayed?: number }
   | { type: 'unsubscribed'; channel: string }
   | { type: 'pong' }
   | { type: 'ping' }
@@ -70,6 +81,13 @@ class LiveEventService {
 
   private readonly subscribedChannels = new Set<string>()
   private readonly channelListeners = new Map<string, Set<LiveEventCallback>>()
+
+  // #14818: highest event_id seen per channel. Sent back as last_event_id on
+  // re-subscribe so the server can replay what was missed while disconnected.
+  // Without this the disconnect window was a silent hole — events vanished with
+  // no error anywhere.
+  private readonly lastEventIds = new Map<string, number>()
+  private readonly resyncListeners = new Map<string, Set<LiveEventResyncCallback>>()
 
   readonly isConnected: Ref<boolean> = ref(false)
   readonly connectionState: Ref<LiveEventConnectionState> = ref('disconnected')
@@ -164,10 +182,19 @@ class LiveEventService {
       return
     }
     if (msg.type === 'pong') return
+    if (msg.type === 'resync') {
+      this._handleResync(msg)
+      return
+    }
+    if (msg.type === 'subscribed') {
+      // `replayed` tells us how much history the server rebuilt for us. Worth a
+      // log line: a non-zero value is the reconnect path actually working.
+      logger.debug('Subscribed', { channel: msg.channel, replayed: msg.replayed ?? 0 })
+      return
+    }
     if (
       msg.type === 'error' ||
       msg.type === 'connection_established' ||
-      msg.type === 'subscribed' ||
       msg.type === 'unsubscribed'
     ) {
       logger.debug('Server ack:', msg.type)
@@ -178,7 +205,61 @@ class LiveEventService {
     }
   }
 
+  /**
+   * Handle a server resync directive (#14818).
+   *
+   * The server could not give us a complete history, so the local view for this
+   * channel is untrustworthy. Drop the marker — resubscribing from a stale one
+   * would ask for a replay the server has already said it cannot produce — and
+   * tell listeners to rebuild.
+   */
+  private _handleResync(msg: LiveEventResync): void {
+    logger.warn('Resync required for channel', { channel: msg.channel, reason: msg.reason })
+    this.lastEventIds.delete(msg.channel)
+    const listeners = this.resyncListeners.get(msg.channel)
+    if (listeners) {
+      listeners.forEach((cb) => {
+        try {
+          cb(msg)
+        } catch (err: unknown) {
+          logger.error('Error in resync listener:', err)
+        }
+      })
+    }
+  }
+
+  /**
+   * Register a callback invoked when `channel` needs a full rebuild (#14818).
+   * Returns an unregister function.
+   */
+  onResync(channel: string, callback: LiveEventResyncCallback): () => void {
+    let listeners = this.resyncListeners.get(channel)
+    if (!listeners) {
+      listeners = new Set()
+      this.resyncListeners.set(channel, listeners)
+    }
+    listeners.add(callback)
+    return () => {
+      const current = this.resyncListeners.get(channel)
+      if (!current) return
+      current.delete(callback)
+      if (current.size === 0) this.resyncListeners.delete(channel)
+    }
+  }
+
+  /** Highest event_id seen on `channel`, or undefined if none yet (#14818). */
+  lastSeenEventId(channel: string): number | undefined {
+    return this.lastEventIds.get(channel)
+  }
+
   private _dispatchLiveEvent(event: LiveEvent): void {
+    // #14818: advance the marker before dispatch. Guard against going backwards
+    // — a replayed batch must never lower the high-water mark.
+    const previous = this.lastEventIds.get(event.channel)
+    if (previous === undefined || event.event_id > previous) {
+      this.lastEventIds.set(event.channel, event.event_id)
+    }
+
     const listeners = this.channelListeners.get(event.channel)
     if (listeners) {
       listeners.forEach((cb) => {
@@ -340,6 +421,17 @@ class LiveEventService {
   }
 
   private _sendAction(action: 'subscribe' | 'unsubscribe', channel: string): void {
+    if (action === 'subscribe') {
+      // #14818: only send a marker we actually hold. Omitting it (rather than
+      // sending 0) keeps a first-ever subscribe distinguishable from a resume.
+      const lastEventId = this.lastEventIds.get(channel)
+      this._send(
+        lastEventId === undefined
+          ? { action, channel }
+          : { action, channel, last_event_id: lastEventId }
+      )
+      return
+    }
     this._send({ action, channel })
   }
 

--- a/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
+++ b/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
@@ -11,14 +11,16 @@
  * it, along with the high-water mark that lets a reconnect replay the gap.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { GlobalWebSocketService } from '@/services/GlobalWebSocketService'
 
 type Privates = {
   _handleMessage: (e: MessageEvent) => void
+  _handleOpen: (resolve: () => void) => void
   _unwrapChannelEvent: (d: Record<string, unknown>) => Record<string, unknown>
   lastGlobalEventId: number | null
   send: (d: Record<string, unknown>) => boolean
+  stopHeartbeat: () => void
 }
 
 function deliver(service: GlobalWebSocketService, payload: unknown): void {
@@ -173,5 +175,61 @@ describe('GlobalWebSocketService global high-water mark (#14818)', () => {
     deliver(service, liveEvent(4))
     deliver(service, { ...liveEvent(0), event_id: 'not-a-number' })
     expect(privates(service).lastGlobalEventId).toBe(4)
+  })
+})
+
+describe('GlobalWebSocketService subscribe-on-open (#14822)', () => {
+  let service: GlobalWebSocketService
+  let sent: Array<Record<string, unknown>>
+
+  beforeEach(() => {
+    service = new GlobalWebSocketService()
+    sent = []
+    privates(service).send = (d) => {
+      sent.push(d)
+      return true
+    }
+  })
+
+  afterEach(() => {
+    // _handleOpen starts the heartbeat interval; leaving it running leaks a
+    // timer into later test files in the same worker.
+    privates(service).stopHeartbeat()
+  })
+
+  it('subscribes to the global channel on open', () => {
+    // The channel socket delivers nothing until something is subscribed, so
+    // without this frame the migrated service would connect and go silent.
+    privates(service)._handleOpen(() => {})
+
+    expect(sent).toContainEqual({ action: 'subscribe', channel: 'global' })
+  })
+
+  it('omits last_event_id on a first connection', () => {
+    privates(service)._handleOpen(() => {})
+
+    const subscribe = sent.find((f) => f.action === 'subscribe')!
+    expect(subscribe).not.toHaveProperty('last_event_id')
+  })
+
+  it('resumes from the marker on a reconnect', () => {
+    deliver(service, liveEvent(17))
+    sent.length = 0
+
+    privates(service)._handleOpen(() => {})
+
+    expect(sent).toContainEqual({ action: 'subscribe', channel: 'global', last_event_id: 17 })
+  })
+
+  it('resolves the connect promise', () => {
+    const resolve = vi.fn()
+    privates(service)._handleOpen(resolve)
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks the service connected', () => {
+    privates(service)._handleOpen(() => {})
+    expect(service.isConnected.value).toBe(true)
+    expect(service.connectionState.value).toBe('connected')
   })
 })

--- a/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
+++ b/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
@@ -233,3 +233,131 @@ describe('GlobalWebSocketService subscribe-on-open (#14822)', () => {
     expect(service.connectionState.value).toBe('connected')
   })
 })
+
+describe('GlobalWebSocketService URL construction (#14822)', () => {
+  const realLocation = window.location
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: realLocation, writable: true })
+  })
+
+  function stubLocation(value: Record<string, string>) {
+    Object.defineProperty(window, 'location', { value, writable: true })
+  }
+
+  it('targets the channel socket behind the nginx proxy', () => {
+    stubLocation({ protocol: 'http:', host: 'autobot.example', port: '', hostname: 'autobot.example' })
+    const service = new GlobalWebSocketService()
+
+    expect(service.getWebSocketUrl().endsWith('/ws/live')).toBe(true)
+    expect(service.getWebSocketUrl()).not.toMatch(/\/ws$/)
+  })
+
+  it('upgrades to wss on an https page', () => {
+    // ws:// on an https page is blocked outright by browsers, so the scheme
+    // has to follow the page.
+    stubLocation({ protocol: 'https:', host: 'autobot.example', port: '', hostname: 'autobot.example' })
+    const service = new GlobalWebSocketService()
+
+    expect(service.getWebSocketUrl().startsWith('wss://')).toBe(true)
+  })
+
+  it('targets the channel socket through the Vite dev proxy too', () => {
+    // The dev branch is a separate code path; if only the production branch
+    // were migrated, local development would still talk to the legacy endpoint
+    // and nobody would notice until deploy.
+    stubLocation({ protocol: 'http:', host: 'localhost:5173', port: '5173', hostname: 'localhost' })
+    const service = new GlobalWebSocketService()
+
+    expect(service.getWebSocketUrl().endsWith('/ws/live')).toBe(true)
+  })
+})
+
+describe('GlobalWebSocketService heartbeat (#14822)', () => {
+  let service: GlobalWebSocketService
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    service = new GlobalWebSocketService()
+  })
+
+  afterEach(() => {
+    service.stopHeartbeat()
+    vi.useRealTimers()
+  })
+
+  it('pings with an action-shaped frame while the socket is open', () => {
+    const sent: Array<Record<string, unknown>> = []
+    privates(service).send = (d) => {
+      sent.push(d)
+      return true
+    }
+    ;(service as unknown as { ws: { readyState: number } }).ws = { readyState: WebSocket.OPEN }
+
+    service.startHeartbeat()
+    vi.advanceTimersByTime(30000)
+
+    expect(sent.some((f) => f.action === 'ping')).toBe(true)
+    // The legacy `type`-shaped ping was silently ignored by the channel socket,
+    // leaving the heartbeat inert while looking healthy.
+    expect(sent.every((f) => !('type' in f))).toBe(true)
+  })
+
+  it('stops itself when the socket is no longer open', () => {
+    const sent: Array<Record<string, unknown>> = []
+    privates(service).send = (d) => {
+      sent.push(d)
+      return true
+    }
+    ;(service as unknown as { ws: { readyState: number } | null }).ws = null
+
+    service.startHeartbeat()
+    vi.advanceTimersByTime(90000)
+
+    expect(sent).toHaveLength(0)
+  })
+})
+
+describe('GlobalWebSocketService testConnection (#14822)', () => {
+  let service: GlobalWebSocketService
+
+  beforeEach(() => {
+    service = new GlobalWebSocketService()
+  })
+
+  it('resolves true when a pong arrives, using an action-shaped ping', async () => {
+    const sent: Array<Record<string, unknown>> = []
+    privates(service).send = (d) => {
+      sent.push(d)
+      return true
+    }
+    service.isConnected.value = true
+
+    const pending = service.testConnection()
+    expect(sent[0]).toMatchObject({ action: 'ping', test: true })
+
+    service.emit('pong', {})
+
+    await expect(pending).resolves.toBe(true)
+  })
+
+  it('reports false when a reconnect attempt fails', async () => {
+    // The disconnected branch tries to reconnect first. connect() is stubbed
+    // because the real one opens a socket — a test must never depend on the
+    // network, and an unstubbed call would hang until the connect timeout.
+    service.isConnected.value = false
+    ;(service as unknown as { connect: () => Promise<void> }).connect = () =>
+      Promise.reject(new Error('no backend'))
+
+    await expect(service.testConnection()).resolves.toBe(false)
+  })
+
+  it('reports the connected state after a successful reconnect', async () => {
+    service.isConnected.value = false
+    ;(service as unknown as { connect: () => Promise<void> }).connect = async () => {
+      service.isConnected.value = true
+    }
+
+    await expect(service.testConnection()).resolves.toBe(true)
+  })
+})

--- a/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
+++ b/autobot-frontend/src/services/__tests__/GlobalWebSocketService.channel.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Channel-socket migration of the global event service (#14822, #14818).
+ *
+ * `GlobalWebSocketService` moved from the legacy `/api/ws` broadcast endpoint to
+ * the channel socket `/api/ws/live`. That endpoint speaks a different shape —
+ * events arrive wrapped as `{type:'live_event', channel, event_type, event_id,
+ * payload}` — while every existing listener in the app is registered against the
+ * old flat `{type, payload}` form.
+ *
+ * The unwrapping seam is what keeps those listeners working, so these tests pin
+ * it, along with the high-water mark that lets a reconnect replay the gap.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { GlobalWebSocketService } from '@/services/GlobalWebSocketService'
+
+type Privates = {
+  _handleMessage: (e: MessageEvent) => void
+  _unwrapChannelEvent: (d: Record<string, unknown>) => Record<string, unknown>
+  lastGlobalEventId: number | null
+  send: (d: Record<string, unknown>) => boolean
+}
+
+function deliver(service: GlobalWebSocketService, payload: unknown): void {
+  ;(service as unknown as Privates)._handleMessage({
+    data: JSON.stringify(payload),
+  } as MessageEvent)
+}
+
+function privates(service: GlobalWebSocketService): Privates {
+  return service as unknown as Privates
+}
+
+function liveEvent(eventId: number, eventType = 'workflow_step_started') {
+  return {
+    type: 'live_event',
+    channel: 'global',
+    event_type: eventType,
+    event_id: eventId,
+    payload: { step: eventId },
+  }
+}
+
+describe('GlobalWebSocketService channel unwrapping (#14822)', () => {
+  let service: GlobalWebSocketService
+
+  beforeEach(() => {
+    service = new GlobalWebSocketService()
+  })
+
+  it('presents a channel event to listeners in the legacy flat shape', () => {
+    // The whole point of the seam: listeners registered before the migration
+    // must keep firing on `event_type`, not on the literal string 'live_event'.
+    const listener = vi.fn()
+    service.on('workflow_step_started', listener)
+
+    deliver(service, liveEvent(1))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener.mock.calls[0][0]).toMatchObject({
+      type: 'workflow_step_started',
+      payload: { step: 1 },
+      channel: 'global',
+    })
+  })
+
+  it('does not emit under the wrapper type', () => {
+    const wrong = vi.fn()
+    service.on('live_event', wrong)
+
+    deliver(service, liveEvent(1))
+
+    expect(wrong).not.toHaveBeenCalled()
+  })
+
+  it('still emits the generic message event', () => {
+    const listener = vi.fn()
+    service.on('message', listener)
+
+    deliver(service, liveEvent(2))
+
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes a non-channel frame through untouched', () => {
+    const unwrapped = privates(service)._unwrapChannelEvent({ type: 'legacy_thing', payload: { a: 1 } })
+    expect(unwrapped).toEqual({ type: 'legacy_thing', payload: { a: 1 } })
+  })
+
+  it('defaults a missing payload to an empty object rather than undefined', () => {
+    const unwrapped = privates(service)._unwrapChannelEvent({
+      type: 'live_event',
+      channel: 'global',
+      event_type: 'x',
+      event_id: 1,
+    })
+    expect(unwrapped.payload).toEqual({})
+  })
+})
+
+describe('GlobalWebSocketService control frames (#14822)', () => {
+  let service: GlobalWebSocketService
+
+  beforeEach(() => {
+    service = new GlobalWebSocketService()
+  })
+
+  it.each(['subscribed', 'unsubscribed', 'connection_established'])(
+    'does not dispatch the %s control frame to listeners',
+    (frameType) => {
+      const listener = vi.fn()
+      service.on('message', listener)
+
+      deliver(service, { type: frameType, channel: 'global' })
+
+      expect(listener).not.toHaveBeenCalled()
+    },
+  )
+
+  it('answers a server ping with an action-shaped frame', () => {
+    // The channel socket dispatches on `action`; the legacy `type`-shaped pong
+    // was silently ignored, leaving the heartbeat inert.
+    const sent: Array<Record<string, unknown>> = []
+    privates(service).send = (d) => {
+      sent.push(d)
+      return true
+    }
+
+    deliver(service, { type: 'ping' })
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0].action).toBe('ping')
+    expect(sent[0]).not.toHaveProperty('type')
+  })
+})
+
+describe('GlobalWebSocketService global high-water mark (#14818)', () => {
+  let service: GlobalWebSocketService
+
+  beforeEach(() => {
+    service = new GlobalWebSocketService()
+  })
+
+  it('starts with no marker', () => {
+    expect(privates(service).lastGlobalEventId).toBeNull()
+  })
+
+  it('advances on each delivered event', () => {
+    deliver(service, liveEvent(5))
+    expect(privates(service).lastGlobalEventId).toBe(5)
+    deliver(service, liveEvent(6))
+    expect(privates(service).lastGlobalEventId).toBe(6)
+  })
+
+  it('never moves backwards on a replayed batch', () => {
+    deliver(service, liveEvent(9))
+    deliver(service, liveEvent(2))
+    expect(privates(service).lastGlobalEventId).toBe(9)
+  })
+
+  it('clears the marker on resync and tells listeners to rebuild', () => {
+    const listener = vi.fn()
+    service.on('resync', listener)
+    deliver(service, liveEvent(9))
+
+    deliver(service, { type: 'resync', channel: 'global', reason: 'gap_exceeds_retention' })
+
+    expect(privates(service).lastGlobalEventId).toBeNull()
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a non-numeric event_id rather than corrupting the marker', () => {
+    deliver(service, liveEvent(4))
+    deliver(service, { ...liveEvent(0), event_id: 'not-a-number' })
+    expect(privates(service).lastGlobalEventId).toBe(4)
+  })
+})

--- a/autobot-frontend/src/services/__tests__/LiveEventService.replay.test.ts
+++ b/autobot-frontend/src/services/__tests__/LiveEventService.replay.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Client-side reconnect replay (#14818).
+ *
+ * The backend half of replay is covered by `events/channel_stream_replay_14818_test.py`.
+ * This is the client half, which was the untested side: tracking the highest
+ * `event_id` seen per channel, sending it back on re-subscribe, and treating a
+ * `resync` directive as "your view is untrustworthy" rather than silently
+ * carrying on.
+ *
+ * The distinguishing cases here are the negative ones — a marker that must not
+ * go backwards, and a resync that must *clear* the marker. Getting either wrong
+ * produces a client that asks the server to replay from a position the server
+ * has already said it cannot serve.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { LiveEventService } from '@/services/LiveEventService'
+
+/** Reach the private message handler without standing up a real socket. */
+function deliver(service: LiveEventService, payload: unknown): void {
+  ;(service as unknown as { _onMessage: (e: MessageEvent) => void })._onMessage({
+    data: JSON.stringify(payload),
+  } as MessageEvent)
+}
+
+/** Capture what the service would put on the wire. */
+function captureSends(service: LiveEventService): Array<Record<string, unknown>> {
+  const sent: Array<Record<string, unknown>> = []
+  ;(service as unknown as { _send: (d: Record<string, unknown>) => boolean })._send = (d) => {
+    sent.push(d)
+    return true
+  }
+  return sent
+}
+
+function liveEvent(channel: string, eventId: number, eventType = 'thing.happened') {
+  return {
+    type: 'live_event',
+    channel,
+    event_type: eventType,
+    event_id: eventId,
+    payload: { n: eventId },
+  }
+}
+
+describe('LiveEventService high-water mark (#14818)', () => {
+  let service: LiveEventService
+
+  beforeEach(() => {
+    service = new LiveEventService()
+  })
+
+  it('has no marker for a channel it has never seen', () => {
+    expect(service.lastSeenEventId('chat:c1')).toBeUndefined()
+  })
+
+  it('records the event_id of a delivered event', () => {
+    deliver(service, liveEvent('chat:c1', 7))
+    expect(service.lastSeenEventId('chat:c1')).toBe(7)
+  })
+
+  it('advances the marker as later events arrive', () => {
+    deliver(service, liveEvent('chat:c1', 7))
+    deliver(service, liveEvent('chat:c1', 8))
+    expect(service.lastSeenEventId('chat:c1')).toBe(8)
+  })
+
+  it('never moves the marker backwards', () => {
+    // A replayed batch arrives with ids below what we already hold. Lowering the
+    // marker would make the next reconnect re-request events we already have.
+    deliver(service, liveEvent('chat:c1', 9))
+    deliver(service, liveEvent('chat:c1', 4))
+    expect(service.lastSeenEventId('chat:c1')).toBe(9)
+  })
+
+  it('keeps a separate marker per channel', () => {
+    deliver(service, liveEvent('chat:c1', 3))
+    deliver(service, liveEvent('session:s1', 11))
+    expect(service.lastSeenEventId('chat:c1')).toBe(3)
+    expect(service.lastSeenEventId('session:s1')).toBe(11)
+  })
+})
+
+describe('LiveEventService subscribe frames (#14818)', () => {
+  let service: LiveEventService
+
+  beforeEach(() => {
+    service = new LiveEventService()
+  })
+
+  it('omits last_event_id on a first-ever subscribe', () => {
+    const sent = captureSends(service)
+    service.subscribe('chat:c1', () => {})
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({ action: 'subscribe', channel: 'chat:c1' })
+    // Omitted rather than sent as 0: the server distinguishes "never seen
+    // anything" from "resume me", and 0 would be a resume request.
+    expect(sent[0]).not.toHaveProperty('last_event_id')
+  })
+
+  it('sends the marker when resuming a channel it has seen', () => {
+    service.subscribe('chat:c1', () => {})
+    deliver(service, liveEvent('chat:c1', 42))
+
+    const sent = captureSends(service)
+    ;(service as unknown as { _sendAction: (a: string, c: string) => void })._sendAction(
+      'subscribe',
+      'chat:c1',
+    )
+
+    expect(sent[0]).toEqual({ action: 'subscribe', channel: 'chat:c1', last_event_id: 42 })
+  })
+
+  it('never sends last_event_id on unsubscribe', () => {
+    deliver(service, liveEvent('chat:c1', 42))
+    const sent = captureSends(service)
+    ;(service as unknown as { _sendAction: (a: string, c: string) => void })._sendAction(
+      'unsubscribe',
+      'chat:c1',
+    )
+
+    expect(sent[0]).toEqual({ action: 'unsubscribe', channel: 'chat:c1' })
+  })
+})
+
+describe('LiveEventService resync handling (#14818)', () => {
+  let service: LiveEventService
+
+  beforeEach(() => {
+    service = new LiveEventService()
+  })
+
+  it('clears the marker so the next subscribe does not resume from a dead position', () => {
+    deliver(service, liveEvent('chat:c1', 42))
+    expect(service.lastSeenEventId('chat:c1')).toBe(42)
+
+    deliver(service, { type: 'resync', channel: 'chat:c1', reason: 'gap_exceeds_retention' })
+
+    expect(service.lastSeenEventId('chat:c1')).toBeUndefined()
+  })
+
+  it('notifies resync listeners with the reason', () => {
+    const seen: string[] = []
+    service.onResync('chat:c1', (r) => seen.push(r.reason))
+
+    deliver(service, { type: 'resync', channel: 'chat:c1', reason: 'replay_unavailable' })
+
+    expect(seen).toEqual(['replay_unavailable'])
+  })
+
+  it('only notifies listeners for the affected channel', () => {
+    const c1: string[] = []
+    const s1: string[] = []
+    service.onResync('chat:c1', (r) => c1.push(r.reason))
+    service.onResync('session:s1', (r) => s1.push(r.reason))
+
+    deliver(service, { type: 'resync', channel: 'chat:c1', reason: 'replay_corrupt' })
+
+    expect(c1).toHaveLength(1)
+    expect(s1).toHaveLength(0)
+  })
+
+  it('stops notifying after the returned disposer runs', () => {
+    const seen: string[] = []
+    const dispose = service.onResync('chat:c1', (r) => seen.push(r.reason))
+    dispose()
+
+    deliver(service, { type: 'resync', channel: 'chat:c1', reason: 'replay_unavailable' })
+
+    expect(seen).toHaveLength(0)
+  })
+
+  it('a throwing resync listener does not stop the others', () => {
+    const survivor: string[] = []
+    service.onResync('chat:c1', () => {
+      throw new Error('listener exploded')
+    })
+    service.onResync('chat:c1', (r) => survivor.push(r.reason))
+
+    deliver(service, { type: 'resync', channel: 'chat:c1', reason: 'replay_unavailable' })
+
+    expect(survivor).toEqual(['replay_unavailable'])
+  })
+})
+
+describe('LiveEventService control frames', () => {
+  let service: LiveEventService
+
+  beforeEach(() => {
+    service = new LiveEventService()
+  })
+
+  it('does not dispatch a subscribed ack to channel listeners', () => {
+    const cb = vi.fn()
+    service.subscribe('chat:c1', cb)
+
+    deliver(service, { type: 'subscribed', channel: 'chat:c1', replayed: 3 })
+
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('delivers a live_event to that channel listener', () => {
+    const cb = vi.fn()
+    service.subscribe('chat:c1', cb)
+
+    deliver(service, liveEvent('chat:c1', 1))
+
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb.mock.calls[0][0].event_id).toBe(1)
+  })
+})

--- a/autobot-frontend/src/services/__tests__/LiveEventService.replay.test.ts
+++ b/autobot-frontend/src/services/__tests__/LiveEventService.replay.test.ts
@@ -88,7 +88,19 @@ describe('LiveEventService subscribe frames (#14818)', () => {
     service = new LiveEventService()
   })
 
+  it('queues rather than sends while disconnected', () => {
+    // subscribe() is guarded on isConnected — subscriptions taken before the
+    // socket opens are replayed by _onOpen instead of being dropped on the
+    // floor. Asserted explicitly so the queueing path is not mistaken for a
+    // silently failed send.
+    const sent = captureSends(service)
+    service.subscribe('chat:c1', () => {})
+
+    expect(sent).toHaveLength(0)
+  })
+
   it('omits last_event_id on a first-ever subscribe', () => {
+    service.isConnected.value = true
     const sent = captureSends(service)
     service.subscribe('chat:c1', () => {})
 
@@ -100,6 +112,7 @@ describe('LiveEventService subscribe frames (#14818)', () => {
   })
 
   it('sends the marker when resuming a channel it has seen', () => {
+    service.isConnected.value = true
     service.subscribe('chat:c1', () => {})
     deliver(service, liveEvent('chat:c1', 42))
 

--- a/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
+++ b/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
@@ -102,6 +102,40 @@ describe('chat store reconciliation (#14821)', () => {
     expect(store.currentMessages).toHaveLength(1)
   })
 
+  it('the echo of our own message confirms it instead of duplicating it', () => {
+    // The defect this guards: our optimistic copy has a local id, the echo has
+    // the server's, so an id-only check misses and renders a second bubble.
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    const localId = store.addMessage({ content: 'hello there', sender: 'user' } as never) as string
+
+    const echo = {
+      id: 'server-echo-1',
+      content: 'hello there',
+      sender: 'user',
+      timestamp: new Date(),
+    } as ChatMessage
+    const applied = store.applyRemoteMessage('s1', echo)
+
+    expect(applied).toBe(false)
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.currentMessages[0].id).toBe('server-echo-1')
+    expect(store.hasPendingMessages).toBe(false)
+    expect(localId).not.toBe('server-echo-1')
+  })
+
+  it('a genuinely different message from another client is still applied', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    store.addMessage({ content: 'mine', sender: 'user' } as never)
+
+    const applied = store.applyRemoteMessage('s1', remoteMessage('other-1', 'theirs'))
+
+    expect(applied).toBe(true)
+    expect(store.currentMessages).toHaveLength(2)
+    expect(store.hasPendingMessages).toBe(true)
+  })
+
   it('server snapshot replaces local contents and clears stale pendings', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')

--- a/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
+++ b/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
@@ -7,10 +7,15 @@
  * branch was taken, not merely that the end state happened to match.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useChatStore } from '@/stores/useChatStore'
 import type { ChatMessage } from '@/types/api'
+import apiClient from '@/utils/ApiClient'
+
+vi.mock('@/utils/ApiClient', () => ({
+  default: { post: vi.fn(), get: vi.fn() },
+}))
 
 function remoteMessage(id: string, content = 'from another client'): ChatMessage {
   return {
@@ -158,5 +163,59 @@ describe('chat store reconciliation (#14821)', () => {
 
     expect(store.currentMessages).toHaveLength(1)
     expect(store.hasPendingMessages).toBe(false)
+  })
+})
+
+
+describe('server-authoritative session creation (#14820)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('adopts the id the server assigns', async () => {
+    // The whole point of #14820: the backend owns session identity. Two clients
+    // minting their own ids can never converge.
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { session_id: 'srv-abc' } })
+    const store = useChatStore()
+
+    const result = await store.createServerSession('My chat')
+
+    expect(result).toEqual({ id: 'srv-abc', authoritative: true })
+    expect(store.currentSessionId).toBe('srv-abc')
+  })
+
+  it('accepts `id` as well as `session_id`', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: 'srv-xyz' } })
+    const store = useChatStore()
+
+    const result = await store.createServerSession()
+
+    expect(result.id).toBe('srv-xyz')
+    expect(result.authoritative).toBe(true)
+  })
+
+  it('falls back to a local session when the backend is unreachable', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(new Error('network down'))
+    const store = useChatStore()
+
+    const result = await store.createServerSession('Offline chat')
+
+    // Usable offline — but flagged, so a caller can tell this session is NOT
+    // synchronized to other clients rather than assuming it is.
+    expect(result.authoritative).toBe(false)
+    expect(result.id).toBeTruthy()
+    expect(store.sessionCount).toBe(1)
+  })
+
+  it('falls back when the response carries no id at all', async () => {
+    // A 200 with an unexpected body must not be mistaken for success — that
+    // would leave the client believing a server session exists when none does.
+    vi.mocked(apiClient.post).mockResolvedValue({ data: {} })
+    const store = useChatStore()
+
+    const result = await store.createServerSession()
+
+    expect(result.authoritative).toBe(false)
   })
 })

--- a/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
+++ b/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
@@ -18,7 +18,7 @@ function remoteMessage(id: string, content = 'from another client'): ChatMessage
     content,
     sender: 'bot',
     timestamp: new Date(),
-  } as ChatMessage
+  }
 }
 
 describe('chat store reconciliation (#14821)', () => {
@@ -30,7 +30,7 @@ describe('chat store reconciliation (#14821)', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
 
-    const id = store.addMessage({ content: 'hello', sender: 'user' } as never)
+    const id = store.addMessage({ content: 'hello', sender: 'user' })
 
     expect(id).not.toBeNull()
     expect(store.hasPendingMessages).toBe(true)
@@ -39,7 +39,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('confirms a pending message when the server echoes it', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    const id = store.addMessage({ content: 'hello', sender: 'user' } as never) as string
+    const id = store.addMessage({ content: 'hello', sender: 'user' }) as string
 
     const confirmed = store.confirmMessage(id)
 
@@ -51,7 +51,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('rewrites the local id to the server id on confirmation', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    const localId = store.addMessage({ content: 'hello', sender: 'user' } as never) as string
+    const localId = store.addMessage({ content: 'hello', sender: 'user' }) as string
 
     store.confirmMessage(localId, 'server-123')
 
@@ -61,7 +61,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('reverts the optimistic effect when the server rejects', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    const id = store.addMessage({ content: 'nope', sender: 'user' } as never) as string
+    const id = store.addMessage({ content: 'nope', sender: 'user' }) as string
     expect(store.currentMessages).toHaveLength(1)
 
     const rejected = store.rejectMessage(id, 'quota exceeded')
@@ -107,14 +107,14 @@ describe('chat store reconciliation (#14821)', () => {
     // the server's, so an id-only check misses and renders a second bubble.
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    const localId = store.addMessage({ content: 'hello there', sender: 'user' } as never) as string
+    const localId = store.addMessage({ content: 'hello there', sender: 'user' }) as string
 
-    const echo = {
+    const echo: ChatMessage = {
       id: 'server-echo-1',
       content: 'hello there',
       sender: 'user',
       timestamp: new Date(),
-    } as ChatMessage
+    }
     const applied = store.applyRemoteMessage('s1', echo)
 
     expect(applied).toBe(false)
@@ -127,7 +127,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('a genuinely different message from another client is still applied', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    store.addMessage({ content: 'mine', sender: 'user' } as never)
+    store.addMessage({ content: 'mine', sender: 'user' })
 
     const applied = store.applyRemoteMessage('s1', remoteMessage('other-1', 'theirs'))
 
@@ -139,7 +139,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('server snapshot replaces local contents and clears stale pendings', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    store.addMessage({ content: 'local only', sender: 'user' } as never)
+    store.addMessage({ content: 'local only', sender: 'user' })
     expect(store.hasPendingMessages).toBe(true)
 
     store.applyServerSnapshot('s1', [remoteMessage('srv-1', 'authoritative')])
@@ -152,7 +152,7 @@ describe('chat store reconciliation (#14821)', () => {
   it('a pending message present in the snapshot stays confirmed, not dropped twice', () => {
     const store = useChatStore()
     store.createNewSession('Test', 's1')
-    const id = store.addMessage({ content: 'kept', sender: 'user' } as never) as string
+    const id = store.addMessage({ content: 'kept', sender: 'user' }) as string
 
     store.applyServerSnapshot('s1', [remoteMessage(id, 'kept')])
 

--- a/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
+++ b/autobot-frontend/src/stores/__tests__/useChatStore.reconciliation.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Write-ahead reconciliation in the chat store (#14820, #14821).
+ *
+ * Session state used to be client-authoritative, so two clients could never
+ * converge. These tests pin the three reconciliation branches — own echo
+ * confirms, foreign message applies, rejection reverts — and assert *which*
+ * branch was taken, not merely that the end state happened to match.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useChatStore } from '@/stores/useChatStore'
+import type { ChatMessage } from '@/types/api'
+
+function remoteMessage(id: string, content = 'from another client'): ChatMessage {
+  return {
+    id,
+    content,
+    sender: 'bot',
+    timestamp: new Date(),
+  } as ChatMessage
+}
+
+describe('chat store reconciliation (#14821)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('marks a locally added message as pending', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+
+    const id = store.addMessage({ content: 'hello', sender: 'user' } as never)
+
+    expect(id).not.toBeNull()
+    expect(store.hasPendingMessages).toBe(true)
+  })
+
+  it('confirms a pending message when the server echoes it', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    const id = store.addMessage({ content: 'hello', sender: 'user' } as never) as string
+
+    const confirmed = store.confirmMessage(id)
+
+    expect(confirmed).toBe(true)
+    expect(store.hasPendingMessages).toBe(false)
+    expect(store.currentMessages).toHaveLength(1)
+  })
+
+  it('rewrites the local id to the server id on confirmation', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    const localId = store.addMessage({ content: 'hello', sender: 'user' } as never) as string
+
+    store.confirmMessage(localId, 'server-123')
+
+    expect(store.currentMessages[0].id).toBe('server-123')
+  })
+
+  it('reverts the optimistic effect when the server rejects', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    const id = store.addMessage({ content: 'nope', sender: 'user' } as never) as string
+    expect(store.currentMessages).toHaveLength(1)
+
+    const rejected = store.rejectMessage(id, 'quota exceeded')
+
+    expect(rejected).toBe(true)
+    expect(store.currentMessages).toHaveLength(0)
+    expect(store.hasPendingMessages).toBe(false)
+  })
+
+  it('confirmMessage reports false for an id it does not hold', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+
+    // The distinguishing assertion: a foreign message must NOT be swallowed as
+    // a confirmation, or the caller would never apply it as new content.
+    expect(store.confirmMessage('never-seen')).toBe(false)
+  })
+
+  it('applies a message that originated on another client', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+
+    const applied = store.applyRemoteMessage('s1', remoteMessage('remote-1'))
+
+    expect(applied).toBe(true)
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.currentMessages[0].content).toBe('from another client')
+  })
+
+  it('does not duplicate a remote message it already holds', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    store.applyRemoteMessage('s1', remoteMessage('remote-1'))
+
+    const applied = store.applyRemoteMessage('s1', remoteMessage('remote-1'))
+
+    expect(applied).toBe(false)
+    expect(store.currentMessages).toHaveLength(1)
+  })
+
+  it('server snapshot replaces local contents and clears stale pendings', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    store.addMessage({ content: 'local only', sender: 'user' } as never)
+    expect(store.hasPendingMessages).toBe(true)
+
+    store.applyServerSnapshot('s1', [remoteMessage('srv-1', 'authoritative')])
+
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.currentMessages[0].id).toBe('srv-1')
+    expect(store.hasPendingMessages).toBe(false)
+  })
+
+  it('a pending message present in the snapshot stays confirmed, not dropped twice', () => {
+    const store = useChatStore()
+    store.createNewSession('Test', 's1')
+    const id = store.addMessage({ content: 'kept', sender: 'user' } as never) as string
+
+    store.applyServerSnapshot('s1', [remoteMessage(id, 'kept')])
+
+    expect(store.currentMessages).toHaveLength(1)
+    expect(store.hasPendingMessages).toBe(false)
+  })
+})

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -271,13 +271,14 @@ export const useChatStore = defineStore('chat', () => {
     if (!session) return
     session.messages = [...messages]
     session.updatedAt = new Date()
-    // Build the surviving set rather than spreading and deleting in place:
-    // one reassignment for reactivity, and no mutation while iterating.
-    const retained = new Set<string>()
-    pendingMessageIds.value.forEach(id => {
-      if (messages.some(m => m.id === id)) retained.add(id)
-    })
-    pendingMessageIds.value = retained
+    // The snapshot is authoritative, so nothing can still be awaiting an answer
+    // against it. A pending message that appears in the snapshot has landed —
+    // it is confirmed, not still pending; one that does not appear did not land,
+    // and has just been replaced away. Either way the pending set is empty.
+    //
+    // Retaining the ones present in the snapshot (as this did) left them stuck
+    // in a permanent 'sending' state for messages the server already held.
+    pendingMessageIds.value = new Set()
   }
 
   /**

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -274,15 +274,48 @@ export const useChatStore = defineStore('chat', () => {
   }
 
   /**
+   * #14821: correlate an inbound server message with a message we sent.
+   *
+   * Our optimistic copy carries a locally generated id while the echo carries
+   * the server's, so ids alone cannot match them. Correlating on
+   * (sender, content) among *pending* messages only — confirmed history is
+   * never rescanned — keeps the echo from rendering a second bubble.
+   *
+   * LIMITATION, stated rather than hidden: two identical unconfirmed messages
+   * from the same sender are indistinguishable here, and the older one is
+   * confirmed first. The complete fix is a client-supplied correlation id that
+   * the backend echoes back (AHP calls this `origin.clientSeq`); this function
+   * is the seam that fix would replace, and nothing else needs to change.
+   *
+   * Returns the local id it confirmed, or null when the message is genuinely
+   * from another client.
+   */
+  function correlatePendingMessage(sessionId: string, message: ChatMessage): string | null {
+    const session = sessions.value.find(s => s.id === sessionId)
+    if (!session) return null
+    for (const localId of pendingMessageIds.value) {
+      const candidate = session.messages.find(m => m.id === localId)
+      if (!candidate) continue
+      if (candidate.sender === message.sender && candidate.content === message.content) {
+        confirmMessage(localId, message.id)
+        return localId
+      }
+    }
+    return null
+  }
+
+  /**
    * #14820: apply a message that originated on another client.
    *
-   * Ignores one we already hold, so a server echo of our own message updates
-   * nothing rather than rendering a duplicate.
+   * Ignores one we already hold, and first checks whether it is really the
+   * echo of something we sent — otherwise our own message would come back as
+   * a duplicate bubble.
    */
   function applyRemoteMessage(sessionId: string, message: ChatMessage): boolean {
     const session = sessions.value.find(s => s.id === sessionId)
     if (!session) return false
     if (session.messages.some(m => m.id === message.id)) return false
+    if (correlatePendingMessage(sessionId, message) !== null) return false
     session.messages.push(message)
     session.updatedAt = new Date()
     return true
@@ -1047,6 +1080,7 @@ export const useChatStore = defineStore('chat', () => {
     rejectMessage,           // #14821
     applyServerSnapshot,     // #14820
     applyRemoteMessage,      // #14820
+    correlatePendingMessage, // #14821
     addOrUpdateMessage,  // Issue #650: ID-based deduplication for streaming
     updateMessage,
     updateMessageMetadata,

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -170,10 +170,14 @@ export const useChatStore = defineStore('chat', () => {
    */
   async function createServerSession(title?: string): Promise<{ id: string; authoritative: boolean }> {
     try {
-      const response = await apiClient.post('/api/chat/sessions', { title })
-      const serverId =
-        (response?.data as { data?: { session_id?: string; id?: string } })?.data?.session_id ??
-        (response?.data as { data?: { session_id?: string; id?: string } })?.data?.id
+      // ApiClient returns the parsed body directly (Promise<T>), not an
+      // axios-style { data } envelope — the backend's own DataResponse wrapper
+      // is the single `data` level here.
+      const body = await apiClient.post<{ data?: { session_id?: string; id?: string } }>(
+        '/api/chat/sessions',
+        { title }
+      )
+      const serverId = body?.data?.session_id ?? body?.data?.id
       if (serverId) {
         return { id: createNewSession(title, serverId), authoritative: true }
       }

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -6,6 +6,7 @@ import { generateChatId, generateMessageId } from '@/utils/ChatIdGenerator.js'
 import { NetworkConstants } from '@/constants/network'
 import { createLogger } from '@/utils/debugUtils'
 import type { ChatMessage } from '@/types/api'
+import apiClient from '@/utils/ApiClient'
 
 // Issue #2066: ChatMessage is now the canonical type from types/api.ts.
 // Re-export so existing consumers that import from this store still work.
@@ -159,6 +160,32 @@ export const useChatStore = defineStore('chat', () => {
     return finalSessionId
   }
 
+  /**
+   * #14820: create a session the backend owns, and adopt the id it assigns.
+   *
+   * `createNewSession` mints an id in the browser, which is why two clients
+   * could never converge — each was its own source of truth. Prefer this for
+   * any new conversation; it falls back to the local path only when the
+   * backend is unreachable, and says so rather than pretending it succeeded.
+   */
+  async function createServerSession(title?: string): Promise<{ id: string; authoritative: boolean }> {
+    try {
+      const response = await apiClient.post('/api/chat/sessions', { title })
+      const serverId =
+        (response?.data as { data?: { session_id?: string; id?: string } })?.data?.session_id ??
+        (response?.data as { data?: { session_id?: string; id?: string } })?.data?.id
+      if (serverId) {
+        return { id: createNewSession(title, serverId), authoritative: true }
+      }
+      logger.warn('Session create returned no id; falling back to a local session')
+    } catch (error: unknown) {
+      logger.warn('Session create failed; falling back to a local session', error)
+    }
+    // Local fallback: usable offline, but this session is NOT synchronized to
+    // other clients until it is reconciled with the backend.
+    return { id: createNewSession(title), authoritative: false }
+  }
+
   function switchToSession(sessionId: string) {
     const session = sessions.value.find(s => s.id === sessionId)
     if (session) {
@@ -172,6 +199,93 @@ export const useChatStore = defineStore('chat', () => {
       isTyping.value = false
       streamingPreview.value = ''
     }
+  }
+
+  /**
+   * #14821: ids of locally-applied messages the server has not confirmed yet.
+   *
+   * The store renders these immediately so typing still feels instant, but they
+   * are not confirmed state. A server echo promotes one (`confirmMessage`); a
+   * rejection removes it and reverts its optimistic effect (`rejectMessage`).
+   * Conflicts are server-wins — the backend is the authority (#14820).
+   *
+   * This is what replaces the #11843 id-matching dedup: identity is now
+   * explicit rather than inferred by comparing two id fields after the fact.
+   */
+  const pendingMessageIds = ref<Set<string>>(new Set())
+
+  /** True while any locally-applied message is still unconfirmed. */
+  const hasPendingMessages = computed(() => pendingMessageIds.value.size > 0)
+
+  /**
+   * #14821: mark a locally-applied message as confirmed by the server.
+   * Optionally rewrites the local id to the server-assigned one so later
+   * echoes match by identity rather than by heuristic.
+   */
+  function confirmMessage(localId: string, serverId?: string): boolean {
+    if (!pendingMessageIds.value.has(localId)) return false
+    pendingMessageIds.value.delete(localId)
+    if (serverId && serverId !== localId) {
+      const session = sessions.value.find(s => s.messages.some(m => m.id === localId))
+      const message = session?.messages.find(m => m.id === localId)
+      if (message) message.id = serverId
+    }
+    // Reassign to trigger Vue reactivity on the Set.
+    pendingMessageIds.value = new Set(pendingMessageIds.value)
+    return true
+  }
+
+  /**
+   * #14821: the server refused a locally-applied message. Remove it and say
+   * why — a silent revert leaves the user believing it was sent.
+   */
+  function rejectMessage(localId: string, reason?: string): boolean {
+    if (!pendingMessageIds.value.has(localId)) return false
+    pendingMessageIds.value.delete(localId)
+    for (const session of sessions.value) {
+      const index = session.messages.findIndex(m => m.id === localId)
+      if (index !== -1) {
+        session.messages.splice(index, 1)
+        break
+      }
+    }
+    pendingMessageIds.value = new Set(pendingMessageIds.value)
+    logger.warn(`Message ${localId} rejected by server: ${reason || 'no reason given'}`)
+    return true
+  }
+
+  /**
+   * #14820: replace a session's contents with the server's version.
+   *
+   * Used on initial load and after a resync directive, when the local view is
+   * known to be untrustworthy. Pending messages are dropped deliberately —
+   * after a resync we cannot know whether they landed, and the server snapshot
+   * is the authority.
+   */
+  function applyServerSnapshot(sessionId: string, messages: ChatMessage[]): void {
+    const session = sessions.value.find(s => s.id === sessionId)
+    if (!session) return
+    session.messages = [...messages]
+    session.updatedAt = new Date()
+    for (const id of [...pendingMessageIds.value]) {
+      if (!messages.some(m => m.id === id)) pendingMessageIds.value.delete(id)
+    }
+    pendingMessageIds.value = new Set(pendingMessageIds.value)
+  }
+
+  /**
+   * #14820: apply a message that originated on another client.
+   *
+   * Ignores one we already hold, so a server echo of our own message updates
+   * nothing rather than rendering a duplicate.
+   */
+  function applyRemoteMessage(sessionId: string, message: ChatMessage): boolean {
+    const session = sessions.value.find(s => s.id === sessionId)
+    if (!session) return false
+    if (session.messages.some(m => m.id === message.id)) return false
+    session.messages.push(message)
+    session.updatedAt = new Date()
+    return true
   }
 
   function addMessage(message: Omit<ChatMessage, 'id' | 'timestamp'>): string | null {
@@ -198,6 +312,11 @@ export const useChatStore = defineStore('chat', () => {
 
     currentSession.value.messages.push(newMessage)
     currentSession.value.updatedAt = new Date()
+
+    // #14821: applied optimistically — the UI shows it now, but it is not
+    // confirmed state until the server echoes it back.
+    pendingMessageIds.value.add(newMessage.id)
+    pendingMessageIds.value = new Set(pendingMessageIds.value)
 
     return newMessage.id
   }
@@ -916,10 +1035,18 @@ export const useChatStore = defineStore('chat', () => {
     sessionCount,
     hasActiveSessions,
 
+    // #14821: reconciliation state
+    hasPendingMessages,
+
     // Actions
     createNewSession,
+    createServerSession,     // #14820: server-assigned session id
     switchToSession,
     addMessage,
+    confirmMessage,          // #14821
+    rejectMessage,           // #14821
+    applyServerSnapshot,     // #14820
+    applyRemoteMessage,      // #14820
     addOrUpdateMessage,  // Issue #650: ID-based deduplication for streaming
     updateMessage,
     updateMessageMetadata,

--- a/autobot-frontend/src/stores/useChatStore.ts
+++ b/autobot-frontend/src/stores/useChatStore.ts
@@ -271,10 +271,13 @@ export const useChatStore = defineStore('chat', () => {
     if (!session) return
     session.messages = [...messages]
     session.updatedAt = new Date()
-    for (const id of [...pendingMessageIds.value]) {
-      if (!messages.some(m => m.id === id)) pendingMessageIds.value.delete(id)
-    }
-    pendingMessageIds.value = new Set(pendingMessageIds.value)
+    // Build the surviving set rather than spreading and deleting in place:
+    // one reassignment for reactivity, and no mutation while iterating.
+    const retained = new Set<string>()
+    pendingMessageIds.value.forEach(id => {
+      if (messages.some(m => m.id === id)) retained.add(id)
+    })
+    pendingMessageIds.value = retained
   }
 
   /**

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
@@ -185,10 +185,18 @@ afterEach(() => {
   while (mountedWrappers.length) mountedWrappers.pop()?.unmount()
 })
 
+// #14854: built once for this file, not once per mount. The `en` bundle is
+// ~400KB and this file mounts 16 times, so constructing a fresh i18n inside the
+// helper re-ingested the entire message tree on every test — which is what
+// pushed two cases past the 10s per-test timeout. The instance is read-only
+// here (no test changes locale or messages), so sharing it is safe.
+const i18nForTests = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 async function mountOnCanvas(fixture?: Fixture) {
   mockApi(fixture)
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
-  const wrapper = mount(OrgChart, { global: { plugins: [i18n], stubs: { HireAgentModal: true } } })
+  const wrapper = mount(OrgChart, {
+    global: { plugins: [i18nForTests], stubs: { HireAgentModal: true } },
+  })
   mountedWrappers.push(wrapper as unknown as VueWrapper)
   await flushPromises()
   await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -62,6 +62,55 @@ def env(name: str, default: Any = None) -> Any:
 # Registered variables — grouped by component
 # ---------------------------------------------------------------------------
 
+# --- events (#14817, #14818) -------------------------------------------------
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHANNEL_SEQ_KEY_PREFIX",
+        type=str,
+        default="autobot:events:seq:",
+        description=("Redis key prefix for per-channel live-event sequence counters."),
+        component="events",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHANNEL_STREAM_KEY_PREFIX",
+        type=str,
+        default="autobot:events:channel:",
+        description=("Redis key prefix for per-channel live-event replay streams."),
+        component="events",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHANNEL_STREAM_MAX_ENTRIES",
+        type=int,
+        default=1000,
+        description=(
+            "Events retained per channel for reconnect replay. A client whose "
+            "last_event_id has fallen outside this window is told to resync "
+            "rather than handed a partial history."
+        ),
+        component="events",
+        range=(1, 1000000),
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHANNEL_STREAM_TTL_SECONDS",
+        type=int,
+        default=86400,
+        description=("Idle expiry for a per-channel replay stream, so session and chat channels do not accumulate."),
+        component="events",
+        range=(60, 2592000),
+    )
+)
+
+
 # --- backend ----------------------------------------------------------------
 
 register_env_var(

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -444,6 +444,10 @@ To add a new variable:
 | `AUTOBOT_BACKEND_PORT` | backend | str | `'8001'` | TCP port of the AutoBot backend service. |
 | `AUTOBOT_BACKEND_URL` | backend | str | `'http://10.255.255.254:8001'` | Full base URL of the AutoBot backend service (overrides HOST+PORT). |
 | `AUTOBOT_BROWSER_STATE_PROMPT_MAX_ELEMENTS` | backend | int | `30` | How many numbered elements the LLM-visible state block renders per browser tool result. The browser worker caps the raw list separately; this bounds only what reaches the prompt (#11537). |
+| `AUTOBOT_CHANNEL_SEQ_KEY_PREFIX` | events | str | `'autobot:events:seq:'` | Redis key prefix for per-channel live-event sequence counters. |
+| `AUTOBOT_CHANNEL_STREAM_KEY_PREFIX` | events | str | `'autobot:events:channel:'` | Redis key prefix for per-channel live-event replay streams. |
+| `AUTOBOT_CHANNEL_STREAM_MAX_ENTRIES` | events | int | `1000` | Events retained per channel for reconnect replay. A client whose last_event_id has fallen outside this window is told to resync rather than handed a partial history. Range: 1–1000000. |
+| `AUTOBOT_CHANNEL_STREAM_TTL_SECONDS` | events | int | `86400` | Idle expiry for a per-channel replay stream, so session and chat channels do not accumulate. Range: 60–2592000. |
 | `AUTOBOT_CHATS_DIRECTORY` | chat | str | `'data/chats'` | Filesystem path where chat session files are stored. |
 | `AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY` | ai | int | `2` | Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede the LLM. |
 | `AUTOBOT_CHAT_TRAJECTORY_CONTEXT` | ai | bool | true | Search past trajectories before answering. Defaults on because the search is one vector query; capture is gated separately since it spends a judge call. |
@@ -541,6 +545,8 @@ To add a new variable:
 | `AUTOBOT_REMEDIATION_HEARTBEAT_WAIT_S` | backend | int | `90` | Seconds to wait for a heartbeat after the reconciler restarts a node's agent before recording the remediation as failed. Remediation exists to restore the heartbeat, so the heartbeat is what success means — the restart exiting 0 only says the command ran (services/reconciler.py, #14344). |
 | `AUTOBOT_REMEDIATION_PLAYBOOK_TIMEOUT_S` | backend | int | `180` | Wall-clock ceiling on the ansible-playbook subprocess _restart_service_via_ansible launches. Previously unbounded — a hung SSH connection or stuck remote task blocked remediation for a node indefinitely. manage-service.yml (the only playbook this call path runs) is a single-host, single-service restart that normally completes in seconds; 180s stays comfortably below REMEDIATION_COOLDOWN (300s) while giving generous headroom (services/reconciler.py, services/playbook_executor.py, #14524). |
 | `AUTOBOT_REMEDIATION_TRACKER_EXPIRY_S` | backend | int | `1800` | Seconds a non-exhausted remediation attempt tracker may sit with no NEW attempt before its count is forgiven. Clamped strictly above REMEDIATION_COOLDOWN plus a reconcile-tick margin — a lower value forgives an attempt in the same instant one becomes due, so count could never exceed 1 (services/reconciler.py, #14465). |
+| `AUTOBOT_REMOTE_APPROVAL_FLAG_TTL_SECONDS` | approvals | int | `604800` | How long a session stays flagged for remote approval routing without being refreshed. Expiry returns the session to asking inline; it never widens autonomy. |
+| `AUTOBOT_REMOTE_APPROVAL_TTL_SECONDS` | approvals | int | `86400` | How long a remotely delivered approval stays correlatable with its reply. After this the reply can no longer be tied to a request and resolves nothing. |
 | `AUTOBOT_REQUIRE_CLASSIFICATION` | orchestrator | bool | false | Fail orchestrator construction when request classification is unavailable. Default (off) degrades gracefully: every request is defaulted to COMPLEX and the reason is reported in the orchestration status. Deployments that depend on classification set this so the failure is loud instead of silent (#13807). |
 | `AUTOBOT_RESTART_CHURN_WINDOW_S` | backend | int | `600` | Seconds a managed autobot/slm-agent service is reported as CURRENTLY churning after its last observed n_restarts increase, for node-status degrade purposes. Must clear health_collector's own 300s discovery-cache TTL by a comfortable margin — a shorter window only fires on the beat that happens to land on a cache refresh (services/reconciler.py, #14465). |
 | `AUTOBOT_RETRIEVAL_REDIS_TIMEOUT` | redis | float | `1.5` | Seconds the retrieval learner waits for its Redis lock before proceeding without it. Short on purpose — retrieval must answer even when the learner cannot record what it learned. |
@@ -578,5 +584,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*140 variables registered as of last generation.*
+*146 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->

--- a/docs/developer/EVENT_STATE_DOCTRINE.md
+++ b/docs/developer/EVENT_STATE_DOCTRINE.md
@@ -1,0 +1,80 @@
+# Event & State Doctrine
+
+> Read before adding an event type, a WebSocket route, an event bus, or a new
+> piece of session state. This is a checklist, not a manual — if a rule needs
+> more than two lines, the reasoning belongs in the linked issue.
+
+The event/state layer carries what the user sees happening: chat turns,
+workflow progress, agent steps, approvals, worker health. AutoBot is **one host
+with many clients** — several tabs, several devices, several users on a shared
+session — so "it works on my screen" is not the bar.
+
+## Principles
+
+1. **One bus.** `events/bus.py` is the single publish entry point.
+   `PersistStrategy` is the durability knob. A second bus is never the answer to
+   a delivery problem — three parallel systems is the state this codebase was
+   already in once, and callers had to publish twice to reach everyone.
+2. **State over notification.** If a user-visible fact is only ever an ephemeral
+   notification, a client that was disconnected can never learn it. Durable,
+   user-visible truth must be recoverable from state or from a replayable
+   stream.
+3. **The backend is the authority.** The server sequences events and resolves
+   conflicts. A client may render optimistically, but it is never the source of
+   truth — two clients that each own the truth cannot converge, by construction.
+4. **Delivery and persistence are separate concerns.** Persisting inside a
+   delivery callback means nothing is recorded when nobody is watching. Publish
+   persists; delivery is what happens next, to however many clients are
+   attached (#14814).
+5. **Channels, not routes.** New event types extend the channel grammar in
+   `live_event_manager.py`. They do not add a WebSocket endpoint. Routing is
+   `(type, channel)` — uniform, so a client, a proxy, or a test can dispatch
+   without per-message knowledge.
+6. **Additive and capability-gated.** A smaller or older client should keep
+   working. Prefer optional fields and negotiated capabilities over changes that
+   force every consumer to upgrade at once.
+
+## Design tests
+
+Ask these before adding to this layer. Any "no" needs a written justification in
+the issue.
+
+- Can a minimal client ignore this and still render a coherent session?
+- Is the durable, user-visible result represented in **state**, rather than only
+  in an ephemeral notification?
+- Does the backend remain the authority for sequencing and conflict resolution?
+- Does this fit an existing channel, or does it genuinely need a new one?
+- Can clients discover support through a capability rather than a version check?
+- If a client is offline when this fires, can it find out afterwards?
+- Does a second connected client see the same thing as the first?
+
+## Anti-goals
+
+This layer does **not** define:
+
+- How agents reason, plan, or manage context. That is the agent loop's concern.
+- A model provider, router, or credential flow.
+- A universal backend tool registry or tool schema.
+- A required UI layout or client framework.
+- Agent-to-agent coordination semantics.
+- Binary or high-volume streams. VNC framebuffers, audio, terminal PTY bytes and
+  log tails stay on their own sockets — multiplexing them onto a JSON event
+  channel serves neither well.
+
+## Rules with teeth
+
+| Rule | Why it exists |
+|---|---|
+| Never hold a broadcast callback as a scalar | A single slot means last-writer-wins and one disconnect silences everyone (#14814) |
+| Never derive a sequence number from process memory | It resets on restart and diverges across workers; a marker clients trust but which restarts is worse than no marker (#14817) |
+| Never return an incomplete history as if it were complete | "You missed nothing" and "I cannot tell you what you missed" must not both be an empty list (#14818) |
+| Never make persistence a side effect of delivery | Zero clients connected must still record the event (#14814) |
+| Fail closed on channel authorization | An unknown or unowned resource is a denial, not an absence of restriction (#14819) |
+
+## See also
+
+- [`docs/research/agent-host-and-agent-client-protocols.md`](../research/agent-host-and-agent-client-protocols.md)
+  — the audit that produced these rules, and the external protocols they draw on
+  (Microsoft's Agent Host Protocol; Zed/JetBrains' Agent Client Protocol).
+- [`CLAUDE_RULES.md`](CLAUDE_RULES.md) — the general engineering rules this
+  refines for one layer.

--- a/docs/research/agent-host-and-agent-client-protocols.md
+++ b/docs/research/agent-host-and-agent-client-protocols.md
@@ -192,6 +192,283 @@ either protocol on the wire**, and that is very likely where the value is.
 
 ---
 
-## Phase 2 — AutoBot Comparison
+---
 
-Not started. Awaiting explicit go-ahead.
+## AutoBot Comparison: AHP + ACP → AutoBot
+
+**Focus (owner-set):** AutoBot is one host, many clients — so AHP's core problem *is* AutoBot's
+problem. This section is scoped to the multi-client session/state-sync path.
+
+**Headline:** AutoBot already has almost every *ingredient* AHP needs — channel-scoped fan-out,
+monotonic per-channel event ids, a Redis Streams replay buffer, per-session multi-connection
+presence — but they are **wired to three different buses, and the main chat WebSocket uses the one
+that is structurally single-client**. The gap is assembly, not invention.
+
+### Audit: what was read
+
+`autobot-backend/api/websockets.py`, `events/bus.py`, `event_manager.py`, `live_event_manager.py`,
+`events/stream_manager.py`, `api/live_events.py`, `api/presence_ws.py`, `websocket/presence.py`,
+`mcp/autobot_server.py`, `a2a/agent_card.py`; frontend
+`src/services/GlobalWebSocketService.ts`, `src/services/LiveEventService.ts`,
+`src/stores/useChatStore.ts`; plus repo-wide greps for `@router.websocket`, `register_ws_broadcast`,
+`PersistStrategy`, `subscribe_ws`, `event_id`, and `acp|agent client protocol`.
+
+---
+
+### Finding 0 (blocking, pre-existing bug) — `/api/ws` is structurally single-client
+
+Not an adoption item — a defect the audit surfaced, and the reason multi-client does not work today.
+
+`api/websockets.py:681` registers each connection's handler via
+`get_event_bus().register_ws_broadcast(broadcast_event)`, which lands on
+`EventManager.register_websocket_broadcast` (`event_manager.py:53`). That setter assigns a **single
+scalar**, not a list:
+
+```python
+self._websocket_broadcast_callback: Callable[...] | None = None   # event_manager.py:31
+```
+
+Consequences, in order of severity:
+
+1. **Last-writer-wins.** Client B connecting silently stops Client A receiving anything on this
+   path. No error, no log.
+2. **First disconnect kills delivery for everyone.** `api/websockets.py:694` clears the callback to
+   `None` on *any* client's teardown — including in the `finally` of a client that was already
+   superseded. Remaining connected clients go permanently silent.
+3. **Chat history stops being written.** `_add_to_chat_history` is invoked from *inside*
+   `broadcast_event` (`api/websockets.py:510`). No callback → no broadcast → **no persistence**.
+   This is a data-loss path, not just a UI path.
+
+Blast radius is wide: `PersistStrategy.NONE` (which routes to this single-callback path) is the
+strategy used by `api/workflow.py` (7 sites), `chat_workflow/cot_events.py:201`, `api/agent.py:194`,
+`orchestrator.py:968`, `orchestration/workflow_runner.py:695`,
+`services/approval_gate_service.py:362`, `services/npu_worker_manager.py:902`, `worker_node.py`,
+`diagnostics.py`. Chain-of-thought, workflow progress, and approval-gate events all ride it.
+
+The frontend's primary socket, `GlobalWebSocketService` (`src/services/GlobalWebSocketService.ts:146`),
+connects to exactly this endpoint (`${getApiBase()}/ws`).
+
+**This should be filed and fixed on its own merits regardless of any protocol adoption.** The fix
+is small — make the callback a set keyed by connection — and does not require AHP.
+
+---
+
+### What We Can Adopt
+
+#### 1. Host-authoritative session state (AHP's central premise) — **adopt-with-conditions**
+
+*Already-exists audit.* `src/stores/useChatStore.ts` is the source of truth for sessions today:
+`createNewSession` mints the id client-side (`:136-138`), messages are appended locally
+(`:199`, `:279`), and the store persists to `localStorage` under `autobot-chat-store` (`:856`).
+There is no server-authoritative session document and no reconciliation anywhere in the store —
+grep for `optimistic|rollback|revert` returns only `hasPendingApproval` (`:462`), which is
+unrelated. Two browsers on one account produce two divergent truths that never converge.
+
+*Visible benefit.* Open the same session on desktop and phone and see the same thing; a refresh
+stops losing state; server-side features (search, audit, quotas) get one thing to read.
+
+*Hidden cost.* This is the single largest item here. It relocates ownership of chat state from the
+store to the backend, touches every writer in `useChatStore.ts`, and demands a
+confirmed/pending/optimistic split in the store to avoid regressing input latency. Pre-1.0 protocol
+churn if AHP's shapes are copied literally.
+
+*Verdict.* **Adopt the doctrine, not the wire format.** Make the backend authoritative for session
+and turn state and give clients a snapshot+delta subscription. Do *not* import AHP's
+`ahp-session:/` / `ahp-chat:/` URI scheme or its full 10-channel/30-command surface — AutoBot has
+one host and one product, so the interop pressure that justifies AHP's size does not apply.
+Effort: **significant**.
+
+#### 2. Reconnect-with-replay via `lastSeenServerSeq` — **adopt** (highest value/effort ratio)
+
+*Already-exists audit.* Three of the four pieces are built:
+- `LiveEventManager.publish` already stamps a **monotonic per-channel `event_id`**
+  (`live_event_manager.py:_next_event_id`, `:88`).
+- `LiveEventService.ts:33,409` already **receives** `event_id` — and does nothing with it but log.
+- `RedisEventStreamManager` (`events/stream_manager.py:125`) is a **real replay buffer**: Redis
+  Streams via `xadd(..., maxlen=config.max_stream_length)` (`:167`), with `xrange` (`:322`),
+  `get_latest` (`:262`), and `get_event` (`:337`).
+
+The missing piece is the wiring, and it is worse than missing — it is *explicitly dropped*:
+
+```python
+if persist is PersistStrategy.REDIS:
+    logger.critical("PersistStrategy.REDIS is not implemented in EventBus — event dropped ...")
+    return                                              # events/bus.py:76-84
+```
+
+Meanwhile `LiveEventManager._event_counters` is a plain in-process dict — it resets on restart and
+is not shared across workers, so today's `event_id` is not even durable.
+
+Reconnect handling exists on both services (`GlobalWebSocketService.ts:447`,
+`LiveEventService.ts:218`) with exponential backoff, and `LiveEventService` correctly re-subscribes
+its channels on reopen (`:148`). But no client sends a last-seen id, so **every event during the
+disconnect window is silently lost** — the failure mode is invisible, which is the worst kind.
+
+*Visible benefit.* No lost workflow/CoT/approval events across a laptop sleep, a WiFi handover, or
+a backend restart.
+
+*Hidden cost.* Sequence allocation must move to Redis to be durable and multi-worker-safe; you
+inherit a retention policy (`maxlen`) and the snapshot-vs-replay branch when the gap exceeds the
+buffer. Modest and well-bounded.
+
+*Verdict.* **Adopt.** Wire `PersistStrategy.REDIS` into `EventBus.publish`, source `event_id` from
+the Redis stream id, accept `last_event_id` on the `/ws/live` subscribe action, and replay via
+`xrange` — falling back to a snapshot when the id is older than `maxlen`. Effort: **moderate**.
+
+#### 3. Uniform `channel` routing key on *every* message — **adopt, narrowly**
+
+*Already-exists audit.* AutoBot has **25 WebSocket routes** (`grep -c '@router.websocket'`,
+excluding tests): `api/websockets.py` ×3, `api/live_events.py`, `api/terminal.py` ×2,
+`api/analytics.py` ×2, `api/advanced_control.py` ×2, `api/presence_ws.py`, `api/monitoring.py`,
+`api/voice_stream.py`, `api/logs.py`, `api/vnc_proxy.py`, `api/overseer_handlers.py`,
+`services/workflow_automation/routes.py`, and others — each with its own hand-rolled envelope,
+auth, keepalive, and teardown.
+
+`LiveEventManager` already validates a channel grammar —
+`{agent,task,workflow,heartbeat,company,board}:{id}` plus `global` (`live_event_manager.py:23,25-32`)
+— so the concept is established and enforced; it is just confined to one endpoint.
+
+*Visible benefit.* One socket, one envelope, one auth path; new event types need no new route.
+Proxies and the frontend dispatch on `(type, channel)` without per-message knowledge.
+
+*Hidden cost.* Consolidating 25 endpoints is a large migration touching binary-ish streams (VNC,
+voice, terminal PTY) that genuinely should *not* be multiplexed onto a JSON event socket.
+
+*Verdict.* **Adopt for the event-shaped subset only** — chat, workflow, agent, approvals, NPU,
+analytics, monitoring. Leave VNC/voice/terminal/logs on dedicated sockets. Extend the existing
+`_VALID_PREFIXES` grammar with `session:{id}` and `chat:{id}` rather than inventing a URI scheme.
+Effort: **significant** (but incremental — one route at a time).
+
+#### 4. Write-ahead reconciliation in the Pinia store — **adopt-with-conditions**
+
+*Already-exists audit.* Nothing resembling this exists. `useChatStore.ts` pushes straight into
+`currentSession.value.messages` with no pending set; the only echo-handling is id-matching dedup at
+`:252` and `:274` (#11843), which is a symptom of exactly the problem AHP's `origin`/`clientSeq`
+solves properly.
+
+*Visible benefit.* Instant local echo *and* convergence between clients; deletes the dedup hacks.
+
+*Hidden cost.* Real complexity in the store — `confirmedState` + `pendingActions[]` + computed
+`optimisticState`, plus rebase. Only pays off **after** item 1 lands; on its own it has nothing to
+reconcile against.
+
+*Verdict.* **Adopt-with-conditions — strictly sequenced after item 1.** AHP's own honesty applies
+here: chat actions are append-only, so rebasing is near-trivial and server-wins settles the rest.
+Effort: **moderate**, conditional.
+
+#### 5. A written doctrine with anti-goals and design tests — **adopt** (cheapest, highest leverage)
+
+*Already-exists audit.* `docs/developer/` covers *process* (`CLAUDE_RULES.md`, `CLAUDE_GIT.md`,
+`CLAUDE_REVIEW.md`, `ARCHITECTURE_EXCEPTIONS.md`) but there is no equivalent of AHP's
+`guide/doctrine.md` — a normative statement of *what the event/state layer is for and what it
+refuses to do*. The three-parallel-bus history recorded in `events/bus.py:7-12` (and its still-open
+"Phase 2/Phase 3" migration plan) is precisely what an anti-goals list prevents.
+
+*Visible benefit.* Kills the "which bus do I publish to?" question permanently; gives reviewers an
+objective test.
+
+*Hidden cost.* Essentially none — one document. Risk is it going stale, mitigated by keeping it a
+checklist per `CLAUDE.md`'s lean-instructions rule.
+
+*Verdict.* **Adopt.** Steal AHP's design tests verbatim — *"Can a minimal client ignore this and
+still render a coherent session?"*, *"Is the durable, user-visible result in state rather than only
+an ephemeral notification?"* — and its anti-goals format. Effort: **trivial**.
+
+#### 6. ACP server surface (let external editors drive AutoBot agents) — **adopt-with-conditions**
+
+*Already-exists audit.* **No ACP anywhere.** A repo-wide grep for
+`agent client protocol|agent-client-protocol` returns only
+`docs/archives/plans/2026-03-04-service-message-bus-design.md:17`, which refers to an unrelated
+"Agent Communication Protocol" from a LangGraph article. AutoBot does expose two adjacent surfaces:
+an MCP **server** (`mcp/autobot_server.py`, with scope checks `_check_scope:526`, rate limiting
+`_is_rate_limited:535`, and Redis token validation `_validate_redis_token:423`) and an A2A agent
+card (`a2a/agent_card.py:build_agent_card:128`). Both **advertise capability outward**; neither lets
+an editor *drive* an AutoBot agent through a prompt/stream/permission loop.
+
+*Visible benefit.* Implementing `initialize` / `session/new` / `session/prompt` / `session/update` /
+`session/request_permission` would make AutoBot agents appear inside Zed, JetBrains, Neovim and
+Emacs via the ACP Registry — real distribution for a protocol with 4k stars and vendor backing.
+
+*Hidden cost.* ACP presumes one client, one human, one editor, one task — the opposite of AutoBot's
+long-running autonomous shape. Sessions would need a mapping from ACP's stdio-scoped model onto
+AutoBot's persistent server-side sessions, and ACP moved v1.0→v1.7 within a year on a cadence set by
+editor-UX priorities.
+
+*Verdict.* **Adopt-with-conditions, and not now.** Correct sequencing is items 0 → 2 → 1: a
+host-authoritative session with replay is a *prerequisite* for an ACP adapter that behaves sanely,
+because ACP's `session/load` replays whole history and `session/resume` needs a durable session to
+resume into. Revisit once item 1 lands. Effort: **significant**.
+
+---
+
+### What We Already Do Better
+
+- **WebSocket authentication.** AHP explicitly punts: *"Access to the AHP endpoint itself is a
+  transport-layer concern and is outside the scope of the AHP wire protocol."* AutoBot has a
+  concrete, uniform, tested convention — `enforce_ws_origin` (`api/ws_security.py`) plus
+  `authenticate_websocket`, with the deliberate accept-then-close-4001 pattern
+  (`api/websockets.py:718-724`, `api/live_events.py:224-231`, #12366) so clients get a real close
+  frame instead of an ambiguous handshake 403. Guarded by `tests/test_websocket_auth_smoke.py` and
+  `tests/test_websockets_auth_reject_12366.py`.
+- **Presence and collaboration.** AHP's `SessionState` has an `activeClients` field and stops
+  there. `websocket/presence.py:PresenceManager` keeps
+  `Dict[session_id][user_id] -> Set[WebSocket]` (`:35`) — note it already models **one user with
+  several concurrent connections**, i.e. the desktop-plus-phone case — with join/leave broadcast
+  (`_broadcast_event:160`), `get_online_users:112`, and targeted `send_to_user:128`. It is wired
+  end-to-end to `src/composables/useSessionCollaboration.ts`,
+  `components/collaboration/ParticipantList.vue` and `PresenceIndicator.vue`. **"Who is here" is
+  solved better than AHP specifies it; "what they see" is the part that is missing.**
+- **MCP depth.** AHP's `mcp://` channel relays a deliberately narrow, capability-gated subset
+  (`serverTools`, `serverResources`, `logging`, `sampling`). AutoBot runs a full MCP server with
+  per-tool scope enforcement and throttling (`mcp/auth_throttle.py`).
+- **Explicit durability as a typed choice.** `PersistStrategy` (`events/bus.py:40`) makes
+  "in-memory vs fan-out vs durable" a decision at the call site. AHP's doctrine assumes durable
+  state but offers no equivalent knob. The enum is the right design — one arm of it just is not
+  implemented yet (see item 2).
+
+### Gaps & Opportunities — prioritised
+
+| # | Gap | Impact | Effort | Note |
+|---|-----|--------|--------|------|
+| 1 | `/api/ws` single-callback broadcast (Finding 0) | **Critical** — multi-client silently broken; chat history silently stops persisting | trivial | Pre-existing bug. File and fix independently of everything else. |
+| 2 | `PersistStrategy.REDIS` logs critical and drops the event | **High** — the durable substrate is built (`events/stream_manager.py`) and unreachable through the unified bus | trivial–moderate | Unwired existing work, not new work. |
+| 3 | No `last_event_id` / replay on reconnect | **High** — events in the disconnect window are lost with no signal | moderate | Depends on #2. |
+| 4 | `event_id` is an in-process counter | **High** — resets on restart, diverges across workers | trivial | Source it from the Redis stream id. |
+| 5 | Two competing event sockets (`/api/ws` vs `/api/ws/live`), frontend uses **both** | **High** — canonical-source violation; `events/bus.py:19-22` still lists Phase 2/3 as outstanding | moderate | `GlobalWebSocketService` → `/api/ws`; `LiveEventService` → `/ws/live`. |
+| 6 | Session state is client-authoritative (Pinia + `localStorage`) | **High** — two clients cannot converge, by construction | significant | The real multi-client blocker. |
+| 7 | No `session:`/`chat:` channel prefixes in `_VALID_PREFIXES` | Medium — no way to scope a subscription to a conversation | trivial | One-line grammar extension; unblocks #6. |
+| 8 | No write-ahead reconciliation in the store | Medium | moderate | Only after #6. |
+| 9 | No doctrine doc for the event/state layer | Medium — three-bus sprawl is the recorded cost of its absence | trivial | Best value-per-hour on the list. |
+| 10 | 25 bespoke WebSocket routes | Medium | significant | Consolidate the event-shaped subset only. |
+| 11 | No ACP server surface | Low *now*, high later | significant | Gated on #6. |
+| 12 | No synchronized drafts / per-chat working directory | Low | moderate | AHP's `chat/draftChanged`; the per-chat-worktree idea maps onto AutoBot's own worktree discipline. |
+
+### Specific Code/Files Affected
+
+- `autobot-backend/event_manager.py:31,53` — `_websocket_broadcast_callback` scalar →
+  `set[Callable]`; `register_websocket_broadcast` → `add`/`discard`. **(Gap 1)**
+- `autobot-backend/api/websockets.py:671-697` — register/unregister per connection instead of
+  overwriting a global; move `_add_to_chat_history` (`:459`) **out** of the broadcast handler so
+  persistence no longer depends on a client being attached. **(Gap 1)**
+- `autobot-backend/events/bus.py:76-84` — implement the `PersistStrategy.REDIS` arm against
+  `RedisEventStreamManager` instead of `logger.critical` + `return`. **(Gaps 2, 4)**
+- `autobot-backend/live_event_manager.py:23,84-88` — add `session`/`chat` to `_VALID_PREFIXES`;
+  source `event_id` from the Redis stream id rather than `_event_counters`. **(Gaps 4, 7)**
+- `autobot-backend/api/live_events.py:_handle_message` — accept `last_event_id` on `subscribe`;
+  replay via `xrange`, else return a snapshot. **(Gap 3)**
+- `autobot-frontend/src/services/LiveEventService.ts:148,251` — track the highest seen `event_id`
+  per channel; send it on re-subscribe; surface a gap as a resync rather than a silent hole.
+  **(Gap 3)**
+- `autobot-frontend/src/services/GlobalWebSocketService.ts:146,153` — migration target: fold onto
+  `/ws/live` once channel coverage is equivalent, retiring the duplicate path. **(Gap 5)**
+- `autobot-frontend/src/stores/useChatStore.ts:136,199,279,252,274` — server-assigned session ids;
+  snapshot+delta subscription; confirmed/pending/optimistic split replacing the id-match dedup.
+  **(Gaps 6, 8)**
+- `docs/developer/` — new `EVENT_STATE_DOCTRINE.md` (principles, design tests, anti-goals), linked
+  from the `CLAUDE.md` trigger table. **(Gap 9)**
+
+### Recommended sequence
+
+**Gap 1 → 2 → 4 → 3 → 7 → 6 → 8 → 5 → 10 → 11.** The first four are small, independently
+valuable, and mostly consist of connecting things AutoBot has already built. Gap 9 (the doctrine
+doc) can land in parallel at any point and makes the rest easier to review.

--- a/docs/research/agent-host-and-agent-client-protocols.md
+++ b/docs/research/agent-host-and-agent-client-protocols.md
@@ -1,0 +1,197 @@
+# Research: Agent Host Protocol (AHP) & Agent Client Protocol (ACP)
+
+**Sources**
+- <https://microsoft.github.io/agent-host-protocol/> · repo `microsoft/agent-host-protocol` (MIT)
+- <https://agentclientprotocol.com/get-started/introduction> · repo `zed-industries/agent-client-protocol` (Apache-2.0)
+- AHP's own comparison page: `docs/guide/ahp-and-acp.md`
+
+**Status:** Phase 1 (source analysis) complete. Phase 2 (AutoBot comparison) not started — awaiting go-ahead.
+
+---
+
+## Source Analysis: AHP + ACP
+
+### What They Are
+
+These are **two layers of the same stack, not competitors** — and AHP's own docs say so explicitly.
+
+**ACP (Agent Client Protocol)** — created by Zed Industries (June 2025), now co-developed with
+JetBrains. Apache-2.0, `v1.7.0`, ~4.0k stars / 349 forks, actively pushed. It standardizes the
+**1:1 conversation between one client (editor/IDE/CLI) and one coding agent**: initialize, auth,
+create session, prompt, stream updates, call tools, request permission. Its explicit model is
+LSP-for-agents — "any editor to any agent, no custom glue". Adoption is the real story: JetBrains
+IDEs (built in since Dec 2025), Zed 1.0's headline feature (Apr 2026), Neovim, Emacs, and a
+co-launched public **ACP Registry** (Jan 2026) listing dozens of agents — Claude Code, Gemini CLI,
+Codex, Copilot, Goose.
+
+**AHP (Agent Host Protocol)** — Microsoft, created 2026-03-12, MIT, ~253 stars / 66 forks, 786
+commits, protocol version `0.3.0`, reference implementation is VS Code's built-in client. It solves
+a **different** problem: *N clients sharing one agent session*. A session stops being trapped in the
+app that started it; IDE, web, CLI and mobile can all attach to the same live session and see the
+same state.
+
+AHP's one-line self-description: *"a portable, standalone server protocol that gives multiple
+clients a synchronized view of AI agent sessions through immutable state, pure reducers, and
+write-ahead reconciliation."*
+
+Maturity: ACP is production infrastructure with an ecosystem. AHP is early (5 months old, 0.3.0,
+`StabilityIndex` markers on individual channel pages ranging 1.2–2), but unusually well-specified
+for its age — RFC 2119 language, generated JSON Schema, five language SDKs.
+
+### Architecture & Key Patterns
+
+**ACP — point-to-point, JSON-RPC 2.0.**
+- Local agents: sub-process over **stdio**. Remote: HTTP/WebSocket (still WIP).
+- Client→Agent methods: `initialize`, `authenticate`, `session/new` (`cwd` + `mcpServers`),
+  `session/prompt`; optional `session/load` (replays whole history as `session/update`s),
+  `session/resume` (reconnect *without* replay), `session/set_mode`, `logout`,
+  `session/cancel` (notification).
+- Agent→Client methods: `session/request_permission` (baseline); optional `fs/read_text_file`,
+  `fs/write_text_file`, `terminal/create|output|release|wait_for_exit|kill`, `elicitation/create`.
+- One notification does the heavy lifting: **`session/update`** — message chunks, agent thought
+  chunks, tool calls, **plans**, available-command changes, mode changes.
+- Capability negotiation at `initialize` (`agentCapabilities.loadSession`,
+  `sessionCapabilities.resume/close/additionalDirectories`, `mcpCapabilities.http/sse`).
+- Conventions: absolute paths only, 1-based line numbers, camelCase keys (snake_case
+  discriminators), Markdown as the default text format, `_meta` + `_`-prefixed methods for
+  extensions. **Reuses MCP's JSON representations** where they exist, adds coding-UX types (diffs).
+
+**AHP — hub-and-spoke, state-first, JSON-RPC 2.0, transport-agnostic** (WebSocket in practice;
+requirement is only "reliable, ordered, bidirectional, complete-message"). Four ideas carry the
+whole design:
+
+1. **Channels are the universal routing key.** Every message — command *and* notification —
+   carries a top-level `channel: URI` on its params. Any peer or proxy dispatches on
+   `(method, params.channel)` with zero per-method deserialization. The invariant is enforced at
+   **compile time** (`types/version/message-checks.ts` fails the build if a new method omits it).
+   URI schemes: `ahp-root://`, `ahp-session:/<uuid>`, `ahp-chat:/<cid>`, `ahp-terminal:/<id>`,
+   `ahp-changeset:/<id>`, `ahp-automations://`, `ahp-automation-run:/<id>`,
+   `ahp-resource-watch:/<id>`, `ahp-otlp:`, `mcp://`.
+2. **State + ordered actions, not events.** State-bearing channels deliver mutations as `action`
+   envelopes `{ channel, action, serverSeq, origin: { clientId, clientSeq } }`. Clients apply pure
+   reducers. Action names are display-oriented and agent-agnostic: `chat/turnStarted`,
+   `chat/delta`, `chat/toolCallStart`, `chat/toolCallReady`, `chat/toolCallConfirmed`,
+   `chat/turnCancelled`, `chat/draftChanged`, `chat/turnsLoaded`, `root/sessionAdded`,
+   `session/chatAdded`, `resourceWatch/changed`.
+3. **Write-ahead reconciliation.** Each client keeps `confirmedState`, `pendingActions[]`, and a
+   computed `optimisticState` (what the UI renders). On an inbound envelope: own echo → pop
+   pending, fold into confirmed; foreign action → fold in and rebase pending; echo carrying
+   `rejectionReason` → drop the pending action, revert the optimistic effect. Conflicts are
+   server-wins. This works because chat actions are overwhelmingly **append-only**, so rebasing is
+   near-trivial.
+4. **Reconnect with replay.** `reconnect { clientId, lastSeenServerSeq, subscriptions[] }` returns
+   either `{type: "replay", actions[], missing[]}` or, if the gap exceeds the buffer,
+   `{type: "snapshot", snapshots[]}`. `missing[]` names subscriptions the server cannot resume.
+   Protocol *notifications* are deliberately not replayed — durable truth must live in state.
+
+Other AHP surface worth noting: `subscribe` takes `delivery.maxLatencyMs` (server-side coalescing
+budget, `0` = no buffering) and `view.turns` (advisory snapshot tail + `turnsNextCursor` for paging
+history via `fetchTurns`). The `resource*` command family (`resourceRead/Write/List/Copy/Delete/
+Move/Resolve/Mkdir/Request` + `createResourceWatch`) is **bidirectional** — the server can call it
+on the client, which is how host-driven per-session filesystem providers and client-published
+`virtual://` URIs work. Auth follows RFC 9728 (Protected Resource Metadata) + RFC 6750 (Bearer)
+semantics over JSON-RPC: agents declare `AgentInfo.protectedResources[]` (with a `required` flag),
+clients push tokens via `authenticate { resource, token }`, and `-32007 AuthRequired` is the
+challenge. The `mcp://` channel relays a **capability-gated subset** of verbatim MCP traffic
+(`serverTools`, `serverResources`, `logging`, `sampling`) against a server the host already runs —
+anything outside the advertised union MUST be rejected `-32601`.
+
+### Notable Implementation Details
+
+- **The layering is stated, not inferred.** AHP's `guide/ahp-and-acp.md` says: *"AHP is a
+  coordination layer. ACP is a communication layer. They compose naturally."* The reference
+  architecture is a host speaking **AHP upstream to clients and ACP downstream to agents**, with an
+  "agent event mapper" translating ACP `session/update` into AHP `chat/*` actions.
+- **"AHP is a mutex over ACP."** Their own analogy. One turn per chat; the first
+  `chat/toolCallConfirmed` wins and later ones are rejected; any client can cancel and the host
+  forwards it as ACP `session/cancel`. ACP needs none of this because it assumes one client.
+- **Doctrine as a spec artifact.** `guide/doctrine.md` is a written constitution with **design
+  tests** ("Can a minimal client ignore this and still render a coherent session?", "Is the
+  durable, user-visible result in state rather than only an ephemeral notification?") and explicit
+  **anti-goals** (no agent loop, no model router, no universal tool registry, no required local
+  filesystem or Git, no agent-to-agent semantics, *not a replacement for ACP*). This is the most
+  transferable artifact in either project.
+- **Per-chat working directories.** `ChatState.workingDirectories` is an optional **subset** of the
+  session's set — the documented use case is allocating a **separate git worktree per chat** so
+  parallel chats edit independently and an orchestrating chat merges back. (Directly mirrors
+  AutoBot's own worktree discipline.)
+- **Forks and side-chats as first-class.** `createChat` takes `source: {kind: "fork"|"sideChat",
+  chat, turnId}`, gated on `AgentInfo.capabilities.multipleChats.{fork,sideChat}`. Side chats
+  snapshot `selection.text` immutably at accept time — later streaming deltas don't retroactively
+  mutate it.
+- **Drafts are protocol state.** `chat/draftChanged` syncs in-progress, unsent user input across
+  clients (debounced, e.g. on blur) — so you can start typing on desktop and finish on mobile.
+- **Telemetry is a channel.** `ahp-otlp:` carries OTLP logs/traces/metrics as
+  `otlp/exportLogs|Traces|Metrics` notifications, opaque URIs advertised at initialize.
+- **`x-` prefix reserved** for implementation-defined extensions across channel schemes, methods,
+  and action types; AHP guarantees it will never assign into that namespace.
+
+### Strengths
+
+**ACP:** proven adoption and network effects (registry + JetBrains + Zed + Neovim + Emacs); tiny,
+learnable surface; stdio means zero infrastructure; deliberate MCP reuse instead of a parallel type
+system; capability negotiation lets small agents ship early.
+
+**AHP:** the multi-client problem is real and nobody else specifies it; the reconciliation model is
+the correct one (optimistic + server-sequenced + rebase) and honestly scoped ("append-only makes
+this easy"); the uniform `channel` invariant is genuinely elegant and *compiler-enforced*;
+reconnect/replay is designed in rather than bolted on; agent-agnostic display state means clients
+never learn a provider's tool vocabulary; five SDKs plus generated JSON Schema at 5 months old.
+
+### Weaknesses / Limitations
+
+**ACP:** remote transport (HTTP/WebSocket) still WIP — stdio-first is an editor-shaped assumption;
+no multi-client story at all; no reconnection/replay semantics at the protocol level; assumes a
+human in an editor invoking an agent for a task, which fits autonomous/long-running/headless
+operation poorly; `session/load` replaying the *entire* history as notifications scales badly.
+
+**AHP:** young and pre-1.0 — 0.3.0, mixed stability indices, breaking changes explicitly allowed;
+253 stars vs ACP's 4k means one real implementation (VS Code) and effectively a single-vendor
+ecosystem so far; a host is a **stateful server you now have to run, persist, sequence, and
+replay-buffer** — a materially heavier operational commitment than "spawn a subprocess on stdio";
+the channel/URI/action/reducer surface is large (10+ channel types, 30+ commands) and demands a
+Redux-shaped client; the transport is unspecified, so cross-vendor interop is not yet guaranteed;
+`ahp-and-acp.md` describes composition, but there is no normative ACP-adapter spec.
+
+### Visible vs Hidden Metrics
+
+**Visible**
+- ACP: 4,044 stars, 349 forks, Apache-2.0, v1.7.0, JetBrains + Zed + Google + GitHub + 25 agents,
+  a public registry. Adoption claims are third-party-verifiable, not self-reported.
+- AHP: 253 stars, 66 forks, MIT, 786 commits, 5 language SDKs (Rust/TS/Kotlin/Go/Swift), generated
+  JSON Schema, VS Code reference client, `MultiHostClient` in three SDKs. "Multi-client sync" is a
+  design claim with exactly one shipping implementation — self-reported.
+
+**Hidden**
+- **ACP's real cost is shape, not code.** The protocol is small, but it encodes *one client, one
+  human, one editor, one task*. Anything long-running, autonomous, or multi-observer has to be
+  fought into that shape. Also: adopting ACP means tracking a fast-moving spec (v1.0→v1.7 inside a
+  year) driven by Zed and JetBrains, whose priorities are editor UX.
+- **AHP's real cost is a new stateful tier.** Authoritative state, monotonic sequencing, a replay
+  buffer, subscription fan-out, snapshot/replay branching, and per-client reconciliation are all
+  things you must now operate, persist, back up, and debug. Client-side, every consumer needs
+  confirmed/pending/optimistic state and rebasing — that is a real rewrite of any straightforward
+  "subscribe to WebSocket, append to array" UI. Add pre-1.0 churn on top.
+- **Both:** taking a protocol as your *internal* model couples your domain vocabulary to someone
+  else's release cadence. AHP mitigates this with `x-` extensions and an anti-goals list; ACP with
+  `_meta`. Neither eliminates it.
+
+**Weighing.** For anyone whose agent already runs in one place for one user, AHP's hidden
+operational cost decisively outweighs its visible win — ACP (or a plain WebSocket) is correct, and
+AHP is over-engineering. AHP's economics flip only when *multiple simultaneous clients over one
+live session* is a real requirement — handoff between desktop and mobile, a shared/observed
+session, or reconnect-without-loss over flaky links. Then the reconciliation machinery is not
+optional complexity, it is the actual problem, and hand-rolling it is worse.
+
+Crucially, the two are **not an either/or**. The cheapest correct read is: ACP is the *southbound*
+interface (how you speak to agents, and how external editors could drive yours); AHP is a
+*northbound design vocabulary* (how N clients share one session). The patterns — channels as
+routing keys, state-first over event-first, write-ahead reconciliation, replay-on-reconnect,
+capability-gated surfaces, doctrine with anti-goals — are adoptable **independently of adopting
+either protocol on the wire**, and that is very likely where the value is.
+
+---
+
+## Phase 2 — AutoBot Comparison
+
+Not started. Awaiting explicit go-ahead.

--- a/docs/research/agent-host-and-agent-client-protocols.md
+++ b/docs/research/agent-host-and-agent-client-protocols.md
@@ -472,3 +472,38 @@ resume into. Revisit once item 1 lands. Effort: **significant**.
 **Gap 1 → 2 → 4 → 3 → 7 → 6 → 8 → 5 → 10 → 11.** The first four are small, independently
 valuable, and mostly consist of connecting things AutoBot has already built. Gap 9 (the doctrine
 doc) can land in parallel at any point and makes the rest easier to review.
+
+---
+
+## Sources
+
+**Agent Host Protocol (AHP)** — Microsoft, MIT, protocol v0.3.0, repo created 2026-03-12
+(253 stars / 66 forks / 786 commits at time of writing).
+- Docs site — <https://microsoft.github.io/agent-host-protocol/>
+- Repository — <https://github.com/microsoft/agent-host-protocol>
+- `docs/guide/ahp-and-acp.md` — the "AHP is a coordination layer, ACP is a communication layer"
+  layering, the mutex analogy, and the AHP-upstream/ACP-downstream host architecture
+- `docs/guide/doctrine.md` — principles, design tests, anti-goals
+- `docs/guide/reconciliation.md` — `confirmedState` / `pendingActions[]` / `optimisticState`
+- `docs/specification/overview.md` — JSON-RPC framing, message categories, channel routing key
+- `docs/specification/subscriptions.md` — channel URI scheme, `subscribe`/`unsubscribe`,
+  `delivery.maxLatencyMs`, `view.turns`
+- `docs/specification/lifecycle.md` — `initialize`, `reconnect` with `lastSeenServerSeq`,
+  replay-vs-snapshot
+- `docs/specification/transport.md` — transport-agnosticism; connection auth declared out of scope
+- `docs/specification/chat-channel.md` — turns, drafts, forks/side-chats, per-chat working
+  directories
+- `docs/specification/mcp-channel.md` — capability-gated MCP relay
+- `docs/specification/authentication.md` — RFC 9728 / RFC 6750 semantics over JSON-RPC
+
+**Agent Client Protocol (ACP)** — Zed Industries + JetBrains, Apache-2.0, v1.7.0, repo created
+2025-06-23 (4,044 stars / 349 forks at time of writing).
+- Introduction — <https://agentclientprotocol.com/get-started/introduction>
+- Protocol overview (full method inventory) — <https://agentclientprotocol.com/protocol/overview>
+- Session setup — <https://agentclientprotocol.com/protocol/session-setup>
+- Repository — <https://github.com/zed-industries/agent-client-protocol>
+- ACP Registry announcement — <https://zed.dev/blog/acp-registry>
+- Zed ACP landing page — <https://zed.dev/acp>
+
+Repository metadata (stars, forks, commit counts, licences, creation dates) read via the GitHub
+API on 2026-08-22.

--- a/pipeline-scripts/check-pre-commit-hook-pr.sh
+++ b/pipeline-scripts/check-pre-commit-hook-pr.sh
@@ -265,7 +265,18 @@ else
 
     # Partition the hook's violation blocks. A block starts at a VIOLATION
     # header carrying "path:line" and runs to the next blank line.
-    filtered=$(printf '%s\n' "$hook_output" | ADDED="$added_lines" awk '
+    # The added-line set is passed through a FILE, not the environment.
+    # ``ADDED="$added_lines" awk`` counted every added line against ARG_MAX
+    # (E2BIG covers argv *and* envp), so a large PR died with
+    # "/usr/bin/awk: Argument list too long" and exit 126 — a checker crash that
+    # blocked the PR while reporting nothing about its actual content. Scales
+    # with diff size now instead of breaking at it.
+    added_file=$(mktemp)
+    # shellcheck disable=SC2064 -- expand $added_file now, not at trap time.
+    trap "rm -f '$added_file'" EXIT
+    printf '%s\n' "$added_lines" > "$added_file"
+
+    filtered=$(printf '%s\n' "$hook_output" | awk -v added_file="$added_file" '
         # is_violation distinguishes a real violation block from the hook'"'"'s
         # banner and trailer. Counting those as kept reported "6 violations on
         # lines this PR added" for a PR that added one clean line — the summary
@@ -295,8 +306,10 @@ else
             return 0
         }
         BEGIN {
-            split(ENVIRON["ADDED"], a, "\n")
-            for (i in a) if (a[i] != "") added[a[i]] = 1
+            # Read the set line by line rather than splitting one giant string:
+            # no single value has to fit in an environment slot or an awk field.
+            while ((getline line < added_file) > 0) if (line != "") added[line] = 1
+            close(added_file)
             keep = 1
         }
         {


### PR DESCRIPTION
Research analysis of two agent protocols, plus the implementation of the multi-client gaps that
audit found.

Closes #14814, #14816, #14817, #14818, #14819, #14820, #14821, #14823, #14825.

**Not closed by this PR** — partially delivered, see *Scope honesty* below: #14822, #14824.
Tracked under umbrella #14815.

## Thinking Path

The owner asked for research on the Agent Host Protocol (AHP) and the Agent Client Protocol (ACP),
then confirmed the framing that matters: **AutoBot is one host with many clients** — precisely the
problem AHP exists to solve — and asked for the findings implemented under a single PR.

Phase 1 established that AHP and ACP are not competitors but two layers of one stack; Microsoft's
own `guide/ahp-and-acp.md` says so outright ("AHP is a coordination layer. ACP is a communication
layer"), with the reference architecture speaking AHP upstream to clients and ACP downstream to
agents.

Phase 2 audited the code rather than reasoning from module names, and reframed the work:
**AutoBot already had almost every ingredient** — channel-scoped fan-out, monotonic per-channel
event ids, a Redis Streams replay buffer, per-session multi-connection presence — but they were
wired to three different buses, and the main chat WebSocket used the one that was structurally
single-client. Most of what follows is assembly, not invention.

The audit also surfaced a pre-existing critical defect (#14814) with a blast radius across
workflow, chain-of-thought and approval events, plus a silent data-loss path: chat history was
written from inside the WebSocket broadcast callback, so with no client attached nothing was
persisted at all.

Ordering was dependency-driven: fix delivery, make ids durable, then replay, then ownership, then
reconciliation on top of ownership, then convergence, then ACP last — because ACP's `session/load`
and `session/resume` need a durable server-side session to resume into.

## What Changed

### Delivery and persistence (#14814)

- `event_manager.py` — the broadcast handler was a **scalar**, so a second client displaced the
  first and the first disconnect cleared delivery for everyone. Now a `set`, with add/discard
  semantics, per-callback failure isolation, and automatic unregistration of dead sockets.
- `api/websockets.py` — registers and unregisters *this* connection rather than overwriting a
  global slot; `_add_to_chat_history` moved **out** of the broadcast handler.
- New publish-time persistence hook (`register_persistence_hook`), wired at startup in
  `initialization/lifespan.py`, so history is written exactly once per publish and with zero
  clients connected.

### Durable sequencing and replay (#14816, #14817, #14818)

- New `events/channel_stream.py` — Redis `INCR` for per-channel sequence allocation (monotonic
  across restarts, safe across workers) and a per-channel Redis Stream as the replay window.
  Degrades to an in-process counter when Redis is unreachable and reports replay as *unavailable*
  rather than serving a partial history.
- New `constants/event_stream_constants.py` — env-var-backed retention/TTL constants, no
  hard-coded values at call sites.
- `events/bus.py` — `PersistStrategy.REDIS` **implemented**; it previously logged critical and
  dropped the event.
- `live_event_manager.py` — `event_id` now comes from the durable stream, not `_event_counters`.
- `api/live_events.py` — `subscribe` accepts `last_event_id`, replays what was missed, and emits an
  explicit `resync` frame when it cannot produce a complete history.
- `LiveEventService.ts` — tracks a high-water mark per channel, replays from it on reconnect, and
  exposes `onResync` so consumers rebuild instead of appending onto a stale view.

### Conversation channels (#14819)

- `session:` and `chat:` added to the channel grammar, with a fail-closed authorization branch
  (`_authorize_conversation_channel`): admins bypass, the owner is allowed, unknown or unowned is
  denied. Without it any authenticated caller could have subscribed to anyone's conversation.

### Host-authoritative session state and reconciliation (#14820, #14821)

- New `api/session_events.py` — publishes session/chat mutations durably; wired into the create,
  update and delete endpoints in `api/chat_sessions.py` and into `chat_history/messages.py`
  `add_message`.
- `useChatStore.ts` — `createServerSession()` adopts a server-assigned id; `pendingMessageIds` +
  `confirmMessage` / `rejectMessage` / `applyServerSnapshot` / `applyRemoteMessage` implement
  confirmed/pending/optimistic with server-wins conflict resolution.
- New `useSessionSync.ts` — subscribes a conversation's channels, applies remote messages,
  confirms our own echoes, and rebuilds from the REST snapshot on a resync directive.

### Doctrine (#14823)

- New `docs/developer/EVENT_STATE_DOCTRINE.md` — principles, design tests and anti-goals, adapted
  from AHP's `guide/doctrine.md`, plus a rules-with-teeth table tying each rule to the issue that
  produced it. Linked from the `CLAUDE.md` trigger table.

### ACP agent surface (#14825)

- New `acp/` package — `protocol.py` (wire vocabulary), `transport.py` (line-delimited JSON-RPC
  over stdio), `server.py` (dispatch, lifecycle, client callbacks), `runner.py` (bridge to
  `ChatWorkflowManager.process_message_stream`), `__main__.py` (`python -m acp`).
- Serves `initialize`, `session/new`, `session/prompt`, `session/cancel`, streams `session/update`,
  and calls back on `session/request_permission`. Permission handling **fails closed**: rejection,
  cancellation, a malformed answer and a transport error all deny.

### Convergence (#14822, partial)

- `GlobalWebSocketService.ts` moved from `/api/ws` to `/api/ws/live`, subscribing to `global` and
  unwrapping channel frames into the legacy flat shape so existing listeners keep working.
- `PersistStrategy.NONE` now also fans out to the channel. This is **behaviour-preserving, not a
  widening**: NONE events already reached WebSocket clients through the broken global slot, so
  without this the frontend migration would have silently dropped every workflow, CoT and approval
  event.
- Heartbeat frames corrected to `action`-shaped — the legacy `type`-shaped ping was inert against
  the channel socket.
- `/api/ws` marked deprecated in its docstring.

## Scope honesty

Two issues are **not** closed here, because partial delivery must not close an issue.

**#14822 — repointing done, retirement outstanding.**
Every in-repo reference now targets the channel socket: a new `liveEventsUrl` getter on
`AutoBotConfig` (with `websocketUrl` marked `@deprecated`), `LiveEventService` reading it instead of
appending `/live` by hand, `frontend_config.py` advertising `/api/ws/live`, plus `network.ts` and
`project_state_manager.py`. One reference was deliberately left alone: the auth allowlist entry is
`startswith`-matched, so `/api/ws` already covers `/api/ws/live` — narrowing it would have silently
started rejecting the legacy route. Outstanding: deleting the route itself,
`register_ws_broadcast`, and the `EventManager` broadcast registry. That needs deployed evidence
nothing external still consumes it, which a PR cannot produce.

**#14824 — blocker found and cleared; the migrations remain.**
The original plan ("~9 routes removed, consumers repointed") was wrong, and measuring showed why:

| | |
|---|---|
| Bidirectional (client sends commands) | analytics ×2, monitoring, startup, long-running-operations, knowledge-research, transcripts, workflow-automation, analytics-quality — **8 of 9** |
| One-way push | process-management — 1 |

`/ws/live` accepted only `subscribe`, `unsubscribe` and `ping`. Migrating any bidirectional route
onto it would have silently dropped half its behaviour — no way for a client to start a research
run, pause an operation, or change a metrics interval.

So this PR adds the missing primitive instead of migrating blind: `events/channel_commands.py`, a
`{action:"command", channel, command, payload}` envelope routed by channel prefix to a registered
handler. Its notable property is that `_authorize_channel` was **extracted so subscribe and command
share one authorization rule** — a second copy is how one path ends up weaker than the other — and
authorization is checked *before* handler lookup, since whether a handler exists is itself
information about what the deployment runs.

The nine route migrations are still to do, and remain incremental by their own acceptance criteria.

## Verification

**Tests added** — 51 across six files, each driving a production entry point and asserting at the
far boundary rather than on a mock's call count:

| File | Covers |
|---|---|
| `event_manager_multiclient_14814_test.py` | two clients both receive; one disconnect does not silence others; persistence with **zero** clients; persistence exactly once with two; failing callback dropped without blocking peers; `None` registration rejected |
| `events/channel_stream_replay_14818_test.py` | ids monotonic; **ids survive a restart**; two workers never collide; replay after marker; gap beyond retention demands resync; no Redis demands resync; corrupt entry demands resync; first subscribe is not a gap |
| `events/bus_channel_fanout_14822_test.py` | NONE reaches the channel (the migration-safety property); MEMORY skips in-process listeners; REDIS publishes durably instead of dropping |
| `acp/server_test.py` | version negotiation never over-claims; capabilities do not advertise unimplemented features; lifecycle enforced; absolute-`cwd` required; full turn streams and ends; notifications unanswered; **permission denial on reject, cancel and transport error** |
| `events/channel_commands_14824_test.py` | command reaches its prefix handler; **unauthorized caller refused and handler never runs**; authorization checked before handler lookup; unknown prefix refused; malformed refused; handler exception becomes a refusal; handler's own refusal reason survives |
| `useChatStore.reconciliation.test.ts` | pending on add; confirm; id rewrite; **rejection reverts**; `confirmMessage` returns false for a foreign id; remote apply; **own echo correlates instead of duplicating**; snapshot replaces and clears pendings |

**Static checks run locally:** `python -m py_compile` across all 21 changed Python files — clean.
No circular import introduced (`events/__init__` pulls only `stream_manager` and `types`; nothing
imports back into `bus` or `live_event_manager`).

**Not run locally, and why:** the Python suite and the frontend type-check/lint were not executed
here. This repository's standing rules are that code is not run from the codebase and nothing is
installed into it — `autobot-frontend/node_modules` is absent and installing it is not permitted.
CI is the verifier for both. **Reviewers should treat CI as the gate on this PR, not my say-so**,
and note that the Python suite is not a required check, so its result needs to be read
deliberately rather than inferred from an overall green.

**Behavioural claims I have NOT verified on a host:** that a second browser tab now receives
events, and that a reconnect replays the gap. Both are covered by unit tests at the seam, but
neither has host evidence. #14822's retirement in particular is gated on exactly that evidence.

## Model Used

Claude Opus 5 (1M context).

---

## Issues from this audit

Tracked under umbrella **#14815** (all 11 registered as its sub-issues).

- [x] #14814 — `/api/ws` single-callback broadcast
- [x] #14816 — `PersistStrategy.REDIS` dropped the event
- [x] #14817 — `event_id` reset on restart, diverged across workers
- [x] #14818 — reconnect with `last_event_id`
- [x] #14819 — `session:` / `chat:` channel grammar + authorization
- [x] #14820 — host-authoritative session state
- [x] #14821 — write-ahead reconciliation
- [ ] #14822 — retire the duplicate event socket *(migration + repointing landed; route deletion pending host evidence)*
- [x] #14823 — event/state doctrine doc
- [ ] #14824 — consolidate the remaining WebSocket routes *(command-dispatch primitive landed; 9 migrations outstanding)*
- [x] #14825 — ACP server surface

## Sources

- **Agent Host Protocol** — Microsoft, MIT, v0.3.0 — https://microsoft.github.io/agent-host-protocol/
  · https://github.com/microsoft/agent-host-protocol
  Pages relied on: `guide/doctrine.md`, `guide/reconciliation.md`, `guide/ahp-and-acp.md`,
  `specification/subscriptions.md`, `specification/lifecycle.md`.
- **Agent Client Protocol** — Zed Industries + JetBrains, Apache-2.0, v1.7.0 —
  https://agentclientprotocol.com/get-started/introduction ·
  https://agentclientprotocol.com/protocol/overview ·
  https://agentclientprotocol.com/protocol/session-setup ·
  https://github.com/zed-industries/agent-client-protocol · registry: https://zed.dev/blog/acp-registry

Full analysis: `docs/research/agent-host-and-agent-client-protocols.md`.

