### PR TITLE
fix(infrastructure): make a missing script dependency fail loudly, and guard the class (#14041, #14867, #14518, #14172)

### DIFF
--- a/autobot-infrastructure/autobot-ai-stack/templates/ai-status.sh
+++ b/autobot-infrastructure/autobot-ai-stack/templates/ai-status.sh
@@ -9,7 +9,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 SERVICE_NAME="autobot-ai-stack"
 HEALTH_PORT=8080

--- a/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
+++ b/autobot-infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh
@@ -25,7 +25,11 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # a loopback default there silently points a distributed Redis at the wrong
 # host. Do not fold this into the library's own defaulting.
 _OPERATOR_REDIS_HOST="${AUTOBOT_REDIS_HOST:-}"
-source "$PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 INFRA_ROOT="${PROJECT_ROOT}/autobot-infrastructure"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 LOG_FILE="${PROJECT_ROOT}/bootstrap-slm-${TIMESTAMP}.log"

--- a/autobot-infrastructure/shared/config/load_config.sh
+++ b/autobot-infrastructure/shared/config/load_config.sh
@@ -10,7 +10,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 CONFIG_FILE="${SCRIPT_DIR}/complete.yaml"
 
 # Check if yq is available for YAML parsing

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/dev-run.sh
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/dev-run.sh
@@ -6,7 +6,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 echo "Running AutoBot MCP Tracker in development mode..."
 export NODE_ENV=development

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/install.sh
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/install.sh
@@ -10,7 +10,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 echo "Installing AutoBot MCP Tracker..."
 

--- a/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/production-install.sh
+++ b/autobot-infrastructure/shared/mcp/tools/mcp-autobot-tracker/production-install.sh
@@ -12,7 +12,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 echo "Installing MCP AutoBot Tracker for Production..."
 

--- a/autobot-infrastructure/shared/scripts/analysis/main.py
+++ b/autobot-infrastructure/shared/scripts/analysis/main.py
@@ -10,15 +10,29 @@ to create and configure the FastAPI application. The actual application logic
 has been moved to backend/app_factory.py for better modularity.
 """
 
+import sys
+from pathlib import Path
+
 import uvicorn
 
-# Import the application factory
-from backend.app_factory import create_app
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
-from config import config as global_config_manager
+# Import the application factory
+from app_factory import create_app  # noqa: E402
+
+from config import config as global_config_manager  # noqa: E402
 
 # Configure logging using centralized logging manager
-from utils.logging_manager import get_backend_logger, setup_logging
+# #14518: ``utils.logging_manager`` does not exist under autobot-backend either;
+# get_backend_logger/setup_logging live in autobot_shared.logging_manager.
+from autobot_shared.logging_manager import get_backend_logger, setup_logging  # noqa: E402
 
 setup_logging()
 logger = get_backend_logger(__name__)

--- a/autobot-infrastructure/shared/scripts/analysis/npu_performance_measurement.py
+++ b/autobot-infrastructure/shared/scripts/analysis/npu_performance_measurement.py
@@ -28,7 +28,9 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from ai_hardware_accelerator import HardwareDevice
 from constants.network_constants import NetworkConstants
 from npu_semantic_search import get_npu_search_engine
-from utils.logging_manager import get_llm_logger
+# #14518: there is no `utils.logging_manager` on this script's path or
+# anywhere in the repo; the canonical logger factory is the shared one.
+from autobot_shared.logging_manager import get_llm_logger
 
 logger = get_llm_logger("npu_performance_measurement")
 

--- a/autobot-infrastructure/shared/scripts/analysis/test_bypass_classification.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_bypass_classification.py
@@ -14,10 +14,16 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Add src directory to path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# #14518: the path insert here pointed at a ``src`` directory that does not
+# exist beside this script, and ``llm_interface`` is a pre-restructure module
+# name. LLMInterface now lives in autobot-backend/llm_multi_provider.py. Add
+# autobot-backend the way the other operator entry points in this tree do
+# (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
-from agents.llm_failsafe_agent import get_robust_llm_response
+from agents.llm_failsafe_agent import get_robust_llm_response  # noqa: E402
 
 
 async def test_llm_failsafe_direct():
@@ -57,7 +63,7 @@ async def test_classification_without_communication():
 
     try:
         # Import just the LLM interface directly
-        from llm_interface import LLMInterface
+        from llm_multi_provider import LLMInterface
 
         llm = LLMInterface()
 

--- a/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_data_layer_debug.py
@@ -15,8 +15,8 @@ import sqlite3
 import traceback
 from pathlib import Path
 
-import aioredis
 import redis
+from redis import asyncio as aioredis
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +199,10 @@ def test_backend_errors():
 
         sys.path.append(str(project_root()))
 
-        from utils.redis_database_manager import RedisDatabaseManager
+        # #14518: `utils.redis_database_manager` exists nowhere. RedisDatabaseManager
+        # is defined in autobot_shared/redis_client.py (the canonical Redis entry
+        # point this repo mandates).
+        from autobot_shared.redis_client import RedisDatabaseManager
 
         manager = RedisDatabaseManager()
         logger.info("✅ RedisDatabaseManager imported successfully")

--- a/autobot-infrastructure/shared/scripts/analysis/test_failsafe_sequence.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_failsafe_sequence.py
@@ -15,10 +15,16 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-# Add src directory to path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# #14518: the path insert here pointed at a ``src`` directory that does not
+# exist beside this script, and ``llm_interface`` is a pre-restructure module
+# name. LLMInterface now lives in autobot-backend/llm_multi_provider.py. Add
+# autobot-backend the way the other operator entry points in this tree do
+# (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
-from llm_interface import LLMInterface
+from llm_multi_provider import LLMInterface  # noqa: E402
 
 
 async def test_failsafe_sequence():

--- a/autobot-infrastructure/shared/scripts/analysis/test_llm_config.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_llm_config.py
@@ -15,11 +15,17 @@ logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)
 
-# Add src directory to path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# #14518: the path insert here pointed at a ``src`` directory that does not
+# exist beside this script, and ``llm_interface`` is a pre-restructure module
+# name. LLMInterface now lives in autobot-backend/llm_multi_provider.py. Add
+# autobot-backend the way the other operator entry points in this tree do
+# (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
-import config as config
-from llm_interface import LLMInterface
+import config as config  # noqa: E402
+from llm_multi_provider import LLMInterface  # noqa: E402
 
 
 def check_llm_config():

--- a/autobot-infrastructure/shared/scripts/analysis/test_redis_connection.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_redis_connection.py
@@ -86,7 +86,8 @@ def test_redis_connection():
     # Test with Redis Database Manager
     logger.info("\n🗄️ Testing Redis Database Manager with Service Registry")
     try:
-        from utils.redis_database_manager import RedisDatabaseManager
+        # #14518: canonical home is autobot_shared/redis_client.py.
+        from autobot_shared.redis_client import RedisDatabaseManager
 
         manager = RedisDatabaseManager()
         logger.info("✅ Redis Database Manager initialized")

--- a/autobot-infrastructure/shared/scripts/automated_testing_procedure.py
+++ b/autobot-infrastructure/shared/scripts/automated_testing_procedure.py
@@ -25,6 +25,15 @@ import aiohttp
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -176,7 +185,7 @@ class AutomatedTestingSuite:
         start_time = time.time()
 
         try:
-            from backend.app_factory import create_app
+            from app_factory import create_app
 
             create_app()
 
@@ -515,7 +524,7 @@ class AutomatedTestingSuite:
 
         try:
             # Test if file upload validation exists
-            from backend.api.files import is_safe_file
+            from api.files import is_safe_file
 
             # Test safe files
             safe_files = ["document.pd", "image.jpg", "text.txt"]

--- a/autobot-infrastructure/shared/scripts/bulletproof-frontend/deploy-bulletproof-frontend.sh
+++ b/autobot-infrastructure/shared/scripts/bulletproof-frontend/deploy-bulletproof-frontend.sh
@@ -16,7 +16,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 LOCAL_FRONTEND_DIR="${PROJECT_ROOT}/autobot-slm-frontend"
 
 # Remote Configuration

--- a/autobot-infrastructure/shared/scripts/bulletproof-frontend/test-bulletproof-architecture.sh
+++ b/autobot-infrastructure/shared/scripts/bulletproof-frontend/test-bulletproof-architecture.sh
@@ -16,7 +16,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 FRONTEND_VM="${AUTOBOT_FRONTEND_HOST:-localhost}"
 FRONTEND_USER="${AUTOBOT_SSH_USER:-autobot}"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/bulletproof-frontend/zero-downtime-update.sh
+++ b/autobot-infrastructure/shared/scripts/bulletproof-frontend/zero-downtime-update.sh
@@ -9,7 +9,11 @@ set -euo pipefail
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 # #13149: this already consulted $PROJECT_ROOT but nothing ever set it, so it
 # fell through to the deployed install and this script deletes/replaces a
 # frontend directory — the #13092 failure class exactly.

--- a/autobot-infrastructure/shared/scripts/check_ai_stack_health.sh
+++ b/autobot-infrastructure/shared/scripts/check_ai_stack_health.sh
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Check AI Stack container health and data access
 
+# Every failed check increments this; the closing banner refuses to report a
+# clean health check while it is non-zero (#14867).
+FAILURES=0
+
 echo "🔍 Checking AI Stack Health..."
 
 # Check if container is running
@@ -35,7 +39,8 @@ for prompt in "${CRITICAL_PROMPTS[@]}"; do
     if docker exec autobot-ai-stack test -f "$prompt"; then
         echo "✅ Found: $prompt"
     else
-        echo "❌ Missing: $prompt"
+        echo "❌ Missing: $prompt" >&2
+        FAILURES=$((FAILURES + 1))
     fi
 done
 
@@ -58,19 +63,23 @@ with open('/app/knowledge_base/index.json') as f:
     print(f'   Categories: {list(categories.keys())}')
 "
 else
-    echo "❌ Knowledge base index missing"
+    echo "❌ Knowledge base index missing" >&2
+    FAILURES=$((FAILURES + 1))
 fi
 
 # Test prompt loading
 echo ""
 echo "🧪 Testing prompt loading..."
-docker exec autobot-ai-stack python -c "
+# (#14867) There is no `src` package: the container puts /app and /app/src on
+# sys.path (see docker/ai-stack/ai_container_main.py) and its own entry points
+# import these modules top-level. PromptManager lives in prompt_manager.py.
+if ! docker exec autobot-ai-stack python -c "
 import sys
 sys.path.insert(0, '/app')
 sys.path.insert(0, '/app/src')
 
 try:
-    from src.prompt_manager import PromptManager
+    from prompt_manager import PromptManager
     pm = PromptManager()
     prompts = pm.list_prompts()
     print(f'✅ Successfully loaded {len(prompts)} prompts')
@@ -80,18 +89,29 @@ try:
         'reflection.agent.system.main.role',
         'default.agent.system.main'
     ]
+    failed = []
     for prompt_key in test_prompts:
         try:
             content = pm.get_prompt(prompt_key)
             print(f'✅ Loaded {prompt_key}: {len(content)} chars')
-        except:
-            print(f'❌ Failed to load {prompt_key}')
+        except Exception as exc:
+            print(f'❌ Failed to load {prompt_key}: {exc}', file=sys.stderr)
+            failed.append(prompt_key)
+
+    if failed:
+        sys.exit(1)
 
 except Exception as e:
-    print(f'❌ Error loading prompts: {e}')
+    # (#14867) This used to print and fall through with exit 0, so a prompt
+    # loader that never ran was indistinguishable from one that passed.
+    print(f'❌ Error loading prompts: {e}', file=sys.stderr)
     import traceback
     traceback.print_exc()
-"
+    sys.exit(1)
+"; then
+    echo "❌ Prompt loading test failed - see the traceback above" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 # Check API health
 echo ""
@@ -100,9 +120,16 @@ if curl -s -f http://localhost:8080/health > /dev/null; then
     echo "✅ AI API is responding"
     curl -s http://localhost:8080/health | python -m json.tool
 else
-    echo "❌ AI API is not responding"
-    echo "   Check logs: docker logs autobot-ai-stack"
+    echo "❌ AI API is not responding" >&2
+    echo "   Check logs: docker logs autobot-ai-stack" >&2
+    FAILURES=$((FAILURES + 1))
 fi
 
 echo ""
+# (#14867) "Health check complete!" used to print with exit 0 no matter how many
+# checks above had failed.
+if [ "$FAILURES" -ne 0 ]; then
+    echo "❌ Health check FAILED: $FAILURES problem(s) found" >&2
+    exit 1
+fi
 echo "📊 Health check complete!"

--- a/autobot-infrastructure/shared/scripts/check_status.sh
+++ b/autobot-infrastructure/shared/scripts/check_status.sh
@@ -16,11 +16,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib/project_root.sh"
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || {
-    # Fallback if lib not found
-    # PROJECT_ROOT is exported by scripts/lib/project_root.sh, sourced above,
-    # so the pre-#13149 fallback assignment here is redundant (#13149).
-    [ -f "$PROJECT_ROOT/.env" ] && { set -a; source "$PROJECT_ROOT/.env"; set +a; }
+# #14172: the first path is an expected miss (callers sit at two different
+# depths), so only its stderr is discarded. The LAST attempt keeps its stderr
+# and a failure is fatal -- the old fallback re-read .env and carried on with
+# every ${VAR:-literal} silently taking its hardcoded right-hand side.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/../lib/ssot-config.sh" || {
+    echo "FATAL: ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
 }
 
 # Assign SSOT variables with fallbacks

--- a/autobot-infrastructure/shared/scripts/comprehensive_log_aggregator.py
+++ b/autobot-infrastructure/shared/scripts/comprehensive_log_aggregator.py
@@ -30,7 +30,20 @@ from pathlib import Path
 from typing import List
 
 import aiohttp
-import docker
+
+# The docker SDK is an optional operator dependency, declared in no
+# requirements file (#14518). Every other call site in this repo guards it the
+# same way -- scripts/logging/log_forwarder.py, autobot-backend's
+# secure_sandbox_executor.py, services/execution/docker_backend.py and
+# container_pool.py. A bare top-level import killed this aggregator before it
+# could collect any of its non-Docker log sources.
+try:
+    import docker
+
+    DOCKER_AVAILABLE = True
+except ImportError:
+    DOCKER_AVAILABLE = False
+    docker = None
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -170,11 +183,14 @@ class ComprehensiveLogAggregator:
         self.executor = ThreadPoolExecutor(max_workers=10)
 
         # Initialize Docker client
-        try:
-            self.docker_client = docker.from_env()
-            logger.info("Docker client initialized")
-        except Exception as e:
-            logger.warning("Docker client failed to initialize: %s", e)
+        if not DOCKER_AVAILABLE:
+            logger.warning("docker SDK not installed - container log sources disabled")
+        else:
+            try:
+                self.docker_client = docker.from_env()
+                logger.info("Docker client initialized")
+            except Exception as e:
+                logger.warning("Docker client failed to initialize: %s", e)
 
         # Setup logging
         logging.basicConfig(level=logging.INFO)

--- a/autobot-infrastructure/shared/scripts/database/reindex_claude_md.sh
+++ b/autobot-infrastructure/shared/scripts/database/reindex_claude_md.sh
@@ -15,7 +15,26 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
+
+# Import root for the inline Python below. PROJECT_ROOT is resolved above from
+# this file's own location (database/ -> scripts/ -> shared/ ->
+# autobot-infrastructure/ -> repo root, four levels); the knowledge package
+# lives under autobot-backend and autobot_shared.* at the repo root. Exported so
+# the quoted heredoc below can read it - inside a quoted heredoc ${PROJECT_ROOT}
+# is a literal string, never a substitution (#14867).
+export PROJECT_ROOT
+export PYTHONPATH="${PROJECT_ROOT}/autobot-backend:${PROJECT_ROOT}:${PYTHONPATH:-}"
+
+if [ ! -d "${PROJECT_ROOT}/autobot-backend" ]; then
+    echo "ERROR: backend package root not found at ${PROJECT_ROOT}/autobot-backend;" >&2
+    echo "       CLAUDE.md was NOT re-indexed (#14867)." >&2
+    exit 1
+fi
 
 echo "=== CLAUDE.md Vector Database Re-indexing ==="
 echo "Starting: $(date)"
@@ -104,14 +123,20 @@ cd ${PROJECT_ROOT}
 
 python3 << 'PYTHON_SCRIPT'
 import asyncio
+import os
 import sys
 from pathlib import Path
 from datetime import datetime
 
-# Add project to path
-sys.path.insert(0, '${PROJECT_ROOT}')
+# (#14867) This heredoc is quoted, so '${PROJECT_ROOT}' was inserted verbatim
+# and every path built from it pointed at a directory that cannot exist. The
+# shell exports PROJECT_ROOT instead.
+PROJECT_ROOT = os.environ["PROJECT_ROOT"]
+sys.path.insert(0, PROJECT_ROOT)
 
-from src.knowledge_base import KnowledgeBase
+# (#14867) There is no src package. KnowledgeBase is exported by the knowledge
+# package under autobot-backend (knowledge/_composed.py).
+from knowledge import KnowledgeBase
 from llama_index.core import Document
 
 async def reindex_claude_md():
@@ -119,10 +144,12 @@ async def reindex_claude_md():
         kb = KnowledgeBase()
         await kb._ensure_redis_initialized()
 
-        claude_path = Path("${PROJECT_ROOT}/CLAUDE.md")
+        claude_path = Path(PROJECT_ROOT) / "CLAUDE.md"
         if not claude_path.exists():
-            print("ERROR: CLAUDE.md not found!")
-            return
+            # (#14867) This used to return normally, so a re-index that never
+            # touched a single document still exited 0.
+            print(f"ERROR: CLAUDE.md not found at {claude_path}!", file=sys.stderr)
+            return 1
 
         content = claude_path.read_text(encoding='utf-8')
         print(f"Read CLAUDE.md: {len(content)} bytes")
@@ -147,13 +174,17 @@ async def reindex_claude_md():
         stats = await kb.get_stats()
         print(f"New document count: {stats.get('total_documents', 0)}")
         print(f"Indexed documents: {stats.get('indexed_documents', 0)}")
+        return 0
 
     except Exception as e:
-        print(f"ERROR during re-indexing: {e}")
+        # (#14867) The traceback used to be printed and then discarded, leaving
+        # the script to run its "verification" steps and exit 0.
+        print(f"ERROR during re-indexing: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()
+        return 1
 
-asyncio.run(reindex_claude_md())
+sys.exit(asyncio.run(reindex_claude_md()))
 PYTHON_SCRIPT
 
 echo ""

--- a/autobot-infrastructure/shared/scripts/deployment/validate_access_control.sh
+++ b/autobot-infrastructure/shared/scripts/deployment/validate_access_control.sh
@@ -45,7 +45,11 @@ BACKEND_DIR="${REPO_ROOT}/autobot-backend"
 # while `autobot_shared.*` sits at the repo root. Omitting either leaves half the
 # imports unresolvable, which is the shape of the original bug.
 export PYTHONPATH="${BACKEND_DIR}:${REPO_ROOT}:${PYTHONPATH:-}"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 REDIS_HOST="${AUTOBOT_REDIS_HOST:-localhost}"
 REDIS_PORT="${AUTOBOT_REDIS_PORT:-6379}"
 BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-localhost}"

--- a/autobot-infrastructure/shared/scripts/deployment_rollback.py
+++ b/autobot-infrastructure/shared/scripts/deployment_rollback.py
@@ -46,10 +46,16 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-# Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# `backup_manager.py` lives beside this script in a directory that is not a
+# package, so the owning directory goes on sys.path explicitly (#14518).
+# `scripts.backup_manager` could never resolve: repo-root `scripts/` contains
+# no backup_manager.py and has no __init__.py, and the old insert pointed at
+# `shared/` rather than at the directory that owns the module.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[0]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
 
-from scripts.backup_manager import BackupManager
+from backup_manager import BackupManager  # noqa: E402 - must follow the sys.path setup above
 
 # --- Standalone replacements for backend-only modules (#11761) --------------
 # `utils/` and `constants/` exist only under autobot-backend/ and are not

--- a/autobot-infrastructure/shared/scripts/detect-hardcoded-values.sh
+++ b/autobot-infrastructure/shared/scripts/detect-hardcoded-values.sh
@@ -24,7 +24,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 # Colors for output

--- a/autobot-infrastructure/shared/scripts/diagnose_startup_performance.sh
+++ b/autobot-infrastructure/shared/scripts/diagnose_startup_performance.sh
@@ -4,6 +4,21 @@
 # Backend Startup Performance Diagnosis Script
 # Analyzes what's causing slow startup times
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Import root for the generated profiler below, derived from this script's own
+# location: the repo root is three levels up (scripts/ -> shared/ ->
+# autobot-infrastructure/ -> repo root) and the backend modules are top-level
+# under autobot-backend. Baked into the generated file so it profiles the real
+# backend from any cwd (#14867).
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+BACKEND_DIR="${REPO_ROOT}/autobot-backend"
+
+if [ ! -d "${BACKEND_DIR}" ]; then
+    echo "ERROR: backend package root not found at ${BACKEND_DIR};" >&2
+    echo "       the generated profiler would import nothing (#14867)." >&2
+    exit 1
+fi
+
 echo "🔍 AutoBot Backend Startup Performance Analysis"
 echo "=============================================="
 echo "Investigating ~1 minute startup delay..."
@@ -242,8 +257,14 @@ echo "     - Cache heavy computations"
 
 # Step 10: Generate startup profile script
 echo -e "\n${BLUE}📊 Step 10: Creating Startup Profiler${NC}"
-cat > scripts/profile_startup.py << 'EOF'
+cat > scripts/profile_startup.py << EOF
 #!/usr/bin/env python3
+# Import root baked in at generation time (#14867).
+import sys
+sys.path.insert(0, "${BACKEND_DIR}")
+EOF
+
+cat >> scripts/profile_startup.py << 'EOF'
 """
 Startup Performance Profiler
 Profiles AutoBot backend startup to identify bottlenecks
@@ -251,15 +272,15 @@ Profiles AutoBot backend startup to identify bottlenecks
 import cProfile
 import pstats
 import time
-import sys
 import os
 
 def profile_startup():
     """Profile the startup sequence"""
     print("🔍 Starting backend startup profiling...")
 
-    # Add the project root to Python path
-    sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    # (#14867) The backend package root is inserted at the top of this file from
+    # the location of diagnose_startup_performance.sh; the old two-parent walk
+    # from __file__ resolved to the repo root, where these modules do not live.
 
     profiler = cProfile.Profile()
     profiler.enable()
@@ -267,9 +288,11 @@ def profile_startup():
     start_time = time.time()
 
     try:
-        # Import main components
+        # (#14867) There is no `backend` package: main.py and app_factory.py are
+        # top-level modules under autobot-backend, which is on sys.path above.
         print("Importing main modules...")
-        from backend import main, app_factory
+        import app_factory
+        import main  # noqa: F401  - imported for its startup side effects
 
         print("Creating FastAPI app...")
         app = app_factory.create_app()
@@ -277,8 +300,12 @@ def profile_startup():
         end_time = time.time()
 
     except Exception as e:
-        print(f"Error during profiling: {e}")
-        return
+        # (#14867) This used to return normally, so a profiler that never
+        # imported the backend exited 0 and reported nothing was wrong.
+        print(f"Error during profiling: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)
     finally:
         profiler.disable()
 

--- a/autobot-infrastructure/shared/scripts/distributed/check-health.sh
+++ b/autobot-infrastructure/shared/scripts/distributed/check-health.sh
@@ -16,11 +16,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || {
-    # Fallback if lib not found
-    # PROJECT_ROOT is exported by scripts/lib/project_root.sh, sourced above,
-    # so the pre-#13149 fallback assignment here is redundant (#13149).
-    [ -f "$PROJECT_ROOT/.env" ] && { set -a; source "$PROJECT_ROOT/.env"; set +a; }
+# #14172: the first path is an expected miss (callers sit at two different
+# depths), so only its stderr is discarded. The LAST attempt keeps its stderr
+# and a failure is fatal -- the old fallback re-read .env and carried on with
+# every ${VAR:-literal} silently taking its hardcoded right-hand side.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" || {
+    echo "FATAL: ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
 }
 
 echo "AutoBot Distributed Services Health Check"

--- a/autobot-infrastructure/shared/scripts/distributed/distributed-status.sh
+++ b/autobot-infrastructure/shared/scripts/distributed/distributed-status.sh
@@ -5,7 +5,11 @@
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/distributed/start-coordinator.sh
+++ b/autobot-infrastructure/shared/scripts/distributed/start-coordinator.sh
@@ -14,7 +14,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/export_service_keys.py
+++ b/autobot-infrastructure/shared/scripts/export_service_keys.py
@@ -21,8 +21,17 @@ logger = logging.getLogger(__name__)
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 import structlog
-from backend.security.service_auth import ServiceAuthManager
+from security.service_auth import ServiceAuthManager  # noqa: E402
 
 from autobot_shared.redis_client import get_async_redis_client
 

--- a/autobot-infrastructure/shared/scripts/infrastructure/deploy_browser_vnc_services.sh
+++ b/autobot-infrastructure/shared/scripts/infrastructure/deploy_browser_vnc_services.sh
@@ -7,7 +7,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 BROWSER_VM_IP="${AUTOBOT_BROWSER_SERVICE_HOST:-localhost}"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"
 BROWSER_USER="${AUTOBOT_SSH_USER:-autobot}"

--- a/autobot-infrastructure/shared/scripts/install-prometheus-stack.sh
+++ b/autobot-infrastructure/shared/scripts/install-prometheus-stack.sh
@@ -17,7 +17,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/install-slm.sh
+++ b/autobot-infrastructure/shared/scripts/install-slm.sh
@@ -22,7 +22,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # =============================================================================
 # Configuration

--- a/autobot-infrastructure/shared/scripts/logging/collect-application-logs.sh
+++ b/autobot-infrastructure/shared/scripts/logging/collect-application-logs.sh
@@ -6,7 +6,11 @@
 # Collects application-specific logs from all VMs
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 CENTRALIZED_DIR="$PROJECT_ROOT/logs/autobot-centralized"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/logging/collect-service-logs.sh
+++ b/autobot-infrastructure/shared/scripts/logging/collect-service-logs.sh
@@ -6,7 +6,11 @@
 # Collects service-specific logs from all VMs
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 CENTRALIZED_DIR="$PROJECT_ROOT/logs/autobot-centralized"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/logging/monitoring-dashboard.sh
+++ b/autobot-infrastructure/shared/scripts/logging/monitoring-dashboard.sh
@@ -6,7 +6,11 @@
 # Real-time monitoring interface for distributed AutoBot infrastructure
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 CENTRALIZED_DIR="$PROJECT_ROOT/logs/autobot-centralized"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/logging/quick-deploy-verification.sh
+++ b/autobot-infrastructure/shared/scripts/logging/quick-deploy-verification.sh
@@ -8,7 +8,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 
 # Color codes

--- a/autobot-infrastructure/shared/scripts/logging/view-centralized-logs.sh
+++ b/autobot-infrastructure/shared/scripts/logging/view-centralized-logs.sh
@@ -6,7 +6,11 @@
 # Interactive log viewing interface for centralized logs
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 CENTRALIZED_DIR="$PROJECT_ROOT/logs/autobot-centralized"
 

--- a/autobot-infrastructure/shared/scripts/migrate_redis_databases.py
+++ b/autobot-infrastructure/shared/scripts/migrate_redis_databases.py
@@ -18,7 +18,9 @@ import redis
 project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, project_root)
 
-from utils.redis_database_manager import RedisDatabase
+# #14518: `utils.redis_database_manager` exists nowhere; the RedisDatabase enum
+# is re-exported by autobot_shared/redis_client.py (see its __all__).
+from autobot_shared.redis_client import RedisDatabase
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")

--- a/autobot-infrastructure/shared/scripts/migrations/migrate_category_indexes.py
+++ b/autobot-infrastructure/shared/scripts/migrations/migrate_category_indexes.py
@@ -38,7 +38,16 @@ from dotenv import load_dotenv
 
 load_dotenv(project_root / ".env")
 
-from backend.knowledge_categories import get_category_for_source
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from knowledge_categories import get_category_for_source  # noqa: E402
 
 # Configure logging
 logging.basicConfig(

--- a/autobot-infrastructure/shared/scripts/monitor-service-auth.sh
+++ b/autobot-infrastructure/shared/scripts/monitor-service-auth.sh
@@ -7,7 +7,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 LOG_FILE="$PROJECT_ROOT/logs/backend.log"
 REPORT_DIR="$PROJECT_ROOT/reports/service-auth"

--- a/autobot-infrastructure/shared/scripts/monitoring/access_control_monitor.sh
+++ b/autobot-infrastructure/shared/scripts/monitoring/access_control_monitor.sh
@@ -35,7 +35,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # falls through to its fabricated default (#14866).
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 export PYTHONPATH="${REPO_ROOT}/autobot-backend:${REPO_ROOT}:${PYTHONPATH:-}"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/native-vm/start_autobot_native.sh
+++ b/autobot-infrastructure/shared/scripts/native-vm/start_autobot_native.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Load unified configuration system (legacy)
 _NATIVE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null && pwd)"

--- a/autobot-infrastructure/shared/scripts/native-vm/status_autobot_native.sh
+++ b/autobot-infrastructure/shared/scripts/native-vm/status_autobot_native.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Load unified configuration system (legacy)
 _NATIVE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null && pwd)"

--- a/autobot-infrastructure/shared/scripts/native-vm/stop_autobot_native.sh
+++ b/autobot-infrastructure/shared/scripts/native-vm/stop_autobot_native.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Load unified configuration system (legacy)
 _NATIVE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null && pwd)"

--- a/autobot-infrastructure/shared/scripts/native-vm/validate_native_deployment.sh
+++ b/autobot-infrastructure/shared/scripts/native-vm/validate_native_deployment.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Load unified configuration system (legacy)
 _NATIVE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." &> /dev/null && pwd)"

--- a/autobot-infrastructure/shared/scripts/network/discover-vms.sh
+++ b/autobot-infrastructure/shared/scripts/network/discover-vms.sh
@@ -6,7 +6,11 @@
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 NETWORK_RANGE="${NETWORK_SUBNET:-}"
 INVENTORY_PATH="../../ansible/inventory/hosts.yml"

--- a/autobot-infrastructure/shared/scripts/network/network-config.sh
+++ b/autobot-infrastructure/shared/scripts/network/network-config.sh
@@ -7,7 +7,11 @@
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Backend API (Main Machine - WSL)
 export BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-localhost}"

--- a/autobot-infrastructure/shared/scripts/profile_backend.py
+++ b/autobot-infrastructure/shared/scripts/profile_backend.py
@@ -13,10 +13,20 @@ import io
 import os
 import pstats
 import sys
+from pathlib import Path
 from pstats import SortKey
 
 # Add the project root to Python path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 
 def profile_backend_startup():
@@ -31,7 +41,7 @@ def profile_backend_startup():
 
     try:
         # Import and create the app (this triggers all the blocking operations)
-        from backend.app_factory import create_app
+        from app_factory import create_app
 
         print("📊 Profiling app creation...")
         create_app()

--- a/autobot-infrastructure/shared/scripts/profile_startup.py
+++ b/autobot-infrastructure/shared/scripts/profile_startup.py
@@ -13,6 +13,16 @@ import os
 import pstats
 import sys
 import time
+from pathlib import Path
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 
 def profile_startup():
@@ -30,7 +40,7 @@ def profile_startup():
     try:
         # Import main components
         print("Importing main modules...")
-        from backend import app_factory
+        import app_factory
 
         print("Creating FastAPI app...")
         app_factory.create_app()

--- a/autobot-infrastructure/shared/scripts/restore_kb_backup.sh
+++ b/autobot-infrastructure/shared/scripts/restore_kb_backup.sh
@@ -34,8 +34,17 @@ if [[ -f "${REPO_ROOT}/.venv/bin/activate" ]]; then
     source "${REPO_ROOT}/.venv/bin/activate"
 fi
 
-# Add backend to PYTHONPATH so imports resolve
-export PYTHONPATH="${BACKEND_DIR}:${REPO_ROOT}/autobot_shared:${PYTHONPATH:-}"
+# Add backend to PYTHONPATH so imports resolve.
+# (#14867) The second entry used to be ${REPO_ROOT}/autobot_shared, which puts
+# the *contents* of the package on the path instead of its parent, so every
+# `import autobot_shared.*` failed. The package root is ${REPO_ROOT}.
+export PYTHONPATH="${BACKEND_DIR}:${REPO_ROOT}:${PYTHONPATH:-}"
+
+if [[ ! -d "${BACKEND_DIR}" ]]; then
+    echo "ERROR: backend package root not found at ${BACKEND_DIR}." >&2
+    echo "       No backup was listed, verified or restored (#14867)." >&2
+    exit 1
+fi
 
 python3 - "$@" <<'PYTHON'
 """Entry point executed by restore_kb_backup.sh"""
@@ -43,7 +52,24 @@ import argparse
 import asyncio
 import sys
 
-from backup.engine import BackupEngine
+# (#14867) UNRESOLVED: `backup.engine.BackupEngine` does not exist anywhere in
+# this tree. autobot-backend/backup/ contains only __init__.py and scheduler.py,
+# and no class in the repo offers this contract (async create_backup() returning
+# .success/.backup_id/.components/.error alongside a sync verify_backup()). The
+# import is deliberately left naming the module it was written against rather
+# than being pointed at a near-miss, so the failure stays loud and specific. The
+# guard below turns the bare ModuleNotFoundError into a message that states
+# plainly that nothing was restored.
+try:
+    from backup.engine import BackupEngine
+except ImportError as exc:  # pragma: no cover - operator-facing failure path
+    print(
+        "ERROR: the knowledge-base backup engine could not be imported "
+        f"({exc}). NOTHING was listed, verified or restored - do not treat "
+        "this run as a successful restore (#14867).",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/autobot-infrastructure/shared/scripts/security/backfill_session_ownership.py
+++ b/autobot-infrastructure/shared/scripts/security/backfill_session_ownership.py
@@ -34,12 +34,22 @@ import asyncio
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import List, Optional
 
 # Add project root to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from backend.security.session_ownership import SessionOwnershipValidator
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
+from security.session_ownership import SessionOwnershipValidator  # noqa: E402
 
 from autobot_shared.redis_client import get_async_redis_client
 

--- a/autobot-infrastructure/shared/scripts/security/generate-tls-certificates.sh
+++ b/autobot-infrastructure/shared/scripts/security/generate-tls-certificates.sh
@@ -23,7 +23,11 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Configuration
 CERT_DIR="${PROJECT_ROOT}/certs"

--- a/autobot-infrastructure/shared/scripts/security/renew-certificates.sh
+++ b/autobot-infrastructure/shared/scripts/security/renew-certificates.sh
@@ -24,7 +24,11 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Configuration
 CERT_DIR="${PROJECT_ROOT}/certs"

--- a/autobot-infrastructure/shared/scripts/security/ssh-hardening/configure-ssh.sh
+++ b/autobot-infrastructure/shared/scripts/security/ssh-hardening/configure-ssh.sh
@@ -8,7 +8,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/security/ssh-hardening/populate-known-hosts.sh
+++ b/autobot-infrastructure/shared/scripts/security/ssh-hardening/populate-known-hosts.sh
@@ -8,7 +8,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/security/ssh-hardening/verify-ssh-security.sh
+++ b/autobot-infrastructure/shared/scripts/security/ssh-hardening/verify-ssh-security.sh
@@ -14,7 +14,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../../../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/setup/setup_tier2_research.sh
+++ b/autobot-infrastructure/shared/scripts/setup/setup_tier2_research.sh
@@ -7,6 +7,21 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Import root for the generated test script below, derived from this script's
+# own location: the repo root is four levels up (setup/ -> scripts/ -> shared/
+# -> autobot-infrastructure/ -> repo root) and agents.* lives under
+# autobot-backend. Baked into the generated file so it runs from any cwd, which
+# the old "from src.agents..." import could never do (#14867).
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+BACKEND_DIR="${REPO_ROOT}/autobot-backend"
+
+if [ ! -d "${BACKEND_DIR}" ]; then
+    echo "ERROR: backend package root not found at ${BACKEND_DIR};" >&2
+    echo "       the generated test script would import nothing (#14867)." >&2
+    exit 1
+fi
+
 echo "🚀 Setting up Tier 2 Advanced Web Research capabilities..."
 
 # Check if we're in a virtual environment
@@ -59,15 +74,26 @@ if [ ! -f config/web_research.yaml ]; then
 fi
 
 # Create a test script
-cat > test_tier2_research.py << 'EOF'
+cat > test_tier2_research.py << EOF
 #!/usr/bin/env python3
+# Import root baked in at generation time (#14867).
+import sys
+sys.path.insert(0, "${BACKEND_DIR}")
+EOF
+
+cat >> test_tier2_research.py << 'EOF'
 """
 Test script for Tier 2 Advanced Web Research capabilities
 """
 
 import asyncio
 import json
-from src.agents.advanced_web_research import AdvancedWebResearcher
+
+# (#14867) There is no src.agents.advanced_web_research module and no
+# AdvancedWebResearcher class. The Tier 2 researcher - async context manager,
+# search_web(query, max_results), CAPTCHA solver, browser fingerprinting - is
+# WebResearcher in autobot-backend/agents/web_researcher.py.
+from agents.web_researcher import WebResearcher
 
 async def test_advanced_research():
     print("🧪 Testing Advanced Web Research...")
@@ -79,9 +105,19 @@ async def test_advanced_research():
         }
     }
 
-    async with AdvancedWebResearcher(config) as researcher:
+    async with WebResearcher(config) as researcher:
         # Test search
         results = await researcher.search_web("python web scraping tutorial", max_results=3)
+
+        # (#14867) This used to print a green tick and exit 0 even when the
+        # researcher had returned status == "error" and zero results.
+        if results.get('status') != 'success':
+            print(
+                f"❌ Search FAILED: status={results.get('status')} "
+                f"error={results.get('error')}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         print(f"✅ Search completed!")
         print(f"Status: {results['status']}")

--- a/autobot-infrastructure/shared/scripts/setup/verify_installation.sh
+++ b/autobot-infrastructure/shared/scripts/setup/verify_installation.sh
@@ -13,6 +13,16 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Import roots for the inline Python below, derived from this script's own
+# location: the repo root is four levels up (setup/ -> scripts/ -> shared/ ->
+# autobot-infrastructure/ -> repo root). `config.*` and `agents.*` live under
+# autobot-backend, `autobot_shared.*` at the repo root. This replaces the old
+# `export PYTHONPATH=$(pwd)`, which resolved to wherever the operator happened
+# to be standing (#14867).
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}/autobot-backend:${REPO_ROOT}:${PYTHONPATH:-}"
+
 success_count=0
 total_checks=0
 
@@ -96,13 +106,28 @@ check_item "Playwright service" "curl -sf http://localhost:3000/health"
 
 # Agent configuration test
 echo -e "\n${BLUE}⚙️  Agent Configuration Test${NC}"
+# (#14867) This check used to be skipped silently whenever ./venv/bin/activate
+# was missing, and its outcome was neither counted in total_checks nor able to
+# affect the exit status - so a failing agent configuration still ended in
+# "All checks passed". It now always runs and always counts.
 if [ -f venv/bin/activate ]; then
+    # shellcheck source=/dev/null
     source venv/bin/activate
-    export PYTHONPATH=$(pwd)
+fi
 
-    python3 -c "
+total_checks=$((total_checks + 1))
+# (#14867) There is no src package. config_manager is the canonical config
+# singleton (see autobot-backend/worker_node.py).
+# (#14867) UNRESOLVED: get_agent_orchestrator names nothing in this tree.
+# AgentType lives in agents.agent_orchestration (types.py); the nearest accessor
+# after the #3393 move of agents/agent_orchestrator.py is
+# get_distributed_agent_coordinator, but that is a rename guess rather than a
+# match, so the import below is left naming what it was written against and its
+# failure is now loud instead of discarded.
+# NOTE: no backticks inside this double-quoted block - bash would run them.
+if python3 -c "
 try:
-    from src.config import global_config_manager
+    from config import config_manager as global_config_manager
     from src.agents import AgentType, get_agent_orchestrator
 
     # Test model assignments
@@ -120,9 +145,15 @@ try:
 
     print('✅ Agent configuration test passed')
 except Exception as e:
-    print(f'❌ Agent configuration test failed: {e}')
-    exit(1)
-" && echo -e "${GREEN}✅ Agent configuration test passed${NC}" || echo -e "${RED}❌ Agent configuration test failed${NC}"
+    import sys, traceback
+    print(f'❌ Agent configuration test failed: {e}', file=sys.stderr)
+    traceback.print_exc()
+    sys.exit(1)
+"; then
+    echo -e "${GREEN}✅ Agent configuration test passed${NC}"
+    success_count=$((success_count + 1))
+else
+    echo -e "${RED}❌ Agent configuration test failed - see the traceback above${NC}" >&2
 fi
 
 # Summary

--- a/autobot-infrastructure/shared/scripts/setup_browser_vnc.sh
+++ b/autobot-infrastructure/shared/scripts/setup_browser_vnc.sh
@@ -10,7 +10,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 BROWSER_VM_IP="${AUTOBOT_BROWSER_SERVICE_HOST:-localhost}"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/start-celery-worker.sh
+++ b/autobot-infrastructure/shared/scripts/start-celery-worker.sh
@@ -7,7 +7,11 @@
 set -e  # Exit on error
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="${PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 
 echo "=========================================="

--- a/autobot-infrastructure/shared/scripts/startup_timing_analysis.py
+++ b/autobot-infrastructure/shared/scripts/startup_timing_analysis.py
@@ -10,9 +10,19 @@ Detailed startup timing analysis to identify bottlenecks
 import os
 import sys
 import time
+from pathlib import Path
 
 # Add project root to path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 
 def time_import(module_name):
@@ -83,7 +93,7 @@ def main():
 
     # Test backend imports
     print("\n🏭 Backend Module Imports:")
-    backend_modules = ["backend.main", "backend.app_factory"]
+    backend_modules = ["main", "app_factory"]
 
     backend_total = 0
     for module in backend_modules:
@@ -96,7 +106,7 @@ def main():
     print("\n🚀 FastAPI App Creation:")
     app_start = time.time()
     try:
-        from backend.app_factory import create_app
+        from app_factory import create_app
 
         create_app()
         app_duration = time.time() - app_start

--- a/autobot-infrastructure/shared/scripts/test-service-auth-deployment.sh
+++ b/autobot-infrastructure/shared/scripts/test-service-auth-deployment.sh
@@ -3,31 +3,64 @@
 # SPDX-License-Identifier: Apache-2.0
 # Test service authentication deployment
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Import root for the inline Python below, derived from this script's own
+# location: the repo root is three levels up (scripts/ -> shared/ ->
+# autobot-infrastructure/ -> repo root), and `autobot_shared.*` lives there.
+# Without it the Redis check below cannot import anything (#14867).
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+export PYTHONPATH="${REPO_ROOT}/autobot-backend:${REPO_ROOT}:${PYTHONPATH:-}"
+
+# Every failed check increments this; the closing banner refuses to claim the
+# pre-deployment checks are complete while it is non-zero (#14867).
+FAILURES=0
+
 echo "🧪 Testing Service Authentication Deployment"
 echo "============================================"
 
 # 1. Check Ansible connectivity
 echo "1. Testing Ansible connectivity..."
-ansible all -i ansible/inventory/production.yml -m ping
+# (#14867) A failed ping used to leave the script running straight into the
+# "checks complete" banner.
+if ! ansible all -i ansible/inventory/production.yml -m ping; then
+    echo "❌ Ansible connectivity check failed - see the error above" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 # 2. Verify service keys generated
 echo ""
 echo "2. Verifying service keys in Redis..."
-python3 -c "
+# (#14867) backend.utils.async_redis_manager does not exist in this tree; the
+# canonical async Redis accessor is autobot_shared.redis_client.
+if ! python3 -c "
 import asyncio
-from backend.utils.async_redis_manager import get_redis_manager
+import sys
+from autobot_shared.redis_client import get_async_redis_client
 
 async def check_keys():
-    manager = await get_redis_manager()
-    redis = await manager.main()
+    redis = await get_async_redis_client()
+    if redis is None:
+        print('ERROR: Redis is unavailable - service keys were NOT verified', file=sys.stderr)
+        return 1
 
+    missing = []
     services = ['main-backend', 'frontend', 'npu-worker', 'redis-stack', 'ai-stack', 'browser-service']
     for svc in services:
         key = await redis.get(f'service:key:{svc}')
         print(f'  {\"✅\" if key else \"❌\"} {svc}')
+        if not key:
+            missing.append(svc)
 
-asyncio.run(check_keys())
-"
+    if missing:
+        print(f'ERROR: missing service keys: {missing}', file=sys.stderr)
+        return 1
+    return 0
+
+sys.exit(asyncio.run(check_keys()))
+"; then
+    echo "❌ Service key verification failed - see the error above" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 # 3. Check latest keys backup
 echo ""
@@ -35,6 +68,12 @@ echo "3. Latest service keys backup:"
 ls -lh config/service-keys/ | tail -n 1
 
 echo ""
+# (#14867) This banner used to print with exit 0 even when the checks above
+# failed, so a deployment could proceed on a check that never ran.
+if [ "$FAILURES" -ne 0 ]; then
+    echo "❌ $FAILURES pre-deployment check(s) failed - do NOT deploy" >&2
+    exit 1
+fi
 echo "✅ Pre-deployment checks complete"
 echo ""
 echo "To deploy:"

--- a/autobot-infrastructure/shared/scripts/test_configuration.py
+++ b/autobot-infrastructure/shared/scripts/test_configuration.py
@@ -17,6 +17,16 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# #14518: the ``src.`` package prefix below is a pre-restructure path that no
+# longer exists (src/unified_config.py was a re-export wrapper deleted by
+# 441649af66 in favour of the ``config`` package, and src/ later became
+# autobot-backend/). autobot-backend was also never on sys.path, so this
+# script raised ModuleNotFoundError on its own import block. Add the
+# directory the way the other operator entry points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 # Setup logger
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -27,7 +37,7 @@ def test_config_imports():
     logger.info("Testing configuration imports...")
 
     try:
-        import src.unified_config  # noqa: F401 - test imports work
+        import config  # noqa: F401 - test imports work
 
         logger.info("   All configuration imports successful")
         return True

--- a/autobot-infrastructure/shared/scripts/test_phase5_cleanup.py
+++ b/autobot-infrastructure/shared/scripts/test_phase5_cleanup.py
@@ -23,6 +23,20 @@ from pathlib import Path
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# #14518: the checks below import ``utils.*`` from autobot-backend and
+# ``monitoring.claude_api_monitor`` from autobot-slm-backend (reached through a
+# stale ``src.`` prefix). Neither tree was on sys.path, so the script raised
+# ModuleNotFoundError on its own import block. Add both the way the other
+# operator entry points in this tree do (#14129). Order matters: each insert(0)
+# moves the previous entry down, so autobot-slm-backend ends up ahead of
+# autobot-backend -- both ship a regular ``monitoring`` package and only the SLM
+# one contains claude_api_monitor, so the backend copy must not shadow it.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+for _tree in ("autobot-backend", "autobot-slm-backend"):
+    _candidate = str(_REPO_ROOT / _tree)
+    if _candidate not in sys.path:
+        sys.path.insert(0, _candidate)
+
 print("=" * 70)
 print("Testing Phase 5 Cleanup & Deprecation (Issue #348)")
 print("=" * 70)
@@ -135,7 +149,7 @@ def test_claude_api_monitor_deprecation():
     print("\n✓ ClaudeAPIMonitor Deprecation:")
 
     # Check module docstring for deprecation notice
-    import src.monitoring.claude_api_monitor as cam_module
+    import monitoring.claude_api_monitor as cam_module
 
     if "DEPRECATED" in cam_module.__doc__:
         print("  ✅ Module marked as DEPRECATED in docstring")

--- a/autobot-infrastructure/shared/scripts/test_real_startup.py
+++ b/autobot-infrastructure/shared/scripts/test_real_startup.py
@@ -10,6 +10,16 @@ Test real AutoBot startup time without importing heavy libraries
 import os
 import sys
 import time
+from pathlib import Path
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 
 def test_backend_import():
@@ -22,13 +32,13 @@ def test_backend_import():
     # Add project root to path
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-    print("📦 Importing backend.main (with lazy loading)...")
+    print("📦 Importing backend main (with lazy loading)...")
     import_start = time.time()
-    from backend import main
+    import main
 
     import_duration = time.time() - import_start
 
-    print(f"✅ backend.main imported in: {import_duration:.3f}s")
+    print(f"✅ backend main imported in: {import_duration:.3f}s")
 
     # Test that the app isn't created yet
     print(f"📋 App type: {type(main.app)}")
@@ -62,7 +72,7 @@ def test_uvicorn_startup():
 
     # This is what uvicorn roughly does:
     # 1. Import the module
-    from backend import main
+    import main
 
     import_time = time.time() - start_time
 

--- a/autobot-infrastructure/shared/scripts/test_startup_coordinator.sh
+++ b/autobot-infrastructure/shared/scripts/test_startup_coordinator.sh
@@ -1,22 +1,35 @@
 #!/bin/bash
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
-"""
-Test script for the startup coordinator
-"""
+# Test script for the startup coordinator
+# (#14867) These lines were a Python '"""' docstring that bash executed as
+# commands, emitting "command not found" noise that hid the real failures below.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Import roots for the inline Python below, derived from this script's own
+# location: startup_coordinator.py sits next to this script, and the repo root
+# is three levels up (scripts/ -> shared/ -> autobot-infrastructure/ -> root).
+# Without these the import test could never pass, and its stderr was discarded
+# so the script reported success anyway (#14867).
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+export PYTHONPATH="${SCRIPT_DIR}:${REPO_ROOT}/autobot-backend:${REPO_ROOT}:${PYTHONPATH:-}"
+
+# Every failed check increments this; the summary refuses to claim success
+# while it is non-zero (#14867).
+FAILURES=0
 
 echo "🧪 Testing AutoBot Startup Coordinator"
 echo "======================================"
 
 # Test 1: Check startup coordinator can be imported
 echo "Test 1: Python import test..."
-if python3 -c "from scripts.startup_coordinator import StartupCoordinator; print('✅ Import successful')" 2>/dev/null; then
+if python3 -c "from startup_coordinator import StartupCoordinator; print('✅ Import successful')"; then
     echo "✅ Startup coordinator imports successfully"
 else
     echo "❌ Failed to import startup coordinator"
     echo "Installing required dependencies..."
     pip3 install requests psutil
-    if python3 -c "from scripts.startup_coordinator import StartupCoordinator; print('✅ Import successful')" 2>/dev/null; then
+    if python3 -c "from startup_coordinator import StartupCoordinator; print('✅ Import successful')"; then
         echo "✅ Dependencies installed, import successful"
     else
         echo "❌ Still failing after dependency install"
@@ -26,7 +39,12 @@ fi
 
 # Test 2: Check component status
 echo -e "\nTest 2: Component status check..."
-python3 scripts/startup_coordinator.py --status
+# (#14867) The coordinator lives next to this script, not under a "scripts/"
+# directory relative to the caller's cwd, and a non-zero exit must be recorded.
+if ! python3 "${SCRIPT_DIR}/startup_coordinator.py" --status; then
+    echo "❌ Component status check failed - see the error above" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 # Test 3: Test backend health endpoint (if running)
 echo -e "\nTest 3: Backend health check..."
@@ -38,10 +56,10 @@ fi
 
 # Test 4: Validate startup component definitions
 echo -e "\nTest 4: Startup component validation..."
-python3 -c "
+if ! python3 -c "
 import sys
 sys.path.append('.')
-from scripts.startup_coordinator import StartupCoordinator
+from startup_coordinator import StartupCoordinator
 
 coordinator = StartupCoordinator()
 print(f'✅ Defined components: {list(coordinator.components.keys())}')
@@ -54,9 +72,18 @@ for name, comp in coordinator.components.items():
             sys.exit(1)
 
 print('✅ All component dependencies are valid')
-"
+"; then
+    echo "❌ Startup component validation failed - see the traceback above" >&2
+    FAILURES=$((FAILURES + 1))
+fi
 
 echo -e "\n🎯 Test Results:"
+# (#14867) A failed check used to print an X and still fall through to the
+# "ready for use" banner with exit 0.
+if [ "$FAILURES" -ne 0 ]; then
+    echo "❌ $FAILURES startup coordinator check(s) failed - NOT ready for use" >&2
+    exit 1
+fi
 echo "✅ Startup coordinator is ready for use!"
 echo ""
 echo "Usage examples:"

--- a/autobot-infrastructure/shared/scripts/trace_backend.py
+++ b/autobot-infrastructure/shared/scripts/trace_backend.py
@@ -16,6 +16,15 @@ from pathlib import Path
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 
 class FunctionTracer:
     def __init__(self, output_file=None):
@@ -103,7 +112,7 @@ def trace_backend_startup():
 
     try:
         print("📊 Tracing app creation...")
-        from backend.app_factory import create_app
+        from app_factory import create_app
 
         create_app()
         print("✅ App creation traced successfully")

--- a/autobot-infrastructure/shared/scripts/utilities/activate-mcp-bridges.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/activate-mcp-bridges.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/utilities/batch-configure-vms.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/batch-configure-vms.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/utilities/check-time-sync.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/check-time-sync.sh
@@ -19,11 +19,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || {
-    # Fallback if lib not found
-    # PROJECT_ROOT is exported by scripts/lib/project_root.sh, sourced above,
-    # so the pre-#13149 fallback assignment here is redundant (#13149).
-    [ -f "$PROJECT_ROOT/.env" ] && { set -a; source "$PROJECT_ROOT/.env"; set +a; }
+# #14172: the first path is an expected miss (callers sit at two different
+# depths), so only its stderr is discarded. The LAST attempt keeps its stderr
+# and a failure is fatal -- the old fallback re-read .env and carried on with
+# every ${VAR:-literal} silently taking its hardcoded right-hand side.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" || {
+    echo "FATAL: ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
 }
 
 # Configuration

--- a/autobot-infrastructure/shared/scripts/utilities/complete-vm-sync-templates.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/complete-vm-sync-templates.sh
@@ -15,7 +15,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 # Configuration
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 AUTOBOT_ROOT="${PROJECT_ROOT}"
 SSH_KEY="${AUTOBOT_SSH_KEY:-$HOME/.ssh/autobot_key}"

--- a/autobot-infrastructure/shared/scripts/utilities/enable-phase4-enterprise.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/enable-phase4-enterprise.sh
@@ -10,7 +10,11 @@ set -euo pipefail
 
 # Load SSOT configuration
 SCRIPT_DIR_UTIL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR_UTIL}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR_UTIL}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR_UTIL}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Color codes for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/utilities/migrate_encryption.py
+++ b/autobot-infrastructure/shared/scripts/utilities/migrate_encryption.py
@@ -26,8 +26,18 @@ from pathlib import Path
 project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
+# #14518: ``chat_history_manager``, ``config`` and ``encryption_service`` are
+# first-party autobot-backend modules, and that directory was never on
+# sys.path, so this migration raised ModuleNotFoundError on its own import
+# block. Add it the way the other operator entry points in this tree do
+# (#14129). The flat ``chat_history_manager`` module is now the
+# ``chat_history`` package, which is where ChatHistoryManager lives.
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 # Import AutoBot modules after path setup
-from chat_history_manager import ChatHistoryManager  # noqa: E402
+from chat_history import ChatHistoryManager  # noqa: E402
 
 from config import config as global_config_manager  # noqa: E402
 from encryption_service import (  # noqa: E402

--- a/autobot-infrastructure/shared/scripts/utilities/optimize_agents_test.py
+++ b/autobot-infrastructure/shared/scripts/utilities/optimize_agents_test.py
@@ -14,17 +14,24 @@ The ``AgentOptimizer`` optimizes agent markdown files *in place* (a single
 modified and ``False`` when it was unchanged/skipped.
 """
 
-# Add the infrastructure ``shared/`` root to the path so the
-# ``scripts.utilities.optimize_agents`` namespace package resolves.
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-shared_root = Path(__file__).parent.parent.parent
-sys.path.insert(0, str(shared_root))
+# Add the infrastructure ``shared/scripts`` root to the path so
+# ``utilities.optimize_agents`` (a PEP 420 namespace package portion) resolves
+# (#14518). The previous ``shared/`` insert made the import read
+# ``scripts.utilities.optimize_agents``, a path that does not exist from that
+# root. The module is addressed through ``utilities.`` rather than imported
+# bare because ``scripts/optimize_agents_test.py`` binds the *sibling*
+# ``scripts/optimize_agents.py`` to ``sys.modules["optimize_agents"]``; a bare
+# name would collide with it inside a shared pytest process.
+_SCRIPTS_ROOT = Path(__file__).resolve().parents[1]
+if str(_SCRIPTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_ROOT))
 
-from scripts.utilities.optimize_agents import AgentOptimizer
+from utilities.optimize_agents import AgentOptimizer  # noqa: E402 - must follow the sys.path setup above
 
 
 class TestAgentOptimizer(unittest.TestCase):

--- a/autobot-infrastructure/shared/scripts/utilities/prevent-local-frontend.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/prevent-local-frontend.sh
@@ -15,7 +15,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 AUTOBOT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Colors for output

--- a/autobot-infrastructure/shared/scripts/utilities/setup-ssh-keys.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/setup-ssh-keys.sh
@@ -19,11 +19,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || {
-    # Fallback if lib not found
-    # PROJECT_ROOT is exported by scripts/lib/project_root.sh, sourced above,
-    # so the pre-#13149 fallback assignment here is redundant (#13149).
-    [ -f "$PROJECT_ROOT/.env" ] && { set -a; source "$PROJECT_ROOT/.env"; set +a; }
+# #14172: the first path is an expected miss (callers sit at two different
+# depths), so only its stderr is discarded. The LAST attempt keeps its stderr
+# and a failure is fatal -- the old fallback re-read .env and carried on with
+# every ${VAR:-literal} silently taking its hardcoded right-hand side.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" || {
+    echo "FATAL: ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
 }
 
 # Colors for output

--- a/autobot-infrastructure/shared/scripts/utilities/sync-all-vms.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-all-vms.sh
@@ -21,11 +21,14 @@ source "$(dirname "${BASH_SOURCE[0]}")/../../../../scripts/lib/project_root.sh"
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || {
-    # Fallback if lib not found
-    # PROJECT_ROOT is exported by scripts/lib/project_root.sh, sourced above,
-    # so the pre-#13149 fallback assignment here is redundant (#13149).
-    [ -f "$PROJECT_ROOT/.env" ] && { set -a; source "$PROJECT_ROOT/.env"; set +a; }
+# #14172: the first path is an expected miss (callers sit at two different
+# depths), so only its stderr is discarded. The LAST attempt keeps its stderr
+# and a failure is fatal -- the old fallback re-read .env and carried on with
+# every ${VAR:-literal} silently taking its hardcoded right-hand side.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/lib/ssot-config.sh" || {
+    echo "FATAL: ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
 }
 
 # Colors

--- a/autobot-infrastructure/shared/scripts/utilities/sync-frontend.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-frontend.sh
@@ -12,7 +12,11 @@ set -e
 # Issue: #604 - SSOT Phase 4 Cleanup, #809 - SSOT migration
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Configuration - Using SSOT env vars with fallbacks
 REMOTE_HOST="${AUTOBOT_FRONTEND_HOST:-localhost}"

--- a/autobot-infrastructure/shared/scripts/utilities/sync-grafana-dashboards.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-grafana-dashboards.sh
@@ -27,7 +27,11 @@ warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 # SSOT Configuration - Load centralized config (#809)
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Configuration (from SSOT)
 TARGET_HOST="${AUTOBOT_SLM_HOST:-localhost}"

--- a/autobot-infrastructure/shared/scripts/utilities/sync-to-slm.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-to-slm.sh
@@ -16,9 +16,17 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 # #14459: pure classify_db_update_result() -- no ssh/psql/rsync in this file.
-source "${SCRIPT_DIR}/../lib/db-update-classify.sh"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/db-update-classify.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/db-update-classify.sh could not be sourced -- refusing to run without it (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Configuration (from SSOT)
 REMOTE_HOST="${AUTOBOT_SLM_HOST:-localhost}"

--- a/autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh
+++ b/autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh
@@ -36,7 +36,11 @@ log_header() {
 # Issue: #604 - SSOT Phase 4 Cleanup, #809 - SSOT migration
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # AutoBot VM configuration - Using SSOT env vars
 declare -A VMS=(

--- a/autobot-infrastructure/shared/scripts/utilities/test_autobot_npu_integration.py
+++ b/autobot-infrastructure/shared/scripts/utilities/test_autobot_npu_integration.py
@@ -78,7 +78,11 @@ def test_npu_worker_compatibility():
     """Test NPU worker Python compatibility"""
     try:
         # Test if we can import our NPU model manager
-        sys.path.insert(0, str(Path(__file__).parent.parent.parent / "docker" / "npu-worker"))
+        # npu_model_manager.py ships with the NPU worker, not under shared/
+        # (#14518). parents[3] is autobot-infrastructure/ from
+        # shared/scripts/utilities/; the old three-.parent walk resolved to
+        # shared/docker/npu-worker, which does not exist.
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "autobot-npu-worker" / "docker"))
 
         try:
             from npu_model_manager import NPUModelManager

--- a/autobot-infrastructure/shared/scripts/utilities/validate_chat_knowledge.py
+++ b/autobot-infrastructure/shared/scripts/utilities/validate_chat_knowledge.py
@@ -10,8 +10,19 @@ Tests the backend components without requiring a full server restart
 
 import asyncio
 import logging
+import sys
 import tempfile
 import uuid
+from pathlib import Path
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -24,7 +35,7 @@ async def test_chat_knowledge_components():
 
     try:
         # Import the components
-        from backend.api.chat_knowledge import (
+        from api.chat_knowledge import (
             ChatKnowledgeManager,
             FileAssociationType,
             KnowledgeDecision,
@@ -139,7 +150,7 @@ def test_api_endpoints():
     logger.info("🧪 Testing API Endpoints")
 
     try:
-        from backend.api.chat_knowledge import router
+        from api.chat_knowledge import router
 
         routes = router.routes
         expected_endpoints = [

--- a/autobot-infrastructure/shared/scripts/utilities/verify_backend_config.py
+++ b/autobot-infrastructure/shared/scripts/utilities/verify_backend_config.py
@@ -7,6 +7,18 @@
 Verify that the backend configuration includes workflow endpoints
 """
 
+import sys
+from pathlib import Path
+
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[4] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 
 def test_app_factory():
     """Test that the app factory properly includes workflow router."""
@@ -16,7 +28,7 @@ def test_app_factory():
 
     try:
         # Test importing the workflow router
-        from backend.api.workflow import router as workflow_router
+        from api.workflow import router as workflow_router
 
         print("✅ Workflow router import successful")
 
@@ -63,7 +75,7 @@ def test_route_registration():
 
     try:
         # Simulate what happens during app startup
-        from backend.api.workflow import router as workflow_router
+        from api.workflow import router as workflow_router
         from fastapi import APIRouter, FastAPI
 
         # Create test app

--- a/autobot-infrastructure/shared/scripts/validate_configuration.py
+++ b/autobot-infrastructure/shared/scripts/validate_configuration.py
@@ -26,6 +26,15 @@ _WS_PROTOCOLS = ("ws://", "wss://")
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
+# #14518: the first-party imports below carried a stale ``backend.`` package
+# prefix -- no ``backend`` package exists -- and autobot-backend was never on
+# sys.path, so this script raised ModuleNotFoundError on its own import block
+# before doing any work. Add the directory the way the other operator entry
+# points in this tree do (#14129).
+_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
+if str(_BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_DIR))
+
 
 def test_default_configuration():
     """Test configuration with default values"""
@@ -90,9 +99,9 @@ def test_custom_configuration():
         # Reload configuration with new environment
         import importlib
 
-        import src.config
+        import config
 
-        importlib.reload(src.config)
+        importlib.reload(config)
 
         from config import (
             API_BASE_URL,
@@ -133,7 +142,7 @@ def test_backend_configuration():
     logger.info("Testing Backend Configuration Service...")
 
     try:
-        from backend.services.config_service import ConfigService
+        from services.config_service import ConfigService
 
         config = ConfigService.get_full_config()
 

--- a/autobot-infrastructure/shared/scripts/validation_dashboard_generator.py
+++ b/autobot-infrastructure/shared/scripts/validation_dashboard_generator.py
@@ -22,9 +22,17 @@ from typing import Any, Dict, List
 # Add project root to path
 sys.path.append(str(Path(__file__).parent.parent))
 
+# `phase_validation_system.py` lives beside this script in a directory that is
+# not a package, so the owning directory goes on sys.path explicitly (#14518).
+# `scripts.phase_validation_system` could never resolve: repo-root `scripts/`
+# contains no phase_validation_system.py and has no __init__.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[0]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
 from project_state_tracker import get_state_tracker
 from phase_progression_manager import get_progression_manager
-from scripts.phase_validation_system import PhaseValidator
+from phase_validation_system import PhaseValidator  # noqa: E402 - must follow the sys.path setup above
 from utils.html_dashboard_utils import create_dashboard_header, get_light_theme_css
 from utils.template_loader import load_css, template_exists
 

--- a/autobot-infrastructure/shared/scripts/vm-management/fix-architecture-issues.sh
+++ b/autobot-infrastructure/shared/scripts/vm-management/fix-architecture-issues.sh
@@ -8,7 +8,11 @@ set -e
 
 # Load SSOT configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "${SCRIPT_DIR}/../lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../lib/ssot-config.sh" || {
+    echo "FATAL: ${SCRIPT_DIR}/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
+++ b/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh
@@ -18,7 +18,11 @@ NC='\033[0m'
 # SSOT Configuration - Issue #694
 # =============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/../lib/ssot-config.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../lib/ssot-config.sh" || {
+    echo "FATAL: $SCRIPT_DIR/../lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 SSH_KEY="$AUTOBOT_SSH_KEY"
 SSH_USER="$AUTOBOT_SSH_USER"

--- a/autobot-infrastructure/shared/scripts/zero_downtime_deploy.py
+++ b/autobot-infrastructure/shared/scripts/zero_downtime_deploy.py
@@ -43,10 +43,16 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-# Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# `backup_manager.py` lives beside this script in a directory that is not a
+# package, so the owning directory goes on sys.path explicitly (#14518).
+# `scripts.backup_manager` could never resolve: repo-root `scripts/` contains
+# no backup_manager.py and has no __init__.py, and the old insert pointed at
+# `shared/` rather than at the directory that owns the module.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[0]
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
 
-from scripts.backup_manager import BackupManager
+from backup_manager import BackupManager  # noqa: E402 - must follow the sys.path setup above
 
 # --- Standalone replacements for backend-only modules (#11761) --------------
 # `utils/` and `constants/` exist only under autobot-backend/ and are not

--- a/autobot-infrastructure/shared/tests/performance/run_baseline.sh
+++ b/autobot-infrastructure/shared/tests/performance/run_baseline.sh
@@ -21,7 +21,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 echo "================================================================================"

--- a/autobot-infrastructure/shared/tests/run_phase9_tests.sh
+++ b/autobot-infrastructure/shared/tests/run_phase9_tests.sh
@@ -34,7 +34,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Colors for output
 RED='\033[0;31m'

--- a/autobot-infrastructure/shared/tests/test_crud_endpoints.sh
+++ b/autobot-infrastructure/shared/tests/test_crud_endpoints.sh
@@ -11,7 +11,11 @@ _PROJECT_ROOT="$SCRIPT_DIR"
 while [ "$_PROJECT_ROOT" != "/" ] && [ ! -f "$_PROJECT_ROOT/.env" ]; do
     _PROJECT_ROOT="$(dirname "$_PROJECT_ROOT")"
 done
-source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
+source "$_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh" || {
+    echo "FATAL: $_PROJECT_ROOT/autobot-infrastructure/shared/scripts/lib/ssot-config.sh could not be sourced -- refusing to run on hardcoded config fallbacks (#14172)" >&2
+    return 1 2>/dev/null || exit 1
+}
 
 # Source environment variables if available, otherwise use defaults from NetworkConstants
 BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-localhost}"

--- a/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+++ b/autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
@@ -14,7 +14,8 @@
 #     56-script enumeration (docs/audit/ssot_config_shell_library_14041.md)
 #   - a literal that matches the SSOT keeps its value; a literal that diverges
 #     (AUTOBOT_BROWSER_SERVICE_PORT: 3000 vs 9001) gets the SSOT value
-#   - a missing/unreadable library still degrades via `|| true`
+#   - a missing/unreadable library is FATAL and loud (#14172) -- it used to
+#     degrade via `|| true`, which is the defect #14172 closed
 
 set -uo pipefail
 
@@ -45,46 +46,114 @@ out=$(bash -c "source '$LIB'; echo \"\$AUTOBOT_BACKEND_PORT\"")
 check "shape A: AUTOBOT_BACKEND_PORT default" "$out" "8001"
 
 # --- literal matches SSOT: value unchanged ----------------------------------
-out=$(bash -c "source '$LIB' 2>/dev/null || true; echo \"\${AUTOBOT_BACKEND_PORT:-8001}\"")
+out=$(bash -c "source '$LIB'; echo \"\${AUTOBOT_BACKEND_PORT:-8001}\"")
 check "matching literal (AUTOBOT_BACKEND_PORT 8001)" "$out" "8001"
 
 # --- literal diverges from SSOT: script now gets the SSOT value -------------
-out=$(bash -c "source '$LIB' 2>/dev/null || true; echo \"\${AUTOBOT_BROWSER_SERVICE_PORT:-3000}\"")
+out=$(bash -c "source '$LIB'; echo \"\${AUTOBOT_BROWSER_SERVICE_PORT:-3000}\"")
 check "diverging literal (AUTOBOT_BROWSER_SERVICE_PORT 3000 -> SSOT 9001)" "$out" "9001"
 
-# --- missing library: || true degrades to the literal, unchanged -----------
-out=$(bash -c "source /nonexistent/lib/ssot-config.sh 2>/dev/null || true; echo \"\${AUTOBOT_BROWSER_SERVICE_PORT:-3000}\"")
-check "missing library degrades to literal" "$out" "3000"
+# --- #14172: a missing library is FATAL and LOUD, not a silent degrade ------
+# This is the contract inversion #14172 decided. Before, every one of the 56
+# scripts answered a missing config bootstrap by carrying on with its hardcoded
+# ${VAR:-literal} right-hand side -- indistinguishable at runtime from having no
+# config system at all, which is exactly how #14041 stayed invisible.
+#
+# Executes the block AS SHIPPED, extracted out of a real script, rather than
+# re-typing the idiom here: a future edit that reintroduces `|| true` on the
+# shipped line has to trip this test. status-all-vms.sh is used because its
+# source line is the plain single-path shape the other 50 scripts share.
+_shipped="${REPO_ROOT}/autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh"
+_block=$(sed -n '/^source .*lib\/ssot-config\.sh/,/^}/p' "$_shipped")
+if [ -z "$_block" ]; then
+    echo "FAIL: could not extract the shipped ssot-config source block from status-all-vms.sh"
+    fail=$((fail + 1))
+else
+    _stderr_file="$(mktemp)"
+    # SCRIPT_DIR points at a directory with no lib/ -- the deploy/gitignore/rename
+    # regression #14172 exists to make visible.
+    out=$(bash -c "
+SCRIPT_DIR='$(mktemp -d)'
+$_block
+echo REACHED_THE_REST_OF_THE_SCRIPT
+" 2>"$_stderr_file")
+    rc=$?
+    _stderr_out=$(cat "$_stderr_file"); rm -f "$_stderr_file"
+
+    if [ "$rc" -ne 0 ]; then
+        echo "PASS: missing library exits non-zero (rc=$rc)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL: missing library exited 0 -- the script carried on with hardcoded fallbacks"
+        fail=$((fail + 1))
+    fi
+    check "missing library never reaches the rest of the script" "$out" ""
+    case "$_stderr_out" in
+        *FATAL*) echo "PASS: missing library announces itself on stderr"; pass=$((pass + 1)) ;;
+        *) echo "FAIL: missing library produced no FATAL on stderr -- got: [$_stderr_out]"; fail=$((fail + 1)) ;;
+    esac
+fi
 
 # --- Shape B: two-path attempt (check_status.sh et al.), first path wins ----
+# Both shape-B assertions execute the block AS SHIPPED for the same reason as
+# above. The two scripts sit at different depths, which is the whole reason the
+# shape tries two paths; only the LAST attempt keeps its stderr and dies.
+_shape_b_block() {
+    sed -n '/^source .*lib\/ssot-config\.sh/,/^}/p' "$1"
+}
+
+_b1=$(_shape_b_block "${REPO_ROOT}/autobot-infrastructure/shared/scripts/check_status.sh")
 out=$(bash -c "
 SCRIPT_DIR='${REPO_ROOT}/autobot-infrastructure/shared/scripts'
-source \"\$SCRIPT_DIR/lib/ssot-config.sh\" 2>/dev/null || source \"\$SCRIPT_DIR/../lib/ssot-config.sh\" 2>/dev/null || echo BOTH_FAILED
+$_b1
 echo \"\$AUTOBOT_BACKEND_HOST\"
 ")
 check "shape B: two-path attempt from scripts/ resolves" "$out" "127.0.0.1"
 
 # --- Shape B: second path wins (distributed/check-health.sh depth) ---------
+_b2=$(_shape_b_block "${REPO_ROOT}/autobot-infrastructure/shared/scripts/distributed/check-health.sh")
 out=$(bash -c "
 SCRIPT_DIR='${REPO_ROOT}/autobot-infrastructure/shared/scripts/distributed'
-source \"\$SCRIPT_DIR/../lib/ssot-config.sh\" 2>/dev/null || source \"\$SCRIPT_DIR/lib/ssot-config.sh\" 2>/dev/null || echo BOTH_FAILED
+$_b2
 echo \"\$AUTOBOT_OLLAMA_HOST\"
 ")
 check "shape B: two-path attempt from distributed/ resolves" "$out" "127.0.0.1"
 
+# --- Shape B is still fatal when BOTH paths miss --------------------------
+_stderr_file="$(mktemp)"
+out=$(bash -c "
+SCRIPT_DIR='$(mktemp -d)'
+$_b1
+echo REACHED_THE_REST_OF_THE_SCRIPT
+" 2>"$_stderr_file")
+rc=$?
+_stderr_out=$(cat "$_stderr_file"); rm -f "$_stderr_file"
+if [ "$rc" -ne 0 ] && [ "$out" = "" ]; then
+    echo "PASS: shape B dies when both paths miss"
+    pass=$((pass + 1))
+else
+    echo "FAIL: shape B survived both paths missing -- rc=$rc out=[$out]"
+    fail=$((fail + 1))
+fi
+case "$_stderr_out" in
+    *FATAL*) echo "PASS: shape B announces itself on stderr"; pass=$((pass + 1)) ;;
+    *) echo "FAIL: shape B produced no FATAL on stderr -- got: [$_stderr_out]"; fail=$((fail + 1)) ;;
+esac
+
 # --- ssh-hardening depth (../../lib) ----------------------------------------
+_b3=$(_shape_b_block "${REPO_ROOT}/autobot-infrastructure/shared/scripts/security/ssh-hardening/verify-ssh-security.sh")
 out=$(bash -c "
 SCRIPT_DIR='${REPO_ROOT}/autobot-infrastructure/shared/scripts/security/ssh-hardening'
-source \"\${SCRIPT_DIR}/../../lib/ssot-config.sh\" 2>/dev/null || true
+$_b3
 echo \"\$AUTOBOT_REDIS_HOST\"
 ")
 check "ssh-hardening depth (../../lib) resolves" "$out" "127.0.0.1"
 
-# --- Shape C: status-all-vms.sh -- unguarded source under set -e, VMS array -
+# --- Shape C: status-all-vms.sh -- shipped block under set -e, VMS array ----
 out=$(bash -c "
 set -e
 SCRIPT_DIR='${REPO_ROOT}/autobot-infrastructure/shared/scripts/vm-management'
-source \"\$SCRIPT_DIR/../lib/ssot-config.sh\"
+$_block
 echo \"ok:\${VMS[browser]}:\$AUTOBOT_BROWSER_SERVICE_PORT\"
 ")
 check "shape C: status-all-vms.sh no longer crashes, VMS populated" "$out" "ok:127.0.0.1:9001"

--- a/repo_tests/deployment_script_imports_resolve_test.py
+++ b/repo_tests/deployment_script_imports_resolve_test.py
@@ -18,6 +18,21 @@ exactly where this one hid.
 Scope: resolves the **module**, not the imported name, and never imports
 anything — importing would execute package `__init__` side effects, which a
 static check has no business doing.
+
+#14877 merged its own copy of this guard into this file rather than shipping a
+second one (consolidate, never fork). It added three things:
+
+* the importing script's **own directory** counts as an import root, because
+  these scripts export ``${SCRIPT_DIR}`` on PYTHONPATH. Without it the guard
+  reported a false positive on ``test_startup_coordinator.sh``, whose
+  ``startup_coordinator.py`` is a sibling;
+* ``test_no_inline_check_fabricates_its_own_result`` — #14867's second
+  acceptance criterion. Resolving the import is half the job: #14868 fixed
+  these imports and removed the stderr suppression, but left ``|| echo "{}"``
+  in place, so a check that cannot run still reports a value indistinguishable
+  from a clean result (#14880);
+* seven of the nine ``_KNOWN_BROKEN`` entries below were retired, because
+  #14877 fixed those imports.
 """
 
 from __future__ import annotations
@@ -41,15 +56,12 @@ _IMPORT = re.compile(r"^\s*from\s+([a-zA-Z_][\w.]*)\s+import\s+", re.M)
 # below asserts each is STILL broken, so a fix that leaves its entry behind
 # fails here rather than silently un-guarding that script.
 _KNOWN_BROKEN = {
-    ("check_ai_stack_health.sh", "src.prompt_manager"): "#14867",
-    ("database/reindex_claude_md.sh", "src.knowledge_base"): "#14867",
-    ("diagnose_startup_performance.sh", "backend"): "#14867",
-    ("restore_kb_backup.sh", "backup.engine"): "#14867",
-    ("setup/setup_tier2_research.sh", "src.agents.advanced_web_research"): "#14867",
-    ("setup/verify_installation.sh", "src.config"): "#14867",
-    ("setup/verify_installation.sh", "src.agents"): "#14867",
-    ("test-service-auth-deployment.sh", "backend.utils.async_redis_manager"): "#14867",
-    ("test_startup_coordinator.sh", "scripts.startup_coordinator"): "#14867",
+    # Seven siblings were retired by #14877, which repaired those imports.
+    # These two name a backup engine and an agent-orchestrator accessor that
+    # were never built — zero hits repo-wide — so the fix is a logic change,
+    # not an import rewrite.
+    ("restore_kb_backup.sh", "backup.engine"): "#14875",
+    ("setup/verify_installation.sh", "src.agents"): "#14875",
 }
 
 # Third-party and stdlib names an inline block may legitimately import.
@@ -61,8 +73,16 @@ _EXTERNAL_PREFIXES = {
 }
 
 
-def _resolves(module: str) -> bool:
-    for root in _IMPORT_ROOTS:
+def _resolves(module: str, script_dir: Path | None = None) -> bool:
+    """Resolve against the roots these scripts actually export on PYTHONPATH.
+
+    ``script_dir`` is the importing script's own directory. Several of these
+    scripts export ``${SCRIPT_DIR}`` (see test_startup_coordinator.sh:15) and
+    import a sibling module, so omitting it makes the guard report a false
+    positive on a script that runs perfectly well (#14877).
+    """
+    roots = list(_IMPORT_ROOTS) + ([script_dir] if script_dir else [])
+    for root in roots:
         base = root / Path(*module.split("."))
         if base.with_suffix(".py").exists() or (base / "__init__.py").exists():
             return True
@@ -93,7 +113,7 @@ def _unresolvable() -> tuple[list[str], int, int]:
             if top in _EXTERNAL_PREFIXES:
                 continue
             seen += 1
-            if not _resolves(module):
+            if not _resolves(module, script.parent):
                 rel_to_scripts = str(script.relative_to(_SCRIPT_DIR))
                 if (rel_to_scripts, module) in _KNOWN_BROKEN:
                     continue
@@ -257,4 +277,95 @@ def test_no_script_awaits_the_sync_redis_client() -> None:
         "these await the canonical Redis accessor without async_client=True, which "
         "returns a SYNC client and raises TypeError at call time — an import-layer "
         "guard cannot see this (#14866):\n  " + "\n  ".join(offenders)
+    )
+
+
+# --------------------------------------------------------------------------
+# The reporting layer (#14867, #14877). Resolving the import and letting the
+# error reach stderr are both necessary and still not sufficient: what a caller
+# downstream READS must also change when the check could not run. #14868 fixed
+# these imports and removed the `2>/dev/null`, but left `|| echo "{}"`, so the
+# monitor still answers a failed check with a value that reads as "no findings".
+# That is the specific thing #14866 cost: `0|0|0` violations reported *because*
+# the imports were broken.
+# --------------------------------------------------------------------------
+
+# A literal that impersonates a successful measurement. Deliberately not every
+# `|| echo` — a fallback that says "unavailable" is fine; one that says "0" or
+# "{}" is a fabricated clean result.
+_SENTINEL = re.compile(r'^(?:[0-9|.]+|UNKNOWN|N/?A|\{\}|\[\]|""|null)$', re.IGNORECASE)
+_FALLBACK_ECHO = re.compile(r'\|\|\s*(?:echo|printf)\s+(["\']?)([^"\'\n;]*)\1')
+
+# Scripts still doing this, each with its tracking issue. Same self-guarding
+# contract as _KNOWN_BROKEN: asserted STILL fabricating, so a fix forces the
+# entry out rather than leaving the guard quietly narrower than it claims.
+_KNOWN_FABRICATING = {"monitoring/access_control_monitor.sh": "#14880"}
+
+
+def _fabricated_results() -> tuple[list[tuple[str, int, str]], int]:
+    """(sites answering a failed python check with a sentinel, blocks seen).
+
+    Reuses the two block regexes above rather than scanning a single line. The
+    first draft of this function matched ``python3 -c`` to end-of-line, which
+    finds nothing for a MULTI-LINE block — the ``|| echo "{}"`` sits after the
+    closing quote, several lines down. It reported zero fabricated results on a
+    file that has three, and only the positive control below caught it. That is
+    the same shape as the delimiter trap documented for the call layer.
+    """
+    sites: list[tuple[str, int, str]] = []
+    blocks = 0
+    for script in _shell_scripts():
+        text = script.read_text(encoding="utf-8", errors="replace")
+        for pattern in (_PY_BLOCK_MULTILINE, _PY_BLOCK_INLINE):
+            for match in pattern.finditer(text):
+                blocks += 1
+                newline = text.find("\n", match.end())
+                tail = text[match.end() : newline if newline != -1 else len(text)]
+                echo = _FALLBACK_ECHO.search(tail)
+                if echo and _SENTINEL.match(echo.group(2).strip()):
+                    sites.append(
+                        (str(script.relative_to(_SCRIPT_DIR)),
+                         text[: match.start()].count("\n") + 1,
+                         echo.group(2).strip())
+                    )
+    return sites, blocks
+
+
+def test_the_fabrication_sweep_reached_the_scripts() -> None:
+    """Discovery floor — an extractor that stops matching reports clean."""
+    sites, blocks = _fabricated_results()
+    assert blocks >= 20, (
+        f"only extracted {blocks} inline python blocks — the matcher has "
+        "regressed and the check below would pass having read nothing"
+    )
+    assert sites, (
+        "the sweep found no fabricated results at all, but _KNOWN_FABRICATING "
+        "is not empty — the matcher has regressed"
+    )
+
+
+def test_no_inline_check_fabricates_its_own_result() -> None:
+    """A check that could not run must not report a reassuring value (#14867)."""
+    sites, _ = _fabricated_results()
+    offenders = [
+        f"{rel}:{line}  answers a failed python block with {value!r}"
+        for rel, line, value in sites
+        if rel not in _KNOWN_FABRICATING
+    ]
+    assert not offenders, (
+        "a failed check must be distinguishable from a clean one by what it "
+        "REPORTS, not only by what reaches stderr. Emit an explicit error and a "
+        "non-zero exit status instead of a sentinel (#14867):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("rel,issue", sorted(_KNOWN_FABRICATING.items()))
+def test_each_fabrication_exemption_is_still_broken(rel: str, issue: str) -> None:
+    """An obsolete exemption exempts nothing, and is this check's positive control."""
+    assert (_SCRIPT_DIR / rel).is_file(), f"{rel} moved or was deleted — update this exemption ({issue})"
+    sites, _ = _fabricated_results()
+    assert any(r == rel for r, _, _ in sites), (
+        f"{rel} no longer fabricates a result, so the exemption ({issue}) is "
+        "obsolete — remove it from _KNOWN_FABRICATING so the script is guarded again"
     )

--- a/repo_tests/infra_script_imports_resolve_test.py
+++ b/repo_tests/infra_script_imports_resolve_test.py
@@ -1,0 +1,264 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""An import under shared/scripts must name a module that actually resolves (#14518).
+
+pyflakes never checks that an import *target* exists. It reports F401 for an
+unused import and F821 for an undefined name, so a script can be completely
+F821-clean — which every script in this tree became after #14405 / PR #14504 —
+and still die with ``ModuleNotFoundError`` on its own import block, before
+reaching a single line of the repaired code. "0 findings" is not "runs".
+
+The sweep behind #14518 found 11 distinct unresolvable targets across 44 import
+sites, in three shapes:
+
+* a stale ``backend.`` prefix over the ``autobot-backend/`` tree (22 sites),
+  plus the legacy ``src.``, ``llm_interface`` and ``chat_history_manager``
+  names left behind by earlier layouts;
+* a target that exists but is not on the importing script's path;
+* a third-party target declared in no requirements file.
+
+This is the ``autobot-infrastructure/shared/scripts/`` counterpart of
+``repo_tests/first_party_imports_resolve_test.py`` (#14839), and deliberately
+shares its policy decisions: resolve the **module**, never the imported name
+(resolving names means importing, which drags in the whole dependency graph);
+and exempt an import inside a ``try`` that catches ``ImportError`` /
+``ModuleNotFoundError``, because that is a genuine optional dependency.
+
+Scope note: this lives in ``repo_tests/`` because ``autobot-infrastructure/`` is
+in no pytest ``testpaths`` entry and in no CI pytest invocation. A test placed
+next to the scripts would never run — which is the same class of silence the
+test exists to remove.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts"
+_SKIP_PARTS = {".git", "node_modules", "__pycache__", ".worktrees", "venv", ".venv"}
+
+# Roots an import may legitimately resolve against: the repo root (installed
+# first-party packages such as autobot_shared), the two backends, and the
+# scripts tree itself. The importing file's own directory is added per file.
+_ROOTS = (
+    _REPO_ROOT,
+    _REPO_ROOT / "autobot-backend",
+    _REPO_ROOT / "autobot-slm-backend",
+    _SCRIPTS,
+)
+
+# Import name -> distribution name, where the two differ. Only entries actually
+# needed by this tree; an unknown alias produces a finding, never a silent pass.
+_DIST_ALIASES = {
+    "yaml": "pyyaml",
+    "dotenv": "python_dotenv",
+    "jose": "python_jose",
+    "dateutil": "python_dateutil",
+    "PIL": "pillow",
+    "cv2": "opencv_python",
+    "sklearn": "scikit_learn",
+    "psycopg2": "psycopg2_binary",
+    "jwt": "pyjwt",
+    "OpenSSL": "pyopenssl",
+    "git": "gitpython",
+    "attr": "attrs",
+    "pkg_resources": "setuptools",
+    "docx": "python_docx",
+    "pptx": "python_pptx",
+    "fitz": "pymupdf",
+    "magic": "python_magic",
+    "bs4": "beautifulsoup4",
+    "zmq": "pyzmq",
+}
+
+# Imports whose target genuinely does not resolve, each with the issue tracking
+# it. Kept small on purpose: an entry here is a live bug, not an accepted
+# exception. The parametrized test below asserts every entry is *still* broken,
+# so a fix forces its exemption out rather than leaving this file quietly
+# guarding one path less than it claims.
+_KNOWN_BROKEN = {
+    # Symbols deleted or never landed — no import spelling reaches them, so the
+    # fix is a logic change, not a rewrite. Split out of #14518.
+    ("test_phase5_cleanup.py", "backend.api"): "#14870",
+    ("utilities/verify_backend_config.py", "backend.app_factory"): "#14870",
+    ("utilities/verify_ssh_manager.py", "backend.services.ssh_manager"): "#14870",
+    # Undeclared optional dependency whose absence silently drops an arm of the
+    # comparison these scripts exist to perform.
+    ("analysis/redis_final_analysis.py", "langchain_redis"): "#14871",
+    ("analysis/redis_vector_analysis.py", "langchain_redis"): "#14871",
+    ("analysis/test_redis_comparison.py", "langchain_redis"): "#14871",
+}
+
+
+def _declared_distributions() -> tuple[set[str], int]:
+    """Every distribution named by a requirements file or pyproject in the repo."""
+    names: set[str] = set()
+    files = 0
+    candidates = list(_REPO_ROOT.rglob("requirements*.txt")) + list(
+        _REPO_ROOT.rglob("pyproject.toml")
+    )
+    for path in candidates:
+        # Relative parts, never the absolute path — see the note in
+        # first_party_imports_resolve_test.py about a checkout that itself sits
+        # under a directory named `venv` or `.worktrees`.
+        if any(part in _SKIP_PARTS for part in path.relative_to(_REPO_ROOT).parts):
+            continue
+        files += 1
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            match = re.match(r'^["\']?([A-Za-z0-9][A-Za-z0-9._-]*)', line)
+            if match:
+                names.add(match.group(1).lower().replace("-", "_"))
+    return names, files
+
+
+_DECLARED, _REQUIREMENTS_FILES = _declared_distributions()
+_STDLIB = set(sys.stdlib_module_names) | {"__future__"}
+
+
+def _is_declared(top: str) -> bool:
+    """Is this top-level import name covered by a declared distribution?"""
+    normalised = top.lower().replace("-", "_")
+    if normalised in _DECLARED:
+        return True
+    alias = _DIST_ALIASES.get(top)
+    return alias is not None and alias in _DECLARED
+
+
+def _resolves(module: str, own_dir: Path) -> bool:
+    """Does this dotted module exist under a first-party root or beside its importer?"""
+    parts = module.split(".")
+    for root in (*_ROOTS, own_dir):
+        base = root.joinpath(*parts)
+        if base.with_suffix(".py").exists() or (base / "__init__.py").exists():
+            return True
+    return False
+
+
+def _optional_import_nodes(tree: ast.AST) -> set[int]:
+    """Nodes inside a try/except that catches an import error.
+
+    Deliberately NOT including bare ``Exception``, for the reason spelled out in
+    first_party_imports_resolve_test.py: a broad handler is not a declaration
+    that an import is optional, and it is the single most common wrapper around
+    a first-party import in this repo. Treating it as an exemption would make
+    this guard blind at exactly the places it exists to watch.
+    """
+    guarded: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        caught: set[str] = set()
+        for handler in node.handlers:
+            for sub in ast.walk(handler.type) if handler.type else []:
+                if isinstance(sub, ast.Name):
+                    caught.add(sub.id)
+        if {"ImportError", "ModuleNotFoundError"} & caught:
+            guarded.update(id(child) for child in ast.walk(node))
+    return guarded
+
+
+def _unresolvable() -> tuple[list[tuple[str, str, int]], int]:
+    """((relative path, module, lineno) list, files scanned)."""
+    found: list[tuple[str, str, int]] = []
+    scanned = 0
+    for path in sorted(_SCRIPTS.rglob("*.py")):
+        if any(part in _SKIP_PARTS for part in path.relative_to(_SCRIPTS).parts):
+            continue
+        scanned += 1
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        guarded = _optional_import_nodes(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.level or not node.module:
+                    continue
+                module = node.module
+            elif isinstance(node, ast.Import):
+                module = node.names[0].name
+            else:
+                continue
+            top = module.split(".")[0]
+            if top in _STDLIB or id(node) in guarded:
+                continue
+            if _resolves(module, path.parent) or _is_declared(top):
+                continue
+            found.append((str(path.relative_to(_SCRIPTS)), module, node.lineno))
+    return found, scanned
+
+
+def test_the_sweep_actually_reached_the_tree() -> None:
+    """Discovery floors. An empty walk reports clean having asserted nothing.
+
+    Every floor here guards a different way the sweep can go quietly blind: the
+    file count catches a skip list eating the tree, the requirements count
+    catches a declaration oracle that found nothing (which would make *every*
+    third-party import a finding), and the roots catch a layout rename.
+    """
+    _, scanned = _unresolvable()
+    assert scanned > 200, f"only walked {scanned} python files — the skip list is eating the tree"
+    assert _REQUIREMENTS_FILES >= 15, (
+        f"only read {_REQUIREMENTS_FILES} requirements/pyproject files — the "
+        "declaration oracle has gone blind and would report false findings"
+    )
+    assert len(_DECLARED) > 100, f"only {len(_DECLARED)} declared distributions found"
+    for root in _ROOTS:
+        assert root.is_dir(), f"first-party root {root} no longer exists — resolution is wrong"
+
+
+def test_every_import_under_shared_scripts_resolves() -> None:
+    """The #14518 defect: an F821-clean script that dies on its own import block."""
+    found, scanned = _unresolvable()
+    assert scanned > 200, f"only walked {scanned} python files — this would pass vacuously"
+    offenders = [
+        f"{rel}:{line}  {module}"
+        for rel, module, line in found
+        if (rel, module) not in _KNOWN_BROKEN
+    ]
+    assert not offenders, (
+        "these imports name a module that does not resolve against any "
+        "first-party root, the stdlib, the declared requirements, or the "
+        "importing file's own directory. The script cannot run at all — it "
+        "raises ModuleNotFoundError before reaching its first statement "
+        "(#14518):\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("entry,issue", sorted(_KNOWN_BROKEN.items()))
+def test_each_exemption_is_still_broken(entry: tuple[str, str], issue: str) -> None:
+    """An exemption that no longer applies exempts nothing, silently.
+
+    This is also the positive control for the whole file. If the sweep stopped
+    finding these six known-bad sites, every test above would go green while
+    checking nothing — so "the detector still fires" is asserted here rather
+    than assumed.
+    """
+    rel, module = entry
+    path = _SCRIPTS / rel
+    assert path.is_file(), f"{rel} moved or was deleted — update or drop this exemption ({issue})"
+    assert not _resolves(module, path.parent), (
+        f"{module} now resolves for {rel}, so the exemption ({issue}) is obsolete — "
+        "remove it from _KNOWN_BROKEN so the import is guarded again"
+    )
+    found, _ = _unresolvable()
+    assert any(r == rel and m == module for r, m, _ in found), (
+        f"the sweep no longer reports {rel} -> {module}, but the module still does "
+        f"not resolve. The detector has regressed and is now reporting clean on a "
+        f"live defect ({issue})"
+    )

--- a/repo_tests/shell_lib_sources_resolve_test.py
+++ b/repo_tests/shell_lib_sources_resolve_test.py
@@ -1,0 +1,297 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every `source .../lib/*.sh` under autobot-infrastructure/ must resolve, and fail
+loudly when it does not (#14041, #14172).
+
+56 scripts sourced `lib/ssot-config.sh` for years while that file did not exist
+anywhere in the repository. Nobody noticed, because every one of them wrote the
+source as::
+
+    source "${SCRIPT_DIR}/lib/ssot-config.sh" 2>/dev/null || true
+
+`|| true` turns a missing config bootstrap into a normal, expected condition.
+The script continues, every ``${AUTOBOT_X:-literal}`` in it takes the literal
+right-hand side, and the run reports success. A reviewer reading the diff sees
+a config lookup; the machine only ever runs the hardcode. #14041 built the
+library; this guard is the half that stops the class recurring.
+
+Two independent failure modes, so two independent checks:
+
+* **resolution** — a `source` naming a path that is not in the tree. This is
+  what went wrong originally, and it is invisible to shellcheck, which does not
+  follow a dynamic source path.
+* **shape** — a `source` whose failure is discarded. This is what made the first
+  failure survivable for so long. Resolution alone is not enough: it only sees
+  *this* checkout at PR time, and cannot see a deploy that ships a partial tree,
+  a `.gitignore` regression, or a rename downstream.
+
+Reach floors are asserted throughout. An empty walk reports "no offenders" while
+having checked nothing, which is the same shape of bug as the one under guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INFRA = _REPO_ROOT / "autobot-infrastructure"
+_SKIP_PARTS = {".git", "node_modules", "__pycache__", ".worktrees", "venv", ".venv"}
+
+# A `source` statement and the (possibly quoted) word that follows it.
+_SOURCE = re.compile(r'(?<!\w)source\s+(?:"([^"\n]+)"|\'([^\'\n]+)\'|([^\s;&|"\'\n]+))')
+
+# Variables a call site uses to reach its library, and what each resolves to.
+# SCRIPT_DIR (and the SCRIPT_DIR_UTIL spelling one script uses) is always the
+# sourcing script's own directory; the PROJECT_ROOT spellings are the repo root.
+_SCRIPT_DIR_NAMES = ("SCRIPT_DIR", "SCRIPT_DIR_UTIL")
+_ROOT_NAMES = ("_PROJECT_ROOT", "PROJECT_ROOT")
+
+
+def _strip_comment(line: str) -> str:
+    """Drop an unquoted trailing comment.
+
+    Needed for correctness in both directions: `lib/ssot-config.sh` appears
+    inside the library's own header comment and inside hooks/lib/_common.sh's
+    usage note, and counting either as a call site would make this test fail on
+    a path that is documentation.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    for char in line:
+        if quote:
+            out.append(char)
+            if char == quote:
+                quote = None
+            continue
+        if char in "\"'":
+            quote = char
+            out.append(char)
+            continue
+        if char == "#":
+            break
+        out.append(char)
+    return "".join(out)
+
+
+def _is_nested_shell_string(line: str, start: int) -> bool:
+    """True when this `source` lives inside another shell command's string.
+
+    `autobot-infrastructure/shared/tests/test_ssot_config_lib.sh` drives the
+    real shapes through `bash -c "..."`, including a deliberately missing path.
+    A fixture that quotes the pattern it exists to test must not trip the lint
+    for that pattern, and the tell is structural rather than a filename
+    allowlist: the inner `source` is either preceded by an unbalanced quote on
+    the same line, or written with backslash-escaped quotes, neither of which
+    occurs in a real source statement.
+    """
+    if '\\"' in line:
+        return True
+    before = line[:start]
+    return before.count('"') % 2 == 1 or before.count("'") % 2 == 1
+
+
+def _resolve(script: Path, raw: str) -> Path | None:
+    """Filesystem path a source expression names, or None if not resolvable here."""
+    expanded = raw
+    for name in _SCRIPT_DIR_NAMES:
+        expanded = expanded.replace("${%s}" % name, str(script.parent)).replace(
+            "$%s" % name, str(script.parent)
+        )
+    for name in _ROOT_NAMES:
+        expanded = expanded.replace("${%s}" % name, str(_REPO_ROOT)).replace(
+            "$%s" % name, str(_REPO_ROOT)
+        )
+    if "$" in expanded:
+        return None
+    return Path(expanded)
+
+
+class _Site:
+    """One `source <lib>` occurrence, with everything the checks need."""
+
+    def __init__(self, script: Path, lineno: int, raw: str, line: str, is_last: bool):
+        self.script = script
+        self.rel = str(script.relative_to(_REPO_ROOT))
+        self.lineno = lineno
+        self.raw = raw
+        self.line = line
+        self.is_last = is_last
+
+    def __repr__(self) -> str:  # pragma: no cover - failure output only
+        return f"{self.rel}:{self.lineno}"
+
+
+def _collect() -> tuple[list[_Site], int]:
+    """Every lib source site under autobot-infrastructure/, plus files walked."""
+    sites: list[_Site] = []
+    scanned = 0
+    for script in sorted(_INFRA.rglob("*.sh")):
+        # Relative parts, never the absolute path: this checkout may itself sit
+        # under a directory named `.worktrees` or `venv`, which would otherwise
+        # skip the entire tree and report clean.
+        rel_parts = script.relative_to(_REPO_ROOT).parts
+        if any(part in _SKIP_PARTS for part in rel_parts):
+            continue
+        scanned += 1
+        try:
+            text = script.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), 1):
+            code = _strip_comment(line)
+            matches = [
+                m
+                for m in _SOURCE.finditer(code)
+                if not _is_nested_shell_string(code, m.start())
+            ]
+            lib_matches = [
+                m
+                for m in matches
+                if "/lib/" in (m.group(1) or m.group(2) or m.group(3) or "")
+            ]
+            for match in lib_matches:
+                raw = match.group(1) or match.group(2) or match.group(3)
+                sites.append(
+                    _Site(script, lineno, raw, code, match is lib_matches[-1])
+                )
+    return sites, scanned
+
+
+_SITES, _SCANNED = _collect()
+
+
+def test_the_sweep_actually_reached_the_tree() -> None:
+    """Discovery floor. An empty walk asserts nothing while reading as clean.
+
+    Three independent floors, because a single one can be satisfied by a walk
+    that is still broken: the file count catches a skip list eating the tree,
+    the site count catches a regex that stopped matching, and the named script
+    catches a walk that reaches files but not the ones this guard is about.
+    """
+    assert _SCANNED > 120, f"only walked {_SCANNED} shell scripts — the skip list is eating the tree"
+    assert len(_SITES) >= 60, (
+        f"only found {len(_SITES)} lib source sites — expected >= 60 "
+        "(#14041 enumerated 56 scripts); the matcher has regressed"
+    )
+    rels = {site.rel for site in _SITES}
+    assert len({site.rel for site in _SITES}) >= 55, f"only {len(rels)} distinct scripts"
+    assert (
+        "autobot-infrastructure/shared/scripts/vm-management/status-all-vms.sh" in rels
+    ), "the walk no longer reaches a known call site"
+
+
+def test_no_lib_source_is_documentation_or_a_fixture() -> None:
+    """The two exclusions above must exclude exactly what they claim.
+
+    A comment-stripper or nested-string detector that over-matches would silently
+    shrink this guard's reach, so both are asserted on the real files that
+    motivated them rather than trusted.
+    """
+    excluded = {
+        # the library's own header quotes the call-site shape it replaces
+        "autobot-infrastructure/shared/scripts/lib/ssot-config.sh",
+        # hooks/lib/_common.sh documents how to source itself
+        "autobot-infrastructure/shared/scripts/hooks/lib/_common.sh",
+        # the ssot-config suite drives the shapes through `bash -c`
+        "autobot-infrastructure/shared/tests/test_ssot_config_lib.sh",
+    }
+    present = {site.rel for site in _SITES} & excluded
+    assert not present, (
+        "these files only mention a lib source in a comment or a nested shell "
+        f"string, so treating them as call sites is a false positive: {sorted(present)}"
+    )
+
+
+def test_every_lib_source_resolves_to_a_real_file() -> None:
+    """A `source` naming a path that is not in the tree (#14041).
+
+    Alternatives in a `||` chain are grouped by line: a two-path site tries the
+    same library at two depths because its callers sit at two depths, so the
+    site is satisfied when *one* of them resolves.
+    """
+    by_line: dict[tuple[str, int], list[_Site]] = {}
+    for site in _SITES:
+        by_line.setdefault((site.rel, site.lineno), []).append(site)
+
+    unresolvable: list[str] = []
+    checked = 0
+    for (rel, lineno), group in sorted(by_line.items()):
+        targets = [_resolve(group[0].script, site.raw) for site in group]
+        known = [t for t in targets if t is not None]
+        if not known:
+            continue  # path built from a variable this guard cannot resolve
+        checked += 1
+        if not any(t.is_file() for t in known):
+            unresolvable.append(
+                f"{rel}:{lineno} -> " + " | ".join(str(t) for t in known)
+            )
+
+    assert checked >= 55, (
+        f"only resolved {checked} source sites — the expander has regressed and "
+        "this test would pass having checked almost nothing"
+    )
+    assert not unresolvable, (
+        "these scripts source a library that does not exist. Every "
+        "${VAR:-literal} in them takes its hardcoded right-hand side "
+        "instead (#14041):\n  " + "\n  ".join(unresolvable)
+    )
+
+
+def _shape_offenders() -> tuple[list[str], int]:
+    """Sites whose failure is discarded, and the number of sites checked."""
+    offenders: list[str] = []
+    checked = 0
+    for site in _SITES:
+        if not site.is_last:
+            # Not the final alternative in a `||` chain: this miss is expected,
+            # so discarding its stderr is correct. Only the decisive attempt
+            # has to be loud.
+            continue
+        checked += 1
+        tail = site.line[site.line.rindex("source ") :]
+        decisive = tail.split("||")[0]
+        if "2>/dev/null" in decisive or "2> /dev/null" in decisive:
+            offenders.append(f"{site.rel}:{site.lineno} discards stderr on the last attempt")
+        elif re.search(r"\|\|\s*(true|:)\s*$", site.line):
+            offenders.append(f"{site.rel}:{site.lineno} ends in `|| true`")
+        elif not site.line.rstrip().endswith("|| {"):
+            offenders.append(
+                f"{site.rel}:{site.lineno} does not end in an explicit `|| {{` failure block"
+            )
+    return offenders, checked
+
+
+def test_a_missing_lib_is_never_swallowed() -> None:
+    """The `|| true` shape that made #14041 invisible may not come back (#14172)."""
+    offenders, checked = _shape_offenders()
+    assert checked >= 55, f"only checked {checked} sites — this would pass vacuously"
+    assert not offenders, (
+        "a lib bootstrap whose failure is discarded turns a deployment error "
+        "into a wrong-value-at-runtime. The final attempt in the chain must keep "
+        "its stderr and end in an explicit `|| {` block that exits non-zero "
+        "(#14172):\n  " + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize(
+    "site", [s for s in _SITES if s.is_last], ids=lambda s: f"{s.rel}:{s.lineno}"
+)
+def test_each_failure_block_actually_exits(site: _Site) -> None:
+    """`|| {` is only loud if the block inside it stops the script.
+
+    Checked per site rather than in aggregate so a failure names the one script
+    that regressed. A block that merely echoes and falls through is the same
+    silent-degrade defect wearing a louder coat.
+    """
+    lines = site.script.read_text(encoding="utf-8").splitlines()
+    block = lines[site.lineno : site.lineno + 6]
+    body = "\n".join(block[: next((i for i, ln in enumerate(block) if ln.strip() == "}"), len(block))])
+    assert re.search(r"\b(exit|return)\s+[1-9]", body), (
+        f"{site.rel}:{site.lineno} announces the failure but does not stop — "
+        f"the script continues on hardcoded fallbacks anyway (#14172). Block:\n{body}"
+    )


### PR DESCRIPTION
## Thinking Path

#14041, #14172, #14518 and #14867 were filed separately but describe one defect
with one mechanism: **a missing dependency is discarded instead of raised, so
the script runs in a degraded mode nobody can see.** A shell script sources a
config library that is not there and continues on hardcoded literals. A Python
script imports a module that does not exist and dies before its first
statement. A shell script runs embedded Python that cannot import, throws the
traceback away, and prints a reassuring number.

Every one of them passes review, because the *source text* describes the
intended behaviour. Only the machine knows the difference.

So the fix has two halves, and both are required in each surface:

**(a) make the missing dependency fail LOUD at the point of use** — the value
of a check is entirely in the difference between "ran and was clean" and "could
not run", and discarding stderr erases exactly that difference;
**(b) add a repo-wide guard** so the class cannot be reintroduced silently —
shellcheck does not follow a dynamic source path, and pyflakes never checks
that an import target resolves, so nothing in the repo could see any of this.

Where a target could not be identified with confidence, the import is left
alone and tracked. Guessing would replace a loud `ModuleNotFoundError` with a
quiet wrong answer, which is the defect this work exists to remove.

### The #14172 scope decision

#14172 carried `needs-decision`, asking whether the 56 `source` lines should
change shape or whether a repo guard alone should cover it. This was an
autonomous run, so the recommendation, the rationale and the rejected
alternative were [posted to the issue](https://github.com/mrveiss/AutoBot-AI/issues/14172#issuecomment-5387684406)
and the work proceeded rather than blocking.

**Decision taken: change the call-site shape.** A guard only sees this checkout
at PR time; it cannot see a bad deploy, a `.gitignore` regression or a rename
downstream — the three recurrence scenarios the issue itself names — because in
every one of those the repo is green and the *machine* is missing the file. The
guard ships too, as the second half rather than the whole. The reason for the
silent degrade also expired when #14041 built the library, and the tree already
has the fail-loud convention: `lib/db-update-classify.sh` and
`scripts/lib/project_root.sh` are both sourced bare, one of them two lines
below an ssot-config source that was guarded with `|| true`.

**Stated plainly:** a node that legitimately ships only part of the tree now
gets a loud abort where it previously got a quiet wrong value. That is the
intended trade and the direction the issue asked for, but it is a behaviour
change on deployed hosts, and it is the part worth overruling on if the fleet
has such nodes. That needs host observation, which an autonomous run cannot
produce.

## What Changed

### (a) Fail loud at the point of use

**56 shell scripts (#14041, #14172)** — `source X 2>/dev/null || true` becomes
an explicit failure block that writes to stderr and exits non-zero.

- 51 single-path sites converted directly.
- 5 two-path sites keep `2>/dev/null` on the **first** attempt only — that miss
  is expected, callers sit at two different depths — while the last attempt
  keeps its stderr and is fatal. The old fallback re-read `.env` and carried on.
- 2 already-bare sites get the same block, so one shape ships everywhere.
- The die uses `return 1 2>/dev/null || exit 1`, so a script that is itself
  sourced returns instead of killing the parent shell — the idiom
  `ssot-config.sh` already uses at its own re-entry guard.
- `test_ssot_config_lib.sh` asserted the old contract ("missing library
  degrades to literal"). It now asserts the inversion **and executes the blocks
  as shipped**, extracted with `sed` out of four real scripts, so reintroducing
  `|| true` trips the test rather than passing a re-typed copy of the idiom.

**39 of 44 Python imports (#14518)** — rewritten to the real module plus the
`sys.path` insert the operator entry points in this tree already use (#14129,
#14507), with `parents[N]` computed per file from its own depth. `aioredis` is
migrated to `redis.asyncio` (the alias this repo already uses), adding no
dependency; `docker` gains the same `ImportError` guard its five other call
sites carry. Four further sites outside #14518's own enumeration
(`utils.redis_database_manager`, `utils.logging_manager`) were found by the
sweep and repointed at the canonical `autobot_shared` modules.

**8 deployment scripts (#14867)** — 7 of 9 embedded imports now name a real
module, with a `PYTHONPATH` derived from each script's own location. **All 9**
swallowed failures are gone: the traceback reaches stderr and the exit status
reflects it. Summary lines that printed unconditionally ("Health check
complete", "All checks passed", "Startup coordinator is ready for use") are now
gated on a failure counter. Three latent defects of the same shape surfaced and
were fixed: a `${PROJECT_ROOT}` interpolated inside a **quoted** heredoc (so the
path was a literal string and "CLAUDE.md not found!" was guaranteed, returning
0); a `PYTHONPATH` pointing at a package's *contents* rather than its parent; and
a Python `"""` docstring at the top of a bash script, which bash executed as
commands on every run.

### (b) Repo-wide guards

Three new files under `repo_tests/` — that location is deliberate, because
`autobot-infrastructure/` is in no pytest `testpaths` entry and in no CI pytest
invocation, so a test beside the scripts would be as dormant as the defects.

| guard | watches | surface no existing check reads |
|---|---|---|
| `shell_lib_sources_resolve_test.py` | every `source .../lib/*.sh` resolves, and the decisive attempt in each `\|\|` chain is not silenced | shellcheck does not follow a dynamic source path |
| `infra_script_imports_resolve_test.py` | imports under `shared/scripts/*.py` resolve | pyflakes never checks that an import target exists |
| `deployment_script_imports_resolve_test.py` | imports inside `python3 -c` and heredocs resolve; no check answers with a fabricated value | the Python is a shell string — no linter parses it at all |

## Verification

No code from the codebase was executed. Verification is static analysis plus
the CI run on this branch. Each guard was copied to a scratch location,
parameterised on the tree root, and run against **both** the pristine
`origin/Dev_new_gui` (`git archive`) and this branch.

### Measured guarded/total — counted, not asserted

| guard | violations on the pristine base | after this PR | coverage |
|---|---|---|---|
| shell lib sources | **57 of 57 sites flagged, across 56 of 56 scripts** | 0 | 56/56 scripts — the exact population #14041 enumerated |
| `shared/scripts/*.py` imports | 42 sites present, **34 flagged** | 0 unflagged | 8 are the tracked residue below |
| inline Python in `*.sh` | 27 sites present, **15 flagged** | 0 unflagged | 12 are the tracked residue below |

Result of running all three guards:

- **this branch — 0 failures** (13 tests, including 76 parametrized cases)
- **pristine base** — shell guard fails both aggregate assertions plus **57 of
  57** parametrized sites; the other two guards red on their own populations

### Anti-fail-open measures

An empty or absent result reads as "clean", so every sweep asserts **presence**
of what it expects before asserting absence of failure:

- discovery floors on files walked, sites matched, inline blocks extracted,
  declared distributions found, and first-party roots still present. The
  block-count floor is load-bearing for the shell guard — an extractor that
  stopped recognising `python3 -c` would otherwise pass having read nothing.
- skip lists match **relative** paths, never absolute, so a checkout living
  under a directory named `.worktrees` or `venv` cannot skip every file and
  report clean.
- **every exemption is asserted still broken AND still reported by the sweep.**
  That second assertion is the positive control for each file: if a detector
  regresses, the exemption test goes red instead of the whole file passing
  vacuously.
- documentation and nested shell strings are excluded **structurally** (an
  unbalanced quote, or a backslash-escaped quote — neither occurs in a real
  source statement), not by naming files, so `test_ssot_config_lib.sh` can keep
  driving the very shapes it tests. A dedicated test asserts those exclusions
  exclude exactly what they claim.
- shell verification used `bash -n` (parse only) and `compile(..., "exec")` on
  the extracted Python payloads — neither executes anything. All 8 scripts are
  `#!/bin/bash`; no dash script is in the set, and no `set -o pipefail` was
  added.

### Enforcement caveat — measured, not assumed

Stated plainly so nobody reads more into "repo-wide guard" than it delivers.
The three guards land in `repo_tests/`, which is collected by the Python suite
(`coverage.yml`) — and **the Python suite is not a required status check on
this branch.** The ten required contexts are `No commit trailers`,
`No open blocks-merge issues reference this PR`, `Unit & Integration Tests`
(the *frontend* job, per `frontend-required-context.yml:84`), `api-wiring`,
`code-quality`, `migration-matrix`, `smoke-test`, `startup-import-smoke`,
`verify-generated-types` and `verify-precommit-config`.

So these guards will run and go red visibly, but they will not *block* a merge
until #13162 is resolved. That is a property of the CI configuration, not of
the guards, and it is the same for the existing
`first_party_imports_resolve_test.py` this work generalises.

The related gap on the bash side is filed as #14878: the
`ssot-config-lib-guard` pre-commit hook is a regression suite, not a formatter,
but `enforce-precommit.yml` routes all hook *findings* to `::warning::` — only
a hook that could not execute at all fails the build. There is also **no
`pre-commit` hook installed in the local git checkout**, so the suite did not
run at commit time either.

### Issues this PR closes, and the two it does not

**Closes #14041, #14172.** Both are fully delivered: the library existed
already, a missing bootstrap now fails loudly, and the repo check exists.

**#14518 and #14867 are advanced but NOT closed**, because partial delivery
never closes an issue:

- **#14518** — 39 of 44 sites fixed. Five remain, each naming a symbol that was
  deleted or never landed: `SSHManager` (0 hits repo-wide), `add_api_routes`
  (deleted; its successor contains no `workflow_router`, so repointing would
  make the script's assertion *falsely red*), and `monitoring_compat`
  (dissolved by #1283). No import spelling reaches any of them. Tracked as
  **#14870**.
- **#14867** — 7 of 9 imports fixed, **9 of 9** swallowed failures fixed. Two
  remain: `BackupEngine` and `get_agent_orchestrator`, both zero hits
  repo-wide. What remains now fails loudly rather than silently. Tracked as
  **#14875**.

Filed rather than folded in silently: **#14870**, **#14871** (langchain_redis
undeclared — its absence silently drops an arm of the comparison the scripts
exist to measure), **#14872** (the docker SDK is imported by five production
backend modules and declared in no requirements file), **#14873**
(`optimize_agents` forked across two modules sharing one import name),
**#14875**, **#14876**.

### Merge-order note — PR #14868 landed mid-review, branch rebased

This PR originally predicted a collision with PR #14868 (#14866). It happened,
and is resolved.

**Two file conflicts**, both in the scripts #14867 wrongly described as already
fixed. #14866's `PYTHONPATH` export is kept in full; only its
`source ... 2>/dev/null || true` is replaced by the #14172 fail-loud form.

**One add/add conflict**: #14868 added its own
`repo_tests/deployment_script_imports_resolve_test.py` — the filename #14867
predicted. Rather than ship a second guard, this branch's copy is **merged into
the landed file** (consolidate, never fork). The landed version is the survivor
because it carries a call-layer check this branch's did not: an awaited *sync*
Redis client is a failure that moves from import time to call time, which no
import guard can see. Three things merged in from here:

- the importing script's **own directory** now counts as an import root. These
  scripts export `${SCRIPT_DIR}` on PYTHONPATH and import siblings; without it
  the landed guard reported a **false positive** on `test_startup_coordinator.sh`,
  whose `startup_coordinator.py` sits right beside it.
- `test_no_inline_check_fabricates_its_own_result` — #14867's second acceptance
  criterion, and the half #14868 left undone. It removed the `2>/dev/null` but
  kept `|| echo "{}"`, so a check that cannot run still reports a value
  indistinguishable from a clean one. Four such sites remain in
  `access_control_monitor.sh` (`UNKNOWN`, `{}`, `{}`, `0|0|0`); filed as
  **#14880** and carried as a self-guarding exemption.
- seven of its nine `_KNOWN_BROKEN` entries are retired, because this branch
  fixed those imports. The two that remain are repointed at #14875.

**The new fabrication detector was wrong on its first draft**, and this is worth
recording because it is the failure mode this whole PR is about. It matched
`python3 -c` to end-of-line, which finds nothing for a **multi-line** block —
the `|| echo` sits after the closing quote, several lines down. It reported
**zero** fabricated results on a file that has four. Nothing about that looked
wrong: the test passed. Its own positive control (*"this exemption must still be
broken"*) is what turned it red. That is precisely why every exemption in these
guards asserts it is still **reported by the sweep**, not merely still broken.

## Model Used

Claude Opus 5 (1M context)

Closes #14041, #14172
