### PR TITLE
test(workflow/frontend): pin that the edge-target index cannot go stale (#14792)

### DIFF
--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts
@@ -130,3 +130,52 @@ describe('the node count this canvas is known to carry (#14766)', () => {
     expect(paths(w).every((d) => d.startsWith('M'))).toBe(true)
   })
 })
+
+describe('the edge-target index cannot go stale (#14792)', () => {
+  // Staleness is structurally impossible today: the index is a plain local Map
+  // built inside the `connections` computed and rebuilt from `props.nodes` on
+  // every evaluation, so whatever invalidates the computed rebuilds the index in
+  // the same pass. Nothing in the existing suite asserts that, because every
+  // case mounts once and asserts immediately.
+  //
+  // The regression these guard against is the obvious future optimisation:
+  // hoisting the Map into a ref, or memoising it outside the computed, to avoid
+  // rebuilding it each time. That would look like a clean win, pass the whole
+  // suite, and silently render edges against stale positions during a drag —
+  // the exact operation the index was introduced to make fast.
+
+  it('redraws against the new positions when a node moves after mount', async () => {
+    const w = mountCanvas([step('n1', 0, 0, ['n2']), step('n2', 400, 200)])
+    const before = paths(w)
+    expect(before).toHaveLength(1)
+
+    await w.setProps({ nodes: [step('n1', 0, 0, ['n2']), step('n2', 900, 600)] })
+
+    const after = paths(w)
+    expect(after).toHaveLength(1)
+    expect(after[0]).not.toBe(before[0])
+  })
+
+  it('resolves an edge to a node added after mount', async () => {
+    // A node absent at mount, then present. A cached index would keep reporting
+    // the target missing and drop the edge for good.
+    const w = mountCanvas([step('n1', 0, 0, ['later'])])
+    expect(paths(w)).toHaveLength(0)
+
+    await w.setProps({ nodes: [step('n1', 0, 0, ['later']), step('later', 300, 300)] })
+
+    expect(paths(w)).toHaveLength(1)
+  })
+
+  it('drops an edge whose target is removed after mount', async () => {
+    // The other direction: a cached index would keep drawing to a node that is
+    // no longer on the canvas.
+    const w = mountCanvas([step('n1', 0, 0, ['n2']), step('n2', 400, 200)])
+    expect(paths(w)).toHaveLength(1)
+
+    await w.setProps({ nodes: [step('n1', 0, 0, ['n2'])] })
+
+    expect(paths(w)).toHaveLength(0)
+  })
+})
+


### PR DESCRIPTION
Closes #14792. Refs #14741.

## Thinking Path

`WorkflowCanvas.connections.test.ts` mounts once per case and asserts immediately.
No case calls `setProps` and re-asserts, so the suite proves the edge-target index
introduced in #14782 produces correct output — and nothing would catch it going
**stale**.

There is no bug today. The index is a plain local `Map` built inside the
`connections` computed and rebuilt from `props.nodes` on every evaluation, so
whatever invalidates the computed rebuilds the index in the same pass.

What these guard is the shape. The obvious future optimisation — hoisting the `Map`
into a `ref`, or memoising it outside the computed to avoid rebuilding it — would
look like a clean win, pass the entire existing suite, and silently render edges
against stale node positions during a drag. That is precisely the operation the
index was added to make fast, so the regression would land exactly where the
feature is meant to help.

Three directions, because a rebuilt-on-move index and a rebuilt-on-add index are
different mistakes:

- a node that **moves** after mount — the path must change
- a target that **appears** after mount — a cached index would keep dropping the edge
- a target that is **removed** after mount — a cached index would keep drawing to it

## What Changed

Three `setProps`-and-reassert cases in
`autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts`.
No production code is touched.

## Verification

Each asserts on the rendered `.connection-line` paths — the far boundary — rather
than on the index or the computed. A test reading the internal Map would pass with a
cached one as readily as a rebuilt one.

The move case asserts the path **differs** rather than matching a literal, so it
cannot pass by coincidence if geometry constants change.

## What this does not do

**#14741 stays open, deliberately.** It was the other half of this batch, and
investigating it changed the premise: `conftest.py` tries the real import first and
only stubs `xxhash` on `ImportError`, while each per-file stub is guarded by
`if "xxhash" not in sys.modules` — so with `xxhash>=4.0.1` installed by the suite,
those stubs may never fire at all.

If they are inert the fix is to delete them; if they do fire the fix is teardown.
The two are opposite changes, and I could not establish which from here — local
`xxhash` is 3.7.0 while the repo pins >=4.0.1, so anything checked locally reports
the opposite of CI. Recorded on the issue rather than guessed at.

## Model Used

Claude Opus 5
