### PR TITLE
fix(frontend): stop rebuilding i18n and leaking mounted trees in the test suite (#14860, #14842, #14854, #14613)

### DIFF
--- a/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
+++ b/autobot-frontend/src/components/__tests__/ChatInterface.test.ts
@@ -13,6 +13,24 @@ import {
 import { webSocketTestUtil } from '../../test/mocks/websocket-mock'
 import { ServiceURLs } from '@/constants/network'
 
+// #14613/#14842: this file's per-test budget, and only this file's.
+//
+// All 23 tests here render the FULL chat tree — sidebar, session list, message
+// list, composer and settings — through `renderComponent()` with a Pinia store
+// and a router. That is the heaviest mount in the suite and it is the subject
+// of the tests, not incidental setup: there is no unresolved promise to fix and
+// nothing to stub away without deleting the coverage. `waitFor()` has its own
+// 1s budget and fails with "unable to find element", so a 10s failure here has
+// always meant the render itself was still running.
+//
+// On the singleton self-hosted runner the reported `environment` cost is ~3x the
+// `tests` cost, so a mount measured at 3-4s idle has repeatedly crossed 10s under
+// contention — on a different test each run, which is why this is set per FILE
+// rather than pinned to whichever test lost the draw. The global `testTimeout`
+// in vitest.config.ts stays at 10s: a genuinely hung test elsewhere must still
+// fail fast.
+vi.setConfig({ testTimeout: 20_000 })
+
 // ---- Module mocks ----
 
 // Mock BatchApiService - the primary initialization path for ChatInterface

--- a/autobot-frontend/src/components/llc/__tests__/OrgPeopleList.contactEdit.test.ts
+++ b/autobot-frontend/src/components/llc/__tests__/OrgPeopleList.contactEdit.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 import OrgPeopleList from '../OrgPeopleList.vue'
@@ -44,9 +45,13 @@ const PEOPLE = buildOrgPeople(
 
 const GROUPS = groupPeopleByTeam(PEOPLE, [])
 
-function makeI18n(locale: 'en' | 'ar' = 'en') {
-  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
-}
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
 
 function mountList(
   overrides: Partial<{

--- a/autobot-frontend/src/components/llc/__tests__/OrgPeopleList.inactive.test.ts
+++ b/autobot-frontend/src/components/llc/__tests__/OrgPeopleList.inactive.test.ts
@@ -20,8 +20,12 @@ const PEOPLE = buildOrgPeople(
   [],
 )
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountList() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(OrgPeopleList, {
     props: {
       groups: groupPeopleByTeam(PEOPLE, []),

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.contextMenu.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.contextMenu.test.ts
@@ -24,6 +24,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -45,9 +46,13 @@ function step(id: string, x: number, y: number): CanvasNode {
   }
 }
 
-function makeI18n(locale: 'en' | 'ar') {
-  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
-}
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
 
 function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
   return mount(WorkflowCanvas, {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.geometry.test.ts
@@ -27,8 +27,12 @@ const NODES: CanvasNode[] = [
   { id: 'b', type: 'step', position: { ...TARGET }, data: { label: 'B' }, connections: [] },
 ]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(readonly = true) {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(WorkflowCanvas, {
     props: { nodes: NODES, selectedNodeId: null, readonly },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.grid.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.grid.test.ts
@@ -44,6 +44,11 @@ function step(id: string, x: number, y: number): CanvasNode {
   }
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(props: Record<string, unknown> = {}) {
   return mount(WorkflowCanvas, {
     props: {
@@ -51,7 +56,7 @@ function mountCanvas(props: Record<string, unknown> = {}) {
       selectedNodeId: null,
       ...props,
     },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.groupKind.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.groupKind.test.ts
@@ -40,8 +40,12 @@ const TREE = [
 
 const TEAMS = [{ id: 't1', name: 'Sales', member_user_ids: ['lead'] }]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(nodes: unknown[]) {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(WorkflowCanvas, {
     props: { nodes, selectedNodeId: null, readonly: true },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.keyboardA11y.test.ts
@@ -19,6 +19,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount, type VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -50,9 +51,13 @@ const WORKFLOW_NODES: CanvasNode[] = [
   },
 ]
 
-function makeI18n(locale: 'en' | 'ar') {
-  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
-}
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
 
 function mountCanvas(
   props: Record<string, unknown>,

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.marquee.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.marquee.test.ts
@@ -50,10 +50,15 @@ const NODES: CanvasNode[] = [
   step('n3', 900, 900), // screen (950,950)-(1190,1050) — well outside the marquee below
 ]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(nodes: CanvasNode[] = NODES) {
   return mount(WorkflowCanvas, {
     props: { nodes, selectedNodeId: null },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.minimap.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.minimap.test.ts
@@ -58,10 +58,15 @@ function node(id: string, x: number, y: number): CanvasNode {
 
 const NODES = [node('a', 0, 0), node('b', 2000, 1000)]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 function mountCanvas(props: Record<string, unknown> = {}) {
   return mount(WorkflowCanvas, {
     props: { nodes: NODES, selectedNodeId: null, readonly: true, ...props },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.multiSelect.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.multiSelect.test.ts
@@ -49,6 +49,11 @@ function step(id: string, x: number, y: number): CanvasNode {
   }
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas(props: Record<string, unknown> = {}) {
   return mount(WorkflowCanvas, {
     props: {
@@ -56,7 +61,7 @@ function mountCanvas(props: Record<string, unknown> = {}) {
       selectedNodeId: null,
       ...props,
     },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.nodeAriaLabel.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.nodeAriaLabel.test.ts
@@ -23,6 +23,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -72,12 +73,18 @@ const TOOL_NODES = buildToolCanvasNodes(
 
 const ALL_NODES = [...PEOPLE_NODES, ...PROCESS_NODES, ...TOOL_NODES]
 
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
+
 function mountCanvas(locale: 'en' | 'ar' = 'en') {
   return mount(WorkflowCanvas, {
     props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
-    global: {
-      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
-    },
+    global: { plugins: [makeI18n(locale)] },
   })
 }
 
@@ -153,7 +160,7 @@ describe('node accessible name identifies the node, not only its type (#14657)',
   it('the search result label draws on the same "{kind}: {name}" text as the accessible name (#14611 consolidation)', async () => {
     const wrapper = mount(WorkflowCanvas, {
       props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
-      global: { plugins: [createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })] },
+      global: { plugins: [makeI18n('en')] },
       attachTo: document.body,
     })
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.orgMode.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -49,9 +50,13 @@ const WORKFLOW_NODES: CanvasNode[] = [
   },
 ]
 
-function makeI18n(locale: 'en' | 'ar') {
-  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
-}
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
 
 function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
   return mount(WorkflowCanvas, {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.panClick.test.ts
@@ -36,8 +36,12 @@ const NODES: CanvasNode[] = [
   },
 ]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(WorkflowCanvas, {
     props: { nodes: NODES, selectedNodeId: null, readonly: true },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeA11y.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeA11y.test.ts
@@ -35,13 +35,17 @@ const LOCALE = en as unknown as {
 }
 const EXPECTED = LOCALE.llc.orgChart.processOpensWorkflow
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en },
+})
+
 function mountCanvas() {
-  const i18n = createI18n({
-    legacy: false,
-    locale: 'en',
-    fallbackLocale: 'en',
-    messages: { en },
-  })
   return mount(WorkflowCanvas, {
     props: { nodes: PROCESS_NODES, selectedNodeId: null, readonly: true },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeDetach.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.processNodeDetach.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -19,13 +20,21 @@ const PROCESS_NODES = buildProcessCanvasNodes(
   0,
 )
 
-function mountCanvas(locale: 'en' | 'ar' = 'en') {
-  const i18n = createI18n({
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({
     legacy: false,
     locale,
     fallbackLocale: 'en',
     messages: { en, ar },
-  })
+  }),
+)
+
+function mountCanvas(locale: 'en' | 'ar' = 'en') {
+  const i18n = makeI18n(locale)
   return mount(WorkflowCanvas, {
     props: { nodes: PROCESS_NODES, selectedNodeId: null, readonly: true },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.rules.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -72,12 +73,18 @@ const WORKFLOW_NODES: CanvasNode[] = [
   },
 ]
 
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
+
 function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
   return mount(WorkflowCanvas, {
     props: { selectedNodeId: null, readonly: true, ...props },
-    global: {
-      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
-    },
+    global: { plugins: [makeI18n(locale)] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.saveDialogFocus.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.saveDialogFocus.test.ts
@@ -19,8 +19,12 @@ const NODES: CanvasNode[] = [
   { id: 'n1', type: 'step', position: { x: 0, y: 0 }, data: { label: 'Step' }, connections: [] },
 ]
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 function mountCanvas() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   return mount(WorkflowCanvas, {
     props: { nodes: NODES, selectedNodeId: null, readonly: false },
     attachTo: document.body,

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.search.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.search.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -79,12 +80,18 @@ const TEAM_NODES = buildTeamCanvasNodes(
 
 const ALL_NODES = [...PEOPLE_NODES, ...PROCESS_NODES, ...TOOL_NODES, ...TEAM_NODES]
 
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
+
 function mountCanvas(locale: 'en' | 'ar' = 'en', nodes = ALL_NODES) {
   return mount(WorkflowCanvas, {
     props: { nodes, selectedNodeId: null, readonly: true },
-    global: {
-      plugins: [createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })],
-    },
+    global: { plugins: [makeI18n(locale)] },
     attachTo: document.body,
   })
 }
@@ -97,11 +104,11 @@ describe('canvas search box (#14611)', () => {
   it('is present when the canvas has nodes, and never gated on readonly', () => {
     const readonlyWrapper = mount(WorkflowCanvas, {
       props: { nodes: ALL_NODES, selectedNodeId: null, readonly: true },
-      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+      global: { plugins: [makeI18n('en')] },
     })
     const authoringWrapper = mount(WorkflowCanvas, {
       props: { nodes: ALL_NODES, selectedNodeId: null, readonly: false },
-      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+      global: { plugins: [makeI18n('en')] },
     })
 
     expect(readonlyWrapper.find('[data-testid="canvas-search-input"]').exists()).toBe(true)
@@ -111,7 +118,7 @@ describe('canvas search box (#14611)', () => {
   it('is absent from an empty canvas — nothing to search', () => {
     const wrapper = mount(WorkflowCanvas, {
       props: { nodes: [], selectedNodeId: null, readonly: true },
-      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+      global: { plugins: [makeI18n('en')] },
     })
 
     expect(wrapper.find('[data-testid="canvas-search-input"]').exists()).toBe(false)

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.toolNodeDetach.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.toolNodeDetach.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -31,13 +32,21 @@ const SHARED_TOOL_NODES = buildToolCanvasNodes(
   0,
 )
 
-function mountCanvas(nodes = ONE_ROLE_TOOL_NODES, locale: 'en' | 'ar' = 'en') {
-  const i18n = createI18n({
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({
     legacy: false,
     locale,
     fallbackLocale: 'en',
     messages: { en, ar },
-  })
+  }),
+)
+
+function mountCanvas(nodes = ONE_ROLE_TOOL_NODES, locale: 'en' | 'ar' = 'en') {
+  const i18n = makeI18n(locale)
   return mount(WorkflowCanvas, {
     props: { nodes, selectedNodeId: null, readonly: true },
     global: { plugins: [i18n] },

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.touch.test.ts
@@ -25,6 +25,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -56,9 +57,13 @@ const STEP_NODE: CanvasNode[] = [
   },
 ]
 
-function makeI18n(locale: 'en' | 'ar') {
-  return createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } })
-}
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, fallbackLocale: 'en', messages: { en, ar } }),
+)
 
 function mountCanvas(props: Record<string, unknown>, locale: 'en' | 'ar' = 'en') {
   return mount(WorkflowCanvas, {

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.undoRedo.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.undoRedo.test.ts
@@ -38,10 +38,15 @@ function step(id: string, x: number, y: number): CanvasNode {
 }
 
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 function mountCanvas(props: Record<string, unknown> = {}) {
   return mount(WorkflowCanvas, {
     props: { nodes: [], selectedNodeId: null, ...props },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 

--- a/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.zoomFit.test.ts
+++ b/autobot-frontend/src/components/workflow/__tests__/WorkflowCanvas.zoomFit.test.ts
@@ -75,10 +75,15 @@ function node(id: string, x: number, y: number): CanvasNode {
   }
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 function mountCanvas(props: Record<string, unknown> = {}) {
   return mount(WorkflowCanvas, {
     props: { nodes: [node('a', 0, 0), node('b', 2000, 1000)], selectedNodeId: null, readonly: true, ...props },
-    global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+    global: { plugins: [i18n] },
   })
 }
 
@@ -185,7 +190,7 @@ describe('the inbound deep link\'s viewport jump (#14611 focus-node-id prop)', (
         readonly: true,
         focusNodeId: 'a',
       },
-      global: { plugins: [createI18n({ legacy: false, locale: 'en', messages: { en } })] },
+      global: { plugins: [i18n] },
       attachTo: document.body,
     })
     await nextTick()

--- a/autobot-frontend/src/test/utils/i18n-cache.ts
+++ b/autobot-frontend/src/test/utils/i18n-cache.ts
@@ -1,0 +1,44 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+//
+// #14860: frontend mount helpers were constructing a fresh `createI18n`
+// instance — carrying the full `en` (and frequently `ar`) message bundle, about
+// 400KB each — on EVERY mount. A file that mounts 30 times re-ingested the
+// whole message tree 30 times for a plugin that is read-only in the test. That
+// cost is what pushed individual specs past the 10s per-test `testTimeout`
+// under runner load (#14854, #14842, #14613).
+//
+// Where a helper builds a *static* instance the fix is a module-scope `const`,
+// which needs no helper. This module exists for the other shape: a helper that
+// takes the locale as a parameter, so each call is deliberately different and a
+// blind hoist would be wrong. Memoizing per locale keeps every call site
+// honest — `makeI18n('ar')` still returns an Arabic instance — while building
+// at most one instance per locale per test file.
+//
+// The cache is module scope, and Vitest runs every test file in its own worker
+// (`isolate: true`, the default), so the cache never spans files.
+//
+// DO NOT use this for an instance a test MUTATES (`i18n.global.locale.value =
+// …`, `setLocaleMessage`, …). A mutated instance handed to the next caller is a
+// cross-test leak. Such call sites must keep building their own instance — see
+// `views/llc/__tests__/OrgChart.teamCanvas.test.ts` for that pattern.
+
+/**
+ * Wrap a per-locale factory so each distinct locale is built at most once.
+ *
+ * Deliberately generic over the built value rather than typed to vue-i18n: the
+ * call site keeps its own precise `createI18n` inference, including which
+ * message bundles it imported.
+ */
+export function memoizeByLocale<T>(build: (locale: string) => T): (locale: string) => T {
+  const cache = new Map<string, T>()
+  return (locale: string): T => {
+    const cached = cache.get(locale)
+    if (cached !== undefined) {
+      return cached
+    }
+    const created = build(locale)
+    cache.set(locale, created)
+    return created
+  }
+}

--- a/autobot-frontend/src/test/utils/test-utils.ts
+++ b/autobot-frontend/src/test/utils/test-utils.ts
@@ -8,15 +8,20 @@ import { vi, type Mock } from 'vitest'
 import type { Component } from 'vue'
 
 // Minimal i18n instance for tests (vue-i18n 11 requires app.use(i18n))
-const createTestI18n = () =>
-  createI18n({
-    legacy: false,
-    locale: 'en',
-    fallbackLocale: 'en',
-    messages: { en: {} },
-    missingWarn: false,
-    fallbackWarn: false,
-  })
+//
+// #14860: built once for the module, not once per `renderComponent()` call.
+// Every render used to construct a fresh instance and install it into a fresh
+// app; `ChatInterface.test.ts` alone renders the full chat tree a dozen times.
+// The messages are empty and no caller can reach this instance to mutate it —
+// `renderComponent()` does not return it — so sharing it is safe.
+const testI18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: {} },
+  missingWarn: false,
+  fallbackWarn: false,
+})
 
 // Common test routes for components that use router
 const testRoutes = [
@@ -61,7 +66,7 @@ export const renderComponent = (
     ...global,
     plugins: [
       ...(global.plugins || []),
-      createTestI18n(),
+      testI18n,
       ...(router ? [createTestRouter(undefined, ['/terminal/test-session'])] : []),
       ...(pinia ? [createTestingPinia({ createSpy: vi.fn })] : []),
     ],

--- a/autobot-frontend/src/test/vitest-setup.ts
+++ b/autobot-frontend/src/test/vitest-setup.ts
@@ -1,7 +1,28 @@
 // Copyright 2025-2026 mrveiss
 // SPDX-License-Identifier: Apache-2.0
 import '@testing-library/jest-dom'
-import { vi, afterAll } from 'vitest'
+import { vi, afterAll, afterEach } from 'vitest'
+import { enableAutoUnmount } from '@vue/test-utils'
+
+// #14842/#14613: destroy every mounted component tree after the test that made
+// it. The `beforeEach` below resets `document.body.innerHTML`, which DETACHES a
+// mounted tree's DOM but never unmounts the app — its component instances,
+// watchers and effects stay live for the rest of the file. A file that mounts
+// 30 times therefore ran its last test with 29 live trees still reacting to
+// every shared ref it touched, and the per-test cost grew as the file
+// progressed. That is why the failures land on a different test each run and
+// why a file passes alone but times out inside a larger, more loaded run.
+//
+// This generalises the per-file teardown that `OrgChart.canvasFilters.test.ts`
+// already carried, where the same accumulation was measured at ~3.4s on a quiet
+// runner against the 10s per-test ceiling on a loaded one. Unmounting is the
+// fix rather than a longer timeout: a longer timeout keeps the accumulation and
+// only raises the load needed to trip it.
+//
+// Safe against a test that unmounts its own wrapper — Vue's `app.unmount()` is
+// idempotent — and against a test that depends on a previous test's DOM,
+// because the `beforeEach` below already made that impossible.
+enableAutoUnmount(afterEach)
 
 // Prevent cross-file pollution: some test files call vi.stubGlobal() (e.g. window,
 // navigator, EventSource) at module scope without restoring. Under parallel file

--- a/autobot-frontend/src/views/llc/__tests__/CostDashboard.contract.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/CostDashboard.contract.test.ts
@@ -65,8 +65,12 @@ function respond(events: unknown[]): void {
   })
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 async function mountDashboard() {
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   const wrapper = mount(CostDashboard, {
     global: { plugins: [i18n], stubs: { BaseModal: true, BaseButton: true, Icon: true } },
   })

--- a/autobot-frontend/src/views/llc/__tests__/CostDashboard.rollup.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/CostDashboard.rollup.test.ts
@@ -44,8 +44,12 @@ function respond(rollup: unknown): void {
   })
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 async function mountDashboard() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   const wrapper = mount(CostDashboard, {
     global: { plugins: [i18n], stubs: { BaseModal: true, BaseButton: true, Icon: true } },
   })

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.canvasFilters.test.ts
@@ -11,9 +11,8 @@
 // suite is reported alongside) to pin the hard requirement that the
 // single-role lens keeps working exactly as it did before this issue.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
-import type { VueWrapper } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import { ref } from 'vue'
 import en from '@/i18n/locales/en.json'
@@ -165,25 +164,15 @@ function mockApi({ people = PEOPLE, teams = TEAMS, tools = TOOLS, processes = PR
   })
 }
 
-/**
- * #14799-adjacent: every mount is tracked so `afterEach` can tear it down.
- *
- * This file mounts the full OrgChart -> WorkflowCanvas tree 15 times and used
- * to unmount none of them, and no global `enableAutoUnmount` is configured. So
- * each test ran with every previous test's component tree still live in jsdom
- * — watchers attached, DOM retained — and the cost grew across the file. It
- * completes in ~3.4s on a quiet runner and timed out at the 10s per-test limit
- * on a loaded one, failing on the FIRST test of a describe rather than
- * anywhere that would point at the cause.
- *
- * Unmounting is the fix rather than a longer timeout: a longer timeout would
- * keep the accumulation and simply raise the load needed to trip it.
+/*
+ * #14799-adjacent: this file mounts the full OrgChart -> WorkflowCanvas tree 15
+ * times and used to unmount none of them, so each test ran with every previous
+ * test's component tree still live in jsdom — ~3.4s on a quiet runner against
+ * the 10s per-test ceiling on a loaded one. The per-file tracking list that
+ * fixed it is gone: `src/test/vitest-setup.ts` now calls
+ * `enableAutoUnmount(afterEach)` for the WHOLE suite (#14842), because every
+ * heavy file had the same accumulation and only this one had the teardown.
  */
-const mountedWrappers: VueWrapper[] = []
-
-afterEach(() => {
-  while (mountedWrappers.length) mountedWrappers.pop()?.unmount()
-})
 
 // #14854: built once for this file, not once per mount. The `en` bundle is
 // ~400KB and this file mounts 16 times, so constructing a fresh i18n inside the
@@ -197,7 +186,6 @@ async function mountOnCanvas(fixture?: Fixture) {
   const wrapper = mount(OrgChart, {
     global: { plugins: [i18nForTests], stubs: { HireAgentModal: true } },
   })
-  mountedWrappers.push(wrapper as unknown as VueWrapper)
   await flushPromises()
   await wrapper.get('[data-testid="org-view-canvas"]').trigger('click')
   await flushPromises()

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.deepLink.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.deepLink.test.ts
@@ -92,8 +92,12 @@ function respond({ processNodesDeferred = false }: { processNodesDeferred?: bool
   return { resolveProcessNodes: () => resolveProcessNodes?.() }
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 async function mountChart() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   const wrapper = mount(OrgChart, {
     global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, HireAgentModal: true, OrgPeopleList: true } },
   })
@@ -175,7 +179,6 @@ describe('a link to a node this company does not have (#14611)', () => {
   it('does not report "not found" until every lazy canvas source has actually answered', async () => {
     currentQuery = { node: 'ghost' }
     const { resolveProcessNodes } = respond({ processNodesDeferred: true })
-    const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
     const wrapper = mount(OrgChart, {
       global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, HireAgentModal: true, OrgPeopleList: true } },
     })

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.processMutation.test.ts
@@ -87,8 +87,12 @@ function processFetchCount(): number {
   return get.mock.calls.filter((c) => String(c[0]).includes('/process-nodes')).length
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 async function mountChart() {
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   const wrapper = mount(OrgChart, {
     global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, OrgPeopleList: true } },
   })

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.processNodes.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.processNodes.test.ts
@@ -78,8 +78,12 @@ function respond(processes: unknown = PROCESSES): void {
   })
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 async function mountChart() {
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   const wrapper = mount(OrgChart, {
     global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, OrgPeopleList: true } },
   })

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.teamCanvas.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.teamCanvas.test.ts
@@ -154,7 +154,14 @@ function makeI18n() {
   return createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en, ar } })
 }
 
-async function mountOnCanvas(fixture?: Fixture, i18n = makeI18n()) {
+// #14860: the default is ONE shared instance. Seven of this file's nine mounts
+// never touch the locale, and each was re-ingesting the ~400KB `en` and `ar`
+// bundles. The two RTL cases below deliberately mutate
+// `i18n.global.locale.value`, so they keep calling makeI18n() and pass their own
+// instance in — a mutated instance must never reach the next test.
+const sharedI18n = makeI18n()
+
+async function mountOnCanvas(fixture?: Fixture, i18n = sharedI18n) {
   mockApi(fixture)
   const wrapper = mount(OrgChart, { global: { plugins: [i18n], stubs: { HireAgentModal: true } } })
   await flushPromises()

--- a/autobot-frontend/src/views/llc/__tests__/OrgChart.toolMutation.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/OrgChart.toolMutation.test.ts
@@ -90,8 +90,12 @@ function toolFetchCount(): number {
   return get.mock.calls.filter((c) => String(c[0]).includes('/tool-nodes')).length
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 async function mountChart() {
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   const wrapper = mount(OrgChart, {
     global: { plugins: [i18n], stubs: { CanvasNodeSidebar: true, OrgPeopleList: true } },
   })

--- a/autobot-frontend/src/views/llc/__tests__/RolesView.operations.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/RolesView.operations.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { memoizeByLocale } from '@/test/utils/i18n-cache'
 import en from '@/i18n/locales/en.json'
 import ar from '@/i18n/locales/ar.json'
 
@@ -48,8 +49,16 @@ function respond(): void {
   })
 }
 
+// #14860: memoized per locale. This helper ran on EVERY mount and each call
+// re-ingested the ~400KB `en` and `ar` message bundles. The locale is a real
+// parameter here, so a blind hoist would be wrong — one instance per locale
+// is not. Nothing in this file mutates the returned instance.
+const makeI18n = memoizeByLocale((locale: string) =>
+  createI18n({ legacy: false, locale, messages: { en, ar } }),
+)
+
 async function mountView(locale: 'en' | 'ar' = 'en') {
-  const i18n = createI18n({ legacy: false, locale, messages: { en, ar } })
+  const i18n = makeI18n(locale)
   const wrapper = mount(RolesView, { global: { plugins: [i18n], stubs: { BaseModal: true } } })
   await flushPromises()
   return wrapper

--- a/autobot-frontend/src/views/llc/__tests__/RolesView.stepCost.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/RolesView.stepCost.test.ts
@@ -69,8 +69,12 @@ function respond(cost: unknown = COSTED, rate: unknown = { hourly_rate: '120.000
   })
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
+
 async function mountView() {
-  const i18n = createI18n({ legacy: false, locale: 'en', fallbackLocale: 'en', messages: { en } })
   // The first role is selected automatically on load (RolesView L472), so the
   // detail pane is present without an explicit click.
   const wrapper = mount(RolesView, { global: { plugins: [i18n], stubs: { BaseModal: true } } })

--- a/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
+++ b/autobot-frontend/src/views/llc/__tests__/RolesView.test.ts
@@ -62,8 +62,12 @@ function respond(overrides: Record<string, unknown> = {}): void {
   })
 }
 
+// #14860: one shared instance for the whole file. A fresh createI18n per
+// mount re-ingested the ~400KB message bundle every time; nothing here
+// mutates the instance, so building it once is enough.
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
 async function mountView() {
-  const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
   const wrapper = mount(RolesView, {
     global: { plugins: [i18n], stubs: { BaseModal: true } },
   })


### PR DESCRIPTION
## Thinking Path

Four issues describe one cluster: frontend specs crossing the 10s per-test
`testTimeout` on a *different* test each run, reddening PRs that touch none of
the code involved. #14860 names the cost — mount helpers rebuilding a ~400KB
i18n instance on every mount — and #14842 asks for the environment overhead
behind it. Both #14842 and #14854 explicitly rule out raising the global
timeout, and they are right to: a bigger ceiling keeps the cost and only raises
the load needed to trip it, while making a genuinely hung test take longer to
say so.

So the work was to remove cost, not to buy time. Reading the files turned up two
independent sources of it, plus one measurement that is not what it looks like:

**1. i18n rebuilt per mount (#14860).** 32 test files still constructed a fresh
`createI18n` — carrying the full `en`, and often also `ar`, bundle at ~400KB
each — inside the mount helper. A file that mounts 30 times re-ingested the
whole message tree 30 times for a plugin that is read-only in the test.

#14860 warns not to sweep this mechanically, and that warning holds: the config
is not uniform. Files were read individually and fall into three shapes —
static-and-never-mutated (hoist), locale-as-a-real-parameter (memoize per
locale, because a hoist would silently return English where Arabic was asked
for), and locale-deliberately-mutated (must keep building its own). All three
appear in this diff and are handled differently.

**2. Nothing was ever unmounted.** `src/test/vitest-setup.ts` resets
`document.body.innerHTML` before each test. That detaches a mounted tree's DOM
but never unmounts the app: component instances, watchers and effects stay live
for the rest of the file. A file that mounts 30 times ran its last test with 29
live trees still reacting to every shared ref it touched, so the per-test cost
grew as the file progressed. This is exactly the "passes alone, fails in a
larger run" shape in #14613, and `OrgChart.canvasFilters.test.ts` had already
diagnosed and fixed it *for itself* — its comment measures the accumulation at
~3.4s on a quiet runner against the 10s ceiling on a loaded one, and notes that
"no global `enableAutoUnmount` is configured". It was the only file that had the
teardown; every heavy file had the problem. That teardown is now global and the
private copy is removed.

The interaction matters: sharing one i18n instance per file (fix 1) makes fix 2
*more* necessary, not less, because a locale change on a shared instance now
reaches every tree still alive from an earlier test.

**3. The "environment is 3x tests" figure in #14842 is a sum, not a ratio of
like things.** Vitest resolves `pool: "forks"` with `isolate: true` (defaults;
neither is overridden here), and an isolated task never shares a runner —
`vitest/dist/chunks/cli-api…js` throws "Isolated tasks should not share runners"
on that path. So each of the 253 files pays its own worker spawn and its own
jsdom construction, and the reported `environment` total is the **sum across
workers running in parallel**, which necessarily exceeds wall clock and is not
comparable to the `tests` figure. #14842's acceptance criterion allows a written
reason instead of a changed number, and this is it. Two consequences follow, and
both are load-bearing for the other three issues:

- cross-file leakage — a leaked mock or shared module state from another file —
  cannot be the cause of #14613's second flake, because files never share a
  process. The interference is *intra*-file accumulation (fix 2) plus contention
  from the parallel run.
- the per-test budget each spec actually gets is whatever the contended runner
  leaves it, which is why the loser is effectively random.

**Where a timeout was raised, and why.** Once only, per file, and stated:
`ChatInterface.test.ts`. All 23 of its tests render the full chat tree — sidebar,
session list, message list, composer, settings — with a Pinia store and a router.
#14613 asks whether that is a slow mount or an unresolved promise; it is a slow
mount, and the file itself proves it: every wait goes through `waitFor()`, which
carries its own 1s budget and fails with "unable to find element", so a 10s
failure has always meant the render was still running. There is nothing to
resolve and nothing to stub away that would not delete the coverage. It gets 20s
for that file; the global stays at 10s. The budget is per *file* rather than
pinned to one test because #14842 recorded a different test failing each run —
naming one would be pretending we know which.

No other timeout was raised. The 30s budget on the 200-node canvas test and the
locale warm-up in `rtl.spec.ts` are already in `Dev_new_gui` (landed with
#14826); this PR adds their measured margin rather than re-doing them.

## What Changed

**Cost removed — i18n (#14860), 32 files:**

- New `autobot-frontend/src/test/utils/i18n-cache.ts` exporting
  `memoizeByLocale()`. Deliberately generic over the built value rather than
  typed to vue-i18n, so each call site keeps its own `createI18n` inference and
  its own message bundles. Documents the one case it must not be used for.
- **Hoisted to a module-scope `const`** (static config, instance never mutated) —
  20 files: `WorkflowCanvas.{geometry,grid,groupKind,marquee,minimap,multiSelect,panClick,processNodeA11y,saveDialogFocus,undoRedo,zoomFit}`,
  `OrgPeopleList.inactive`, `CostDashboard.{contract,rollup}`,
  `OrgChart.{deepLink,processMutation,processNodes,toolMutation}`,
  `RolesView.{stepCost,test}`. This matches the pattern already landed in ~50
  other files rather than introducing a second one.
- **Memoized per locale** (the helper takes `locale` as a real parameter, so a
  blind hoist would be wrong) — 11 files:
  `WorkflowCanvas.{contextMenu,keyboardA11y,orgMode,touch,rules,search,nodeAriaLabel,processNodeDetach,toolNodeDetach}`,
  `OrgPeopleList.contactEdit`, `RolesView.operations`. `RolesView.operations` is
  the file #14860 warned must not be hoisted as-is; it is one of these.
- **Left per-call, deliberately** — `OrgChart.teamCanvas.test.ts` mutates
  `i18n.global.locale.value` in two RTL cases. Its factory stays and those two
  cases keep building their own instance; only the shared default for the other
  seven mounts changed.
- `src/test/utils/test-utils.ts`: `renderComponent()` built a fresh instance on
  every render. Now one per module.

**Cost removed — mounted trees (#14842, #14613):**

- `src/test/vitest-setup.ts` calls `enableAutoUnmount(afterEach)`, so every
  mounted tree is destroyed after the test that made it.
- `OrgChart.canvasFilters.test.ts`: its private `mountedWrappers` list and
  `afterEach` teardown are removed in favour of the global one, and its comment
  now points at it.

**Timeout raised, once, with a reason (#14613, #14842):**

- `ChatInterface.test.ts`: `vi.setConfig({ testTimeout: 20_000 })` at file scope,
  with the reasoning recorded next to it. `vitest.config.ts` is unchanged —
  `testTimeout` stays 10000.

No assertion, fixture, message bundle or node count was altered anywhere in this
diff.

## Verification

**Constraint on the session that wrote this, stated plainly:** it could not
execute the suite or install anything, so every number below is from CI on this
branch. Where a claim could not be settled that way it says so rather than
asserting.

### Suite outcome — four runs, all green

| run | commit | Test Files | wall | transform | setup | import | tests | environment |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| base 32653009997 | a0202ec20 | 259 passed | 268.17s | 96.00 | 196.90 | 339.28 | 345.81 | 1251.74 |
| PR 32657637862 | 6498a5253 | 259 passed | 444.58s | 149.31 | 525.83 | 428.72 | 586.10 | 2080.47 |
| PR 32659232366 #1 | 603a17b95 | 259 passed | 210.25s | 72.11 | 237.27 | 197.30 | 268.16 | 962.44 |
| PR 32659232366 #2 | 603a17b95 | 259 passed | 233.51s | 80.53 | 269.17 | 219.91 | 273.21 | 1075.60 |

The last two are **the same commit, re-run** — #14842's first acceptance
criterion, both green. Zero failed files in any of the four.

### `environment` is a sum across parallel workers — measured, not argued

Run 32659232366 #1 reports `environment 962.44s` in a run whose **wall clock was
210.25s**. A per-run cost cannot be 4.58x the run. It is the sum of each file's
own jsdom construction across workers executing at the same time, which is what
`pool: "forks"` + `isolate: true` produces — and it is why the figure looks like
a multiple of `tests`. #14842's second criterion allows a written reason instead
of a changed number; this is the measurement behind it.

### What the change is worth — and the honest limit on saying so

The per-file durations move together with the runner, in both directions. Summing
every file's own reported duration:

| comparison | files this PR touched | files it did not | 
|---|---:|---:|
| PR run 1 (slow machine) vs base | 1.67x | 1.70x |
| PR run 2 (fast machine) vs base | 0.78x | 0.76x |

Touched and untouched move by the same factor each time. **So these runs cannot
separate the effect of this change from runner load, and no speedup is claimed
from them.** What they do establish is the absence of a regression: if removing
33 per-mount i18n constructions and adding a global unmount had cost anything
per file, the touched column would have diverged from the untouched one. It does
not, in either direction.

The work removed is provable by reading instead: 32 files went from one
`createI18n` **per mount** to one per file (or one per locale), and every
mounted tree is now destroyed instead of accumulating.

### Margin against the ceiling — the thing the issues actually asked for

Slowest **individual** test in the entire suite, excluding the one test with a
declared budget:

| run | slowest test | vs the 10s ceiling |
|---|---:|---|
| PR run 1 (the slowest machine of the four) | 5500ms | 45% margin |
| PR run 2 | 1684ms | 83% margin |
| PR run 3 | 2508ms | 75% margin |

On the *loaded* run — the one that came in at 1.67x base — nothing unbudgeted got
closer than 4.5 seconds to the limit.

The two files named in #14854, before (from the issue) and after:

| file / test | before | run 1 (loaded) | run 2 | run 3 |
|---|---|---:|---:|---:|
| `WorkflowCanvas.connections.test.ts` (whole file, 9 tests) | 11476ms passing | 22411ms | 9806ms | 9167ms |
| — `renders 200 nodes…` (declared 30s budget) | **15305ms, timed out at 10s** | 17154ms | 7669ms | 6728ms |
| — its other 8 tests | — | all under 2445ms | — | — |
| `i18n/__tests__/rtl.spec.ts` (whole file, 18 tests) | 8440ms passing | 4774ms | 3188ms | 3835ms |
| — `sets dir=rtl for Hebrew (he)` | **10043ms, timed out at 10s** | under 2445ms | — | — |
| `ChatInterface.test.ts` — `renders the main chat interface` | **timed out at 10s** (#14613, #14842) | 2617ms | 1455ms | 1966ms |

`rtl.spec.ts` now clears #14854's "comfortably under half the limit" target with
room to spare. The 200-node case does not and is not meant to: it holds the one
declared per-test budget, and it used 17.2s of its 30s even on the slowest run —
recorded here so the next person has the number rather than a guess. Both of
those fixes landed with #14826; what this PR adds for them is the measurement.

### The auto-unmount change did not disturb anything

`[Vue warn]` count in the job log: **347 on base, and 347 on each of the three PR
runs** — identical. No new warning, including from the 19 files that unmount
their own wrappers and from the 4 that use `@testing-library/vue`'s own cleanup.

Verified by reading beforehand, and borne out: no test file mounts inside
`beforeAll` (only `rtl.spec.ts` uses `beforeAll`, and it mounts nothing); Vue's
`app.unmount()` is guarded by `isMounted` so a second call cannot throw; and no
test can depend on a previous test's DOM because the existing `beforeEach`
already wipes `document.body`. Hook order is right too — the setup file's
`afterEach` is registered outermost and Vitest's default `sequence.hooks:
"stack"` runs `afterEach` in reverse, so a file's own teardown still goes first.

### Found while verifying, not caused by this PR — filed as #14879

The job log carries 23 `EnvironmentTeardownError` lines from
`ChatInterface.test.ts`, one per test: an async `ProviderFallbackChip` import
that outlives the environment, so those tests render an `ErrorBoundary` fallback
instead of the component and pass anyway. **23 on base and 23 on PR run 1; 0 on
runs 2 and 3** — so which component tree those 23 tests exercise depends on
runner load, and the suite reports the same green either way. Pre-existing on
both sides; filed rather than folded into this PR.

### Reproductions, for a reviewer who can run them

    cd autobot-frontend
    npx vitest run src/components/__tests__/ChatInterface.test.ts
    npx vitest run src/composables/llc src/components/llc src/views/llc
    npx vitest run src/components/workflow/__tests__/WorkflowCanvas.connections.test.ts src/i18n/__tests__/rtl.spec.ts

The second is #14613's ordering reproduction (367 tests). It is a **contention**
reproduction, not a deterministic one — it did not fail on every run when it was
reported either.

## Risks

- `enableAutoUnmount` was the one change with suite-wide blast radius. Four green
  runs and an unchanged `[Vue warn]` count (347 on base, 347 on each PR run)
  settle it; if it had reddened anything the right response would have been to
  drop that commit, not to widen a timeout to hide it.
- `memoizeByLocale` would be wrong for a call site that mutates the instance it
  gets back. The module says so, and the one file in the suite that does mutate
  is explicitly excluded and keeps its factory.
- The before/after runs are not load-matched — the runner is a contended
  singleton and the four runs span 210s to 445s of wall clock for the same 259
  files. That is why the touched/untouched control above is the load-bearing
  comparison and no speedup is claimed from the raw totals.
- The 200-node canvas test used 17.2s of its declared 30s budget on the slowest
  run. It is within budget, but the headroom is 1.75x rather than the 3x the
  number suggests at rest.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #14860, #14842, #14854, #14613

Note: closing keywords do not fire on merges into `Dev_new_gui` — these are
closed by hand after merge.

## Changelog fragment

- [x] N/A — internal test-infrastructure change, no user-visible behaviour

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (or N/A with reason) — this PR *is* a change to the
      test suite; no assertion was altered
- [x] Documentation updated if behavior changed — the reasoning lives next to the
      code it explains
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff
