### PR TITLE
fix(deploy): close three ways a change could not reach a host (#13828, #13786, #14176)

### DIFF
--- a/autobot-infrastructure/README.md
+++ b/autobot-infrastructure/README.md
@@ -112,7 +112,7 @@ cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-full.yml
 
 # Service control (start/stop/restart)
-ansible-playbook playbooks/slm-service-control.yml -e "service=autobot-backend action=restart"
+ansible-playbook playbooks/slm-service-control.yml -e "target=<group-or-host> service=autobot-backend action=restart"
 
 # Deploy specific roles
 ansible-playbook playbooks/deploy-full.yml --tags frontend,backend

--- a/autobot-infrastructure/autobot-ai-stack/README.md
+++ b/autobot-infrastructure/autobot-ai-stack/README.md
@@ -53,7 +53,7 @@ ansible-playbook playbooks/deploy-full.yml --tags ai-stack --limit ai_stack_vm
 
 # Restart
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-ai-stack action=restart"
+  -e "target=<group-or-host> service=autobot-ai-stack action=restart"
 
 # Manual sync
 ./infrastructure/shared/scripts/utilities/sync-to-vm.sh ai-stack autobot-ai-stack/

--- a/autobot-infrastructure/autobot-backend/README.md
+++ b/autobot-infrastructure/autobot-backend/README.md
@@ -65,7 +65,7 @@ ansible-playbook playbooks/deploy-full.yml --tags backend --limit backend_node
 
 # Service restart only
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-backend action=restart"
+  -e "target=<group-or-host> service=autobot-backend action=restart"
 
 # Manual sync (dev)
 # rsync directly — the sync-to-vm.sh script targets the autobot-backend/ dir

--- a/autobot-infrastructure/autobot-browser-worker/README.md
+++ b/autobot-infrastructure/autobot-browser-worker/README.md
@@ -57,7 +57,7 @@ ansible-playbook playbooks/deploy-full.yml --tags browser --limit browser_vm
 
 # Restart (use correct service name!)
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-playwright action=restart"
+  -e "target=<group-or-host> service=autobot-playwright action=restart"
 
 # Manual sync
 ./infrastructure/shared/scripts/utilities/sync-to-vm.sh browser autobot-browser-worker/

--- a/autobot-infrastructure/autobot-frontend/README.md
+++ b/autobot-infrastructure/autobot-frontend/README.md
@@ -58,7 +58,7 @@ ansible-playbook playbooks/deploy-full.yml --tags frontend --limit frontend_vm
 
 # nginx reload only (config change)
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-frontend action=reload"
+  -e "target=<group-or-host> service=autobot-frontend action=reload"
 
 # Manual sync + build
 ./infrastructure/shared/scripts/utilities/sync-to-vm.sh frontend autobot-frontend/

--- a/autobot-infrastructure/autobot-monitoring/README.md
+++ b/autobot-infrastructure/autobot-monitoring/README.md
@@ -58,7 +58,7 @@ ansible-playbook playbooks/deploy-slm-manager.yml --tags monitoring
 
 # Restart Grafana only
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-monitoring-grafana action=restart"
+  -e "target=<group-or-host> service=autobot-monitoring-grafana action=restart"
 ```
 
 ---

--- a/autobot-infrastructure/autobot-npu-worker/README.md
+++ b/autobot-infrastructure/autobot-npu-worker/README.md
@@ -53,7 +53,7 @@ ansible-playbook playbooks/deploy-full.yml --tags npu-worker --limit npu_vm
 
 # Restart
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-npu-worker action=restart"
+  -e "target=<group-or-host> service=autobot-npu-worker action=restart"
 
 # Manual sync
 ./infrastructure/shared/scripts/utilities/sync-to-vm.sh npu autobot-npu-worker/

--- a/autobot-infrastructure/autobot-ollama/README.md
+++ b/autobot-infrastructure/autobot-ollama/README.md
@@ -54,7 +54,7 @@ ssh autobot@172.16.168.20 'ollama pull llama3.2'
 
 # Restart Ollama service
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=ollama action=restart"
+  -e "target=<group-or-host> service=ollama action=restart"
 ```
 
 ---

--- a/autobot-infrastructure/autobot-slm-agent/README.md
+++ b/autobot-infrastructure/autobot-slm-agent/README.md
@@ -61,7 +61,7 @@ ansible-playbook playbooks/deploy-full.yml --tags slm_agent --limit 02-Frontend
 
 # Restart on all nodes
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-slm-agent action=restart"
+  -e "target=<group-or-host> service=autobot-slm-agent action=restart"
 ```
 
 ---

--- a/autobot-infrastructure/autobot-slm-backend/README.md
+++ b/autobot-infrastructure/autobot-slm-backend/README.md
@@ -64,7 +64,7 @@ ansible-playbook playbooks/deploy-slm-manager.yml --tags backend,nginx
 
 # Service restart
 ansible-playbook playbooks/slm-service-control.yml \
-  -e "service=autobot-slm-backend action=restart"
+  -e "target=<group-or-host> service=autobot-slm-backend action=restart"
 
 # Manual sync
 ./infrastructure/shared/scripts/utilities/sync-to-slm.sh

--- a/autobot-slm-backend/ansible/playbooks/enroll-node.yml
+++ b/autobot-slm-backend/ansible/playbooks/enroll-node.yml
@@ -333,7 +333,7 @@
 
             - name: "Deploy SLM post-commit hook"
               copy:
-                src: "{{ playbook_dir }}/../../scripts/hooks/slm-post-commit"
+                src: "{{ playbook_dir }}/../../../autobot-infrastructure/shared/scripts/hooks/slm-post-commit"
                 dest: "{{ slm_code_repository | default('${AUTOBOT_PROJECT_ROOT:-/opt/autobot/code_source}') }}/.git/hooks/post-commit"
                 mode: '0755'
 

--- a/autobot-slm-backend/ansible/playbooks/slm-service-control.yml
+++ b/autobot-slm-backend/ansible/playbooks/slm-service-control.yml
@@ -6,7 +6,12 @@
 # Related to Issue #728
 
 - name: "SLM Service Control"
-  hosts: target
+  # #13786: `target` is supplied by the caller at run time, and no shipped
+  # inventory defines it. As a bare name, a run that forgets to pass one matches
+  # nothing and Ansible skips the play silently -- ok=0, changed=0, exit 0 --
+  # which for a service-control playbook reads as "the restart succeeded".
+  # Templated, an unset variable is an undefined-variable error instead.
+  hosts: "{{ target }}"
   gather_facts: false
   become: true
 

--- a/autobot-slm-backend/ansible/playbooks/slm-service-logs.yml
+++ b/autobot-slm-backend/ansible/playbooks/slm-service-logs.yml
@@ -6,7 +6,12 @@
 # Related to Issue #728
 
 - name: "SLM Get Service Logs"
-  hosts: target
+  # #13786: `target` is supplied by the caller at run time, and no shipped
+  # inventory defines it. As a bare name, a run that forgets to pass one matches
+  # nothing and Ansible skips the play silently -- ok=0, changed=0, exit 0 --
+  # which for a service-control playbook reads as "the restart succeeded".
+  # Templated, an unset variable is an undefined-variable error instead.
+  hosts: "{{ target }}"
   gather_facts: false
   become: true
 

--- a/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
@@ -24,20 +24,32 @@
 # "[PLAY 2] Backend | Restart service" task after this; adding a second restart
 # here would bounce the backend twice per update.
 ---
-- name: "Backend | Render systemd unit from template (#12777)"
+# #13828: this rendered ONLY autobot-backend.service, so a change to a celery
+# unit template could never reach a host through the updater -- it landed only
+# on a full `roles/backend` run, which the update path does not do. The whole
+# point of unit_only is that unit-file changes reach hosts without one, and it
+# did that for one of the three units the role owns.
+#
+# Looped rather than three copied tasks: a fourth unit added to the role should
+# need a list entry, not another block to forget.
+- name: "Backend | Render systemd units from templates (#12777, #13828)"
   ansible.builtin.template:
-    src: autobot-backend.service.j2
-    dest: /etc/systemd/system/autobot-backend.service
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
     mode: "0644"
     owner: root
     group: root
   become: true
-  register: _backend_unit_rendered
+  loop:
+    - autobot-backend.service
+    - autobot-celery.service
+    - autobot-celery-beat.service
+  register: _backend_units_rendered
   tags: [backend, systemd, unit]
 
 - name: "Backend | Reload systemd after unit change (#12777)"
   ansible.builtin.systemd:
     daemon_reload: true
   become: true
-  when: _backend_unit_rendered.changed
+  when: _backend_units_rendered.changed
   tags: [backend, systemd, unit]

--- a/autobot-slm-backend/tests/test_update_delivery_gaps_13828.py
+++ b/autobot-slm-backend/tests/test_update_delivery_gaps_13828.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Three ways a change could not reach a host, or a no-op reported success.
+
+#13828 — `roles/backend/tasks/unit_only.yml` rendered only autobot-backend.service.
+         The include exists so unit changes reach hosts WITHOUT a full role run
+         (#12777), and the update path never does a full run — so celery unit
+         changes could not reach a host at all.
+
+#13786 — `slm-service-control.yml` / `slm-service-logs.yml` declared `hosts: target`.
+         No inventory defines it. A play whose pattern matches nothing is skipped
+         silently (ok=0, changed=0, exit 0), which for a service-control playbook
+         reads as "the restart succeeded".
+
+#14176 — enroll-node.yml copied the post-commit hook from a path that does not
+         exist, and two different hooks share that basename: the repo-root one
+         heals stash-pop conflict markers (#2416), the infrastructure one notifies
+         the SLM agent of commits (#741). A node needs the second.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_REPO = Path(__file__).resolve().parents[2]
+_ANSIBLE = _REPO / "autobot-slm-backend" / "ansible"
+_UNIT_ONLY = _ANSIBLE / "roles" / "backend" / "tasks" / "unit_only.yml"
+_TEMPLATES = _ANSIBLE / "roles" / "backend" / "templates"
+_ENROLL = _ANSIBLE / "playbooks" / "enroll-node.yml"
+_SERVICE_PLAYBOOKS = ("slm-service-control.yml", "slm-service-logs.yml")
+
+
+#: #14827 — templated, monitored, and rendered by nothing. Excluded by NAME with
+#: a pointer to the issue rather than by a pattern, so it cannot quietly absorb a
+#: future unit that is merely forgotten. Delete this line when #14827 lands.
+_NOT_YET_WIRED = {"autobot-mcp-bridge@.service"}
+
+
+def _load(path: Path):
+    assert path.is_file(), f"file under test is missing: {path}"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _walk_tasks(container):
+    """Yield tasks from a play or block, including nested ones.
+
+    `tasks` alone is not enough: enroll-node.yml nests the hook copy inside a
+    block, and a guard reading only the top level reports "not found" — which
+    looks exactly like the task having been removed.
+    """
+    if isinstance(container, list):
+        for item in container:
+            yield from _walk_tasks(item)
+        return
+    if not isinstance(container, dict):
+        return
+    yield container
+    for key in ("tasks", "pre_tasks", "post_tasks", "block", "rescue", "always"):
+        if container.get(key):
+            yield from _walk_tasks(container[key])
+
+
+def test_unit_only_renders_every_unit_the_role_owns() -> None:
+    """Derived from the templates on disk, not from a hand-written list.
+
+    A guard listing the same three names it checks would pass forever; this one
+    fails when a fourth unit template is added and not wired in.
+    """
+    owned = {p.name[: -len(".j2")] for p in _TEMPLATES.glob("*.service.j2")} - _NOT_YET_WIRED
+    assert owned, "no unit templates found — this guard would pass vacuously"
+    assert len(owned) >= 3, f"expected at least the three managed units, got {sorted(owned)}"
+
+    rendered: set[str] = set()
+    for task in _load(_UNIT_ONLY):
+        if not isinstance(task, dict):
+            continue
+        for item in task.get("loop") or []:
+            rendered.add(str(item))
+        dest = str((task.get("ansible.builtin.template") or {}).get("dest", ""))
+        if dest:
+            rendered.add(Path(dest).name)
+
+    missing = owned - rendered
+    assert not missing, (
+        f"unit_only.yml does not render {sorted(missing)} — changes to those units "
+        "cannot reach a host through the updater"
+    )
+
+
+def test_service_control_playbooks_fail_loudly_without_a_target() -> None:
+    """A bare group name that matches nothing is skipped silently."""
+    for name in _SERVICE_PLAYBOOKS:
+        plays = _load(_ANSIBLE / "playbooks" / name)
+        for play in plays:
+            hosts = str(play.get("hosts", ""))
+            assert "{{" in hosts, (
+                f"{name} declares `hosts: {hosts}` as a bare name — a run that passes no "
+                "target matches nothing and reports success"
+            )
+
+
+def test_enroll_node_hook_source_exists() -> None:
+    """The copy pointed at a directory that has never existed."""
+    src = None
+    for task in _walk_tasks(_load(_ENROLL)):
+        if "post-commit hook" in str(task.get("name", "")).lower():
+            src = str((task.get("copy") or task.get("ansible.builtin.copy") or {}).get("src", ""))
+    assert src, "no post-commit hook copy task found — this guard would pass vacuously"
+
+    resolved = (_ANSIBLE / "playbooks" / src.replace("{{ playbook_dir }}/", "")).resolve()
+    assert resolved.is_file(), f"hook source does not exist: {resolved}"
+
+
+def test_the_node_hook_is_the_agent_notifier_not_the_developer_hook() -> None:
+    """Two different files share this basename; a node needs the notifier."""
+    node_hook = _REPO / "autobot-infrastructure" / "shared" / "scripts" / "hooks" / "slm-post-commit"
+    dev_hook = _REPO / "scripts" / "hooks" / "slm-post-commit"
+    assert node_hook.is_file() and dev_hook.is_file(), "expected both hooks to exist"
+    assert node_hook.read_bytes() != dev_hook.read_bytes(), (
+        "the two hooks are now identical — if they were deduplicated, this guard and "
+        "the enroll-node src both need revisiting"
+    )
+    assert "agent" in node_hook.read_text(encoding="utf-8").lower(), "the node hook no longer looks like the notifier"

--- a/autobot-slm-backend/tests/test_update_delivery_gaps_13828.py
+++ b/autobot-slm-backend/tests/test_update_delivery_gaps_13828.py
@@ -28,16 +28,11 @@ yaml = pytest.importorskip("yaml")
 
 _REPO = Path(__file__).resolve().parents[2]
 _ANSIBLE = _REPO / "autobot-slm-backend" / "ansible"
-_UNIT_ONLY = _ANSIBLE / "roles" / "backend" / "tasks" / "unit_only.yml"
-_TEMPLATES = _ANSIBLE / "roles" / "backend" / "templates"
+_ROLES = _ANSIBLE / "roles"
+_UNIT_ONLY = _ROLES / "backend" / "tasks" / "unit_only.yml"
+_MAIN = _ROLES / "backend" / "tasks" / "main.yml"
 _ENROLL = _ANSIBLE / "playbooks" / "enroll-node.yml"
 _SERVICE_PLAYBOOKS = ("slm-service-control.yml", "slm-service-logs.yml")
-
-
-#: #14827 — templated, monitored, and rendered by nothing. Excluded by NAME with
-#: a pointer to the issue rather than by a pattern, so it cannot quietly absorb a
-#: future unit that is merely forgotten. Delete this line when #14827 lands.
-_NOT_YET_WIRED = {"autobot-mcp-bridge@.service"}
 
 
 def _load(path: Path):
@@ -64,31 +59,62 @@ def _walk_tasks(container):
             yield from _walk_tasks(container[key])
 
 
-def test_unit_only_renders_every_unit_the_role_owns() -> None:
-    """Derived from the templates on disk, not from a hand-written list.
+def _systemd_units(path: Path) -> set[str]:
+    """Unit basenames a task file writes under /etc/systemd/system.
 
-    A guard listing the same three names it checks would pass forever; this one
-    fails when a fourth unit template is added and not wired in.
+    Reads both the direct `dest:` form and a loop over unit names, so the two
+    files can be compared however each happens to be written.
     """
-    owned = {p.name[: -len(".j2")] for p in _TEMPLATES.glob("*.service.j2")} - _NOT_YET_WIRED
-    assert owned, "no unit templates found — this guard would pass vacuously"
-    assert len(owned) >= 3, f"expected at least the three managed units, got {sorted(owned)}"
+    units: set[str] = set()
+    for task in _walk_tasks(_load(path)):
+        for mod in ("ansible.builtin.template", "template", "ansible.builtin.copy", "copy"):
+            spec = task.get(mod)
+            dest = str(spec.get("dest", "")) if isinstance(spec, dict) else ""
+            if "/etc/systemd/system/" in dest and dest.endswith(".service"):
+                units.add(Path(dest).name)
+            if "/etc/systemd/system/" in dest and "{{ item }}" in dest:
+                units.update(str(i) for i in (task.get("loop") or []))
+    return units
 
-    rendered: set[str] = set()
-    for task in _load(_UNIT_ONLY):
-        if not isinstance(task, dict):
-            continue
-        for item in task.get("loop") or []:
-            rendered.add(str(item))
-        dest = str((task.get("ansible.builtin.template") or {}).get("dest", ""))
-        if dest:
-            rendered.add(Path(dest).name)
 
-    missing = owned - rendered
+def test_unit_only_renders_every_unit_main_installs() -> None:
+    """The set rendered by unit_only.yml must equal the set main.yml installs.
+
+    Compared against `main.yml` rather than against the templates on disk: a
+    template can exist without the role installing it (`autobot-mcp-bridge@.service`
+    is exactly that, #14827), so the templates are the wrong denominator. What
+    matters for the update path is that every unit the role *installs* can also be
+    refreshed without a full role run.
+    """
+    installed = _systemd_units(_MAIN)
+    rendered = _systemd_units(_UNIT_ONLY)
+    assert installed, "main.yml installs no units — this guard would pass vacuously"
+
+    missing = installed - rendered
     assert not missing, (
         f"unit_only.yml does not render {sorted(missing)} — changes to those units "
-        "cannot reach a host through the updater"
+        "cannot reach a host through the updater, which is the whole point of the include"
     )
+
+    extra = rendered - installed
+    assert not extra, (
+        f"unit_only.yml renders {sorted(extra)} that main.yml does not install — "
+        "the two have diverged in the other direction"
+    )
+
+
+def test_backend_is_still_the_only_role_with_a_unit_only_include() -> None:
+    """The cross-role audit, pinned rather than recorded once and forgotten.
+
+    #13828 asked whether other roles share the main/unit_only asymmetry. At the
+    time only `backend` had a `unit_only.yml`, so there was nothing else to
+    diverge. If another role gains one, it needs the same equality check and this
+    fails to say so.
+    """
+    roles = sorted(p.parent.parent.name for p in _ROLES.glob("*/tasks/unit_only.yml"))
+    assert roles == [
+        "backend"
+    ], f"roles with a unit_only.yml are now {roles} — extend the equality check above to each of them"
 
 
 def test_service_control_playbooks_fail_loudly_without_a_target() -> None:
@@ -115,13 +141,26 @@ def test_enroll_node_hook_source_exists() -> None:
     assert resolved.is_file(), f"hook source does not exist: {resolved}"
 
 
-def test_the_node_hook_is_the_agent_notifier_not_the_developer_hook() -> None:
-    """Two different files share this basename; a node needs the notifier."""
-    node_hook = _REPO / "autobot-infrastructure" / "shared" / "scripts" / "hooks" / "slm-post-commit"
-    dev_hook = _REPO / "scripts" / "hooks" / "slm-post-commit"
-    assert node_hook.is_file() and dev_hook.is_file(), "expected both hooks to exist"
-    assert node_hook.read_bytes() != dev_hook.read_bytes(), (
-        "the two hooks are now identical — if they were deduplicated, this guard and "
-        "the enroll-node src both need revisiting"
+def test_the_enrolled_hook_is_the_agent_notifier() -> None:
+    """A node needs the notifier, whichever file ends up providing it.
+
+    Two files currently share this basename: the repo-root one heals stash-pop
+    conflict markers (#2416), the infrastructure one notifies the SLM agent of
+    commits (#741). #14176 asks for them to be consolidated into one with both
+    behaviours folded in, so this deliberately asserts the *behaviour* the
+    enrolled hook must have rather than which of the two files it is — otherwise
+    this guard would fail the moment that consolidation happens.
+    """
+    src = None
+    for task in _walk_tasks(_load(_ENROLL)):
+        if "post-commit hook" in str(task.get("name", "")).lower():
+            src = str((task.get("copy") or task.get("ansible.builtin.copy") or {}).get("src", ""))
+    assert src, "no post-commit hook copy task found — this guard would pass vacuously"
+
+    resolved = (_ANSIBLE / "playbooks" / src.replace("{{ playbook_dir }}/", "")).resolve()
+    assert resolved.is_file(), f"hook source does not exist: {resolved}"
+    body = resolved.read_text(encoding="utf-8").lower()
+    assert "agent" in body, (
+        "the hook a node is given no longer notifies the SLM agent — enrolment would deploy "
+        "a hook that does not do the job enrolment needs"
     )
-    assert "agent" in node_hook.read_text(encoding="utf-8").lower(), "the node hook no longer looks like the notifier"

--- a/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
+++ b/autobot-slm-backend/tests/test_updater_browser_port_and_backend_unit.py
@@ -120,7 +120,24 @@ def test_unit_only_renders_the_template_and_does_not_restart() -> None:
     tasks = yaml.safe_load(_UNIT_ONLY.read_text(encoding="utf-8"))
     blob = str(tasks)
 
-    assert "autobot-backend.service.j2" in blob, "the unit template must be rendered"
+    # #13828: asserted on the rendered SET rather than on the literal string
+    # "autobot-backend.service.j2". unit_only.yml now renders the three units the
+    # backend role installs through a loop, so the template name appears as
+    # "{{ item }}.j2" and a substring check reported the unit as missing while it
+    # was being rendered perfectly well. What matters is that the unit is
+    # rendered, not how the task spells it.
+    rendered = set()
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        dest = str((task.get("ansible.builtin.template") or {}).get("dest", ""))
+        if dest.endswith(".service"):
+            rendered.add(Path(dest).name)
+        if "{{ item }}" in dest:
+            rendered.update(str(i) for i in (task.get("loop") or []))
+    assert (
+        "autobot-backend.service" in rendered
+    ), f"the backend unit must be rendered; unit_only renders {sorted(rendered)}"
     assert "daemon_reload" in blob, "systemd must be reloaded after a unit change"
     assert "restarted" not in blob, (
         "unit_only must not restart — the play already restarts the backend, and "

--- a/docs/developer/AUTOBOT_REFERENCE.md
+++ b/docs/developer/AUTOBOT_REFERENCE.md
@@ -123,7 +123,7 @@ autobot-infrastructure/
 cd autobot-slm-backend/ansible
 
 ansible-playbook playbooks/deploy-full.yml
-ansible-playbook playbooks/slm-service-control.yml -e "service=autobot-backend action=restart"
+ansible-playbook playbooks/slm-service-control.yml -e "target=<group-or-host> service=autobot-backend action=restart"
 ansible-playbook playbooks/deploy-full.yml --tags frontend,backend
 ansible-playbook playbooks/deploy-full.yml --limit slm_server
 ```
@@ -188,7 +188,7 @@ redis-cli -h <database-ip> ping
 # Ansible Deployment
 cd autobot-slm-backend/ansible
 ansible-playbook playbooks/deploy-full.yml
-ansible-playbook playbooks/slm-service-control.yml -e "service=autobot-backend action=restart"
+ansible-playbook playbooks/slm-service-control.yml -e "target=<group-or-host> service=autobot-backend action=restart"
 
 # Manual sync
 ./autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh main autobot-backend/

--- a/repo_tests/documented_playbook_invocations_test.py
+++ b/repo_tests/documented_playbook_invocations_test.py
@@ -29,7 +29,13 @@ from pathlib import Path
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PLAYBOOK_DIRS = ["autobot-slm-backend/ansible/playbooks"]
+# Every directory that can hold a playbook, not just the main one. A narrower
+# scan misses a templated `hosts:` added elsewhere and reports clean — the same
+# under-approximation this guard exists to catch.
+PLAYBOOK_DIRS = [
+    "autobot-slm-backend/ansible/playbooks",
+    "autobot-slm-backend/ansible/tests/playbooks",
+]
 SKIP_DIRS = {".git", ".worktrees", ".claude", "node_modules", "venv", ".venv"}
 
 # `hosts: "{{ target }}"` — a play whose host list comes from a run-time variable.
@@ -40,7 +46,9 @@ def _playbooks_requiring_a_variable() -> dict[str, str]:
     """Map playbook filename -> the variable its `hosts:` needs."""
     required: dict[str, str] = {}
     for rel in PLAYBOOK_DIRS:
-        for path in sorted((REPO_ROOT / rel).glob("*.yml")):
+        directory = REPO_ROOT / rel
+        assert directory.is_dir(), f"{rel} is not a directory — re-point PLAYBOOK_DIRS rather than scanning nothing"
+        for path in sorted(directory.glob("*.yml")):
             match = _TEMPLATED_HOSTS.search(path.read_text(encoding="utf-8"))
             if match:
                 required[path.name] = match.group(1)

--- a/repo_tests/documented_playbook_invocations_test.py
+++ b/repo_tests/documented_playbook_invocations_test.py
@@ -1,0 +1,88 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A documented ansible invocation must actually run (#13786).
+
+`slm-service-control.yml` used a bare `hosts: target`, which matches nothing
+when the caller forgets to pass one — ok=0, changed=0, exit 0. For a
+service-control playbook that reads as "the restart succeeded". #13786 changed
+it to `hosts: "{{ target }}"` so the same mistake is an undefined-variable
+error instead.
+
+That fix turned every documented example into a hard failure: all twelve
+invocations across eleven files passed `service=` and `action=` and no
+`target=`. The docs were wrong before too — they just failed silently, which is
+the direction that hides.
+
+This derives which playbooks need `target` from the **playbooks themselves**, so
+a newly templated `hosts:` is covered without anyone remembering to add it here.
+A hardcoded list of playbook names would go stale in the silent direction: a
+missing entry checks nothing and reports clean.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK_DIRS = ["autobot-slm-backend/ansible/playbooks"]
+SKIP_DIRS = {".git", ".worktrees", ".claude", "node_modules", "venv", ".venv"}
+
+# `hosts: "{{ target }}"` — a play whose host list comes from a run-time variable.
+_TEMPLATED_HOSTS = re.compile(r"^\s*hosts:\s*[\"']?\{\{\s*([a-z_][a-z0-9_]*)\s*\}\}", re.M | re.I)
+
+
+def _playbooks_requiring_a_variable() -> dict[str, str]:
+    """Map playbook filename -> the variable its `hosts:` needs."""
+    required: dict[str, str] = {}
+    for rel in PLAYBOOK_DIRS:
+        for path in sorted((REPO_ROOT / rel).glob("*.yml")):
+            match = _TEMPLATED_HOSTS.search(path.read_text(encoding="utf-8"))
+            if match:
+                required[path.name] = match.group(1)
+    return required
+
+
+def _markdown_files() -> list[Path]:
+    return [
+        p
+        for p in REPO_ROOT.rglob("*.md")
+        if not any(part in SKIP_DIRS for part in p.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def _invocations(text: str, playbook: str) -> list[str]:
+    """Each `ansible-playbook ... <playbook> ...` command, line continuations joined."""
+    joined = re.sub(r"\\\s*\n\s*", " ", text)
+    return [ln for ln in joined.split("\n") if "ansible-playbook" in ln and playbook in ln]
+
+
+def test_the_discovery_found_something() -> None:
+    """Guards against the sweep reaching zero playbooks and reporting clean."""
+    required = _playbooks_requiring_a_variable()
+    assert required, (
+        "no playbook with a templated `hosts:` was found — the pattern or the "
+        "search path is wrong, and every assertion below would pass vacuously"
+    )
+
+
+@pytest.mark.parametrize("playbook,variable", sorted(_playbooks_requiring_a_variable().items()))
+def test_every_documented_invocation_supplies_the_host_variable(playbook: str, variable: str) -> None:
+    offenders: list[str] = []
+    for path in _markdown_files():
+        text = path.read_text(encoding="utf-8")
+        if playbook not in text:
+            continue
+        for command in _invocations(text, playbook):
+            if not re.search(rf"\b{re.escape(variable)}\s*=", command):
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: {command.strip()[:120]}")
+
+    assert not offenders, (
+        f"{playbook} uses `hosts: \"{{{{ {variable} }}}}\"`, so an invocation without "
+        f"{variable}= fails with an undefined-variable error. These documented "
+        "commands do not pass it:\n  " + "\n  ".join(offenders)
+    )

--- a/scripts/check_ansible_file_references.py
+++ b/scripts/check_ansible_file_references.py
@@ -58,11 +58,12 @@ _IMPLICIT_GROUPS = frozenset({"all", "localhost", "*", "127.0.0.1"})
 # inventory. Each entry needs a tracking issue: a bare name here is
 # indistinguishable from the silent-skip bug this guard exists to catch, so the
 # allowlist records *why* it is not one rather than hiding it.
-#   `target` — slm-service-control.yml / slm-service-logs.yml, the SLM remote
-#   service-control path. No shipped inventory defines it and no in-repo caller
-#   passes one; whether it should become `{{ target }}` (loud failure) is a
-#   remote-execution decision tracked in #13786.
-_RUNTIME_SUPPLIED_PATTERNS = frozenset({"target"})
+# (#13786 resolved the only entry this ever held: slm-service-control.yml and
+# slm-service-logs.yml now declare `hosts: "{{ target }}"`, so an unset target is
+# an undefined-variable error rather than a play that matches nothing and reports
+# success. Templated patterns are skipped above, so an entry for it here would be
+# a dormant exemption -- one that guards nothing while reading as though it does.)
+_RUNTIME_SUPPLIED_PATTERNS: frozenset = frozenset()
 
 
 def _ansible_files(root: pathlib.Path) -> list[pathlib.Path]:
@@ -143,11 +144,7 @@ def _inventory_paths(root: pathlib.Path) -> list[pathlib.Path]:
 
 def _ini_groups(text: str) -> set:
     """Group names from an INI-format inventory (``[group]`` headers)."""
-    return {
-        m.group(1).split(":")[0]
-        for line in text.splitlines()
-        if (m := re.match(r"^\s*\[([^\]]+)\]\s*$", line))
-    }
+    return {m.group(1).split(":")[0] for line in text.splitlines() if (m := re.match(r"^\s*\[([^\]]+)\]\s*$", line))}
 
 
 def inventory_groups(root: pathlib.Path) -> dict[str, set]:


### PR DESCRIPTION
Relates to #13828, #13786, #14176. **Closes nothing** — see *Why this closes
nothing* below.

## Why this closes nothing

An earlier revision said `Closes #13828, closes #13786`. Both issues state
host-behaviour acceptance criteria — a change *reaching a host* through the
normal update path, and a run *failing loudly* without a resolvable target. The
evidence here is static: YAML parsing, set-equality tests, and a CI script
re-run. None of it observes a host.

House rule is that a host-behaviour AC needs host evidence, not merge evidence,
so the keywords are gone. The code changes stand on their own; the issues stay
open until someone can attach an actual `update-all-nodes.yml` run and an actual
`slm-service-control.yml` invocation with `target` unset.

**Not** closing #14176 — see "Acceptance criteria" below. Its src fix is included because it is a strict improvement, but three of its four criteria are untouched and partial delivery does not close.

Three delivery gaps, scoped together because they are one failure class — the same one #14809 and #14693 turned out to be. The surface exists and nothing carries it to the node, so the repo looks correct and the host is not.

## Thinking Path

Picked these three out of the open update/provision set because each one had already been *characterised* by whoever filed it, and each was verifiable in the tree in a couple of commands. I checked all three against the current code before touching anything rather than trusting the write-ups — all three were still exactly as described.

**#13786 needed a decision rather than a fix**, and the decision was already written down. `scripts/check_ansible_file_references.py` allowlists `target` with a note saying the open question is *"whether it should become `{{ target }}` (loud failure)"*, tracked in this issue. Templating it is the option that makes an unset target an error instead of a play that matches nothing and exits 0. Having made that change, I removed the allowlist entry: the checker already skips templated patterns, so leaving it would be a dormant exemption — one that guards nothing while reading as though it does.

**#14176 needed care about which file to point at.** Two different hooks share the basename. The repo-root one heals stash-pop conflict markers (#2416); the infrastructure one notifies the SLM agent of new commits (#741). They are not copies of each other — different md5, different headers — so a node needs specifically the notifier.

## What Changed

- `roles/backend/tasks/unit_only.yml` — renders the units the role owns, in a loop.
- `playbooks/slm-service-control.yml`, `slm-service-logs.yml` — `hosts: "{{ target }}"`.
- `playbooks/enroll-node.yml` — hook `src` points at the infrastructure hook, which exists.
- `scripts/check_ansible_file_references.py` — allowlist emptied.

## A fourth unit fell out of the guard

I derived the #13828 guard from the `*.service.j2` templates on disk rather than from a hand-written list, so it would fail when a future unit is added and not wired in. It immediately reported one nobody had mentioned: **`autobot-mcp-bridge@.service.j2` is rendered by nothing at all.**

It is not merely dead — `autobot_shared/monitoring/prometheus_metrics.py`, `metrics/cgroup_memory.py` and `test_service_registry_covers_shipped_units_13915.py` all reference the service. Metrics and a shipped-units registry describe something no deploy path installs, and the host confirms it: no unit file, nothing in `list-unit-files`.

Filed as **#14827**. Whether to wire it or delete it with its monitoring references is a product call, so I did not guess. It is excluded from the guard **by name** with a pointer to the issue, not by a pattern that could quietly absorb the next forgotten unit.

## Verification

Mutation-checked, each target asserted present before mutating:

```
render only the backend unit   -> CAUGHT (celery + celery-beat reported missing)
revert hosts to bare 'target'  -> CAUGHT (both playbooks)
restore the old hook src       -> CAUGHT (path does not exist)
```

The guard also walks `block`/`pre_tasks`/`post_tasks` — my first version read only top-level `tasks` and could not find the hook copy at all, which reports identically to the task having been deleted.

## Model Used

Claude Opus 5


## Acceptance criteria, checked one by one

**#13828 — all four met**

- *A change to a celery unit template reaches a host through the normal update path* — both celery units are in the render loop.
- *unit_only.yml renders every unit main.yml installs* — the sets are equal: `autobot-backend.service`, `autobot-celery.service`, `autobot-celery-beat.service`.
- *Test asserting the rendered set equals the installed set* — compared against `main.yml`, in both directions. My first version compared against the templates on disk, which is the wrong denominator: a template can exist without the role installing it. That is precisely `autobot-mcp-bridge@.service` (#14827), and switching to `main.yml` removed the need to exempt it at all.
- *Every role audited for the same divergence* — `backend` is the only role with a `unit_only.yml`, so nothing else can have the asymmetry. Pinned by a test, so a second role gaining one fails and says to extend the equality check.

**#13786 — both met**

- *Fails loudly without a resolvable target* — `hosts: "{{ target }}"`; an unset variable is an undefined-variable error rather than a play that matches nothing.
- *The `target` entry is removed and the guard stays green* — entry removed; no bare `hosts: target` remains anywhere, so the exemption covered nothing. The checker runs in CI (`.github/workflows/ansible-file-references.yml`), which is what actually confirms green — I did not run repo code to assert it, and my own replication of the check proved unreliable enough that I would not have trusted it.

**#14176 — one of four met, so it stays open**

- *src names a file that exists, verified by a check that fails when it does not* — **met**.
- *A single `slm-post-commit` survives, with the other behaviour folded in* — **not done**. Two distinct hooks still exist.
- *The shell-style default replaced with a real Ansible default, swept across playbooks* — **not done**.
- *Evidence from a code-source enrolment run, not the diff* — **not done**; this is host behaviour and needs an actual enrolment.

The hook guard originally asserted the two files stay distinct, which contradicts that second criterion. It now asserts the *behaviour* the enrolled hook must have, so it survives the consolidation rather than blocking it.