### PR TITLE
fix(llc): resolve replay transcripts for every subprocess adapter, not just claude_code (#14760)

### DIFF
--- a/autobot-backend/llc/adapters/claude_code_adapter.py
+++ b/autobot-backend/llc/adapters/claude_code_adapter.py
@@ -129,6 +129,7 @@ class ClaudeCodeAdapter(SubprocessLifecycleAdapter):
 
     _LOG_NAME = "ClaudeCodeAdapter"
     _state_path = staticmethod(_state_path)
+    _output_path = staticmethod(_output_path)
     _required_cli = "claude"  # GH#9793: CLI-availability gate in heartbeat dispatch
 
     def _configured_cli_path(self) -> Optional[str]:

--- a/autobot-backend/llc/adapters/copilot_local_adapter.py
+++ b/autobot-backend/llc/adapters/copilot_local_adapter.py
@@ -75,6 +75,7 @@ class CopilotLocalAdapter(SubprocessLifecycleAdapter):
 
     _LOG_NAME = "CopilotLocalAdapter"
     _state_path = staticmethod(_state_path)
+    _output_path = staticmethod(_output_path)
     _required_cli = "gh"  # GH#9793: CLI-availability gate in heartbeat dispatch
 
     async def _invoke(self, agent_config: dict, context: dict) -> str:

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -82,6 +82,95 @@ def session_id_from_run_id(run_id: str) -> str:
     return run_id.split("/", 1)[-1]
 
 
+def adapter_transcript_helpers(
+    adapter_type: str,
+) -> Optional[tuple[Callable[..., str], Callable[..., str]]]:
+    """The ``(_output_path, _state_path)`` pair for a subprocess adapter type.
+
+    Resolved from the adapter object in the registry rather than from a
+    type-name lookup table. A table is a second list of adapter types that has
+    to be kept in step with the registry by hand, and the failure mode is
+    silent: the missing entry makes transcript resolution return nothing, which
+    is indistinguishable from a run that produced no transcript.
+
+    Returns None when the type is unregistered, is not a subprocess adapter
+    (in-process agents write no transcript), or declares neither helper.
+    """
+    from .base import get_adapter
+
+    try:
+        adapter = get_adapter(adapter_type)
+    except KeyError:
+        return None
+    if not is_subprocess_adapter(adapter):
+        return None
+
+    # Read off the class: both are staticmethods, and the base class only
+    # *annotates* them, so an adapter that never assigned one yields None here
+    # instead of inheriting some other adapter's scheme.
+    output_path = getattr(type(adapter), "_output_path", None)
+    state_path = getattr(type(adapter), "_state_path", None)
+    if output_path is None or state_path is None:
+        return None
+    return output_path, state_path
+
+
+def resolve_transcript_path(
+    adapter_type: str,
+    output_dir: str,
+    agent_id: str,
+    external_run_id: str,
+) -> Optional[str]:
+    """Locate the transcript a subprocess adapter run actually wrote (#13614, #14760).
+
+    The state file is the authority, not a recomputed path. ``_output_path`` is
+    called by the adapter *before* the process is spawned — it has to be, the
+    file is the child's stdout — so the run id in its name is the placeholder
+    ``0/<session>``, while the id the adapter returns is ``<pid>/<session>``.
+    Two places deriving the same path from different inputs is how a complete
+    37 KB transcript sat on disk while ``output_text`` stayed empty.
+
+    When the state file is missing or unreadable the path is recomputed — but
+    from the *placeholder* id the adapter actually named the file with, not
+    from ``external_run_id``. Rebuilding it from the returned id names a file no
+    run has ever written, so the fallback would miss every time, precisely in
+    the case it exists to cover.
+
+    Each adapter family supplies its own path pair, so the copilot scheme
+    (``llc_copilot_*``) resolves as readily as the claude_code one
+    (``llc_agent_*``); previously only the latter did (#14760).
+    """
+    helpers = adapter_transcript_helpers(adapter_type)
+    if helpers is None:
+        logger.warning(
+            "No transcript path helpers for adapter_type %r — replay output cannot "
+            "be resolved for run %s. A subprocess adapter must declare both "
+            "_output_path and _state_path.",
+            adapter_type,
+            external_run_id,
+        )
+        return None
+    output_path, state_path = helpers
+
+    state_file = state_path(output_dir, external_run_id)
+    try:
+        with open(state_file, "r", encoding="utf-8") as fh:
+            recorded = json.load(fh).get("output_file")
+        if recorded:
+            return str(recorded)
+        logger.warning(
+            "Adapter state file %s carries no output_file — falling back to the computed path",
+            state_file,
+        )
+    except (OSError, ValueError):
+        logger.warning(
+            "Could not read adapter state file %s — falling back to the computed path",
+            state_file,
+        )
+
+    return output_path(output_dir, agent_id, placeholder_run_id(session_id_from_run_id(external_run_id)))
+
+
 def _common_cli_search_dirs() -> list[str]:
     """Common install dirs, plus the npm global bin dir when NPM_CONFIG_PREFIX is set."""
     dirs = list(_COMMON_CLI_INSTALL_DIRS)
@@ -154,6 +243,10 @@ class SubprocessLifecycleAdapter:
     _LOG_NAME: str = "SubprocessAdapter"
     # staticmethod (output_dir, run_id) -> str; set by each subclass.
     _state_path: Callable[[str, str], str]
+    # staticmethod (output_dir, agent_id, run_id) -> str; set by each subclass.
+    # Declared, not defaulted: an adapter that never sets it must be *findable*
+    # rather than silently unresolvable, which is what #14760 was.
+    _output_path: Callable[[str, str, str], str]
     # Name of the CLI binary required by this adapter (e.g. "claude", "gh").
     # Subclasses declare this; None means no external CLI required (GH#9793).
     _required_cli: Optional[str] = None
@@ -301,6 +394,11 @@ __all__ = [
     "resolve_timeout",
     "resolve_cli_binary",
     "is_subprocess_adapter",
+    "adapter_transcript_helpers",
+    "resolve_transcript_path",
+    "placeholder_run_id",
+    "session_id_from_run_id",
+    "PLACEHOLDER_PID",
 ]
 
 

--- a/autobot-backend/llc/adapters/subprocess_base.py
+++ b/autobot-backend/llc/adapters/subprocess_base.py
@@ -33,7 +33,7 @@ from typing import Callable, Iterable, Optional
 from autobot_shared.logging_manager import get_logger
 
 from ..models.enums import LLCRunStatus
-from .base import AdapterRunStatus
+from .base import AdapterRunStatus, get_adapter
 from .subprocess_support import probe_pid, render_context_markdown, terminate_pid
 
 logger = get_logger(__name__)
@@ -96,8 +96,6 @@ def adapter_transcript_helpers(
     Returns None when the type is unregistered, is not a subprocess adapter
     (in-process agents write no transcript), or declares neither helper.
     """
-    from .base import get_adapter
-
     try:
         adapter = get_adapter(adapter_type)
     except KeyError:

--- a/autobot-backend/llc/scheduler/heartbeat_scheduler.py
+++ b/autobot-backend/llc/scheduler/heartbeat_scheduler.py
@@ -723,62 +723,31 @@ def get_heartbeat_scheduler() -> HeartbeatScheduler:
 # ------------------------------------------------------------------
 
 
-def _resolve_adapter_output_file(output_dir: str, agent_id: str, external_run_id: str) -> Optional[str]:
-    """Locate the transcript an adapter run actually wrote (#13614).
+def _resolve_adapter_output_file(
+    adapter_type: str, output_dir: str, agent_id: str, external_run_id: str
+) -> Optional[str]:
+    """Locate the transcript an adapter run actually wrote (#13614, #14760).
 
-    The state file is the authority, not a recomputed path. `_output_path` is
-    called by the adapter *before* the process is spawned — it has to be, the
-    file is the child's stdout — so the run id in its name is the placeholder
-    `0/<session>`, while the id the adapter returns is `<pid>/<session>`. Two
-    places deriving the same path from different inputs is how a complete 37 KB
-    transcript sat on disk while `output_text` stayed empty and
-    `recorded_events` NULL.
-
-    The adapter records the real path in its state file, keyed by the run id it
-    returns, so reading that removes the second derivation entirely rather than
-    trying to keep the two in step.
-
-    When the state file is missing or unreadable the path is recomputed — but
-    from the *placeholder* id the adapter actually named the file with, not
-    from `external_run_id`. Rebuilding it from the returned id names a file no
-    run has ever written, so the fallback would miss every time, precisely in
-    the case it exists to cover.
-
-    Only the claude_code family is resolvable here; the copilot adapters use a
-    different filename scheme and are tracked separately (#14760).
+    Delegates to the adapters package, which resolves the path helpers from the
+    adapter registered under *adapter_type* rather than importing one family's
+    helpers directly. The previous version imported `claude_code_adapter`'s pair
+    unconditionally, so the copilot adapters — which name their files
+    `llc_copilot_*` rather than `llc_agent_*` — missed on both the state-file
+    lookup and the recomputed fallback, every time. The function was generic in
+    name only (#14760).
     """
-    import json as _json
-
     try:
-        from ..adapters.claude_code_adapter import _output_path as _cc_output_path
-        from ..adapters.claude_code_adapter import _state_path as _cc_state_path
-        from ..adapters.subprocess_base import placeholder_run_id, session_id_from_run_id
+        from ..adapters.subprocess_base import resolve_transcript_path
     except ImportError:
         # Losing the helpers is a wiring fault, not an absent transcript. The
         # caller cannot tell those apart from a None, so say which it was.
         logger.exception(
-            "Could not import adapter path helpers — replay transcript resolution " "is disabled for run %s",
+            "Could not import adapter path helpers — replay transcript resolution is disabled for run %s",
             external_run_id,
         )
         return None
 
-    state_file = _cc_state_path(output_dir, external_run_id)
-    try:
-        with open(state_file, "r", encoding="utf-8") as fh:
-            recorded = _json.load(fh).get("output_file")
-        if recorded:
-            return str(recorded)
-        logger.warning(
-            "Adapter state file %s carries no output_file — falling back to the computed path",
-            state_file,
-        )
-    except (OSError, ValueError):
-        logger.warning(
-            "Could not read adapter state file %s — falling back to the computed path",
-            state_file,
-        )
-
-    return _cc_output_path(output_dir, agent_id, placeholder_run_id(session_id_from_run_id(external_run_id)))
+    return resolve_transcript_path(adapter_type, output_dir, agent_id, external_run_id)
 
 
 async def _record_run_for_replay(
@@ -810,7 +779,9 @@ async def _record_run_for_replay(
             cfg = agent.get("adapter_config") or {}
             output_dir: str = cfg.get("output_dir", "/tmp")  # nosec B108
             agent_id_str = str(agent.get("agent_id", ""))
-            output_file: Optional[str] = _resolve_adapter_output_file(output_dir, agent_id_str, external_run_id)
+            output_file: Optional[str] = _resolve_adapter_output_file(
+                adapter_type, output_dir, agent_id_str, external_run_id
+            )
 
             if output_file and _os.path.exists(output_file):
                 try:

--- a/autobot-backend/llc/tests/test_replay_transcript_resolution_14760.py
+++ b/autobot-backend/llc/tests/test_replay_transcript_resolution_14760.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Replay transcript resolution must cover every subprocess adapter (#14760).
+
+#13614 fixed transcript resolution by reading the adapter's state file instead
+of recomputing a path from the wrong run id. It fixed it for one adapter family:
+`_resolve_adapter_output_file` imported `claude_code_adapter`'s helpers directly,
+so the copilot adapters — whose files are `llc_copilot_*`, not `llc_agent_*` —
+missed on both the state-file lookup and the fallback, every time. The run
+completed, a transcript was written, and `output_text` stayed empty: the exact
+symptom #13614 was filed for, still live for two of the four subprocess types.
+
+The function was generic in name only. These drive the real scheduler entry
+point for **every registered subprocess adapter**, so a family that resolves to
+nothing is a failure here rather than a silently empty replay record.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from llc.adapters import subprocess_base
+from llc.adapters.base import registered_adapter_types
+from llc.adapters.subprocess_base import (
+    adapter_transcript_helpers,
+    is_subprocess_adapter,
+    placeholder_run_id,
+)
+from llc.scheduler.heartbeat_scheduler import _resolve_adapter_output_file
+
+SUBPROCESS_TYPES = [
+    "claude_code",
+    "claude_code_subscription",
+    "copilot_local",
+    "copilot_subscription",
+]
+
+
+def _subprocess_types_in_registry() -> list[str]:
+    """Every registered type whose adapter runs an external CLI subprocess.
+
+    Derived from the registry rather than listed here, so a newly registered
+    adapter is covered the moment it is added.
+    """
+    from llc.adapters.base import get_adapter
+
+    return [t for t in registered_adapter_types() if is_subprocess_adapter(get_adapter(t))]
+
+
+class TestEverySubprocessAdapterResolvesItsTranscript:
+    @pytest.mark.parametrize("adapter_type", SUBPROCESS_TYPES)
+    def test_the_state_file_is_the_authority(self, adapter_type, tmp_path):
+        """The recorded path wins, whatever scheme the adapter names files with."""
+        _, state_path = adapter_transcript_helpers(adapter_type)
+        external_run_id = "4242/sess-abc"
+        recorded = str(tmp_path / "the-real-transcript.jsonl")
+
+        with open(state_path(str(tmp_path), external_run_id), "w", encoding="utf-8") as fh:
+            json.dump({"output_file": recorded}, fh)
+
+        resolved = _resolve_adapter_output_file(adapter_type, str(tmp_path), "agent-1", external_run_id)
+
+        assert resolved == recorded
+
+    @pytest.mark.parametrize("adapter_type", SUBPROCESS_TYPES)
+    def test_the_fallback_names_the_file_the_adapter_actually_wrote(self, adapter_type, tmp_path):
+        """No state file: rebuild from the PLACEHOLDER id, in this family's scheme.
+
+        Two things have to be right at once, and #14760 had the second wrong for
+        the copilot pair: the run id must be the placeholder the adapter named
+        the file with (`0/<session>`, not the returned `<pid>/<session>`), and
+        the filename scheme must be this adapter's own.
+        """
+        output_path, _ = adapter_transcript_helpers(adapter_type)
+        external_run_id = "4242/sess-abc"
+
+        resolved = _resolve_adapter_output_file(adapter_type, str(tmp_path), "agent-1", external_run_id)
+
+        expected = output_path(str(tmp_path), "agent-1", placeholder_run_id("sess-abc"))
+        assert resolved == expected
+        # The placeholder pid, not the returned one — rebuilding from 4242 names
+        # a file no run has ever written.
+        assert "4242" not in os.path.basename(resolved)
+
+    def test_the_two_families_do_not_share_a_scheme(self, tmp_path):
+        """Guards the shape of the bug itself.
+
+        If copilot resolution ever collapses back onto the claude_code helpers,
+        both would resolve to the same name and every assertion above would
+        still pass — each family would simply be checked against whatever it
+        resolved to.
+        """
+        claude = _resolve_adapter_output_file("claude_code", str(tmp_path), "agent-1", "1/s")
+        copilot = _resolve_adapter_output_file("copilot_local", str(tmp_path), "agent-1", "1/s")
+
+        assert claude != copilot
+        assert "llc_agent_" in os.path.basename(claude)
+        assert "llc_copilot_" in os.path.basename(copilot)
+
+
+class TestTheCoverageIsDerivedNotListed:
+    def test_every_registered_subprocess_adapter_has_path_helpers(self):
+        """A new subprocess adapter cannot land without transcript resolution.
+
+        This is the assertion that makes the fix durable. A lookup table keyed by
+        adapter_type would be a second list to maintain by hand, and its failure
+        mode is silent — the missing entry yields no transcript, which reads
+        exactly like a run that produced none.
+        """
+        missing = [t for t in _subprocess_types_in_registry() if adapter_transcript_helpers(t) is None]
+
+        assert not missing, (
+            f"registered subprocess adapters with no transcript path helpers: {missing}. "
+            "Declare _output_path and _state_path as staticmethods on the adapter class, "
+            "or replay records for these types will be silently empty (#14760)."
+        )
+
+    def test_the_parametrized_list_still_matches_the_registry(self):
+        """Keeps the list above honest.
+
+        The tests in this file parametrize over a literal list for readable ids.
+        If the registry grows a subprocess adapter, that list is now wrong — say
+        so here rather than let the new type go unexercised.
+        """
+        assert sorted(_subprocess_types_in_registry()) == sorted(SUBPROCESS_TYPES)
+
+
+class TestNonSubprocessAdaptersResolveToNothing:
+    @pytest.mark.parametrize("adapter_type", ["autobot_agent", "codex_subscription", "no_such_adapter"])
+    def test_no_path_is_invented_for_them(self, adapter_type, tmp_path):
+        """In-process and unimplemented adapters write no transcript.
+
+        Returning None is right; returning some other family's path would make
+        the caller stat a file that never exists and record the run as though
+        the transcript were merely missing.
+        """
+        assert _resolve_adapter_output_file(adapter_type, str(tmp_path), "agent-1", "1/s") is None
+
+
+class TestAMisdeclaredAdapterIsNotSilentlyResolved:
+    def test_an_adapter_missing_output_path_yields_no_helpers(self, monkeypatch):
+        """The base class annotates the helpers; it does not default them.
+
+        So an adapter that never assigns one must resolve to None rather than
+        inherit some other family's scheme.
+        """
+
+        class HalfDeclared(subprocess_base.SubprocessLifecycleAdapter):
+            _state_path = staticmethod(lambda output_dir, run_id: "/tmp/x")  # nosec B108  # test double
+
+        from llc.adapters import base as adapters_base
+
+        monkeypatch.setitem(adapters_base._registry, "_test_half_declared", HalfDeclared())
+
+        assert adapter_transcript_helpers("_test_half_declared") is None


### PR DESCRIPTION
Closes #14760.

## Thinking Path

`_resolve_adapter_output_file` was generic in name only. It imported
`claude_code_adapter`'s `_output_path` / `_state_path` unconditionally, so for
`copilot_local` and `copilot_subscription` — which name files `llc_copilot_*`
rather than `llc_agent_*` — both the state-file lookup **and** the recomputed
fallback missed on every run. The run completed, a transcript was written to
disk, and `output_text` / `recorded_events` stayed empty: the exact symptom
#13614 was filed for, still live for two of the four subprocess types.

The obvious fix is a `dict` keyed by `adapter_type`. I did not do that. A table
is a second list of adapter types maintained by hand alongside the registry, and
its failure mode is silent in the worst direction — a missing entry yields *no*
transcript, which is indistinguishable from a run that produced none. This
codebase has been bitten by exactly that shape repeatedly (most recently #14469,
where a hand-written verb list decided a permission guard's reach while the set
of real tools grew independently of it).

So resolution reads the helpers off the **adapter object in the registry**.
There are four subprocess types but only two schemes: both subscription adapters
subclass their local counterpart and reuse its module-level helpers, so binding
`_output_path` as a staticmethod on `ClaudeCodeAdapter` and `CopilotLocalAdapter`
covers all four by inheritance. `SubprocessLifecycleAdapter` *annotates* both
helpers without defaulting them, so an adapter that declares neither resolves to
`None` rather than silently inheriting another family's scheme.

## What Changed

- `llc/adapters/subprocess_base.py` — new `adapter_transcript_helpers()` and
  `resolve_transcript_path()`; `_output_path` declared alongside `_state_path` on
  the base class; the three run-id helpers added to `__all__`.
- `llc/adapters/claude_code_adapter.py`, `copilot_local_adapter.py` — bind
  `_output_path` as a staticmethod (their subscription subclasses inherit it).
- `llc/scheduler/heartbeat_scheduler.py` — `_resolve_adapter_output_file` now
  takes `adapter_type` and delegates. The caller already had `adapter_type`
  resolved. Net **−29 lines** on a file that is over its recorded size ceiling.
- `llc/tests/test_replay_transcript_resolution_14760.py` — new; the function had
  no test at all, which is part of why this gap survived #13614.

`codex_subscription` and `autobot_agent` are not `SubprocessLifecycleAdapter`s
and correctly resolve to `None` — they write no transcript, and inventing one
would make the caller stat a file that never exists.

## Verification

The three ACs, each asserted rather than asserted-about:

- **Resolution works for both copilot types** — parametrized over all four
  subprocess types, both for the state-file path and the fallback.
- **Every registered type is covered, not only claude_code** — the coverage set
  is *derived* from the registry (`registered_adapter_types()` filtered by
  `is_subprocess_adapter`), not listed. A second test asserts the readable
  parametrize list still equals that derived set, so a new adapter cannot go
  unexercised quietly.
- **Fails if a new adapter type is registered without a mapping** — a
  `HalfDeclared` adapter that sets only `_state_path` is injected into the
  registry and must resolve to `None`.

**Mutation evidence.** A test suite that only ever sees correct code proves
nothing, so I reproduced the resolution logic faithfully in a scratch module and
re-ran the three core assertions against the pre-fix shape (claude helpers
regardless of type):

```
assertion                                 FIXED  PRE-FIX
state_file_is_authority                    PASS     FAIL
fallback_uses_own_scheme                   PASS     FAIL
families_do_not_share_a_scheme             PASS     FAIL
```

All three flip. The third exists because the first two would keep passing if
copilot resolution ever collapsed back onto the claude_code helpers — each
family would simply be checked against whatever it resolved to.

The fallback test also asserts the returned basename does **not** contain the
returned pid, pinning the #13614 placeholder-id rule that the scheme fix sits on
top of.

Not verified by running the suite locally: this repo's tests are not run from
the working tree. CI is the evidence for the suite itself.

## Model Used

Claude Opus 5 (1M context)
