### PR TITLE
fix(provision): resolve node dependencies from declared roles, not detected ones (#14859)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -392,9 +392,23 @@ def _apply_role_host_vars(
         if node.node_id in node_id_to_roles:
             hosts[inv_name]["node_roles"] = node_id_to_roles[node.node_id]
         hosts[inv_name]["node_roles_declared"] = _declared_roles(node)
-        roles = hosts[inv_name].get("node_roles", [])
+        # #14859: dependencies resolve from DECLARED roles, not from the
+        # declared-plus-detected union `node_roles` carries.
+        #
+        # Detection legitimately drives plays -- a node running redis that
+        # nobody declared still needs the redis plays to reach it, which is what
+        # `_union_roles` documents. Installing OS packages and enabling services
+        # is a different act: that is provisioning a role, not reconciling one
+        # that is already there.
+        #
+        # A node contaminated by #14513 detects `backend`, `celery`, `frontend`,
+        # `scheduler`, `slm-backend` and `slm-frontend` (the residue tracked in
+        # #14667). Resolved from the union, a vnc + slm-agent node was given
+        # nginx, nodejs, postgresql and python314 -- and nginx failing to start
+        # there aborted provisioning for the WHOLE fleet at phase 7.
+        declared_for_deps = hosts[inv_name].get("node_roles_declared") or []
         deps: set[str] = set()
-        for role in roles:
+        for role in declared_for_deps:
             deps.update(ROLE_DEPENDENCIES.get(role, []))
         hosts[inv_name]["node_dependencies"] = sorted(deps)
         pending = (node.extra_data or {}).get("pending_dep_removals", [])

--- a/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
+++ b/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
 
 _SLM_ROOT = Path(__file__).resolve().parents[2]
 _REGISTRY = _SLM_ROOT / "services" / "role_registry.py"

--- a/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
+++ b/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Dependencies come from declared roles, never from detected ones (#14859).
+
+A vnc + slm-agent node contaminated by #14513 detects `backend`, `celery`,
+`frontend`, `scheduler`, `slm-backend` and `slm-frontend` — the residue tracked
+in #14667. Resolved from the declared-plus-detected union it was handed
+`nodejs` and `postgresql` on top of what it actually needs, for roles it never
+declared.
+
+`vnc` genuinely requires `nginx` and `python314`, so those are correct and are
+NOT what this fixes. (I first read this as nginx being the intruder, from a
+truncated view of the dependency map. It is not: nginx failing to start on that
+node is a missing-certificate problem, tracked under #14861.)
+
+Detection legitimately drives plays: a node running redis that nobody declared
+still needs the redis plays to reach it. Installing OS packages and enabling
+services is a different act — that is provisioning a role, not reconciling one
+that is already running.
+
+The dependency map is read from source rather than imported: conftest does not
+real-load `role_registry` (it pulls SQLAlchemy, above the dependency-light bar
+`_REAL_SERVICE_MODULES` holds to), so an import resolves to a MagicMock or the
+real module depending on shard order — and a MagicMock iterates as empty, which
+would make every assertion here pass while checking nothing (#14307).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SLM_ROOT = Path(__file__).resolve().parents[2]
+_REGISTRY = _SLM_ROOT / "services" / "role_registry.py"
+_WIZARD = _SLM_ROOT / "api" / "setup_wizard.py"
+
+#: The exact shape observed on b9a29e04 when phase 7 failed.
+_DECLARED = ["vnc", "slm-agent"]
+_DETECTED = [
+    "slm-backend",
+    "slm-frontend",
+    "slm-database",
+    "slm-monitoring",
+    "backend",
+    "celery",
+    "scheduler",
+    "frontend",
+    "redis",
+    "chromadb",
+    "autobot-llm-cpu",
+    "autobot-llm-gpu",
+    "vnc",
+    "autobot_shared",
+    "slm-agent",
+]
+
+
+def _role_dependencies() -> dict:
+    """`ROLE_DEPENDENCIES` read from source, without importing role_registry."""
+    src = _REGISTRY.read_text(encoding="utf-8")
+    for node in ast.parse(src).body:
+        target = None
+        if isinstance(node, ast.AnnAssign):
+            target = getattr(node.target, "id", None)
+        elif isinstance(node, ast.Assign) and node.targets:
+            target = getattr(node.targets[0], "id", None)
+        if target == "ROLE_DEPENDENCIES":
+            return ast.literal_eval(node.value)
+    raise AssertionError("ROLE_DEPENDENCIES not found — this guard would pass vacuously")
+
+
+def _resolve(roles) -> set[str]:
+    deps = _role_dependencies()
+    out: set[str] = set()
+    for role in roles:
+        out.update(deps.get(role, []))
+    return out
+
+
+def test_the_contaminated_node_gets_only_what_it_declares() -> None:
+    """The regression: two packages were installed for roles it never declared."""
+    declared = _resolve(_DECLARED)
+    union = _resolve(set(_DECLARED) | set(_DETECTED))
+
+    assert declared == {
+        "nginx",
+        "python314",
+    }, f"vnc + slm-agent should resolve to exactly vnc's own dependencies; got {sorted(declared)}"
+    unwanted = union - declared
+    assert unwanted, "the union no longer differs from declared — this test's premise is stale"
+    assert unwanted == {"nodejs", "postgresql"}, f"the packages detection would add have changed: {sorted(unwanted)}"
+
+
+def test_vnc_really_does_need_nginx() -> None:
+    """Guards the correction, not just the fix.
+
+    The first diagnosis of #14859 claimed a vnc node needed nothing at all, from
+    a truncated read of the dependency map. If someone repeats that reasoning,
+    this says plainly that `nginx` belongs to `vnc` and removing it is a
+    different change from the one #14859 made.
+    """
+    assert set(_role_dependencies().get("vnc", [])) == {
+        "python314",
+        "nginx",
+    }, "vnc's dependencies changed — #14859's fix and its issue text both assume nginx is legitimate here"
+
+
+def test_a_declared_backend_still_gets_its_packages() -> None:
+    """The fix must not stop real roles being provisioned."""
+    resolved = _resolve(["backend"])
+    assert {"python314", "nginx"} <= resolved, f"a declared backend lost its dependencies: {sorted(resolved)}"
+
+
+def test_the_wizard_resolves_dependencies_from_the_declared_hostvar() -> None:
+    """Asserted on the source, because the seam is a hostvar name.
+
+    Executing this path needs a database and a full inventory build; what is
+    load-bearing is which of the two hostvars the loop reads, and that is
+    visible without either.
+    """
+    src = _WIZARD.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+
+    loops = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.For)
+        and any(
+            isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "get"
+            and isinstance(c.func.value, ast.Name)
+            and c.func.value.id == "ROLE_DEPENDENCIES"
+            for c in ast.walk(n)
+        )
+    ]
+    assert loops, "no loop resolves ROLE_DEPENDENCIES — this guard would pass vacuously"
+
+    for loop in loops:
+        iterated = ast.unparse(loop.iter)
+        assert "declared" in iterated, (
+            f"dependencies are resolved from {iterated!r}, which is not the declared-roles hostvar — "
+            "a contaminated node would be provisioned for roles it never declared (#14859)"
+        )

--- a/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
+++ b/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
@@ -117,28 +117,41 @@ def test_the_wizard_resolves_dependencies_from_the_declared_hostvar() -> None:
     Executing this path needs a database and a full inventory build; what is
     load-bearing is which of the two hostvars the loop reads, and that is
     visible without either.
+
+    Only the INNERMOST matching loop counts. `ast.walk` also reports every
+    enclosing loop — the `for node in db_nodes:` wrapper contains the
+    dependency loop, so a naive search "finds" it iterating `db_nodes` and
+    fails on a correct file. That is exactly what happened here on the first
+    attempt.
     """
     src = _WIZARD.read_text(encoding="utf-8")
     tree = ast.parse(src)
 
-    loops = [
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, ast.For)
-        and any(
+    def resolves_dependencies(node: ast.AST) -> bool:
+        return any(
             isinstance(c, ast.Call)
             and isinstance(c.func, ast.Attribute)
             and c.func.attr == "get"
             and isinstance(c.func.value, ast.Name)
             and c.func.value.id == "ROLE_DEPENDENCIES"
-            for c in ast.walk(n)
+            for c in ast.walk(node)
+        )
+
+    candidates = [n for n in ast.walk(tree) if isinstance(n, ast.For) and resolves_dependencies(n)]
+    assert candidates, "no loop resolves ROLE_DEPENDENCIES — this guard would pass vacuously"
+
+    # Drop any loop that merely encloses another matching loop.
+    innermost = [
+        loop
+        for loop in candidates
+        if not any(
+            other is not loop and resolves_dependencies(other) for other in ast.walk(loop) if isinstance(other, ast.For)
         )
     ]
-    assert loops, "no loop resolves ROLE_DEPENDENCIES — this guard would pass vacuously"
+    assert len(innermost) == 1, f"expected exactly one dependency loop, found {len(innermost)}"
 
-    for loop in loops:
-        iterated = ast.unparse(loop.iter)
-        assert "declared" in iterated, (
-            f"dependencies are resolved from {iterated!r}, which is not the declared-roles hostvar — "
-            "a contaminated node would be provisioned for roles it never declared (#14859)"
-        )
+    iterated = ast.unparse(innermost[0].iter)
+    assert "declared" in iterated, (
+        f"dependencies are resolved from {iterated!r}, which is not the declared-roles hostvar — "
+        "a contaminated node would be provisioned for roles it never declared (#14859)"
+    )

--- a/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
+++ b/autobot-slm-backend/tests/api/test_node_dependencies_declared_only_14859.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-
 _SLM_ROOT = Path(__file__).resolve().parents[2]
 _REGISTRY = _SLM_ROOT / "services" / "role_registry.py"
 _WIZARD = _SLM_ROOT / "api" / "setup_wizard.py"


### PR DESCRIPTION
Closes #14859

## Thinking Path

Provisioning failed at phase 7 on a `vnc` + `slm-agent` node, and I traced dependencies to `node_roles` — the declared-plus-detected union stamped by `inventory_builder:447` — rather than to `node_roles_declared`, which exists for precisely this distinction (#14594) and sits two lines above the loop that ignored it.

**I then got the diagnosis wrong and have corrected it on the issue.** I claimed the node should never have been given nginx, from a `grep -A 40` that truncated the dependency map before `vnc`. It does need nginx:

```
vnc -> ['python314', 'nginx']
```

What the union actually adds is different, and still wrong:

```
declared ['vnc','slm-agent'] -> nginx, python314               (correct)
union (current behaviour)    -> nginx, python314, nodejs, postgresql
unwanted                     -> nodejs, postgresql
```

`nodejs` and `postgresql` come from detected `frontend`/`slm-frontend`/`slm-database` — the #14513 residue tracked in #14667. So this is over-installation for undeclared roles, not a wrong nginx.

I only caught the error because I checked the fix against the real map before pushing rather than trusting my own issue text.

**This does not unblock phase 7.** That is nginx failing on an absent certificate, because `Deps | Install nginx` runs 131 lines before the vnc role generates it — tracked under #14861 with the mandatory-encryption requirement.

## What Changed

`api/setup_wizard.py` — dependencies resolve from the `node_roles_declared` hostvar. Detection continues to drive plays and group membership, untouched.

## Verification

Against the real dependency map, not the issue text:

```
declared       : ['nginx', 'python314']
union          : ['nginx', 'nodejs', 'postgresql', 'python314']
unwanted       : ['nodejs', 'postgresql']
vnc deps       : ['nginx', 'python314']
backend intact : True
```

Four guards: the contaminated node resolves to exactly its declared dependencies; `vnc` really does need nginx (pinning the correction, so the truncated-grep reasoning is not repeated); a declared `backend` still gets its packages; and the wizard's loop is asserted by AST to iterate the declared hostvar, so reverting to the union fails with the reason.

The dependency map is parsed from source with `ast.literal_eval` rather than imported — conftest does not real-load `role_registry`, so an import resolves to a MagicMock depending on shard order, and a MagicMock iterates as empty, which would make every assertion pass while checking nothing (#14307).

## Model Used

Claude Opus 5
