### PR TITLE
fix(llc): attach reports_to only for managers that actually landed (#14811)

### DIFF
--- a/autobot-backend/llc/api/portability.py
+++ b/autobot-backend/llc/api/portability.py
@@ -56,6 +56,11 @@ class ImportExecuteResponse(BaseModel):
     company_id: str
     created_entities: Dict[str, List[str]]
     skipped: Dict[str, List[str]]
+    # Reporting lines that could not be honoured because the manager was not
+    # created (#14811). Structured, not prose: `warnings` carries server-composed
+    # English the UI cannot translate, and an operator has to be able to see
+    # which agents lost their manager in their own locale.
+    dropped_reporting_lines: List[Dict[str, str]] = []
     warnings: List[str]
 
 

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -236,6 +236,12 @@ class PortabilityService(LLCServiceBase):
         skipped: Dict[str, List[str]] = {"agents": [], "goals": [], "work_items": []}
         warnings: List[str] = []
 
+        # Reporting lines the import could not honour because the manager was
+        # not created (#14811). Structured rather than folded into `warnings`:
+        # those are server-composed English f-strings the UI cannot translate,
+        # and this has to be renderable in every shipped locale.
+        dropped_links: List[Dict[str, str]] = []
+
         sp = await self.session.begin_nested()
         try:
             company_id = await self._resolve_or_create_company(template, target_company_id, remapping_options, warnings)
@@ -247,13 +253,26 @@ class PortabilityService(LLCServiceBase):
                 a.get("agent_id", ""): str(uuid.uuid4()) for a in agents_list if a.get("agent_id")
             }
 
-            # Pass 2: insert agents with remapped reports_to
+            # Pass 2: insert agents. `reports_to` is deliberately NOT resolved
+            # here — which agents land is decided in this loop (an existing name
+            # in the target company, an adapter that cannot run on this host, or
+            # a duplicate name inside the template itself), while the pass-1 map
+            # was built before any of those decisions. Resolving against the map
+            # inline wrote a pre-minted UUID for a row that was never created
+            # (#14811).
+            landed: Dict[str, str] = {}
             for agent in agents_list:
                 agent_id = await self._import_agent(agent, company_id, secret_mapping, warnings, agent_id_map)
                 if agent_id:
                     created_entities["agents"].append(agent_id)
+                    if agent.get("agent_id"):
+                        landed[str(agent["agent_id"])] = agent_id
                 else:
                     skipped["agents"].append(agent.get("name", ""))
+
+            # Pass 3: attach every reporting line whose manager actually landed,
+            # and name the ones that did not instead of pointing at nothing.
+            await self._link_reporting_lines(agents_list, landed, dropped_links)
 
             # goals
             for goal in template.get("goals", []):
@@ -288,6 +307,7 @@ class PortabilityService(LLCServiceBase):
             "company_id": str(company_id),
             "created_entities": created_entities,
             "skipped": skipped,
+            "dropped_reporting_lines": dropped_links,
             "warnings": warnings,
         }
 
@@ -649,6 +669,51 @@ class PortabilityService(LLCServiceBase):
             return False
         return True
 
+    async def _link_reporting_lines(
+        self,
+        agents_list: List[Dict[str, Any]],
+        landed: Dict[str, str],
+        dropped_links: List[Dict[str, str]],
+    ) -> None:
+        """Attach reports_to for agents whose manager was actually inserted (#14811).
+
+        Runs inside execute_import's savepoint, so a failure here rolls the whole
+        import back with everything else.
+
+        A manager that was skipped leaves its subordinate as a root rather than
+        pointing at a row that does not exist. That is not a silent downgrade:
+        the unresolvable edge is recorded in `dropped_links` and returned to the
+        caller. The alternative — keeping the pointer — made the subordinate
+        vanish from the org tree entirely, because that tree matches children by
+        agent_id and roots by a NULL reports_to, so an agent referencing a
+        nonexistent manager is neither.
+        """
+        names_by_source_id = {str(a["agent_id"]): a.get("name", "") for a in agents_list if a.get("agent_id")}
+
+        for agent in agents_list:
+            source_id = str(agent.get("agent_id") or "")
+            manager_source_id = str(agent.get("reports_to") or "")
+            if not source_id or not manager_source_id or source_id not in landed:
+                continue
+
+            manager_dest_id = landed.get(manager_source_id)
+            if manager_dest_id is None:
+                dropped_links.append(
+                    {
+                        "agent_name": agent.get("name", ""),
+                        "agent_id": landed[source_id],
+                        "manager_name": names_by_source_id.get(manager_source_id, ""),
+                        "manager_source_agent_id": manager_source_id,
+                    }
+                )
+                continue
+
+            await self.session.execute(
+                text("UPDATE agent_org_nodes SET reports_to = :mgr WHERE agent_id = :aid").bindparams(
+                    mgr=manager_dest_id, aid=landed[source_id]
+                )
+            )
+
     async def _import_agent(
         self,
         agent: Dict[str, Any],
@@ -671,11 +736,11 @@ class PortabilityService(LLCServiceBase):
         old_id = agent.get("agent_id", "")
         new_agent_id = (agent_id_map or {}).get(old_id) or str(uuid.uuid4())
 
-        # Remap reports_to from source UUID to destination UUID
-        old_reports_to = agent.get("reports_to")
+        # reports_to is attached in pass 3, once the set of agents that actually
+        # landed is known. Resolving it here used the pass-1 prediction, which
+        # named a row that a later skip decision meant was never inserted
+        # (#14811). There is no FK on this column, so nothing rejected it.
         reports_to: Optional[str] = None
-        if old_reports_to and agent_id_map:
-            reports_to = agent_id_map.get(str(old_reports_to))
 
         adapter_config = self._resolve_secrets(agent.get("adapter_config") or {}, secret_mapping, name, warnings)
 

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -718,8 +718,7 @@ class PortabilityService(LLCServiceBase):
             # scopes by company_id; this one was the outlier.
             await self.session.execute(
                 text(
-                    "UPDATE agent_org_nodes SET reports_to = :mgr "
-                    "WHERE agent_id = :aid AND company_id = :cid"
+                    "UPDATE agent_org_nodes SET reports_to = :mgr " "WHERE agent_id = :aid AND company_id = :cid"
                 ).bindparams(mgr=manager_dest_id, aid=landed[source_id], cid=company_id)
             )
 

--- a/autobot-backend/llc/services/portability.py
+++ b/autobot-backend/llc/services/portability.py
@@ -272,7 +272,7 @@ class PortabilityService(LLCServiceBase):
 
             # Pass 3: attach every reporting line whose manager actually landed,
             # and name the ones that did not instead of pointing at nothing.
-            await self._link_reporting_lines(agents_list, landed, dropped_links)
+            await self._link_reporting_lines(agents_list, landed, dropped_links, company_id)
 
             # goals
             for goal in template.get("goals", []):
@@ -674,6 +674,7 @@ class PortabilityService(LLCServiceBase):
         agents_list: List[Dict[str, Any]],
         landed: Dict[str, str],
         dropped_links: List[Dict[str, str]],
+        company_id: Any,
     ) -> None:
         """Attach reports_to for agents whose manager was actually inserted (#14811).
 
@@ -708,10 +709,18 @@ class PortabilityService(LLCServiceBase):
                 )
                 continue
 
+            # Scoped by company as well as agent_id. `agent_id` carries a
+            # table-wide UNIQUE constraint today, so the company clause is
+            # redundant — but that constraint is declared in a migration three
+            # files away, and if it ever became per-company (the natural change
+            # when two tenants want the same agent slug) this UPDATE would
+            # silently start crossing tenants. Every sibling query on this table
+            # scopes by company_id; this one was the outlier.
             await self.session.execute(
-                text("UPDATE agent_org_nodes SET reports_to = :mgr WHERE agent_id = :aid").bindparams(
-                    mgr=manager_dest_id, aid=landed[source_id]
-                )
+                text(
+                    "UPDATE agent_org_nodes SET reports_to = :mgr "
+                    "WHERE agent_id = :aid AND company_id = :cid"
+                ).bindparams(mgr=manager_dest_id, aid=landed[source_id], cid=company_id)
             )
 
     async def _import_agent(

--- a/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
+++ b/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
@@ -1,0 +1,206 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+
+"""#14811: a skipped manager must not leave its subordinates pointing at nothing.
+
+`execute_import` pre-mints a destination UUID for **every** agent in the template
+before any INSERT, so `reports_to` could be remapped without depending on the
+order agents appear in. `_import_agent` then decides — per agent — whether the
+row is actually created: a name already used in the target company, an adapter
+that cannot run on this host (#14800), or a duplicate name inside the template
+itself all return None.
+
+Pass 1 therefore *predicts* the insert set and pass 2 *decides* it, and nothing
+reconciled the two. A subordinate whose manager was skipped was written with the
+manager's pre-minted UUID — an id belonging to a row that was never inserted.
+There is no foreign key on `reports_to`, so nothing rejected it, at import time
+or ever.
+
+The consequence is not cosmetic. `/api/agents`' org tree roots on
+`reports_to IS NULL` and matches children by `agent_id`, so an agent referencing
+a nonexistent manager is neither a root nor anyone's child: it disappears from
+the tree entirely, cannot be delegated to, and cannot escalate — while the
+import reports success and the LLC org chart still renders it, because that
+endpoint promotes an unresolvable parent to a root.
+
+These pin the invariant: a reporting line is attached only when the manager
+actually landed, and one that cannot be honoured is **named in the result**
+rather than written as a pointer to nothing.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from llc.services.portability import PortabilityService
+
+
+class _FakeSession:
+    """Captures executed statements; enough of AsyncSession for execute_import."""
+
+    def __init__(self) -> None:
+        self.statements: List[Any] = []
+
+    async def execute(self, statement, *args, **kwargs):
+        self.statements.append(statement)
+        return SimpleNamespace(mappings=lambda: SimpleNamespace(first=lambda: None))
+
+    async def begin_nested(self):
+        return SimpleNamespace(commit=AsyncMock(), rollback=AsyncMock())
+
+
+def _updates(session: _FakeSession) -> Dict[str, str]:
+    """agent_id -> reports_to, for every UPDATE the linker issued."""
+    out: Dict[str, str] = {}
+    for stmt in session.statements:
+        if "UPDATE agent_org_nodes SET reports_to" not in str(stmt):
+            continue
+        params = stmt.compile().params
+        out[params["aid"]] = params["mgr"]
+    return out
+
+
+def _agent(agent_id: str, name: str, reports_to: str | None = None) -> Dict[str, Any]:
+    return {"agent_id": agent_id, "name": name, "reports_to": reports_to}
+
+
+class TestALandedManagerGetsItsReportingLine:
+    @pytest.mark.asyncio
+    async def test_the_line_uses_the_destination_id_not_the_source_id(self):
+        """The remap still has to happen — it just has to happen against reality."""
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")]
+        landed = {"src-mgr": "dst-mgr", "src-sub": "dst-sub"}
+        dropped: List[Dict[str, str]] = []
+
+        await svc._link_reporting_lines(agents, landed, dropped)
+
+        assert _updates(session) == {"dst-sub": "dst-mgr"}
+        assert dropped == []
+
+
+class TestASkippedManagerLeavesNoDanglingPointer:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reason", ["name-already-exists", "adapter-cannot-run"])
+    async def test_the_subordinate_is_left_a_root_and_the_loss_is_named(self, reason):
+        """Both skip routes reach this code the same way — by the manager's absence.
+
+        Parametrised on the reason to document that the linker does not know or
+        care which gate declined the manager; what matters is that it is not in
+        `landed`.
+        """
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")]
+        landed = {"src-sub": "dst-sub"}  # the manager did not land, for `reason`
+        dropped: List[Dict[str, str]] = []
+
+        await svc._link_reporting_lines(agents, landed, dropped)
+
+        assert _updates(session) == {}, "no UPDATE may name a manager that was never inserted"
+        assert dropped == [
+            {
+                "agent_name": "Engineer",
+                "agent_id": "dst-sub",
+                "manager_name": "CEO",
+                "manager_source_agent_id": "src-mgr",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_manager_absent_from_the_template_entirely_is_also_reported(self):
+        """A hand-authored template can name an id that was never in the file."""
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [_agent("src-sub", "Engineer", reports_to="never-existed")]
+        dropped: List[Dict[str, str]] = []
+
+        await svc._link_reporting_lines(agents, {"src-sub": "dst-sub"}, dropped)
+
+        assert _updates(session) == {}
+        assert len(dropped) == 1
+        assert dropped[0]["manager_source_agent_id"] == "never-existed"
+        assert dropped[0]["manager_name"] == "", "no name is knowable for an id not in the template"
+
+    @pytest.mark.asyncio
+    async def test_a_skipped_subordinate_is_not_reported_as_a_dropped_line(self):
+        """It has no reporting line to lose — it was never created."""
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")]
+        dropped: List[Dict[str, str]] = []
+
+        await svc._link_reporting_lines(agents, {"src-mgr": "dst-mgr"}, dropped)
+
+        assert _updates(session) == {}
+        assert dropped == []
+
+
+class TestNothingIsLostWhenNothingIsSkipped:
+    @pytest.mark.asyncio
+    async def test_every_declared_reporting_line_survives_a_clean_import(self):
+        """The no-data-loss invariant, asserted rather than assumed."""
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [
+            _agent("a", "CEO"),
+            _agent("b", "VP", reports_to="a"),
+            _agent("c", "Engineer", reports_to="b"),
+            _agent("d", "Engineer II", reports_to="b"),
+        ]
+        landed = {"a": "A", "b": "B", "c": "C", "d": "D"}
+        dropped: List[Dict[str, str]] = []
+
+        await svc._link_reporting_lines(agents, landed, dropped)
+
+        assert _updates(session) == {"B": "A", "C": "B", "D": "B"}
+        assert dropped == []
+        declared = sum(1 for a in agents if a["reports_to"])
+        assert len(_updates(session)) + len(dropped) == declared, "every declared line is either attached or reported"
+
+
+class TestTheImportActuallyRunsPassThree:
+    """The wiring, not just the helper.
+
+    A correct `_link_reporting_lines` that `execute_import` never calls would
+    leave every imported agent a root and every one of the tests above green.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_import_links_landed_agents_and_reports_the_rest(self):
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        template = {
+            "agents": [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")],
+        }
+        company_id = uuid.uuid4()
+
+        async def _import_agent(agent, *a, **kw):
+            # The manager is skipped; the subordinate lands.
+            return None if agent["name"] == "CEO" else "dst-sub"
+
+        with (
+            patch.object(PortabilityService, "_validate_schema", return_value=None),
+            patch.object(PortabilityService, "_resolve_or_create_company", AsyncMock(return_value=company_id)),
+            patch.object(PortabilityService, "_import_agent", side_effect=_import_agent),
+        ):
+            result = await svc.execute_import(template)
+
+        assert result["skipped"]["agents"] == ["CEO"]
+        assert _updates(session) == {}, "pass 3 must not link a manager that was skipped"
+        assert result["dropped_reporting_lines"] == [
+            {
+                "agent_name": "Engineer",
+                "agent_id": "dst-sub",
+                "manager_name": "CEO",
+                "manager_source_agent_id": "src-mgr",
+            }
+        ], "the lost reporting line must reach the caller, not only the log"

--- a/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
+++ b/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
@@ -56,6 +56,18 @@ class _FakeSession:
         return SimpleNamespace(commit=AsyncMock(), rollback=AsyncMock())
 
 
+COMPANY = "co-under-test"
+
+
+def _update_params(session: _FakeSession) -> List[Dict[str, Any]]:
+    """Bound params of every reporting-line UPDATE the linker issued."""
+    return [
+        stmt.compile().params
+        for stmt in session.statements
+        if "UPDATE agent_org_nodes SET reports_to" in str(stmt)
+    ]
+
+
 def _updates(session: _FakeSession) -> Dict[str, str]:
     """agent_id -> reports_to, for every UPDATE the linker issued."""
     out: Dict[str, str] = {}
@@ -81,7 +93,7 @@ class TestALandedManagerGetsItsReportingLine:
         landed = {"src-mgr": "dst-mgr", "src-sub": "dst-sub"}
         dropped: List[Dict[str, str]] = []
 
-        await svc._link_reporting_lines(agents, landed, dropped)
+        await svc._link_reporting_lines(agents, landed, dropped, COMPANY)
 
         assert _updates(session) == {"dst-sub": "dst-mgr"}
         assert dropped == []
@@ -103,7 +115,7 @@ class TestASkippedManagerLeavesNoDanglingPointer:
         landed = {"src-sub": "dst-sub"}  # the manager did not land, for `reason`
         dropped: List[Dict[str, str]] = []
 
-        await svc._link_reporting_lines(agents, landed, dropped)
+        await svc._link_reporting_lines(agents, landed, dropped, COMPANY)
 
         assert _updates(session) == {}, "no UPDATE may name a manager that was never inserted"
         assert dropped == [
@@ -123,7 +135,7 @@ class TestASkippedManagerLeavesNoDanglingPointer:
         agents = [_agent("src-sub", "Engineer", reports_to="never-existed")]
         dropped: List[Dict[str, str]] = []
 
-        await svc._link_reporting_lines(agents, {"src-sub": "dst-sub"}, dropped)
+        await svc._link_reporting_lines(agents, {"src-sub": "dst-sub"}, dropped, COMPANY)
 
         assert _updates(session) == {}
         assert len(dropped) == 1
@@ -138,7 +150,7 @@ class TestASkippedManagerLeavesNoDanglingPointer:
         agents = [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")]
         dropped: List[Dict[str, str]] = []
 
-        await svc._link_reporting_lines(agents, {"src-mgr": "dst-mgr"}, dropped)
+        await svc._link_reporting_lines(agents, {"src-mgr": "dst-mgr"}, dropped, COMPANY)
 
         assert _updates(session) == {}
         assert dropped == []
@@ -159,7 +171,7 @@ class TestNothingIsLostWhenNothingIsSkipped:
         landed = {"a": "A", "b": "B", "c": "C", "d": "D"}
         dropped: List[Dict[str, str]] = []
 
-        await svc._link_reporting_lines(agents, landed, dropped)
+        await svc._link_reporting_lines(agents, landed, dropped, COMPANY)
 
         assert _updates(session) == {"B": "A", "C": "B", "D": "B"}
         assert dropped == []
@@ -204,3 +216,29 @@ class TestTheImportActuallyRunsPassThree:
                 "manager_source_agent_id": "src-mgr",
             }
         ], "the lost reporting line must reach the caller, not only the log"
+
+
+class TestTheUpdateCannotReachAnotherCompany:
+    @pytest.mark.asyncio
+    async def test_every_update_is_scoped_to_the_importing_company(self):
+        """`agent_id` is table-wide UNIQUE today, so the company clause is
+        redundant — and that is exactly why it is easy to drop.
+
+        The constraint is declared in a migration three files away. If it ever
+        became per-company — the natural change the first time two tenants want
+        the same agent slug — an UPDATE matching on `agent_id` alone would begin
+        rewriting another tenant's hierarchy with no error. Asserting the bound
+        parameter keeps that safety visible at this call site rather than
+        inferred from a distant schema.
+        """
+        session = _FakeSession()
+        svc = PortabilityService(session)
+        agents = [_agent("src-mgr", "CEO"), _agent("src-sub", "Engineer", reports_to="src-mgr")]
+
+        await svc._link_reporting_lines(agents, {"src-mgr": "M", "src-sub": "S"}, [], COMPANY)
+
+        params = _update_params(session)
+        assert params, "no UPDATE was issued, so this guard would pass vacuously"
+        assert all(p["cid"] == COMPANY for p in params), (
+            f"an UPDATE was not scoped to the importing company: {params}"
+        )

--- a/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
+++ b/autobot-backend/llc/tests/test_portability_reporting_lines_14811.py
@@ -62,9 +62,7 @@ COMPANY = "co-under-test"
 def _update_params(session: _FakeSession) -> List[Dict[str, Any]]:
     """Bound params of every reporting-line UPDATE the linker issued."""
     return [
-        stmt.compile().params
-        for stmt in session.statements
-        if "UPDATE agent_org_nodes SET reports_to" in str(stmt)
+        stmt.compile().params for stmt in session.statements if "UPDATE agent_org_nodes SET reports_to" in str(stmt)
     ]
 
 
@@ -239,6 +237,4 @@ class TestTheUpdateCannotReachAnotherCompany:
 
         params = _update_params(session)
         assert params, "no UPDATE was issued, so this guard would pass vacuously"
-        assert all(p["cid"] == COMPANY for p in params), (
-            f"an UPDATE was not scoped to the importing company: {params}"
-        )
+        assert all(p["cid"] == COMPANY for p in params), f"an UPDATE was not scoped to the importing company: {params}"

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Füllen Sie alle Geheimniswerte oben aus, bevor Sie importieren.",
       "importSuccess": "Import erfolgreich — Unternehmens-ID:",
       "warningsLabel": "Warnungen:",
+      "droppedReportingLinesLabel": "Berichtslinien, die nicht übernommen werden konnten:",
+      "droppedReportingLine": "{agent} wurde ohne Vorgesetzten importiert: {manager} wurde nicht erstellt.",
       "importFailed": "Import fehlgeschlagen:",
       "toastTemplateExported": "Vorlage erfolgreich exportiert",
       "toastTemplateExportFailed": "Vorlagenexport fehlgeschlagen",

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -8440,6 +8440,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Complete todos los valores de secretos anteriores antes de importar.",
       "importSuccess": "Importación exitosa — ID de empresa:",
       "warningsLabel": "Advertencias:",
+      "droppedReportingLinesLabel": "Líneas de reporte que no se pudieron conservar:",
+      "droppedReportingLine": "{agent} se importó sin responsable: {manager} no se creó.",
       "importFailed": "La importación falló:",
       "toastTemplateExported": "Plantilla exportada correctamente",
       "toastTemplateExportFailed": "Error al exportar la plantilla",

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Renseignez toutes les valeurs de secret ci-dessus avant d'importer.",
       "importSuccess": "Importation réussie — ID de l'entreprise :",
       "warningsLabel": "Avertissements :",
+      "droppedReportingLinesLabel": "Liens hiérarchiques non conservés :",
+      "droppedReportingLine": "{agent} a été importé sans responsable : {manager} n'a pas été créé.",
       "importFailed": "Échec de l'importation :",
       "toastTemplateExported": "Modèle exporté avec succès",
       "toastTemplateExportFailed": "Échec de l'exportation du modèle",

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Preencha todos os valores de segredos acima antes de importar.",
       "importSuccess": "Importação bem-sucedida — ID da empresa:",
       "warningsLabel": "Avisos:",
+      "droppedReportingLinesLabel": "Linhas de reporte que não puderam ser mantidas:",
+      "droppedReportingLine": "{agent} foi importado sem gestor: {manager} não foi criado.",
       "importFailed": "Falha na importação:",
       "toastTemplateExported": "Modelo exportado com sucesso",
       "toastTemplateExportFailed": "Falha ao exportar o modelo",

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -8452,6 +8452,8 @@
       "secretMappingIncomplete": "Fill in all secret values above before importing.",
       "importSuccess": "Import successful — company ID:",
       "warningsLabel": "Warnings:",
+      "droppedReportingLinesLabel": "Reporting lines that could not be kept:",
+      "droppedReportingLine": "{agent} was imported without a manager: {manager} was not created.",
       "importFailed": "Import failed:",
       "toastTemplateExported": "Template exported successfully",
       "toastTemplateExportFailed": "Template export failed",

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -76524,6 +76524,13 @@ export interface components {
             skipped: {
                 [key: string]: string[];
             };
+            /**
+             * Dropped Reporting Lines
+             * @default []
+             */
+            dropped_reporting_lines: {
+                [key: string]: string;
+            }[];
             /** Warnings */
             warnings: string[];
         } & {

--- a/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
+++ b/autobot-frontend/src/views/llc/CompanyPortabilityView.vue
@@ -186,6 +186,14 @@
             <ul v-if="importResult.created_entities" class="result-counts">
               <li v-for="(v, k) in importResult.created_entities" :key="k">{{ k }}: {{ v }}</li>
             </ul>
+            <div v-if="importResult.droppedReportingLines.length > 0" class="dropped-reporting-lines">
+              <p>{{ t('llc.portability.droppedReportingLinesLabel') }}</p>
+              <ul>
+                <li v-for="(link, i) in importResult.droppedReportingLines" :key="i">
+                  {{ t('llc.portability.droppedReportingLine', { agent: link.agent_name, manager: link.manager_name }) }}
+                </li>
+              </ul>
+            </div>
             <div v-if="importResult.warnings.length > 0">
               <p>{{ t('llc.portability.warningsLabel') }}</p>
               <ul><li v-for="(w, i) in importResult.warnings" :key="i">{{ w }}</li></ul>
@@ -256,11 +264,22 @@ interface ImportPreview {
   warnings: string[]
 }
 
+interface DroppedReportingLine {
+  agent_name: string
+  agent_id: string
+  manager_name: string
+  manager_source_agent_id: string
+}
+
 interface ImportResultDisplay {
   ok: boolean
   company_id?: string
   created_entities?: Record<string, number>
   warnings: string[]
+  // Reporting lines the import could not honour (#14811). Kept structured so it
+  // can be rendered in the operator's locale; `warnings` is server-composed
+  // English and cannot be translated.
+  droppedReportingLines: DroppedReportingLine[]
   error?: string
 }
 
@@ -433,6 +452,7 @@ async function executeImport(): Promise<void> {
       importResult.value = {
         ok: false,
         warnings: [],
+        droppedReportingLines: [],
         error: (errBody.detail as string) ?? `${res.status} ${res.statusText}`,
       }
       showToast(t('llc.portability.toastImportFailed'), 'error')
@@ -444,12 +464,13 @@ async function executeImport(): Promise<void> {
       company_id: body.company_id as string,
       created_entities: body.created_entities as Record<string, number>,
       warnings: (body.warnings as string[]) ?? [],
+      droppedReportingLines: (body.dropped_reporting_lines as DroppedReportingLine[]) ?? [],
     }
     showToast(t('llc.portability.toastImportCompleted'), 'success')
   } catch (e) {
     const msg = e instanceof Error ? e.message : t('llc.portability.toastImportFailed')
     logger.error('Import execute failed:', e)
-    importResult.value = { ok: false, warnings: [], error: msg }
+    importResult.value = { ok: false, warnings: [], droppedReportingLines: [], error: msg }
     showToast(t('llc.portability.toastImportFailedMsg', { msg }), 'error')
   } finally {
     executingImport.value = false


### PR DESCRIPTION
Closes #14811.

## Thinking Path

`execute_import` pre-mints a destination UUID for every agent in the template
before any INSERT, so `reports_to` can be remapped without depending on the order
agents appear in. `_import_agent` then decides, per agent, whether the row is
actually created — a name already used in the target company, an adapter that
cannot run on this host (#14800), or a duplicate name inside the template itself
all return `None`.

So **pass 1 predicts the insert set and pass 2 decides it**, and nothing
reconciled the two. A subordinate whose manager was skipped was written with the
manager's pre-minted UUID: an id belonging to a row that was never inserted.
There is no foreign key on `reports_to` — confirmed in both the migration and the
model — so nothing rejected it, at import time or ever.

The consequence is worse than a broken pointer. `/api/agents`' org tree roots on
`reports_to IS NULL` and matches children by `agent_id`, so an agent referencing
a nonexistent manager is **neither a root nor anyone's child**: it disappears
from the tree entirely, cannot be delegated to, and cannot escalate — while the
import reports success and the LLC org chart still renders it, because that
endpoint promotes an unresolvable parent to a root. That asymmetry is why this
survived: the UI most people look at hides it.

**Rejected alternatives.** Hoisting the skip checks into pass 1 does not work —
the intra-template duplicate-name route is only decidable *during* pass 2, and
duplicating the adapter gate would fork it from the INSERT, exactly the drift
`TestTheGateAndTheInsertAgree` was written to prevent. Failing the whole import
reverses #14800's deliberate choice of skip-with-warning. Adding an FK is not
available either: it would fail to apply against any database already carrying
orphans.

## What Changed

- `llc/services/portability.py` — pass 2 records what actually **landed**; a new
  pass 3 (`_link_reporting_lines`) attaches `reports_to` only for managers in
  that set. `_import_agent` no longer resolves `reports_to` at all.
- Unhonourable lines are returned as structured `dropped_reporting_lines`, not
  folded into `warnings` — those are server-composed English f-strings the UI
  cannot translate.
- `llc/api/portability.py` — `ImportExecuteResponse.dropped_reporting_lines`.
- `CompanyPortabilityView.vue` — renders them **above** the warnings list, so a
  lost manager is not buried under unrelated prose.
- All 11 locales get `droppedReportingLinesLabel` and `droppedReportingLine`.

On nulling and the no-data-loss rule: the edge is already unhonourable — the
target does not exist. The choice is between an unresolvable pointer (invisible,
undelegatable agent) and a resolvable absence (a visible root). Nothing in the
source template is mutated, and the intended manager's source id is carried into
the response verbatim, so the information is reported rather than discarded. The
requirement this had to meet is that the drop is **named in the result**, not
merely logged — it is.

## Verification

Six tests in `llc/tests/test_portability_reporting_lines_14811.py`: a landed
manager links to the *destination* id; both skip routes leave the subordinate a
root and name the loss; a manager absent from the template entirely is reported
too; a skipped **subordinate** is not reported (it had no line to lose); and a
clean import asserts `attached + reported == declared`, so no line can vanish
unaccounted for.

The last class drives `execute_import` itself, not just the helper — a correct
`_link_reporting_lines` that pass 3 never calls would leave every agent a root
and keep the other five green.

**Mutation evidence.** The linker reproduced faithfully, then mutated to resolve
against the pass-1 prediction (the pre-fix behaviour), with the manager skipped:

```
FIXED    updates={}                         no_dangling_update=PASS  loss_is_named=PASS
PRE-FIX  updates={'dst-sub': 'dst-mgr'}     no_dangling_update=FAIL  loss_is_named=FAIL
```

`dst-mgr` is precisely the pre-minted id of a row that was never inserted. Both
assertions flip.

**i18n:** the four keys already translated in this namespace (de/es/fr/pt) got
real translations; the six that carry English placeholders throughout
`llc.portability` (ar, fa, he, lv, pl, ur) follow that existing convention rather
than inventing translations I cannot check. Key parity holds across all 11, which
is what `locale-parity.test.ts` enforces.

Not run locally — this repo's suites are not executed from the working tree. CI
is the evidence for the suite itself.

## Model Used

Claude Opus 5 (1M context)
