### PR TITLE
fix(security): an unreadable enforcement mode must not disable ownership checks (#14010)

### DIFF
--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException, Request
 from auth_middleware import get_auth_middleware
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_30_DAYS
+from services.feature_flags import EnforcementModeUnavailable
 
 logger = get_logger(__name__)
 
@@ -52,6 +53,15 @@ def build_owner_metadata(user_data: "dict | None", team_id: str | None = None) -
     if team_id:
         metadata["team_id"] = team_id
     return metadata
+
+
+# What an *undetermined* enforcement mode degrades to (#14010). Deliberately not
+# "disabled": an unreachable flag store must not read as "authorization is off".
+# log_only keeps every check running and every violation recorded without
+# changing what requests succeed, so an outage is loud in the logs and metrics
+# instead of silently permissive. Choosing the *default* posture when the flag is
+# simply unset is a separate decision and is untouched here.
+DEGRADED_ENFORCEMENT_MODE = "log_only"
 
 
 class SessionOwnershipValidator:
@@ -243,14 +253,34 @@ class SessionOwnershipValidator:
             Enforcement mode string: "disabled", "log_only", or "enforced"
         """
         if not self.feature_flags:
-            return "disabled"
+            # No flags service means `get_feature_flags()` failed at
+            # construction — an infrastructure fault, not a policy decision.
+            logger.warning(
+                "Ownership enforcement mode is UNDETERMINED (no feature-flags service); "
+                "degrading to log_only. Checks still run and violations are recorded. "
+                "This is not a deliberate 'disabled' (#14010)."
+            )
+            return DEGRADED_ENFORCEMENT_MODE
 
         try:
             mode_enum = await self.feature_flags.get_enforcement_mode()
             return mode_enum.value
+        except EnforcementModeUnavailable as exc:
+            logger.warning(
+                "Ownership enforcement mode is UNDETERMINED (%s); degrading to log_only. "
+                "Checks still run and violations are recorded. This is not a deliberate "
+                "'disabled' (#14010).",
+                exc,
+            )
+            return DEGRADED_ENFORCEMENT_MODE
         except Exception as e:
-            logger.error(f"Failed to get enforcement mode: {e}, defaulting to disabled")
-            return "disabled"
+            # Anything unexpected is still a failure to determine policy, so it
+            # degrades the same way rather than silently disabling every check.
+            logger.warning(
+                "Ownership enforcement mode could not be resolved (%s); degrading to log_only (#14010).",
+                e,
+            )
+            return DEGRADED_ENFORCEMENT_MODE
 
     def _audit_log_violation(
         self,

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -839,7 +839,11 @@ async def validate_session_ownership(session_id: str, request: Request) -> Dict:
     try:
         feature_flags = await get_feature_flags()
     except Exception as e:
-        logger.warning("Feature flags unavailable, defaulting to disabled mode: %s", e)
+        logger.warning(
+            "Feature flags unavailable, degrading ownership enforcement to log_only "
+            "(checks still run, violations still recorded): %s",
+            e,
+        )
         feature_flags = None
 
     # Get metrics service (optional)

--- a/autobot-backend/security/session_ownership_enforcement_mode_test.py
+++ b/autobot-backend/security/session_ownership_enforcement_mode_test.py
@@ -62,9 +62,7 @@ class TestAPolicyDecisionIsUnchanged:
     """The half that must NOT move: a mode someone actually set."""
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "mode", [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED]
-    )
+    @pytest.mark.parametrize("mode", [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED])
     async def test_a_resolved_mode_is_returned_verbatim(self, mode):
         assert await _validator(_flags_returning(mode))._get_enforcement_mode() == mode.value
 
@@ -86,9 +84,7 @@ class TestAnUndeterminedModeDoesNotDisableEnforcement:
         mode = await validator._get_enforcement_mode()
 
         assert mode == DEGRADED_ENFORCEMENT_MODE == "log_only"
-        assert mode != "disabled", (
-            "an unreachable flag store was read as 'authorization is off' — the #14010 defect"
-        )
+        assert mode != "disabled", "an unreachable flag store was read as 'authorization is off' — the #14010 defect"
 
     @pytest.mark.asyncio
     async def test_a_missing_flags_service_degrades_to_log_only(self):
@@ -116,9 +112,7 @@ class TestAnUndeterminedModeDoesNotDisableEnforcement:
 
         warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert warnings, "an undetermined enforcement mode must not degrade quietly"
-        assert any("log_only" in r.getMessage() for r in warnings), (
-            "the warning must say what it degraded to"
-        )
+        assert any("log_only" in r.getMessage() for r in warnings), "the warning must say what it degraded to"
 
 
 class TestTheFlagStoreReportsFailureInsteadOfInventingAnAnswer:

--- a/autobot-backend/security/session_ownership_enforcement_mode_test.py
+++ b/autobot-backend/security/session_ownership_enforcement_mode_test.py
@@ -1,0 +1,148 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""An unreachable flag store must not read as "authorization is off" (#14010).
+
+`_get_enforcement_mode` returned `"disabled"` in three situations, and
+`validate_ownership` fast-paths on that value — skipping the check entirely. Two
+of the three were infrastructure faults, not decisions:
+
+- the feature-flags service could not be constructed (`get_feature_flags()` raised)
+- reading the mode raised
+
+A fourth route sat one layer deeper and is the reason the other two rarely fired:
+`FeatureFlags.get_enforcement_mode` caught every exception itself and returned
+`DISABLED`, commented "Fail-safe". For an authorization control that is fail-
+**open**: a Redis blip silently turned off every ownership check platform-wide,
+for its duration, with nothing louder than a debug line.
+
+The distinction these pin: *deliberately disabled* and *could not be determined*
+are different facts. The first is policy and is left exactly as it was. The
+second now degrades to `log_only` — every check still runs and every violation is
+still recorded — and says so at WARNING.
+
+What this does **not** change is the default posture when the flag is simply
+unset. That is a separate decision with real blast radius (#14010 step 2), and
+is deliberately untouched here.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from security.session_ownership import DEGRADED_ENFORCEMENT_MODE, SessionOwnershipValidator
+from services.feature_flags import EnforcementMode, EnforcementModeUnavailable
+
+
+def _validator(feature_flags):
+    validator = SessionOwnershipValidator.__new__(SessionOwnershipValidator)
+    validator.redis = MagicMock()
+    validator.feature_flags = feature_flags
+    validator.metrics_service = None
+    return validator
+
+
+def _flags_returning(mode: EnforcementMode):
+    flags = MagicMock()
+    flags.get_enforcement_mode = AsyncMock(return_value=mode)
+    return flags
+
+
+def _flags_raising(exc: Exception):
+    flags = MagicMock()
+    flags.get_enforcement_mode = AsyncMock(side_effect=exc)
+    return flags
+
+
+class TestAPolicyDecisionIsUnchanged:
+    """The half that must NOT move: a mode someone actually set."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mode", [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED]
+    )
+    async def test_a_resolved_mode_is_returned_verbatim(self, mode):
+        assert await _validator(_flags_returning(mode))._get_enforcement_mode() == mode.value
+
+    @pytest.mark.asyncio
+    async def test_a_deliberate_disabled_still_disables(self):
+        """The operator's own choice is still honoured — this is not a posture change."""
+        validator = _validator(_flags_returning(EnforcementMode.DISABLED))
+
+        assert await validator._get_enforcement_mode() == "disabled"
+
+
+class TestAnUndeterminedModeDoesNotDisableEnforcement:
+    """The half that was fail-open."""
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_mode_degrades_to_log_only(self):
+        validator = _validator(_flags_raising(EnforcementModeUnavailable("redis down")))
+
+        mode = await validator._get_enforcement_mode()
+
+        assert mode == DEGRADED_ENFORCEMENT_MODE == "log_only"
+        assert mode != "disabled", (
+            "an unreachable flag store was read as 'authorization is off' — the #14010 defect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_missing_flags_service_degrades_to_log_only(self):
+        """`feature_flags=None` means construction failed, not that policy is off."""
+        mode = await _validator(None)._get_enforcement_mode()
+
+        assert mode == DEGRADED_ENFORCEMENT_MODE
+        assert mode != "disabled"
+
+    @pytest.mark.asyncio
+    async def test_an_unexpected_error_degrades_rather_than_disabling(self):
+        mode = await _validator(_flags_raising(RuntimeError("boom")))._get_enforcement_mode()
+
+        assert mode == DEGRADED_ENFORCEMENT_MODE
+
+    @pytest.mark.asyncio
+    async def test_the_degrade_is_audible(self, caplog):
+        """A silent degrade is the same bug one level quieter.
+
+        The original failure logged at debug, so a deployment could run
+        indefinitely with every check inert and nothing saying so.
+        """
+        with caplog.at_level(logging.WARNING):
+            await _validator(_flags_raising(EnforcementModeUnavailable("redis down")))._get_enforcement_mode()
+
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "an undetermined enforcement mode must not degrade quietly"
+        assert any("log_only" in r.getMessage() for r in warnings), (
+            "the warning must say what it degraded to"
+        )
+
+
+class TestTheFlagStoreReportsFailureInsteadOfInventingAnAnswer:
+    """The deepest of the four routes, and the one that hid the others."""
+
+    @pytest.mark.asyncio
+    async def test_a_read_failure_raises_rather_than_returning_disabled(self):
+        from services.feature_flags import FeatureFlags
+
+        flags = FeatureFlags.__new__(FeatureFlags)
+        flags._get_redis = AsyncMock(side_effect=ConnectionError("redis down"))
+
+        with pytest.raises(EnforcementModeUnavailable):
+            await flags.get_enforcement_mode()
+
+    @pytest.mark.asyncio
+    async def test_an_unset_flag_still_means_disabled(self):
+        """The default posture is a separate decision (#14010 step 2) — untouched."""
+        from services.feature_flags import FeatureFlags
+
+        redis = MagicMock()
+        redis.get = AsyncMock(return_value=None)
+        flags = FeatureFlags.__new__(FeatureFlags)
+        flags._get_redis = AsyncMock(return_value=redis)
+        flags._enforcement_default_logged = False
+
+        assert await flags.get_enforcement_mode() == EnforcementMode.DISABLED

--- a/autobot-backend/security/session_ownership_enforcement_mode_test.py
+++ b/autobot-backend/security/session_ownership_enforcement_mode_test.py
@@ -30,7 +30,7 @@ is deliberately untouched here.
 from __future__ import annotations
 
 import logging
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -146,3 +146,69 @@ class TestTheFlagStoreReportsFailureInsteadOfInventingAnAnswer:
         flags._enforcement_default_logged = False
 
         assert await flags.get_enforcement_mode() == EnforcementMode.DISABLED
+
+
+class TestTheDegradedModeStillRunsAndRecordsTheCheck:
+    """The wiring, not the helper.
+
+    Every test above pins `_get_enforcement_mode` in isolation. A correct
+    resolver whose *consumer* still short-circuits would leave all of them
+    green while the check remained inert — which is the shape of the bug being
+    fixed, one level up. So this drives `validate_ownership` itself, with a real
+    ownership mismatch, and asserts the violation is both allowed **and**
+    recorded.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_mismatch_during_an_outage_is_allowed_but_audited(self):
+        validator = _validator(_flags_raising(EnforcementModeUnavailable("redis down")))
+        validator.get_session_owner = AsyncMock(return_value="alice")
+        validator._is_org_admin_access = AsyncMock(return_value=False)
+        validator._audit_log_violation = MagicMock()
+        validator._record_violation_metrics = AsyncMock()
+        validator._get_authenticated_user = MagicMock(
+            return_value={"username": "bob", "auth_disabled": False}
+        )
+
+        auth = MagicMock()
+        auth.enable_auth = True
+        with patch("security.session_ownership.get_auth_middleware", return_value=auth):
+            result = await validator.validate_ownership("sess-1234abcd", MagicMock())
+
+        # Allowed — log_only does not block, so no request that works today breaks.
+        assert result["authorized"] is True
+        assert result["reason"] == "log_only_mode"
+        assert result["actual_owner"] == "alice"
+
+        # ...but the check ran and the violation was recorded. Under the pre-fix
+        # "disabled" mode this path was short-circuited before the ownership
+        # lookup, so neither of these was ever called.
+        validator._audit_log_violation.assert_called_once()
+        validator._record_violation_metrics.assert_awaited_once()
+        assert validator.get_session_owner.await_count >= 1, (
+            "the ownership lookup never ran — the check is still being skipped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_deliberate_disabled_still_short_circuits(self):
+        """The contrast case, so the test above cannot pass for the wrong reason."""
+        validator = _validator(_flags_returning(EnforcementMode.DISABLED))
+        validator.get_session_owner = AsyncMock(return_value="alice")
+        validator._is_org_admin_access = AsyncMock(return_value=False)
+        validator._audit_log_violation = MagicMock()
+        validator._record_violation_metrics = AsyncMock()
+        validator._get_authenticated_user = MagicMock(
+            return_value={"username": "bob", "auth_disabled": False}
+        )
+
+        auth = MagicMock()
+        auth.enable_auth = True
+        with patch("security.session_ownership.get_auth_middleware", return_value=auth):
+            result = await validator.validate_ownership("sess-1234abcd", MagicMock())
+
+        assert result["authorized"] is True
+        assert result["reason"] != "log_only_mode"
+        validator._audit_log_violation.assert_not_called()
+        assert validator.get_session_owner.await_count == 0, (
+            "a deliberate 'disabled' should still skip the lookup — that is policy, unchanged"
+        )

--- a/autobot-backend/security/session_ownership_enforcement_mode_test.py
+++ b/autobot-backend/security/session_ownership_enforcement_mode_test.py
@@ -160,9 +160,7 @@ class TestTheDegradedModeStillRunsAndRecordsTheCheck:
         validator._is_org_admin_access = AsyncMock(return_value=False)
         validator._audit_log_violation = MagicMock()
         validator._record_violation_metrics = AsyncMock()
-        validator._get_authenticated_user = MagicMock(
-            return_value={"username": "bob", "auth_disabled": False}
-        )
+        validator._get_authenticated_user = MagicMock(return_value={"username": "bob", "auth_disabled": False})
 
         auth = MagicMock()
         auth.enable_auth = True
@@ -179,9 +177,9 @@ class TestTheDegradedModeStillRunsAndRecordsTheCheck:
         # lookup, so neither of these was ever called.
         validator._audit_log_violation.assert_called_once()
         validator._record_violation_metrics.assert_awaited_once()
-        assert validator.get_session_owner.await_count >= 1, (
-            "the ownership lookup never ran — the check is still being skipped"
-        )
+        assert (
+            validator.get_session_owner.await_count >= 1
+        ), "the ownership lookup never ran — the check is still being skipped"
 
     @pytest.mark.asyncio
     async def test_a_deliberate_disabled_still_short_circuits(self):
@@ -191,9 +189,7 @@ class TestTheDegradedModeStillRunsAndRecordsTheCheck:
         validator._is_org_admin_access = AsyncMock(return_value=False)
         validator._audit_log_violation = MagicMock()
         validator._record_violation_metrics = AsyncMock()
-        validator._get_authenticated_user = MagicMock(
-            return_value={"username": "bob", "auth_disabled": False}
-        )
+        validator._get_authenticated_user = MagicMock(return_value={"username": "bob", "auth_disabled": False})
 
         auth = MagicMock()
         auth.enable_auth = True
@@ -203,6 +199,6 @@ class TestTheDegradedModeStillRunsAndRecordsTheCheck:
         assert result["authorized"] is True
         assert result["reason"] != "log_only_mode"
         validator._audit_log_violation.assert_not_called()
-        assert validator.get_session_owner.await_count == 0, (
-            "a deliberate 'disabled' should still skip the lookup — that is policy, unchanged"
-        )
+        assert (
+            validator.get_session_owner.await_count == 0
+        ), "a deliberate 'disabled' should still skip the lookup — that is policy, unchanged"

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -48,6 +48,20 @@ class EnforcementMode(str, Enum):
     ENFORCED = "enforced"  # Full enforcement, block violations
 
 
+class EnforcementModeUnavailable(RuntimeError):
+    """The enforcement mode could not be read (#14010).
+
+    Deliberately distinct from :attr:`EnforcementMode.DISABLED`. An operator
+    turning enforcement off and the flag store being unreachable are different
+    facts, and collapsing them into one value is how an outage silently became
+    "authorization is off" platform-wide, with nothing louder than a debug line
+    saying so.
+
+    Callers that display the mode may surface this as unknown; callers that
+    *gate* on it must not read it as permission.
+    """
+
+
 class FeatureFlags(AsyncRedisClientMixin):
     """
     Redis-backed feature flags for access control rollout
@@ -91,9 +105,12 @@ class FeatureFlags(AsyncRedisClientMixin):
             return EnforcementMode.DISABLED
 
         except Exception as e:
-            logger.error("Failed to get enforcement mode: %s", e)
-            # Fail-safe: default to DISABLED on error
-            return EnforcementMode.DISABLED
+            # NOT a fail-safe: this is an authorization control, and returning
+            # DISABLED here made an unreachable flag store indistinguishable
+            # from a deliberate "off" (#14010). Raise so the caller decides,
+            # rather than deciding "no enforcement" on its behalf.
+            logger.error("Could not read enforcement mode: %s", e)
+            raise EnforcementModeUnavailable(str(e)) from e
 
     async def set_enforcement_mode(self, mode: EnforcementMode) -> bool:
         """


### PR DESCRIPTION
Part of #14010 — **step 1 only**. Deliberately does not close it; step 2 is a
decision, not code.

## Thinking Path

`validate_ownership` fast-paths on `_get_enforcement_mode() == "disabled"` and
skips the check entirely. That value arrived from three routes, two of which
were infrastructure faults rather than decisions: the flags service failing to
construct, and reading the mode raising.

Tracing it turned up a **fourth route the issue's own analysis missed**, and it
is the one that hid the other two. `FeatureFlags.get_enforcement_mode` caught
every exception itself:

```python
except Exception as e:
    logger.error("Failed to get enforcement mode: %s", e)
    # Fail-safe: default to DISABLED on error
    return EnforcementMode.DISABLED
```

For an authorization control that comment is exactly backwards — it is
fail-**open**. Because it never propagated, `session_ownership`'s own `except`
almost never fired; the failure had already been converted into "policy says
off" one layer down.

**The distinction the fix rests on:** *deliberately disabled* and *could not be
determined* are different facts, and collapsing them is what let a Redis blip
silently turn off every ownership check platform-wide for its duration, with
nothing louder than a debug line.

## What Changed

- `services/feature_flags.py` — new `EnforcementModeUnavailable`. A read failure
  now raises it instead of inventing `DISABLED`. **An unset flag still returns
  `DISABLED`** — that is policy, and it is step 2's decision.
- `security/session_ownership.py` — all three undetermined routes degrade to
  `DEGRADED_ENFORCEMENT_MODE = "log_only"` and log at **WARNING**, saying
  explicitly that this is not a deliberate `disabled`.

`log_only` is the deliberate choice over denying: every check runs and every
violation is recorded, while **no request that works today starts failing**. An
outage becomes loud in logs and metrics instead of silently permissive, without
smuggling in the posture change that step 2 exists to decide.

Checked both other consumers of `get_enforcement_mode`: `api/feature_flags.py`
already wraps it in a try that returns 500 (more honest than reporting a
fabricated "disabled"), and `get_rollout_status` has its own `except` returning a
dict. Neither breaks.

## Verification

`security/session_ownership_enforcement_mode_test.py`:

- a resolved mode is returned verbatim for all three values — the policy path is
  provably unmoved
- each of the three undetermined routes degrades to `log_only`, asserted
  explicitly as `!= "disabled"`
- the degrade is **audible** — asserts a WARNING is emitted naming what it
  degraded to, since a silent degrade is the same bug one level quieter
- the flag store raises rather than returning `DISABLED` on a read failure
- an unset flag still means `DISABLED`, pinning that step 2 is untouched

**Mutation evidence** — the resolver reproduced faithfully and re-run against the
pre-fix shape:

```
case                                PRE-FIX      FIXED   enforcement runs?
flag store unreachable             disabled   log_only   YES
no flags service at all            disabled   log_only   YES
flag simply unset (policy)         disabled   disabled   no (by policy)

assertion 'unreadable mode != disabled':  FIXED=PASS  PRE-FIX=FAIL
```

The third row is the important one: the policy path is identical before and
after, so this changes what happens when the control **breaks**, not what it
does when it works.

## What remains on #14010

Step 2 — deciding the default when the flag is unset (`log_only` first to size
the fallout, then `enforced`). That flips requests that succeed today, so it
needs its own change and rollout. Issue stays open.

## Model Used

Claude Opus 5 (1M context)
