### PR TITLE
feat(chat): add an explicit dry-run backfill for legacy agent session scoping (#14756)

### DIFF
--- a/autobot-backend/chat_history/session_scope_backfill.py
+++ b/autobot-backend/chat_history/session_scope_backfill.py
@@ -1,0 +1,236 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""One-time backfill of tenancy scoping onto legacy agent sessions (#14756).
+
+#12685 gave LLC agent conversations first-class ``company_id`` / ``session_kind``
+metadata and filtered them out of the general ``GET /api/chat/sessions`` list.
+Sessions created before that carry neither field, so they still appear there —
+including the one named in #12685's reproduction.
+
+They were deliberately not reclassified on read. The only signal a legacy agent
+session carries is its display title (``"CEO · <company_id>"``), and matching on
+a title is precisely the fragility #12685 removed; rebuilding the guard on it
+would put the bug back inside the fix. So this is an explicit, operator-run
+backfill instead of an implicit filter.
+
+**What makes a classification confident rather than a guess.** The title alone is
+not enough. A session is only tagged when the id parsed out of its title
+resolves to a company that actually exists. A user who happens to name a chat
+``"CEO · notes"`` — or even ``"CEO · <a uuid that is not a company>"`` — is
+reported and left alone. A heuristic that silently *hides* someone's
+conversation is worse than one that leaves an agent conversation visible, so
+every ambiguous case fails towards visible.
+
+Additive and idempotent: it only ever writes the two scoping fields, via
+``update_session_metadata`` (which merges rather than replaces, #12129), and
+skips any session that already carries either field. Nothing is deleted,
+renamed, or moved.
+
+Not auto-run: nothing here executes on import, there is no scheduled or Celery
+hook, and the CLI defaults to a dry run. Writing requires ``--apply``.
+
+Usage::
+
+    python -m chat_history.session_scope_backfill              # dry run, writes nothing
+    python -m chat_history.session_scope_backfill --apply
+
+Like ``session_reply_backfill``, this is an unlocked read-modify-write: run it
+when the sessions it touches have no concurrent writer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Set
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+SESSION_KIND_AGENT = "agent"
+
+# The title #12685's producer wrote: `CEO · ${company_id}` (CeoChatView.vue).
+# The role half is captured but never trusted on its own — only the id is acted
+# on, and only after it is confirmed to name a real company.
+_AGENT_TITLE = re.compile(
+    r"^(?P<role>[^\W\d_][\w .\-]*)\s+·\s+(?P<company_id>[0-9a-fA-F-]{8,})$",
+    re.UNICODE,
+)
+
+_UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+
+
+@dataclass
+class Candidate:
+    """One legacy session and what the backfill decided about it."""
+
+    session_id: str
+    name: str
+    company_id: str = ""
+    reason: str = ""
+
+
+@dataclass
+class BackfillPlan:
+    """What a dry run found. ``taggable`` is the only group that gets written."""
+
+    taggable: List[Candidate] = field(default_factory=list)
+    already_tagged: List[Candidate] = field(default_factory=list)
+    unclassified: List[Candidate] = field(default_factory=list)
+
+    @property
+    def scanned(self) -> int:
+        return len(self.taggable) + len(self.already_tagged) + len(self.unclassified)
+
+
+def is_already_scoped(session: Dict[str, Any]) -> bool:
+    """Mirrors ``api/chat_sessions._is_agent_scoped_session``.
+
+    Deliberately the same predicate the read path uses: a session this returns
+    True for is one the existing filter already covers, so tagging it again
+    would be a no-op write. Keeping the two in step is what makes a re-run
+    idempotent.
+    """
+    return bool(session.get("companyId")) or session.get("sessionKind") == SESSION_KIND_AGENT
+
+
+def classify(session: Dict[str, Any], known_company_ids: Set[str]) -> Candidate:
+    """Decide what to do with one session. Pure — no I/O, no writes.
+
+    The whole judgement of this backfill lives here so it can be tested and
+    mutated directly, rather than inferred from what a run happened to write.
+    """
+    session_id = str(session.get("chatId") or "")
+    name = str(session.get("name") or "")
+    candidate = Candidate(session_id=session_id, name=name)
+
+    if is_already_scoped(session):
+        candidate.reason = "already carries scoping metadata"
+        return candidate
+
+    match = _AGENT_TITLE.match(name.strip())
+    if match is None:
+        candidate.reason = "title does not have the legacy agent shape"
+        return candidate
+
+    parsed = match.group("company_id").lower()
+    if not _UUID.match(parsed):
+        candidate.reason = "the id in the title is not a company id"
+        return candidate
+    if parsed not in known_company_ids:
+        # The check that separates a confident classification from a guess: the
+        # title says "CEO · <id>", but no such company exists, so this is a user
+        # chat that merely looks like one.
+        candidate.reason = "no company with that id exists"
+        return candidate
+
+    candidate.company_id = parsed
+    candidate.reason = "legacy agent session for an existing company"
+    return candidate
+
+
+def build_plan(sessions: Iterable[Dict[str, Any]], known_company_ids: Set[str]) -> BackfillPlan:
+    """Sort every session into exactly one bucket. Writes nothing."""
+    plan = BackfillPlan()
+    normalised = {str(cid).lower() for cid in known_company_ids}
+    for session in sessions:
+        candidate = classify(session, normalised)
+        if candidate.company_id:
+            plan.taggable.append(candidate)
+        elif is_already_scoped(session):
+            plan.already_tagged.append(candidate)
+        else:
+            plan.unclassified.append(candidate)
+    return plan
+
+
+async def apply_plan(plan: BackfillPlan, chat_mgr) -> int:
+    """Write the scoping fields for every taggable session. Returns count written.
+
+    Only ``company_id`` and ``session_kind`` are written, through
+    ``update_session_metadata``, which merges into the existing metadata rather
+    than replacing it — nothing else about the session is touched.
+    """
+    written = 0
+    for candidate in plan.taggable:
+        ok = await chat_mgr.update_session_metadata(
+            candidate.session_id,
+            {"company_id": candidate.company_id, "session_kind": SESSION_KIND_AGENT},
+        )
+        if ok:
+            written += 1
+        else:
+            logger.error(
+                "Could not write scoping metadata for session %s — leaving it untagged",
+                candidate.session_id,
+            )
+    return written
+
+
+async def load_known_company_ids() -> Set[str]:
+    """Every organization id, so a title's id can be confirmed against reality."""
+    from sqlalchemy import text
+
+    from user_management.database import get_async_session_factory
+
+    factory = get_async_session_factory()
+    async with factory() as session:
+        result = await session.execute(text("SELECT id FROM organizations"))
+        return {str(row[0]).lower() for row in result.fetchall()}
+
+
+def render(plan: BackfillPlan, *, applied: int | None = None) -> str:
+    """A report an operator can read before deciding to apply it."""
+    lines = [
+        f"scanned {plan.scanned} sessions",
+        f"  taggable       {len(plan.taggable)}",
+        f"  already tagged {len(plan.already_tagged)}",
+        f"  unclassified   {len(plan.unclassified)} (left untouched)",
+    ]
+    if plan.taggable:
+        lines.append("\ntaggable:")
+        lines += [f"  {c.session_id}  {c.name!r} -> company {c.company_id}" for c in plan.taggable]
+    if plan.unclassified:
+        lines.append("\nunclassified (reported, never guessed):")
+        lines += [f"  {c.session_id}  {c.name!r} — {c.reason}" for c in plan.unclassified]
+    if applied is None:
+        lines.append("\nDRY RUN — nothing was written. Re-run with --apply to write.")
+    else:
+        lines.append(f"\napplied: {applied} session(s) tagged")
+    return "\n".join(lines)
+
+
+async def _main(apply_changes: bool) -> None:
+    from chat_history import ChatHistoryManager
+
+    chat_mgr = ChatHistoryManager()
+    sessions = await chat_mgr.list_sessions()
+    plan = build_plan(sessions, await load_known_company_ids())
+
+    if not apply_changes:
+        print(render(plan))
+        return
+    written = await apply_plan(plan, chat_mgr)
+    print(render(plan, applied=written))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill company_id/session_kind onto legacy agent chat sessions (#14756).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="write the metadata. Without this the run reports and changes nothing.",
+    )
+    args = parser.parse_args()
+    asyncio.run(_main(args.apply))
+
+
+if __name__ == "__main__":
+    main()

--- a/autobot-backend/chat_history/session_scope_backfill.py
+++ b/autobot-backend/chat_history/session_scope_backfill.py
@@ -212,11 +212,14 @@ async def _main(apply_changes: bool) -> None:
     sessions = await chat_mgr.list_sessions()
     plan = build_plan(sessions, await load_known_company_ids())
 
+    # Reported through the logger, not print(), matching
+    # `session_reply_backfill` and `workflow_redis_backfill` — the two existing
+    # operator-run backfills — and the repo's logging standard.
     if not apply_changes:
-        print(render(plan))
+        logger.info("%s", render(plan))
         return
     written = await apply_plan(plan, chat_mgr)
-    print(render(plan, applied=written))
+    logger.info("%s", render(plan, applied=written))
 
 
 def main() -> None:

--- a/autobot-backend/chat_history/session_scope_backfill.py
+++ b/autobot-backend/chat_history/session_scope_backfill.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import pathlib
 import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Set
@@ -205,12 +206,42 @@ def render(plan: BackfillPlan, *, applied: int | None = None) -> str:
     return "\n".join(lines)
 
 
+def _sessions_on_disk(chat_mgr) -> int:
+    """How many session files exist, independent of the listing path.
+
+    `list_sessions` catches its own errors and returns `[]`, so a failed listing
+    and an install with no chats produce the identical "scanned 0". That reads
+    as "nothing to do" — the shape this repo keeps getting bitten by — and for a
+    backfill it would mean reporting success having examined nothing.
+    """
+    directory = pathlib.Path(chat_mgr._get_chats_directory())
+    if not directory.is_dir():
+        return 0
+    return len(list(directory.glob("*_chat.json")))
+
+
 async def _main(apply_changes: bool) -> None:
     from chat_history import ChatHistoryManager
 
     chat_mgr = ChatHistoryManager()
     sessions = await chat_mgr.list_sessions()
-    plan = build_plan(sessions, await load_known_company_ids())
+
+    on_disk = _sessions_on_disk(chat_mgr)
+    if not sessions and on_disk:
+        raise RuntimeError(
+            f"listing returned no sessions while {on_disk} session file(s) exist on disk — "
+            "the listing failed silently. Refusing to report a clean scan of nothing."
+        )
+
+    try:
+        known = await load_known_company_ids()
+    except Exception as exc:
+        raise RuntimeError(
+            f"could not read the company list, so no title could be confirmed against a real "
+            f"company: {exc}. Nothing was written."
+        ) from exc
+
+    plan = build_plan(sessions, known)
 
     # Reported through the logger, not print(), matching
     # `session_reply_backfill` and `workflow_redis_backfill` — the two existing

--- a/autobot-backend/chat_history/session_scope_backfill_test.py
+++ b/autobot-backend/chat_history/session_scope_backfill_test.py
@@ -1,0 +1,177 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#14756: the legacy-session backfill must never guess.
+
+#12685 left pre-existing agent sessions untagged on purpose — the only signal
+they carry is a display title, and matching on titles is the fragility that
+issue removed. This backfill is the explicit, operator-run alternative, and its
+whole safety argument rests on one thing: a title is acted on **only** when the
+id inside it names a company that actually exists.
+
+The direction of failure matters and is asserted here. Leaving an agent chat
+visible is a cosmetic miss; hiding a user's own conversation is data loss from
+their point of view. So every ambiguous case must land in `unclassified`, not
+in `taggable`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chat_history.session_scope_backfill import (
+    SESSION_KIND_AGENT,
+    apply_plan,
+    build_plan,
+    classify,
+    is_already_scoped,
+    render,
+)
+
+REAL_COMPANY = "22d907a9-31fd-4bb4-8b42-89aa1c2d3e4f"
+OTHER_UUID = "11111111-2222-3333-4444-555555555555"
+KNOWN = {REAL_COMPANY}
+
+
+def _session(chat_id, name, **extra):
+    return {"chatId": chat_id, "name": name, **extra}
+
+
+LEGACY_AGENT = _session("s-legacy", f"CEO · {REAL_COMPANY}")
+ODD_USER_TITLE = _session("s-user", "CEO · notes from standup")
+ALREADY_TAGGED = _session("s-tagged", f"CEO · {REAL_COMPANY}", companyId=REAL_COMPANY, sessionKind="agent")
+
+
+class TestTheFixtureFromTheIssue:
+    """A legacy agent session, an odd user title, and an already-tagged one."""
+
+    def test_each_lands_in_exactly_one_bucket(self):
+        plan = build_plan([LEGACY_AGENT, ODD_USER_TITLE, ALREADY_TAGGED], KNOWN)
+
+        assert [c.session_id for c in plan.taggable] == ["s-legacy"]
+        assert [c.session_id for c in plan.already_tagged] == ["s-tagged"]
+        assert [c.session_id for c in plan.unclassified] == ["s-user"]
+        assert plan.scanned == 3
+
+    def test_the_legacy_session_is_tagged_with_the_id_from_its_title(self):
+        candidate = classify(LEGACY_AGENT, KNOWN)
+        assert candidate.company_id == REAL_COMPANY
+
+
+class TestAnAmbiguousSessionIsReportedNeverGuessed:
+    @pytest.mark.parametrize(
+        "name,why",
+        [
+            ("CEO · notes from standup", "the id is not a uuid at all"),
+            (f"CEO · {OTHER_UUID}", "a well-formed uuid that names no company"),
+            ("Quarterly planning", "no separator, an ordinary chat name"),
+            (f"{REAL_COMPANY}", "the bare id with no role half"),
+            (f"CEO·{REAL_COMPANY}", "no spaces around the separator"),
+        ],
+    )
+    def test_it_is_never_taggable(self, name, why):
+        plan = build_plan([_session("s", name)], KNOWN)
+
+        assert plan.taggable == [], f"would have tagged a session where {why}"
+        assert len(plan.unclassified) == 1
+        assert plan.unclassified[0].reason, "an unclassified session must say why"
+
+    def test_a_uuid_that_names_no_company_is_the_case_that_matters(self):
+        """The check that separates a classification from a guess.
+
+        This title is byte-for-byte the shape the real producer wrote. Only the
+        lookup against existing companies tells them apart, so a backfill that
+        trusted the title would tag this and hide a user's chat.
+        """
+        candidate = classify(_session("s", f"CEO · {OTHER_UUID}"), KNOWN)
+
+        assert candidate.company_id == ""
+        assert "no company" in candidate.reason
+
+
+class TestReRunningChangesNothing:
+    @pytest.mark.asyncio
+    async def test_an_already_tagged_session_is_never_rewritten(self):
+        writes = []
+
+        class _Mgr:
+            async def update_session_metadata(self, session_id, metadata):
+                writes.append((session_id, metadata))
+                return True
+
+        plan = build_plan([ALREADY_TAGGED], KNOWN)
+        written = await apply_plan(plan, _Mgr())
+
+        assert written == 0
+        assert writes == [], "a re-run must not rewrite what the first run tagged"
+
+    @pytest.mark.asyncio
+    async def test_the_second_pass_over_applied_output_finds_nothing_to_do(self):
+        """Idempotency asserted end to end, not by inspection.
+
+        The session dict is updated the way the read path would see it after a
+        write, then re-planned.
+        """
+        session = dict(LEGACY_AGENT)
+        plan = build_plan([session], KNOWN)
+        assert len(plan.taggable) == 1
+
+        applied = {**session, "companyId": plan.taggable[0].company_id, "sessionKind": SESSION_KIND_AGENT}
+        second = build_plan([applied], KNOWN)
+
+        assert second.taggable == []
+        assert len(second.already_tagged) == 1
+
+
+class TestApplyWritesOnlyTheScopingFields:
+    @pytest.mark.asyncio
+    async def test_exactly_two_keys_are_written(self):
+        writes = []
+
+        class _Mgr:
+            async def update_session_metadata(self, session_id, metadata):
+                writes.append((session_id, metadata))
+                return True
+
+        plan = build_plan([LEGACY_AGENT, ODD_USER_TITLE, ALREADY_TAGGED], KNOWN)
+        written = await apply_plan(plan, _Mgr())
+
+        assert written == 1
+        assert writes == [("s-legacy", {"company_id": REAL_COMPANY, "session_kind": "agent"})], (
+            "the backfill must write the scoping fields and nothing else — anything "
+            "more risks clobbering metadata it does not own"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failed_write_is_not_counted_as_applied(self):
+        class _Mgr:
+            async def update_session_metadata(self, session_id, metadata):
+                return False
+
+        plan = build_plan([LEGACY_AGENT], KNOWN)
+
+        assert await apply_plan(plan, _Mgr()) == 0
+
+
+class TestThePredicateMatchesTheReadPath:
+    def test_it_agrees_with_the_filter_it_has_to_satisfy(self):
+        """If these drift, a "tagged" session stays visible and the run looks done.
+
+        Mirrors `api/chat_sessions._is_agent_scoped_session`'s cases.
+        """
+        assert is_already_scoped({"companyId": "co-1"}) is True
+        assert is_already_scoped({"sessionKind": "agent"}) is True
+        assert is_already_scoped({"companyId": "", "sessionKind": "user"}) is False
+        assert is_already_scoped({}) is False
+
+
+class TestTheDryRunReportSaysItWroteNothing:
+    def test_it_names_the_unclassified_and_marks_itself_a_dry_run(self):
+        plan = build_plan([LEGACY_AGENT, ODD_USER_TITLE], KNOWN)
+        report = render(plan)
+
+        assert "DRY RUN" in report
+        assert "nothing was written" in report
+        assert "s-user" in report, "an operator must see what was skipped, not just the count"
+        assert "applied" not in report.replace("Re-run with --apply", "")


### PR DESCRIPTION
Closes #14756.

## Thinking Path

#12685 gave LLC agent conversations first-class `company_id` / `session_kind`
metadata and filtered them out of the general session list. Sessions created
before it carry neither field and still appear there. They were deliberately not
reclassified on read, because the only signal they carry is a display title
(`"CEO · <company_id>"`) and matching on titles is precisely the fragility
#12685 removed — rebuilding the guard on it would put the bug back inside the
fix.

**The problem is that a title match alone is still a guess.** A user can name a
chat `"CEO · notes from standup"`, and — the case that actually matters — a user
can name one `"CEO · <a well-formed uuid that is not a company>"`. That second
title is byte-for-byte the shape the real producer wrote. Nothing about the
string distinguishes them.

So the classification is not "does the title look right" but **"does the id in
the title name a company that exists"**. The lookup against `organizations` is
what turns a guess into a confident classification, and it is the only reason
this is safe to run at all.

**The direction of failure was the design constraint.** Leaving an agent chat
visible is a cosmetic miss. Hiding a user's own conversation is, from their
point of view, data loss — and it would be silent. Every ambiguous case
therefore lands in `unclassified` and is reported, never tagged.

I followed the shape of the two existing backfills rather than inventing one:
`chat_history/session_reply_backfill.py` (same subsystem) and
`services/workflow_redis_backfill.py`. Same properties — nothing runs on import,
no scheduled or Celery hook, dry run by default, writing requires `--apply`.

## What Changed

- `chat_history/session_scope_backfill.py` — `classify` / `build_plan` are pure
  and hold the entire judgement, so it can be tested and mutated directly rather
  than inferred from what a run happened to write. `apply_plan` writes through
  `update_session_metadata`, which merges rather than replaces (#12129).
- `is_already_scoped` mirrors `api/chat_sessions._is_agent_scoped_session`
  deliberately: if those two drift, a "tagged" session stays visible and the run
  still reports success.

Only `company_id` and `session_kind` are ever written. Nothing is deleted,
renamed, or moved.

## Verification

The four acceptance criteria:

- **dry-run reports without modifying** — `--apply` is required to write; the
  report names every skipped session and its reason, not just a count.
- **applying makes the existing filter cover them** — the fields written are
  exactly the two `_is_agent_scoped_session` reads. No new matching logic in the
  read path.
- **cannot-classify is left untouched and reported** — five parametrised cases.
- **idempotent** — asserted end to end: plan, apply, re-plan, expect zero.

Exercised against the issue's fixture plus four adversarial titles:

```
OK  s-legacy   CEO · 22d907a9-…                -> taggable
OK  s-user     CEO · notes from standup        -> unclassified
OK  s-tag      CEO · 22d907a9-… (tagged)       -> already
OK  s-fake     CEO · 11111111-…                -> unclassified
OK  s-plain    Quarterly planning              -> unclassified
OK  s-bare     22d907a9-…                      -> unclassified
OK  s-nospc    CEO·22d907a9-…                  -> unclassified
OK  s-cfo      CFO · 22d907a9-…                -> taggable

applied=2  writes=[('s-legacy', {'company_id': '22d907a9-…', 'session_kind': 'agent'}), …]
second pass taggable: 0
```

**Mutation evidence.** The safety property is the company-existence lookup, so I
removed it and re-ran:

```
FIXED (company lookup present)     taggable=[]           user_chat_hidden=no
MUTANT (title trusted blindly)     taggable=['s-fake']   user_chat_hidden=YES -- data loss
```

Without that check a user's chat named `CEO · <any uuid>` is silently hidden.
`test_a_uuid_that_names_no_company_is_the_case_that_matters` is the assertion
that fails on the mutant.

Not run against any live data, and not run from the working tree — this is the
repair-path convention the sibling backfills follow. CI is the evidence for the
suite.

## Model Used

Claude Opus 5 (1M context)
