### PR TITLE
fix(provision): stop a vector database installing an LLM runtime, and pin the deploy gate (#14682, #14681)

### DIFF
--- a/autobot-slm-backend/ansible/inventory/group_vars/all.yml
+++ b/autobot-slm-backend/ansible/inventory/group_vars/all.yml
@@ -418,9 +418,17 @@ role_xrdp_active: >-
 # It previously had two byte-identical siblings kept in step by a diff guard;
 # the guard worked but enforcing three copies was never the fix #7095 asked for.
 # The test inventory's copy is generated from this file at CI time.
+# #14682: `ai_stack` is NOT an LLM signal. It is granted by `chromadb` and
+# `tts-worker` as well as by `ai-stack` and `autobot-llm-*`, so gating on it
+# meant declaring a vector database or a speech synthesiser ran roles/llm --
+# curl https://ollama.ai/install.sh piped to a root shell, a systemd unit, and
+# a model pull -- on that host.
+#
+# `llm_nodes` carries exactly the two tokens that do mean "runs an LLM runtime"
+# (`ai-stack`, `autobot-llm-`), so it is the correct signal and the `ai_stack`
+# clause is dropped. A node declaring `llm` still matches on the first clause.
 role_llm_active: >-
   {{ ('llm' in (node_roles_declared | default(node_roles | default([])))) or
-     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
      (inventory_hostname in (groups.get('llm_nodes', []) | default([]))) }}
 
 role_tts_worker_active: >-

--- a/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
+++ b/autobot-slm-backend/ansible/playbooks/vars/role_active_facts.yml
@@ -116,9 +116,17 @@ role_xrdp_active: >-
 # closed over the role map. Per #14560 a fact gating a privileged group must
 # read node_roles_declared, or the group half is gated while the node_roles
 # half is not and a detected-but-undeclared node still activates the role.
+# #14682: `ai_stack` is NOT an LLM signal. It is granted by `chromadb` and
+# `tts-worker` as well as by `ai-stack` and `autobot-llm-*`, so gating on it
+# meant declaring a vector database or a speech synthesiser ran roles/llm --
+# curl https://ollama.ai/install.sh piped to a root shell, a systemd unit, and
+# a model pull -- on that host.
+#
+# `llm_nodes` carries exactly the two tokens that do mean "runs an LLM runtime"
+# (`ai-stack`, `autobot-llm-`), so it is the correct signal and the `ai_stack`
+# clause is dropped. A node declaring `llm` still matches on the first clause.
 role_llm_active: >-
   {{ ('llm' in (node_roles_declared | default(node_roles | default([])))) or
-     (inventory_hostname in (groups.get('ai_stack', []) | default([]))) or
      (inventory_hostname in (groups.get('llm_nodes', []) | default([]))) }}
 
 role_tts_worker_active: >-

--- a/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
@@ -77,6 +77,30 @@ all:
       expected_role_slm_active: false
 
     # 5. AI Stack + LLM (co-located).
+    # #14682: chromadb grants ai_stack but is a vector database, not an LLM
+    # runtime. Gating role_llm_active on ai_stack meant declaring this ran the
+    # ollama installer under a root shell on that host.
+    test-chromadb-only-no-llm:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - chromadb
+      expected_role_ai_stack_active: true
+      expected_role_llm_active: false
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
+    # #14682: same shape via tts-worker — speech synthesis, not an LLM.
+    test-tts-worker-only-no-llm:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      node_roles:
+        - tts-worker
+      expected_role_ai_stack_active: true
+      expected_role_llm_active: false
+      expected_role_backend_active: false
+      expected_role_slm_active: false
+
     test-ai-stack-and-llm:
       ansible_host: 127.0.0.1
       ansible_connection: local

--- a/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
+++ b/autobot-slm-backend/ansible/tests/inventory/test_role_facts.yml
@@ -204,6 +204,13 @@ all:
     main:
       hosts:
         test-empty-roles-via-group: {}
+    # #14682: chromadb and tts-worker both GRANT ai_stack, so this is the real
+    # shape — a node legitimately in ai_stack that must not run an LLM. Before
+    # the fix, role_llm_active gated on ai_stack membership and fired here.
+    ai_stack:
+      hosts:
+        test-chromadb-only-no-llm: {}
+        test-tts-worker-only-no-llm: {}
     # SLM Manager hosts must be in slm_server group (matches install.sh
     # localhost.yml + seed-fleet-nodes.yml inventory layout).
     slm_server:

--- a/autobot-slm-backend/services/inventory_deploy_gate_test.py
+++ b/autobot-slm-backend/services/inventory_deploy_gate_test.py
@@ -95,18 +95,13 @@ def test_a_detection_only_node_is_no_deploy_target():
     )
     groups = _groups(node)
 
-    for leaked in (
-        "ai_stack",
-        "npu_worker",
-        "npu_workers",
-        "browser_worker",
-        "aiml",
-        "npu",
-        "browser",
-        "frontend",
-        "backend",
-        "slm_server",
-    ):
+    # #14681: this was a hand-written list of ten names and had drifted — it
+    # omitted `llm_nodes`, `ai` and `main`, so three gated groups had no
+    # detection-leak assertion at all. Derived from the gate itself now, which
+    # is the only version that cannot fall behind it.
+    gated = set(inventory_builder._DECLARED_ONLY_GROUPS)
+    assert {"llm_nodes", "ai", "main"} <= gated, "the gate no longer covers the groups this test was missing"
+    for leaked in sorted(gated):
         assert leaked not in groups, f"{leaked} still granted by detection alone"
 
     assert "redis" in groups, "ordinary groups must still come from detection"
@@ -182,3 +177,66 @@ def test_declaring_a_vector_database_does_not_activate_the_llm_runtime() -> None
     assert "chromadb" not in llm_tokens, "declaring chromadb would run the ollama installer"
     assert "tts-worker" not in llm_tokens, "declaring tts-worker would run the ollama installer"
     assert llm_tokens, "no token grants llm_nodes — role_llm_active could never fire"
+
+
+def test_the_legacy_vocabulary_cannot_grant_a_gated_group_by_detection() -> None:
+    """#14681: the legacy `ROLE_ANSIBLE_GROUPS` is a second way to reach a group.
+
+    `_close_over_role_groups` closes over `_ROLE_TO_GROUPS` only. If the legacy
+    map grants a gated group for a token the primary map does not, detection
+    through that route would bypass the closure's reasoning entirely. `vnc`
+    reaches its group solely through that map (#14638), so it is a live path,
+    not a theoretical one.
+    """
+    try:
+        from services.role_registry import ROLE_ANSIBLE_GROUPS
+    except Exception:  # pragma: no cover - registry unavailable in some harnesses
+        import pytest
+
+        pytest.skip("role_registry unavailable in this harness")
+
+    gated = set(inventory_builder._DECLARED_ONLY_GROUPS)
+    for token, granted in ROLE_ANSIBLE_GROUPS.items():
+        names = {granted} if isinstance(granted, str) else set(granted or ())
+        privileged = names & gated
+        if not privileged:
+            continue
+        node = _node(declared=[], detected=[token])
+        leaked = _groups(node) & privileged
+        assert not leaked, (
+            f"the legacy vocabulary lets detected token {token!r} grant gated group(s) {sorted(leaked)} "
+            "— the closure only reasons about _ROLE_TO_GROUPS"
+        )
+
+
+def test_a_new_non_deploy_role_shrinks_the_gate_and_the_pin_catches_it() -> None:
+    """#14681: the failure mode is a role added later, not a group edited today.
+
+    `_close_over_role_groups` excuses any group also granted by a role that
+    intersects no seed name (`shared_with_non_deploy`). So adding a token that
+    grants `llm_nodes` and nothing seed-adjacent does not widen the gate — it
+    REMOVES `llm_nodes` from it, because the group now looks shared with a
+    non-deploy role. Detection would then hand out `llm_nodes`, which is the
+    root-level ollama install path (#14682).
+
+    Nothing about that edit looks dangerous in review: a role is added to a map
+    and a group silently loses its gating. The set-equality pin above is what
+    turns it into a failing test, so this asserts the mechanism directly rather
+    than trusting that it will be noticed.
+    """
+    original = dict(inventory_builder._ROLE_TO_GROUPS)
+    try:
+        before = set(inventory_builder._close_over_role_groups(inventory_builder._DEPLOY_GATED_SEED))
+        assert "llm_nodes" in before, "llm_nodes is not gated to begin with — this test proves nothing"
+
+        inventory_builder._ROLE_TO_GROUPS["some-future-llm-role"] = frozenset({"llm_nodes"})
+        after = set(inventory_builder._close_over_role_groups(inventory_builder._DEPLOY_GATED_SEED))
+
+        assert "llm_nodes" not in after, (
+            "the closure no longer drops a group shared with a non-deploy role. If that was fixed "
+            "deliberately, this test should be replaced by one asserting the group STAYS gated."
+        )
+        assert before != after, "the gate did not change, so the pinned-set assertion would not catch this"
+    finally:
+        inventory_builder._ROLE_TO_GROUPS.clear()
+        inventory_builder._ROLE_TO_GROUPS.update(original)

--- a/autobot-slm-backend/services/inventory_deploy_gate_test.py
+++ b/autobot-slm-backend/services/inventory_deploy_gate_test.py
@@ -124,3 +124,61 @@ def test_declared_roles_keep_every_group_they_grant():
         ("tts-worker", "ai_stack"),
     ):
         assert expected in _groups(_node([role], [role])), f"declared {role} lost {expected}"
+
+
+# ---------------------------------------------------------------------------
+# #14681 — the derived gate must not be able to shrink unnoticed
+# ---------------------------------------------------------------------------
+
+
+def test_every_gated_group_is_pinned_by_name() -> None:
+    """The gate is derived, so a change to the role map can silently shrink it.
+
+    Four of the six derived names were pinned; `llm_nodes` and `ai` appeared
+    nowhere in this file, and neither did the seed name `main`. A group that
+    drops out of the gate stops being stripped from an undeclared node, which
+    reopens the privileged path the gate exists to close — silently, because
+    nothing asserted it was ever in there.
+
+    Pinned as a whole set rather than by adding two more names: the next group
+    to appear would otherwise be unpinned in exactly the same way.
+    """
+    from services.inventory_builder import _DECLARED_ONLY_GROUPS
+
+    expected = {
+        # seed (#14552)
+        "slm_server",
+        "backend",
+        "main",
+        "frontend",
+        "aiml",
+        "npu",
+        "browser",
+        # derived by _close_over_role_groups (#14567)
+        "ai",
+        "ai_stack",
+        "browser_worker",
+        "llm_nodes",
+        "npu_worker",
+        "npu_workers",
+    }
+    assert set(_DECLARED_ONLY_GROUPS) == expected, (
+        "the deploy gate changed. If a group was added, add it above. If one was REMOVED, "
+        "check that an undeclared node can no longer reach whatever that group provisions "
+        f"before updating this test.\n  missing: {sorted(expected - set(_DECLARED_ONLY_GROUPS))}"
+        f"\n  unexpected: {sorted(set(_DECLARED_ONLY_GROUPS) - expected)}"
+    )
+
+
+def test_declaring_a_vector_database_does_not_activate_the_llm_runtime() -> None:
+    """#14682: chromadb and tts-worker grant ai_stack but do not run an LLM.
+
+    Asserted on the role map rather than on the jinja: `llm_nodes` is the signal
+    `role_llm_active` now uses, so what matters is which tokens reach it.
+    """
+    from services.inventory_builder import _ROLE_TO_GROUPS
+
+    llm_tokens = {token for token, groups in _ROLE_TO_GROUPS.items() if "llm_nodes" in groups}
+    assert "chromadb" not in llm_tokens, "declaring chromadb would run the ollama installer"
+    assert "tts-worker" not in llm_tokens, "declaring tts-worker would run the ollama installer"
+    assert llm_tokens, "no token grants llm_nodes — role_llm_active could never fire"

--- a/autobot-slm-backend/services/inventory_deploy_gate_test.py
+++ b/autobot-slm-backend/services/inventory_deploy_gate_test.py
@@ -19,6 +19,7 @@ Two properties of that closure are load-bearing and pinned below.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -179,6 +180,29 @@ def test_declaring_a_vector_database_does_not_activate_the_llm_runtime() -> None
     assert llm_tokens, "no token grants llm_nodes — role_llm_active could never fire"
 
 
+def _legacy_role_groups() -> dict:
+    """`ROLE_ANSIBLE_GROUPS` read from source, without importing role_registry.
+
+    #14307's guard is right to object to importing it here: conftest does not
+    real-load `role_registry` (it pulls SQLAlchemy, above the dependency-light
+    bar that list holds to), so an import resolves to a MagicMock or not
+    depending on shard order — and a MagicMock iterates as empty, which would
+    make this test pass by examining nothing.
+
+    Parsing the literal is deterministic and needs no import at all.
+    """
+    src = (_SLM_ROOT / "services" / "role_registry.py").read_text(encoding="utf-8")
+    for node in ast.parse(src).body:
+        target = None
+        if isinstance(node, ast.AnnAssign):
+            target = getattr(node.target, "id", None)
+        elif isinstance(node, ast.Assign) and node.targets:
+            target = getattr(node.targets[0], "id", None)
+        if target == "ROLE_ANSIBLE_GROUPS":
+            return ast.literal_eval(node.value)
+    raise AssertionError("ROLE_ANSIBLE_GROUPS not found — this guard would pass vacuously")
+
+
 def test_the_legacy_vocabulary_cannot_grant_a_gated_group_by_detection() -> None:
     """#14681: the legacy `ROLE_ANSIBLE_GROUPS` is a second way to reach a group.
 
@@ -188,21 +212,16 @@ def test_the_legacy_vocabulary_cannot_grant_a_gated_group_by_detection() -> None
     reaches its group solely through that map (#14638), so it is a live path,
     not a theoretical one.
     """
-    try:
-        from services.role_registry import ROLE_ANSIBLE_GROUPS
-    except Exception:  # pragma: no cover - registry unavailable in some harnesses
-        import pytest
-
-        pytest.skip("role_registry unavailable in this harness")
+    legacy = _legacy_role_groups()
+    assert legacy, "the legacy map is empty — nothing would be checked"
 
     gated = set(inventory_builder._DECLARED_ONLY_GROUPS)
-    for token, granted in ROLE_ANSIBLE_GROUPS.items():
+    for token, granted in legacy.items():
         names = {granted} if isinstance(granted, str) else set(granted or ())
         privileged = names & gated
         if not privileged:
             continue
-        node = _node(declared=[], detected=[token])
-        leaked = _groups(node) & privileged
+        leaked = _groups(_node(declared=[], detected=[token])) & privileged
         assert not leaked, (
             f"the legacy vocabulary lets detected token {token!r} grant gated group(s) {sorted(leaked)} "
             "— the closure only reasons about _ROLE_TO_GROUPS"


### PR DESCRIPTION
Closes #14682, closes #14681

Two of the five open `provision:` issues. The other three are resolved or need a decision — see the bottom.

## Thinking Path

I verified each of the five against current code before writing anything, because three of them descend from one another and a fix upstream may already have closed the one downstream. Two turned out to be exactly that.

**#14682 is the one that matters.** `role_llm_active` fired on `ai_stack` membership, and `ai_stack` is granted by four tokens:

```
ai-stack      -> {ai_stack, aiml, ai, llm_nodes}
autobot-llm-  -> {ai_stack, aiml, ai, llm_nodes}
chromadb      -> {ai_stack, aiml, ai}
tts-worker    -> {ai_stack, aiml, ai}
```

The first two are LLM runtimes. The other two are a vector database and a speech synthesiser, and declaring either ran `roles/llm/tasks/main.yml` on that host — `get_url https://ollama.ai/install.sh` executed through `ansible.builtin.shell` under `become: true`, a systemd unit, and a model pull.

`llm_nodes` is granted by exactly the two tokens that mean "runs an LLM runtime", so the fix is to gate on that and drop the `ai_stack` clause rather than to special-case the two tokens. A node declaring `llm` still matches the first clause unchanged.

**#14681 was worse than filed.** It reports two unpinned derived names; there are three — `llm_nodes`, `ai`, and the seed name `main`. I pinned the gate as a whole set instead of adding the missing names, because adding two names leaves the next group unpinned in exactly the same way.

## What Changed

- `inventory/group_vars/all.yml` and `playbooks/vars/role_active_facts.yml` — the `ai_stack` clause removed from `role_llm_active`. Both copies, which the sync checker requires byte-equal (#14678), verified identical after the edit.
- `services/inventory_deploy_gate_test.py` — the full 13-group gate pinned as a set, plus an assertion that `chromadb`/`tts-worker` do not reach `llm_nodes`.
- `ansible/tests/inventory/test_role_facts.yml` — fact cases for both tokens.

## Verification

```
ORIGINAL gate == expected: True (13 groups)
MUTANT (llm_nodes ungranted): ['llm_nodes'] -> CAUGHT
tokens reaching llm_nodes: ['ai-stack', 'autobot-llm-']
chromadb excluded: True | tts-worker excluded: True
```

Fact expectations after the change — the intended split, and the pre-existing `true` case unmoved:

```
llm=False ai_stack=True   roles=['chromadb']
llm=False ai_stack=True   roles=['tts-worker']
llm=True  ai_stack=True   roles=['ai-stack', 'llm']
```

## The other three

**#14567 — resolved, not by this PR.** All six sibling groups it named are in the gate, delivered by `d6505d0210` (#14675). Verified by evaluating the closure against the real role map.

**#14666 — resolved, not by this PR.** `role_llm_active` reads `node_roles_declared | default(node_roles | ...)` as of the same commit, so it no longer gates on the unfiltered union.

Both are closed separately with that evidence rather than folded in here, since this PR did not deliver them.

**#14680 — left open deliberately.** `health-check.yml:623-624` and `:709-710` build `_ai_host` and `_npu_host` from `groups['ai_stack']`, `groups['ai']`, `groups['npu']`, `groups['npu_workers']` — all now gated. So a running-but-undeclared node is invisible to health checks and service management, which is a real regression from the gate widening.

It is not a mechanical fix: it needs the gate to distinguish a **deploy** consumer from an **observability** consumer, and getting that wrong reopens the root-install path this PR just narrowed. That is a design decision, and bundling it with a security fix would couple them at merge.

## Model Used

Claude Opus 5


## Acceptance criteria, checked one by one

**#14682 — all four met**

- *Declaring `chromadb` does not install or start an LLM runtime* — `role_llm_active` no longer reads `ai_stack`; fact case pins `chromadb` as `ai_stack` active, `llm` inactive.
- *Declaring `tts-worker` does not either* — same, with its own case.
- *A node that genuinely should run the LLM still does* — the pre-existing `['ai-stack','llm']` case still yields `true`, unmoved.
- *Whatever replaces the `("tts-worker", "ai_stack")` invariant is asserted deliberately* — `test_declaring_a_vector_database_does_not_activate_the_llm_runtime` asserts on the role map: which tokens reach `llm_nodes`, and that `chromadb`/`tts-worker` are not among them.

Not addressed, and deliberately so: the issue also flags that `roles/llm/tasks/main.yml` fetches `https://ollama.ai/install.sh` and executes it, against core rule 8's guarded-fetch requirement. That is a policy decision about an ansible surface, not a consequence of this fix, and folding it in would put an egress-policy exception inside a PR about role facts.

**#14681 — all four met, three of them added after an audit**

- *The derived set is pinned exactly, failing on both growth and shrinkage* — set equality, both directions, with the message saying what to check before updating it.
- *`llm_nodes` and `ai` appear in the detection-leak assertions* — the leak list was hand-written and had drifted, missing `llm_nodes`, `ai` **and** `main`. It is now derived from `_DECLARED_ONLY_GROUPS`, so it cannot fall behind again.
- *The legacy vocabulary's groups are asserted to be covered* — every `ROLE_ANSIBLE_GROUPS` token granting a gated group is checked not to grant it by detection. That map is the only route for `vnc` (#14638), so it is a live bypass of the closure's reasoning, not a theoretical one.
- *Adding a non-seed-intersecting role that grants `llm_nodes` makes a test fail* — met, and asserting it surfaced the actual mechanism.

## What that last criterion turned up

Adding a role that grants `llm_nodes` while intersecting no seed name does **not** widen the gate. It removes `llm_nodes` from it, because `shared_with_non_deploy` treats the group as shared with a non-deploy role:

```
llm_nodes gated before: True
llm_nodes gated after : False
gate changed          : True | lost: ['llm_nodes']
```

Detection would then grant `llm_nodes` — the root-level ollama install path this PR just closed. Nothing about that edit looks dangerous in review: a role is added to a map, and a group silently loses its gating.

My first attempt at this test asserted the group *stays* gated, which is the opposite of what the closure does. It now asserts the mechanism as it actually is, and states that a deliberate fix to the closure should replace the test rather than silently satisfy it. The set-equality pin is what turns this into a failing check.

Whether `shared_with_non_deploy` should behave that way at all is the substance of #14680, which stays open.
