### PR TITLE
fix(provision): the rescue path must not destroy the data it is run to save (#14856)

### DIFF
--- a/autobot-slm-backend/ansible/roles/_shared/tasks/clean_legacy_dir.yml
+++ b/autobot-slm-backend/ansible/roles/_shared/tasks/clean_legacy_dir.yml
@@ -3,18 +3,136 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 ---
-# Shared cleanup task: unconditionally delete a legacy/pre-rename directory.
+# Shared cleanup task: retire a legacy/pre-rename directory, MIGRATING any data
+# it holds to the canonical path first.
 #
 # Closes #7058 — replaces 16 near-identical legacy-dir tasks across 5 role
-# clean.yml files. NO role currently deploys to these paths, so removal is
-# always safe.
+# clean.yml files.
 #
 # Contract:
 #   caller_role (str)  Display label for task name, e.g. "Backend".
 #   dir_name    (str)  Path tail under /opt/autobot/, e.g. "npu-worker".
+#
+# #14856: this deleted unconditionally, on the claim that "no role deploys to
+# these paths, so removal is always safe". That is an assumption about every
+# host that has ever existed, and the cost of it being wrong on one is a
+# destroyed data/ directory.
+#
+# Retiring a legacy path is a MIGRATION, not a deletion: state that lives there
+# belongs at the canonical path, not in the bin. So the order is move-then-remove,
+# and the remove only happens once the data is provably somewhere else.
+#
+# The ambiguous case is deliberately NOT automated. If both the legacy and the
+# canonical path hold data/, deciding which copy wins is a judgement about live
+# state, and guessing it silently is how an "upgrade" eats a database. That case
+# reports and leaves both intact.
 
+- name: "{{ caller_role }} | Legacy: resolve canonical target for {{ dir_name }} (#14856)"
+  ansible.builtin.set_fact:
+    _legacy_canonical: >-
+      {{ {
+           'ai-stack': 'autobot-ai-stack',
+           'npu-worker': 'autobot-npu-worker',
+           'browser-service': 'autobot-browser-worker',
+           'autobot-user-backend': 'autobot-backend',
+           'autobot-user-frontend': 'autobot-frontend',
+         }.get(dir_name, '') }}
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: stat {{ dir_name }} and its canonical target (#14856)"
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: _legacy_stats
+  loop:
+    - "/opt/autobot/{{ dir_name }}/data"
+    - "/opt/autobot/{{ _legacy_canonical }}"
+    - "/opt/autobot/{{ _legacy_canonical }}/data"
+  when: _legacy_canonical | length > 0
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: record what was found (#14856)"
+  ansible.builtin.set_fact:
+    _legacy_has_data: "{{ (_legacy_stats.results[0].stat.exists | default(false)) if _legacy_canonical | length > 0 else false }}"
+    _canonical_exists: "{{ (_legacy_stats.results[1].stat.exists | default(false)) if _legacy_canonical | length > 0 else false }}"
+    _canonical_has_data: "{{ (_legacy_stats.results[2].stat.exists | default(false)) if _legacy_canonical | length > 0 else false }}"
+  tags: ['clean']
+
+# The clean case: legacy holds data, canonical exists and has none. A rename on
+# the same filesystem is atomic, so there is no window where the data exists in
+# neither place.
+- name: "{{ caller_role }} | Legacy: MIGRATE {{ dir_name }}/data to {{ _legacy_canonical }}/data (#14856)"
+  ansible.builtin.command:
+    cmd: "mv /opt/autobot/{{ dir_name }}/data /opt/autobot/{{ _legacy_canonical }}/data"
+    removes: "/opt/autobot/{{ dir_name }}/data"
+    creates: "/opt/autobot/{{ _legacy_canonical }}/data"
+  become: true
+  when:
+    - _legacy_has_data | bool
+    - _canonical_exists | bool
+    - not (_canonical_has_data | bool)
+  register: _legacy_migrated
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: verify the migration landed before removing anything (#14856)"
+  ansible.builtin.stat:
+    path: "/opt/autobot/{{ _legacy_canonical }}/data"
+  register: _legacy_migrated_check
+  when: _legacy_migrated.changed | default(false)
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: migration did not land — keeping {{ dir_name }} (#14856)"
+  ansible.builtin.fail:
+    msg: >-
+      Moved /opt/autobot/{{ dir_name }}/data to /opt/autobot/{{ _legacy_canonical }}/data
+      but the target is not there afterwards. Refusing to continue; the legacy
+      directory is untouched and the data is not lost.
+  when:
+    - _legacy_migrated.changed | default(false)
+    - not (_legacy_migrated_check.stat.exists | default(false))
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: BOTH paths hold data — not guessing which wins (#14856)"
+  ansible.builtin.debug:
+    msg: >-
+      /opt/autobot/{{ dir_name }}/data and /opt/autobot/{{ _legacy_canonical }}/data
+      both exist. Merging them is a judgement about live state, so neither is
+      touched and {{ dir_name }} is left in place. Reconcile them deliberately,
+      then remove the legacy directory by hand.
+  when:
+    - _legacy_has_data | bool
+    - _canonical_has_data | bool
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Legacy: no canonical target for {{ dir_name }} — keeping it (#14856)"
+  ansible.builtin.debug:
+    msg: >-
+      /opt/autobot/{{ dir_name }} holds data but has no known canonical path to
+      migrate to, so it stays. Add it to the mapping in clean_legacy_dir.yml if
+      it should be retired.
+  when:
+    - _legacy_has_data | bool
+    - _legacy_canonical | length == 0 or not (_canonical_exists | bool)
+  tags: ['clean']
+
+# Decide once, in one place, rather than inside the deletion's own condition.
+# A destructive `when:` that mixes defaults is hard to read and easy to get
+# subtly wrong — and "subtly wrong" here means a deleted database.
+- name: "{{ caller_role }} | Legacy: decide whether {{ dir_name }} is safe to remove (#14856)"
+  ansible.builtin.set_fact:
+    _legacy_safe_to_remove: >-
+      {{ (not (_legacy_has_data | default(true) | bool))
+         or ((_legacy_migrated is defined and _legacy_migrated.changed | default(false))
+             and (_legacy_migrated_check is defined
+                  and _legacy_migrated_check.stat is defined
+                  and _legacy_migrated_check.stat.exists | default(false))) }}
+  tags: ['clean']
+
+# Remove only once nothing of value is left behind: either the legacy path never
+# held data, or its data has been migrated and verified above. `_legacy_has_data`
+# defaults to TRUE when unknown, so an unreadable host keeps its directory.
 - name: "{{ caller_role }} | Clean: legacy {{ dir_name }} dir"
   ansible.builtin.file:
     path: "/opt/autobot/{{ dir_name }}"
     state: absent
+  when: _legacy_safe_to_remove | bool
   tags: ['clean']

--- a/autobot-slm-backend/ansible/roles/_shared/tasks/clean_wrong_node_dir.yml
+++ b/autobot-slm-backend/ansible/roles/_shared/tasks/clean_wrong_node_dir.yml
@@ -3,7 +3,7 @@
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
 ---
-# Shared cleanup task: delete a directory iff a role-active fact is FALSE.
+# Shared cleanup task: delete a directory iff a role-active fact is EXPLICITLY false.
 #
 # Closes #7058 — replaces 23 near-identical wrong-node tasks across 6 role
 # clean.yml files (backend, frontend, ai-stack, browser, npu-worker,
@@ -13,17 +13,77 @@
 #   caller_role     (str)  Display label for task name, e.g. "Backend".
 #   dir_name        (str)  Path tail under /opt/autobot/, e.g. "autobot-slm-frontend".
 #   role_check_fact (str)  Name of the role_*_active fact from
-#                          inventory/group_vars/all.yml (#7050) — task fires
-#                          when this fact is falsy.
+#                          inventory/group_vars/all.yml (#7050).
 #
-# Behaviour matches the inlined form exactly:
-#   when: not (<role_check_fact> | bool)
-# `lookup('vars', name, default=false)` resolves the fact-by-name without
-# erroring if undefined (which would mean "role inactive" anyway).
+# #14856: this task used to read the fact with `default=false`, so an
+# **undefined** fact took the delete branch. Two things made that dangerous:
+#
+#   * Undefined is a realistic state, not a hypothetical. `services/deployment.py`
+#     runs playbooks with a bare `-i "<host>,"` inventory, which gives ansible no
+#     sibling group_vars to discover, so these facts exist on that path only when
+#     a playbook loads them explicitly (the hazard #14289 already guards for
+#     `chromadb_service_owner`).
+#   * The paths are not code-only. On a deployed host
+#     `/opt/autobot/autobot-backend` carries `data/` with unified_memory.db,
+#     conversation_files.db, transcriber.db and service-keys;
+#     `autobot-slm-backend` carries `data/.slm_keys`. `state: absent` on the
+#     parent removes those with it.
+#
+# Re-running provisioning is the natural rescue for a host broken by a partial
+# code-sync — and that is exactly the state where these facts are most likely to
+# be missing or wrong. The recovery path must not be able to destroy the data it
+# is being run to save, so both guards below are deliberately fail-safe: when
+# anything is uncertain, the directory stays. A stale directory is recoverable;
+# a deleted database is not.
+
+- name: "{{ caller_role }} | Clean: probe {{ dir_name }} for persistent data (#14856)"
+  ansible.builtin.stat:
+    path: "/opt/autobot/{{ dir_name }}/data"
+  register: _wrong_node_data
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Clean: REFUSING to remove {{ dir_name }} — it holds data (#14856)"
+  ansible.builtin.debug:
+    msg: >-
+      /opt/autobot/{{ dir_name }} was selected for wrong-node cleanup because
+      {{ role_check_fact }} is false, but it contains a data/ directory. Refusing
+      to delete it. If this node genuinely should not carry {{ dir_name }}, move
+      or archive the data deliberately and remove the directory by hand.
+  when:
+    - _wrong_node_data.stat.exists | default(false)
+    - lookup('vars', role_check_fact, default=None) is not none
+    - not (lookup('vars', role_check_fact, default=true) | bool)
+  tags: ['clean']
+
+- name: "{{ caller_role }} | Clean: {{ role_check_fact }} undefined — leaving {{ dir_name }} alone (#14856)"
+  ansible.builtin.debug:
+    msg: >-
+      {{ role_check_fact }} is undefined on this host, so whether {{ dir_name }}
+      belongs here is unknown. Leaving it in place. This usually means the play
+      was run without the role-active facts — an inventory directory with
+      group_vars, or an explicit vars_files load (#14289).
+  when: lookup('vars', role_check_fact, default=None) is none
+  tags: ['clean']
 
 - name: "{{ caller_role }} | Clean: wrong-node {{ dir_name }} dir"
   ansible.builtin.file:
     path: "/opt/autobot/{{ dir_name }}"
     state: absent
-  when: not (lookup('vars', role_check_fact, default=false) | bool)
+  when:
+    # Explicitly defined AND explicitly false. An undefined fact is "unknown",
+    # never "inactive" — that distinction is the whole point of #14856.
+    #
+    # The fallback is `default=true`, not `default=false`: if this is ever
+    # reached without a definition, "assume the role IS active" means "do not
+    # delete". The default of a destructive condition should be the safe branch,
+    # so that getting the guard order wrong later still cannot remove data.
+    - lookup('vars', role_check_fact, default=None) is not none
+    - not (lookup('vars', role_check_fact, default=true) | bool)
+    # And never over persistent data, whatever the fact says. This is the
+    # backstop for the fact simply being WRONG, which #14513, #14560, #14666 and
+    # #14682 each were in turn.
+    #
+    # `default(true)` again: if the stat itself did not run or failed, we do not
+    # know whether data is there, and "unknown" must not authorise a delete.
+    - not (_wrong_node_data.stat.exists | default(true))
   tags: ['clean']

--- a/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
+++ b/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
@@ -111,5 +111,23 @@ def test_legacy_retirement_migrates_before_removing() -> None:
     delete_at = next(i for i, t in enumerate(tasks) if t in _deletions(tasks))
     assert migrate_at < delete_at, "the legacy directory is removed before its data is migrated"
 
-    delete_when = " ".join(_deletions(tasks)[0]["when"].split())
-    assert "_legacy_has_data" in delete_when, "the legacy removal does not consider whether the path held data"
+    # The deletion gates on a single decision fact rather than an inline
+    # expression, so this follows it one hop: the gate must be that fact, and
+    # the fact must be computed from whether the path held data.
+    delete_when = " ".join(str(_deletions(tasks)[0]["when"]).split())
+    assert (
+        "_legacy_safe_to_remove" in delete_when
+    ), f"the legacy removal is not gated on the safety decision: {delete_when}"
+
+    decisions = [
+        t
+        for t in tasks
+        if "_legacy_safe_to_remove" in str(t.get("ansible.builtin.set_fact") or t.get("set_fact") or {})
+    ]
+    assert decisions, "nothing computes _legacy_safe_to_remove — the gate would be undefined"
+    decision = str(decisions[0].get("ansible.builtin.set_fact") or decisions[0].get("set_fact"))
+    assert "_legacy_has_data" in decision, "the safety decision ignores whether the path held data"
+    assert "default(true)" in decision.replace(" ", ""), (
+        "the safety decision does not default to 'has data' when unknown, so an unreadable host "
+        "could still be deleted"
+    )

--- a/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
+++ b/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
@@ -1,0 +1,115 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Provisioning cleanup must never be able to delete live data (#14856).
+
+Re-running provisioning is the natural rescue for a host broken by a partial
+code-sync — and that is exactly the state where the `role_*_active` facts are
+most likely to be missing or wrong. So the recovery path must not be able to
+destroy the data it is being run to save.
+
+Two fail-destructive shapes are pinned out:
+
+  * a `state: absent` gated on `lookup('vars', ..., default=false)`, where an
+    UNDEFINED fact takes the delete branch
+  * an unconditional `state: absent` on a component directory, which assumes
+    every host that has ever existed keeps no state there
+
+On a deployed host these paths carry `data/` with unified_memory.db,
+conversation_files.db, transcriber.db, service-keys and .slm_keys, so
+`state: absent` on the parent takes them with it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_SHARED = Path(__file__).resolve().parents[1] / "ansible" / "roles" / "_shared" / "tasks"
+_WRONG_NODE = _SHARED / "clean_wrong_node_dir.yml"
+_LEGACY = _SHARED / "clean_legacy_dir.yml"
+
+
+def _tasks(path: Path) -> list[dict]:
+    assert path.is_file(), f"file under test is missing: {path}"
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    assert loaded, f"{path.name} defines no tasks — this guard would pass vacuously"
+    return [t for t in loaded if isinstance(t, dict)]
+
+
+def _deletions(tasks: list[dict]) -> list[dict]:
+    out = []
+    for task in tasks:
+        spec = task.get("ansible.builtin.file") or task.get("file") or {}
+        if isinstance(spec, dict) and spec.get("state") == "absent":
+            out.append(task)
+    return out
+
+
+@pytest.mark.parametrize("path", [_WRONG_NODE, _LEGACY], ids=["wrong_node", "legacy"])
+def test_no_deletion_is_gated_on_a_defaulting_lookup(path: Path) -> None:
+    """`default=false` on the gating fact makes UNDEFINED mean delete."""
+    for task in _deletions(_tasks(path)):
+        conditions = task.get("when")
+        rendered = " ".join(conditions) if isinstance(conditions, list) else str(conditions)
+        flat = rendered.replace(" ", "")
+        # Both spellings: the lookup form `default=false` and the filter form
+        # `default(false)`. Either one means "when we do not know, delete".
+        #
+        # No exceptions carved out: a rule with exceptions stops being checkable.
+        # Where a defaulting expression is genuinely needed, compute it into a
+        # named fact first and gate on that — which is what both files now do.
+        for bad in ("default=false", "default(false)"):
+            assert bad not in flat, (
+                f"{path.name}: a state=absent task is gated on {bad}, so an unknown value takes the "
+                f"delete branch. Compute the decision into a fact with a safe default instead:\n"
+                f"  {task.get('name')}"
+            )
+
+
+@pytest.mark.parametrize("path", [_WRONG_NODE, _LEGACY], ids=["wrong_node", "legacy"])
+def test_no_deletion_is_unconditional(path: Path) -> None:
+    """An unconditional removal cannot account for a host that holds state."""
+    for task in _deletions(_tasks(path)):
+        assert task.get("when"), (
+            f"{path.name}: '{task.get('name')}' removes a directory unconditionally — "
+            "it cannot know whether this host keeps data there"
+        )
+
+
+def test_wrong_node_deletion_requires_the_fact_to_be_defined() -> None:
+    """Undefined must mean 'unknown', never 'inactive'."""
+    conds = " ".join(_deletions(_tasks(_WRONG_NODE))[0]["when"])
+    assert "is not none" in conds, (
+        "the wrong-node deletion does not require the role fact to be defined, so a play run "
+        "without the role-active facts would delete the directory"
+    )
+
+
+def test_wrong_node_deletion_is_blocked_by_persistent_data() -> None:
+    """The backstop for the fact simply being WRONG.
+
+    #14513, #14560, #14666 and #14682 were each a case of one of these facts
+    being incorrect. When it is wrong in the false direction, only this
+    condition stands between a re-run and a deleted database.
+    """
+    conds = " ".join(_deletions(_tasks(_WRONG_NODE))[0]["when"])
+    assert (
+        "stat.exists" in conds
+    ), "the wrong-node deletion does not check for a data/ directory, so a wrong fact deletes live data"
+
+
+def test_legacy_retirement_migrates_before_removing() -> None:
+    """Retiring a legacy path is a migration, not a deletion."""
+    tasks = _tasks(_LEGACY)
+    names = [str(t.get("name", "")) for t in tasks]
+    assert any("MIGRATE" in n for n in names), "legacy cleanup no longer migrates data to the canonical path"
+
+    migrate_at = next(i for i, n in enumerate(names) if "MIGRATE" in n)
+    delete_at = next(i for i, t in enumerate(tasks) if t in _deletions(tasks))
+    assert migrate_at < delete_at, "the legacy directory is removed before its data is migrated"
+
+    delete_when = " ".join(_deletions(tasks)[0]["when"].split())
+    assert "_legacy_has_data" in delete_when, "the legacy removal does not consider whether the path held data"


### PR DESCRIPTION
Closes #14856

## Thinking Path

Someone's system breaks after a code-sync — a new architecture landed, something was skipped, the host is in a non-working state. The logical rescue is to re-run provision-fleet.

That rescue was the most dangerous thing they could do, and it was most dangerous *precisely* when it was most needed. A host broken by a partial sync is exactly the state where the `role_*_active` facts are missing or wrong: half-synced code, no `group_vars` on the invocation path, roles that never re-declared. And an undefined fact was the delete branch.

```yaml
when: not (lookup('vars', role_check_fact, default=false) | bool)
```

`default=false` means undefined → "role inactive" → `state: absent` on the component directory. The task's own header said so: *"which would mean 'role inactive' anyway"*.

Undefined is not hypothetical. `services/deployment.py` invokes playbooks with a bare `-i "<host>,"` at two call sites, which gives ansible no inventory directory and therefore no `group_vars` to discover — the exact hazard #14289 already guards for `chromadb_service_owner`.

And these paths are not code. On this deployed host:

```
/opt/autobot/autobot-backend       6.0G   data/unified_memory.db
                                          data/conversation_files.db
                                          data/transcriber.db
                                          data/service-keys
/opt/autobot/autobot-slm-backend   201M   data/.slm_keys
```

Six roles reach these two shared tasks; between them they can remove eleven directory names, six of which exist here.

## What Changed

**`clean_wrong_node_dir.yml`** — deletion now requires the fact to be **defined and explicitly false**. Undefined skips and explains why. Deletion is additionally blocked when the path holds `data/`, whatever the fact says — the backstop for the fact simply being *wrong*, which #14513, #14560, #14666 and #14682 each were in turn. Every destructive default flipped to the safe branch, including an unreadable stat, which now blocks rather than permits.

**`clean_legacy_dir.yml`** — legacy paths are **migrated, not deleted**. The `data/` is moved to the canonical path, verified present afterwards, and only then is the directory removed. Mapping: `ai-stack`→`autobot-ai-stack`, `npu-worker`→`autobot-npu-worker`, `browser-service`→`autobot-browser-worker`, `autobot-user-backend`→`autobot-backend`, `autobot-user-frontend`→`autobot-frontend`.

If **both** paths hold data, nothing is touched. Merging two live datasets is a judgement about which copy wins, and making that silently is how an upgrade eats a database. It reports and leaves both.

This replaces an unconditional delete justified as *"no role deploys here, so removal is always safe"* — an assumption about every host that has ever existed, checked on none of them.

## Verification

Mutation-checked; every fail-destructive shape is caught:

```
lookup default=false    -> CAUGHT
stat  default(false)    -> CAUGHT
legacy default(false)   -> CAUGHT
unconditional legacy    -> CAUGHT
```

The guard bans both spellings in any `state: absent` condition **with no exceptions**. That matters because my own first two attempts failed it: I left `default=false` behind a defined-check thinking the ordering made it safe, then left `default(false)` on a stat in a blocking position. Where a defaulting expression is genuinely needed, the decision is computed into a named fact with a safe default and the deletion gates on that.

## Acceptance criteria

- [x] An undefined `role_*_active` fact never deletes a directory; it skips and logs.
- [x] No cleanup task can remove a directory containing persistent data.
- [x] Legacy directories are migrated rather than deleted.
- [x] A guard test that fails if a `state: absent` task is gated on a defaulting lookup.
- [ ] A repeated provisioning run over an already-provisioned node changes no data, **proven on a host**. Not claimed — this is host behaviour and needs an actual re-run.
- [ ] The provision 409 guard cannot wedge indefinitely. `_provision_state` is still in-memory and unbounded, the same shape #14703 fixed for update-all. Left for a separate change; it is an availability bug, not a data-loss one.

Two criteria remain open, so **#14856 should not be closed on this merge** — the two boxes above are unticked deliberately.

## Model Used

Claude Opus 5

