### PR TITLE
fix(ci): drop the baseline entry #14890 made stale (#14371)

### DIFF
--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -1208,7 +1208,6 @@
 1|other|autobot-slm-backend/ansible/roles/_shared/tasks/clean_legacy_dir.yml|"/opt/autobot/{{ dir_name }}
 2|other|autobot-slm-backend/ansible/roles/_shared/tasks/clean_legacy_dir.yml|"/opt/autobot/{{ dir_name }}/data
 1|other|autobot-slm-backend/ansible/roles/_shared/tasks/clean_wrong_node_dir.yml|"/opt/autobot/{{ dir_name }}
-1|other|autobot-slm-backend/ansible/roles/_shared/tasks/clean_wrong_node_dir.yml|"/opt/autobot/{{ dir_name }}/data
 1|other|autobot-slm-backend/ansible/roles/access_control/defaults/main.yml|300
 1|other|autobot-slm-backend/ansible/roles/agent_config/defaults/main.yml|"/opt/autobot
 1|other|autobot-slm-backend/ansible/roles/agent_config/defaults/main.yml|"/opt/autobot/venv


### PR DESCRIPTION
## Thinking Path

`SSOT Configuration Compliance` is failing on `Dev_new_gui`, so every open PR and every new branch inherits a red required check. This restores it.

The cause is a correct guard firing. #14883 added a blocking stale-baseline audit; #14890 then rewrote `clean_wrong_node_dir.yml` and eliminated a hardcoded path that was baselined, without removing its baseline line. The audit does exactly what it was built to do:

```
STALE  other|autobot-slm-backend/ansible/roles/_shared/tasks/clean_wrong_node_dir.yml|"/opt/autobot/{{ dir_name }}/data
```

This is the failure mode the guard's own message describes: *an entry naming a path that has moved exempts nothing, silently, and re-permits the value the moment the path comes back.*

**This is my error, not #14890's.** I merged #14890 while `SSOT Configuration Compliance` was red on its head. The check had moved to a new head sha after an automatic base update, and I read the check state and merged in one step instead of gating on it. #14890's content is correct and reviewed; only its baseline bookkeeping was missing.

## What Changed

One line removed from `pipeline-scripts/hardcoded_values_baseline.txt`.

- 1434 → 1433 lines; total 1977 → 1976
- The value is genuinely gone: `grep '/opt/autobot/{{ dir_name }}/data' roles/_shared/tasks/clean_wrong_node_dir.yml` returns 0 on this tree

Nothing else is touched. No detection rule, no threshold, no exemption is changed — a fixed violation simply takes its baseline line with it, which is the contract.

## Verification

- The stale entry named by the failing run is the only one removed, matched exactly.
- The removed value no longer appears at the path the entry named, confirmed against the merged tree.
- The baseline shrinks. `check_baseline_no_growth.sh` permits shrinkage and blocks growth, so this direction is allowed by design.
- Post-merge, `--audit-baseline` should report no stale entries and `SSOT Configuration Compliance` should return green.

## Model Used

Claude Opus 5 (1M context)


Closes #14911
Refs #14371 — this restores the baseline audit that PR added.
