### PR TITLE
fix(audit): count a dropped permission-denied record in both backends (#14750)

### DIFF
--- a/autobot-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-backend/user_management/middleware/rbac_middleware.py
@@ -19,6 +19,7 @@ from typing import Callable, List, Set
 from fastapi import HTTPException, Request, status
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_constants import TTL_5_MINUTES
 from user_management.config import get_deployment_config
@@ -432,6 +433,12 @@ async def _emit_permission_denied_audit(
             session.add(entry)
     except Exception as exc:
         logger.error("RBAC: failed to persist permission-denied audit entry: %s", exc)
+        # #14750: this handler is byte-identical to the SLM's, which #14674
+        # instrumented — same bug, same audit_logs table, one backend counting
+        # dropped records and the other silent. Keep swallowing, since a failing
+        # audit must never turn a clean 403 into a 500, but stop letting the loss
+        # be invisible.
+        record_audit_write_failure_safely(AuditAction.PERMISSION_DENIED, type(exc).__name__)
 
 
 def _request_audit_context(request: Request) -> tuple[str, str | None, str | None]:

--- a/autobot-slm-backend/tests/test_bi_dashboard.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard.py
@@ -108,6 +108,17 @@ sys.modules["autobot_shared.network_constants"] = _nc
 _pq = types.ModuleType("autobot_shared.monitoring.prometheus_query")
 _pq.query_instant = AsyncMock(return_value=None)
 _monitoring_pkg = types.ModuleType("autobot_shared.monitoring")
+# Keep it a *package*. Without __path__ this plain module shadows the real
+# `autobot_shared.monitoring` for the whole process, and any later import of a
+# submodule it does not stub fails with "is not a package" — even though the
+# submodule exists on disk. It is installed at import scope with no teardown, so
+# the damage is not confined to this file: it broke collection of
+# test_rbac_middleware_cache.py and test_rbac_permission_denied_audit.py in
+# seven of twelve shards the moment something imported
+# `autobot_shared.monitoring.metrics.audit` (#14750, same class as #14741).
+# Pointing __path__ at the real directory keeps the stubbed `prometheus_query`
+# in place while letting every other submodule resolve from disk.
+_monitoring_pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "autobot_shared" / "monitoring")]
 sys.modules["autobot_shared.monitoring"] = _monitoring_pkg
 sys.modules["autobot_shared.monitoring.prometheus_query"] = _pq
 

--- a/autobot-slm-backend/tests/test_bi_dashboard_10778.py
+++ b/autobot-slm-backend/tests/test_bi_dashboard_10778.py
@@ -114,6 +114,17 @@ sys.modules["autobot_shared.network_constants"] = _nc
 _pq = types.ModuleType("autobot_shared.monitoring.prometheus_query")
 _pq.query_instant = AsyncMock(return_value=None)
 _monitoring_pkg = types.ModuleType("autobot_shared.monitoring")
+# Keep it a *package*. Without __path__ this plain module shadows the real
+# `autobot_shared.monitoring` for the whole process, and any later import of a
+# submodule it does not stub fails with "is not a package" — even though the
+# submodule exists on disk. It is installed at import scope with no teardown, so
+# the damage is not confined to this file: it broke collection of
+# test_rbac_middleware_cache.py and test_rbac_permission_denied_audit.py in
+# seven of twelve shards the moment something imported
+# `autobot_shared.monitoring.metrics.audit` (#14750, same class as #14741).
+# Pointing __path__ at the real directory keeps the stubbed `prometheus_query`
+# in place while letting every other submodule resolve from disk.
+_monitoring_pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "autobot_shared" / "monitoring")]
 sys.modules["autobot_shared.monitoring"] = _monitoring_pkg
 sys.modules["autobot_shared.monitoring.prometheus_query"] = _pq
 

--- a/autobot-slm-backend/tests/test_rbac_middleware_cache.py
+++ b/autobot-slm-backend/tests/test_rbac_middleware_cache.py
@@ -69,6 +69,13 @@ _MOCK_NAMES = [
     # audit model imported at module level by rbac_middleware (#11794)
     "user_management.models",
     "user_management.models.audit",
+    # The shared audit counter rbac_middleware imports at module level (#14750).
+    # Same reason as autobot_shared.logging_manager above (#13312): the parent
+    # `autobot_shared` here is a path-less MagicMock, so the import machinery
+    # cannot walk down to a submodule. Pre-registering the FULL dotted name
+    # works because _find_and_load returns early when the exact key is already
+    # in sys.modules, so no parent resolution is attempted at all.
+    "autobot_shared.monitoring.metrics.audit",
 ]
 for _name in _MOCK_NAMES:
     sys.modules[_name] = MagicMock()

--- a/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
+++ b/autobot-slm-backend/tests/test_rbac_permission_denied_audit.py
@@ -59,6 +59,13 @@ _MOCK_NAMES = [
     "user_management.models.audit",
     "user_management.models",
     "user_management.models.base",
+    # The shared audit counter rbac_middleware imports at module level (#14750).
+    # Same reason as autobot_shared.logging_manager (#13312): the parent
+    # `autobot_shared` here is a path-less MagicMock, so the import machinery
+    # cannot walk down to a submodule. Pre-registering the FULL dotted name
+    # works because _find_and_load returns early when the exact key is already
+    # in sys.modules, so no parent resolution is attempted at all.
+    "autobot_shared.monitoring.metrics.audit",
 ]
 for _name in _MOCK_NAMES:
     sys.modules[_name] = MagicMock()

--- a/autobot-slm-backend/user_management/middleware/rbac_middleware.py
+++ b/autobot-slm-backend/user_management/middleware/rbac_middleware.py
@@ -19,6 +19,7 @@ from typing import Callable, List, Set
 from fastapi import HTTPException, Request, status
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_constants import TTL_5_MINUTES
 from user_management.config import get_deployment_config
@@ -436,26 +437,7 @@ async def _emit_permission_denied_audit(
         # 403 into a 500 -- but stop letting the loss be invisible. A live SLM
         # dropped every audit record for hours behind a 200, with the only
         # trace in an error log.
-        _record_audit_write_failure(AuditAction.PERMISSION_DENIED, type(exc).__name__)
-
-
-def _record_audit_write_failure(action: str, error_type: str) -> None:
-    """Count a dropped audit record, without ever raising from the attempt.
-
-    Metrics are best-effort here by construction: this runs inside the handler
-    that exists so an audit problem cannot break a request, so it must not
-    become a way for one to do so.
-    """
-    try:
-        from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
-
-        get_metrics_manager().record_audit_write_failure(action=str(action), error_type=error_type)
-    except Exception as exc:  # nosec B110  # see docstring: never raise from the audit path
-        # #14674 review: without this the counter's own failure is both
-        # unrecorded AND uncounted — a failure counter reporting zero, which is
-        # worse than no counter. Debug-level keeps it out of normal operation
-        # while leaving a trace when the metric is inexplicably flat.
-        logger.debug("audit write-failure metric could not be recorded: %s", exc)
+        record_audit_write_failure_safely(AuditAction.PERMISSION_DENIED, type(exc).__name__)
 
 
 def _request_audit_context(request: Request) -> tuple[str, str | None, str | None]:

--- a/autobot_shared/monitoring/metrics/audit.py
+++ b/autobot_shared/monitoring/metrics/audit.py
@@ -21,7 +21,11 @@ has.
 
 from prometheus_client import Counter
 
+from autobot_shared.logging_manager import get_logger
+
 from .base import BaseMetricsRecorder
+
+logger = get_logger(__name__)
 
 
 class AuditMetricsRecorder(BaseMetricsRecorder):
@@ -47,7 +51,7 @@ class AuditMetricsRecorder(BaseMetricsRecorder):
         self.audit_write_failures.labels(action=action, error_type=error_type).inc()
 
 
-__all__ = ["AuditMetricsRecorder"]
+__all__ = ["AuditMetricsRecorder", "record_audit_write_failure_safely"]
 
 
 def record_audit_write_failure_safely(action: object, error_type: str) -> None:
@@ -61,8 +65,6 @@ def record_audit_write_failure_safely(action: object, error_type: str) -> None:
     was previously defined in only one of them — same bug, same `audit_logs`
     table, one instrumented and the other silent (#14750).
     """
-    import logging
-
     try:
         from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
 
@@ -72,4 +74,4 @@ def record_audit_write_failure_safely(action: object, error_type: str) -> None:
         # uncounted — a failure counter reporting zero, which is worse than no
         # counter. Debug keeps it out of normal operation while leaving a trace
         # when the metric is inexplicably flat.
-        logging.getLogger(__name__).debug("audit write-failure metric could not be recorded: %s", exc)
+        logger.debug("audit write-failure metric could not be recorded: %s", exc)

--- a/autobot_shared/monitoring/metrics/audit.py
+++ b/autobot_shared/monitoring/metrics/audit.py
@@ -48,3 +48,28 @@ class AuditMetricsRecorder(BaseMetricsRecorder):
 
 
 __all__ = ["AuditMetricsRecorder"]
+
+
+def record_audit_write_failure_safely(action: object, error_type: str) -> None:
+    """Count a dropped audit record, without ever raising from the attempt.
+
+    Metrics are best-effort here by construction: every caller runs inside a
+    handler that exists so an audit problem cannot break a request, so this must
+    not become a way for one to do so (#14654, #14674).
+
+    Lives here rather than in a middleware because both backends need it and it
+    was previously defined in only one of them — same bug, same `audit_logs`
+    table, one instrumented and the other silent (#14750).
+    """
+    import logging
+
+    try:
+        from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
+
+        get_metrics_manager().record_audit_write_failure(action=str(action), error_type=error_type)
+    except Exception as exc:  # nosec B110  # see docstring: never raise from the audit path
+        # Without this the counter's own failure is both unrecorded AND
+        # uncounted — a failure counter reporting zero, which is worse than no
+        # counter. Debug keeps it out of normal operation while leaving a trace
+        # when the metric is inexplicably flat.
+        logging.getLogger(__name__).debug("audit write-failure metric could not be recorded: %s", exc)

--- a/autobot_shared/monitoring/metrics/audit_metrics_test.py
+++ b/autobot_shared/monitoring/metrics/audit_metrics_test.py
@@ -17,8 +17,6 @@ present while nothing emits), so the wiring is asserted, not assumed.
 
 from __future__ import annotations
 
-import ast
-from pathlib import Path
 
 import pytest
 
@@ -26,9 +24,6 @@ prometheus_client = pytest.importorskip("prometheus_client")
 
 from autobot_shared.monitoring.metrics.audit import AuditMetricsRecorder  # noqa: E402
 
-_SHARED = Path(__file__).resolve().parent.parent.parent
-_MANAGER = _SHARED / "monitoring" / "prometheus_metrics.py"
-_MIDDLEWARE = _SHARED.parent / "autobot-slm-backend" / "user_management" / "middleware" / "rbac_middleware.py"
 
 
 def _sample(counter, action: str, error_type: str) -> float:
@@ -108,34 +103,39 @@ def test_a_second_failure_increments_rather_than_replaces():
     ), "three failures must count as three, not one"
 
 
-def test_the_swallowing_path_emits_the_counter():
-    """The whole point: the place that drops the record is the place that counts it.
+def test_the_shared_helper_reaches_the_exported_registry():
+    """The hop the middleware actually depends on, executed rather than inspected.
 
-    If this call is removed, audit loss goes back to being invisible while every
-    other rule here still passes.
+    `test_the_manager_records_and_exports_the_counter` above proves a manager
+    you construct yourself exports the sample. The middleware does not construct
+    one — it calls `record_audit_write_failure_safely`, which resolves the
+    *singleton* via `get_metrics_manager()`. That resolution is the one hop
+    nothing covered, and it is the hop that decides whether a dropped audit is
+    visible in production.
+
+    It is also the hop that fails quietly: the helper swallows everything by
+    design, so a singleton wired to a different registry would leave the counter
+    flat with no error anywhere.
+
+    Replaces two tests that read `rbac_middleware.py` as text and asserted a
+    function name appeared in it (#14750 review). Those broke when the helper
+    was extracted to `autobot_shared`, and would have passed against a helper
+    whose body did nothing. Their invariants are covered by execution instead:
+    the middleware call sites by `repo_tests/audit_write_failure_counted_test.py`,
+    and "counting never raises" by that file's
+    `test_the_counter_never_raises_from_the_audit_path`, which drives a failing
+    metrics backend through the real helper.
     """
-    source = _MIDDLEWARE.read_text(encoding="utf-8")
+    from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
+    from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
 
-    assert (
-        "_record_audit_write_failure(" in source
-    ), "the RBAC middleware no longer counts a dropped audit entry (#14654)"
+    record_audit_write_failure_safely("permission_denied", "IntegrityError")
 
+    text = get_metrics_manager().get_metrics().decode()
 
-def test_counting_never_raises_from_the_audit_path():
-    """It runs inside the handler that exists so audits cannot break requests.
-
-    A metrics backend problem must not become the thing that returns a 500 —
-    which would invert the decision this whole path is built on.
-    """
-    source = _MIDDLEWARE.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    helper = next(
-        (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "_record_audit_write_failure"),
-        None,
+    assert 'autobot_audit_write_failures_total{action="permission_denied",error_type="IntegrityError"} 1.0' in text, (
+        "the shared helper did not reach the exported registry. The helper "
+        "swallows its own failures, so this is exactly the case that leaves no "
+        "trace: the middleware counts a dropped audit and nothing is exported. "
+        "Exported text:\n" + text[:2000]
     )
-
-    assert helper is not None, "the counting helper is gone"
-    assert any(
-        isinstance(node, ast.Try) for node in ast.walk(helper)
-    ), "the counting helper does not guard itself; a metrics failure could propagate into the audit path"

--- a/autobot_shared/monitoring/metrics/audit_metrics_test.py
+++ b/autobot_shared/monitoring/metrics/audit_metrics_test.py
@@ -17,13 +17,11 @@ present while nothing emits), so the wiring is asserted, not assumed.
 
 from __future__ import annotations
 
-
 import pytest
 
 prometheus_client = pytest.importorskip("prometheus_client")
 
 from autobot_shared.monitoring.metrics.audit import AuditMetricsRecorder  # noqa: E402
-
 
 
 def _sample(counter, action: str, error_type: str) -> float:

--- a/autobot_shared/monitoring/metrics/audit_metrics_test.py
+++ b/autobot_shared/monitoring/metrics/audit_metrics_test.py
@@ -29,6 +29,23 @@ def _sample(counter, action: str, error_type: str) -> float:
     return counter.labels(action=action, error_type=error_type)._value.get()
 
 
+def _exported_sample(manager, action: str, error_type: str) -> float:
+    """Current value of the labelled sample in the manager's exported text.
+
+    Read as a delta rather than asserted as an exact 1.0: `get_metrics_manager()`
+    is a process-wide singleton that is never reset, so any other test that
+    drives this same label pair through it first would break an absolute
+    assertion while the code under test is perfectly correct. A false failure is
+    cheaper than a false pass but still a trap, and the delta form has no such
+    dependence on what ran before.
+    """
+    needle = f'autobot_audit_write_failures_total{{action="{action}",error_type="{error_type}"}} '
+    for line in manager.get_metrics().decode().splitlines():
+        if line.startswith(needle):
+            return float(line[len(needle) :])
+    return 0.0
+
+
 def test_the_counter_actually_counts():
     """Executed, not inspected — a recorder that cannot increment is decoration."""
     registry = prometheus_client.CollectorRegistry()
@@ -127,13 +144,16 @@ def test_the_shared_helper_reaches_the_exported_registry():
     from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
     from autobot_shared.monitoring.prometheus_metrics import get_metrics_manager
 
+    manager = get_metrics_manager()
+    before = _exported_sample(manager, "permission_denied", "IntegrityError")
+
     record_audit_write_failure_safely("permission_denied", "IntegrityError")
 
-    text = get_metrics_manager().get_metrics().decode()
+    after = _exported_sample(manager, "permission_denied", "IntegrityError")
 
-    assert 'autobot_audit_write_failures_total{action="permission_denied",error_type="IntegrityError"} 1.0' in text, (
+    assert after == before + 1, (
         "the shared helper did not reach the exported registry. The helper "
         "swallows its own failures, so this is exactly the case that leaves no "
-        "trace: the middleware counts a dropped audit and nothing is exported. "
-        "Exported text:\n" + text[:2000]
+        f"trace: the middleware counts a dropped audit and nothing is exported. "
+        f"Sample went {before} -> {after}."
     )

--- a/repo_tests/audit_write_failure_counted_test.py
+++ b/repo_tests/audit_write_failure_counted_test.py
@@ -1,0 +1,79 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+
+"""#14750: a dropped audit record must be counted in BOTH backends.
+
+#14654 was a live SLM dropping every audit record for hours behind a 200, the
+only trace in an error log. #14674 made that countable — in one backend. The
+other carried a byte-identical handler, same `audit_logs` table, with the same
+silent swallow and no counter.
+
+These assert the invariant rather than today's call sites: wherever a
+permission-denied audit write is swallowed, the loss is counted.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+MIDDLEWARES = [
+    "autobot-backend/user_management/middleware/rbac_middleware.py",
+    "autobot-slm-backend/user_management/middleware/rbac_middleware.py",
+]
+
+
+@pytest.mark.parametrize("rel", MIDDLEWARES, ids=["backend", "slm-backend"])
+def test_a_swallowed_permission_denied_audit_is_counted(rel: str) -> None:
+    path = REPO_ROOT / rel
+    assert path.is_file(), f"{rel} is missing — this guard would pass vacuously"
+    text = path.read_text(encoding="utf-8")
+
+    assert "failed to persist permission-denied audit entry" in text, (
+        f"{rel} no longer swallows a permission-denied audit write, so this guard "
+        "is pointed at the wrong place — re-point it rather than deleting it"
+    )
+    assert "record_audit_write_failure_safely" in text, (
+        f"{rel} swallows a failed audit write without counting it. That is the "
+        "#14654 shape: the record is lost and nothing says so (#14750)."
+    )
+
+
+def test_both_backends_use_the_same_counter() -> None:
+    """One definition, so instrumenting one backend cannot leave the other behind.
+
+    The two handlers were byte-identical and only one was instrumented; a second
+    local copy would let them drift again.
+    """
+    for rel in MIDDLEWARES:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert (
+            "from autobot_shared.monitoring.metrics.audit import" in text
+        ), f"{rel} does not import the shared counter"
+        assert not re.search(
+            r"^def _record_audit_write_failure", text, re.M
+        ), f"{rel} defines its own copy of the counter again"
+
+
+def test_the_counter_never_raises_from_the_audit_path() -> None:
+    """It runs inside the handler that exists so audit trouble cannot break a request."""
+    from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
+
+    import autobot_shared.monitoring.prometheus_metrics as pm
+
+    original = pm.get_metrics_manager
+
+    def explode():
+        raise RuntimeError("metrics backend down")
+
+    pm.get_metrics_manager = explode
+    try:
+        record_audit_write_failure_safely("PERMISSION_DENIED", "OperationalError")
+    finally:
+        pm.get_metrics_manager = original


### PR DESCRIPTION
Refs #14750. **Deliberately not `Closes`** — see "What this does not fix".

## Thinking Path

#14674 made a dropped audit record countable, and wired it to exactly one call
site. `autobot-backend/user_management/middleware/rbac_middleware.py:433` carries a
**byte-identical** handler — its own docstring says it was ported from the SLM —
with the same silent swallow and no counter:

```python
except Exception as exc:
    logger.error("RBAC: failed to persist permission-denied audit entry: %s", exc)
```

`grep -rn record_audit_write_failure autobot-backend/` returned nothing. Same bug,
same `audit_logs` table, one backend counting dropped records and the other silent.

## What Changed

The counter has **one definition**, in `autobot_shared/monitoring/metrics/audit.py`
beside the metric it records, and both middlewares import it. The SLM's local copy
is removed rather than left alongside — a second copy is what allowed the two to
diverge in the first place, so deleting it is part of the fix.

Both still swallow. A failing audit must never turn a clean 403 into a 500; what
changes is that the loss is counted instead of living only in an error log.

## Verification

```
autobot-backend      swallow=True  counted=True  local_copy=False
autobot-slm-backend  swallow=True  counted=True  local_copy=False
```

The guard asserts the **invariant** — wherever a permission-denied audit write is
swallowed, the loss is counted — in both backends, and fails if either grows its own
copy of the counter again. It also pins its own reachability: if the swallow message
disappears, it says re-point me rather than passing quietly.

A third test drives the shared helper with a metrics backend that raises, because a
counter that can throw from inside the handler protecting a request would defeat the
handler's purpose.

## What this does not fix

**The login path, which is what #14750 is actually about.** I traced it rather than
assuming, and the issue's premise needs correcting:

`UserService._audit_log` (`user_service.py:834`) does `session.add(audit_entry)` —
no flush, no commit, and no try/except. Its `LOGIN_SUCCESS` caller at `:658` does not
wrap it either. So the write fails at **transaction commit**, elsewhere, and #14654's
symptom — a 200 returned while the audit write failed — means something upstream
catches it.

Instrumenting `_audit_log` would therefore count nothing. The correct site is
wherever that commit failure is swallowed, and finding it means tracing the login
route's transaction handling, including the `api/auth.py` and `api/sso_auth.py` call
sites #13849 already catalogued.

That is a larger and more delicate change than this one, and guessing the site would
produce a counter that stays at zero for the very incident it was added for — which
is worse than no counter. Recorded on the issue so the remaining work starts from
evidence.

## Model Used

Claude Opus 5
