### PR TITLE
fix(ci): give the stale-baseline audit a one-command recovery (#14912)

### DIFF
--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -155,6 +155,34 @@ already existed when the three former detectors were merged. It only ever
 shrinks: a finding that is not in it fails the build, and every run prints how
 many baselined findings it suppressed.
 
+### "STALE baseline entry" — what to do (#14912)
+
+If `ssot-coverage` fails with `N baseline entr(ies) … no longer match anything`,
+you have almost certainly just **fixed or moved** a hardcoded value. That is the
+outcome the guard wants; the baseline simply still lists it. Recover with one
+command:
+
+```bash
+./pipeline-scripts/detect-hardcoded-values.sh --prune-baseline
+```
+
+then commit the changed baseline alongside your fix.
+
+`--prune-baseline` **only ever removes**. It cannot add a key or raise a count,
+by construction: it iterates the keys already in the baseline and writes
+`min(baseline_count, found_count)`. So it cannot be used to silence a new
+finding — that direction is blocked independently by
+`pipeline-scripts/check_baseline_no_growth.sh`, which fails on any new key or
+increased count.
+
+It also refuses to run when the scan found **nothing**. An empty result and a
+broken detector are indistinguishable, and this is the one path that rewrites
+the record, so it will not turn a failed scan into an emptied baseline.
+
+Why the audit blocks rather than warns: an entry naming a path that has moved
+exempts nothing today, but silently re-permits the value the moment that path
+comes back.
+
 ---
 
 ## ConfigRegistry Fallback Pattern (Issue #2671)

--- a/pipeline-scripts/detect-hardcoded-values.sh
+++ b/pipeline-scripts/detect-hardcoded-values.sh
@@ -20,7 +20,7 @@
 #   * it always exits 0. ssot-coverage.yml decides pass/fail from the reported
 #     counts, and has done since #2874.
 #
-# Usage: detect-hardcoded-values.sh [--json|--report|--audit-baseline|--help]
+# Usage: detect-hardcoded-values.sh [--json|--report|--audit-baseline|--prune-baseline|--help]
 
 set -euo pipefail
 
@@ -36,17 +36,20 @@ BASELINE="${REPO_ROOT}/pipeline-scripts/hardcoded_values_baseline.txt"
 OUTPUT_FORMAT="text"
 REPORT_MODE=false
 AUDIT_BASELINE=false
+PRUNE_BASELINE=false
 
 for arg in "$@"; do
     case "$arg" in
         --json)            OUTPUT_FORMAT="json" ;;
         --report)          REPORT_MODE=true ;;
         --audit-baseline)  AUDIT_BASELINE=true ;;
+        --prune-baseline)  PRUNE_BASELINE=true ;;
         --help)
-            echo "Usage: $0 [--json|--report|--audit-baseline|--help]"
+            echo "Usage: $0 [--json|--report|--audit-baseline|--prune-baseline|--help]"
             echo "  --json            Output results as JSON"
             echo "  --report          Show the detailed violation report"
             echo "  --audit-baseline  Fail on baseline entries that match nothing"
+            echo "  --prune-baseline  Rewrite the baseline to what is actually found (REMOVES only)"
             exit 0
             ;;
     esac
@@ -91,15 +94,70 @@ STATUS="pass"
 if [ "$AUDIT_BASELINE" = true ]; then
     STALE=$(hv_stale_baseline_entries)
     if [ -n "$STALE" ]; then
-        echo "Baseline entries in ${BASELINE#"$REPO_ROOT"/} that match nothing any more:"
+        STALE_COUNT=$(printf '%s\n' "$STALE" | grep -c . || true)
+        echo "${STALE_COUNT} baseline entr(ies) in ${BASELINE#"$REPO_ROOT"/} no longer match anything:"
+        echo
         printf '%s\n' "$STALE" | sed 's/^/  STALE  /'
         echo
-        echo "A fixed violation must take its baseline line with it. An entry naming a"
-        echo "path that has moved exempts nothing, silently, and re-permits the value"
-        echo "the moment the path comes back."
+        # #14912: this used to stop at "here is what is wrong". Most of the cost
+        # of this check was never the rule, it was that the person who hit it --
+        # usually the person who just FIXED a hardcoded value -- was not told how
+        # to recover, and the file to edit has nothing to do with their change.
+        echo "You almost certainly just fixed or moved these. Recover with one command:"
+        echo
+        echo "    ./pipeline-scripts/detect-hardcoded-values.sh --prune-baseline"
+        echo
+        echo "then commit the changed baseline. Prune only ever REMOVES entries — it"
+        echo "cannot add a key or raise a count — so it cannot be used to silence a new"
+        echo "finding. That direction is blocked independently by"
+        echo "pipeline-scripts/check_baseline_no_growth.sh."
+        echo
+        echo "Why this blocks rather than warns: an entry naming a path that has moved"
+        echo "exempts nothing today, but silently re-permits the value the moment that"
+        echo "path comes back."
         exit 1
     fi
     echo "hardcoded-values: every baseline entry still matches something"
+    exit 0
+fi
+
+if [ "$PRUNE_BASELINE" = true ]; then
+    # Refuse to write the result of a scan that found nothing. An empty result
+    # and a broken detector are indistinguishable here, and this path REWRITES
+    # the record: a rules file that failed to load, or a scan directory that has
+    # moved, would take all ${#HV_BASELINE[@]} entries with it and the no-growth
+    # guard would not object, because shrinking is allowed by design.
+    TOTAL_FOUND=$(grep -c . "$RAW" || true)
+    if [ "$TOTAL_FOUND" -eq 0 ]; then
+        echo "FATAL: the scan found 0 findings, so pruning would empty the baseline." >&2
+        echo "  A tree carrying ${#HV_BASELINE[@]} baselined findings does not legitimately" >&2
+        echo "  drop to zero. This looks like a broken scan, not a fixed repository —" >&2
+        echo "  refusing to rewrite the baseline from it." >&2
+        exit 1
+    fi
+    PRUNED=$(mktemp)
+    trap 'rm -f "$RAW" "$NEWFILE" "$PRUNED"' EXIT
+    hv_pruned_baseline | sort -t'|' -k3,3 -k2,2 -k4,4 > "$PRUNED"
+    KEPT=$(grep -c . "$PRUNED" || true)
+    BEFORE=${#HV_BASELINE[@]}
+    # Header first, then the pruned body. The leading comment block carries the
+    # rules governing this file -- including "this file only ever shrinks" --
+    # and a rewrite that dropped it would delete the reason the file exists.
+    # Taken as the run of leading `#` lines, so it stays correct if the header
+    # is edited later.
+    { awk '/^#/ { print; next } { exit }' "$BASELINE"; cat "$PRUNED"; } > "${BASELINE}.tmp"
+    HEADER_LINES=$(awk '/^#/ { c++; next } { exit } END { print c + 0 }' "${BASELINE}.tmp")
+    if [ "$HEADER_LINES" -eq 0 ]; then
+        rm -f "${BASELINE}.tmp"
+        echo "FATAL: refusing to write a baseline with no header — the rules governing" >&2
+        echo "  this file live in it." >&2
+        exit 1
+    fi
+    mv "${BASELINE}.tmp" "$BASELINE"
+    echo "hardcoded-values: baseline pruned — ${BEFORE} key(s) -> ${KEPT} key(s), $((BEFORE - KEPT)) removed"
+    echo "  Removal-only: no key was added and no count raised (hv_pruned_baseline"
+    echo "  iterates existing keys and emits min(baseline, found))."
+    echo "  Review the diff and commit it with the change that fixed the violations."
     exit 0
 fi
 

--- a/pipeline-scripts/detect-hardcoded-values.sh
+++ b/pipeline-scripts/detect-hardcoded-values.sh
@@ -67,6 +67,30 @@ SCAN_DIRS=(
     "autobot-infrastructure"
 )
 
+# Every scan directory must exist before anything is scanned (#14912 review).
+#
+# hv_scan_tree treats a missing directory as a silent no-op (`[ -d "$root" ] ||
+# return 0`), so one moved or renamed entry in SCAN_DIRS yields nothing while
+# the other five still yield hundreds. Reproduced: with autobot-slm-backend
+# absent, a prune run dropped every baseline key under it, exited 0, and printed
+# the same success line a legitimate one-entry cleanup prints — and the audit
+# then passed, because every surviving entry still matched. The empty-scan
+# refusal below never fired, because the scan was not empty.
+#
+# Checked here rather than only in the prune branch, because a partial scan
+# corrupts EVERY mode: --json under-reports the violation counts that
+# ssot-coverage.yml decides pass/fail from, and --audit-baseline reports the
+# unreached directory's entries as STALE, which is a false accusation that
+# sends an author to prune away real records.
+for dir in "${SCAN_DIRS[@]}"; do
+    [ -d "$REPO_ROOT/$dir" ] && continue
+    echo "FATAL: scan directory '${dir}' does not exist under ${REPO_ROOT}." >&2
+    echo "  Refusing to scan a partial tree: findings under it would be missing," >&2
+    echo "  its baseline entries would look stale, and a prune would delete them." >&2
+    echo "  If the layout changed on purpose, update SCAN_DIRS in this script." >&2
+    exit 1
+done
+
 hv_load_baseline "$BASELINE" || exit 1
 
 RAW=$(mktemp); NEWFILE=$(mktemp)
@@ -124,9 +148,18 @@ fi
 if [ "$PRUNE_BASELINE" = true ]; then
     # Refuse to write the result of a scan that found nothing. An empty result
     # and a broken detector are indistinguishable here, and this path REWRITES
-    # the record: a rules file that failed to load, or a scan directory that has
-    # moved, would take all ${#HV_BASELINE[@]} entries with it and the no-growth
-    # guard would not object, because shrinking is allowed by design.
+    # the record; the no-growth guard will not object either, because shrinking
+    # is allowed by design.
+    #
+    # The PARTIAL-scan case -- far more dangerous, because the total stays
+    # non-zero and this check never fires -- is handled by the SCAN_DIRS
+    # existence assertion near the top, not here.
+    #
+    # No proportional-loss guard, deliberately: a percentage threshold has no
+    # non-arbitrary value, and it would block the one legitimate large prune
+    # (a genuine sweep that fixes many violations at once) while still passing
+    # any loss that happened to fall under it. The existence check removes the
+    # cause rather than rationing the symptom.
     TOTAL_FOUND=$(grep -c . "$RAW" || true)
     if [ "$TOTAL_FOUND" -eq 0 ]; then
         echo "FATAL: the scan found 0 findings, so pruning would empty the baseline." >&2
@@ -136,8 +169,12 @@ if [ "$PRUNE_BASELINE" = true ]; then
         exit 1
     fi
     PRUNED=$(mktemp)
-    trap 'rm -f "$RAW" "$NEWFILE" "$PRUNED"' EXIT
-    hv_pruned_baseline | sort -t'|' -k3,3 -k2,2 -k4,4 > "$PRUNED"
+    trap 'rm -f "$RAW" "$NEWFILE" "$PRUNED" "${BASELINE}.tmp"' EXIT
+    # LC_ALL=C pins the collation. Nothing is broken today -- the committed
+    # baseline is byte-identical under this runner's C.UTF-8 -- but an unpinned
+    # locale means a different shell or CI image could reorder every line on a
+    # legitimate no-op prune, turning a zero-change run into a whole-file diff.
+    hv_pruned_baseline | LC_ALL=C sort -t'|' -k3,3 -k2,2 -k4,4 > "$PRUNED"
     KEPT=$(grep -c . "$PRUNED" || true)
     BEFORE=${#HV_BASELINE[@]}
     # Header first, then the pruned body. The leading comment block carries the

--- a/pipeline-scripts/detect-hardcoded-values_test.py
+++ b/pipeline-scripts/detect-hardcoded-values_test.py
@@ -31,6 +31,8 @@ import stat
 import subprocess  # nosec B404  # fixed argv, no shell
 from pathlib import Path
 
+import pytest
+
 _SCRIPT = Path(__file__).with_name("detect-hardcoded-values.sh")
 # #14371: the entry point is thin now — the rules live in the shared library and
 # the known backlog lives in the baseline, so a hermetic tree needs both. The
@@ -40,6 +42,17 @@ _SCRIPT = Path(__file__).with_name("detect-hardcoded-values.sh")
 # exercises the same load-and-partition path CI runs.
 _LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib" / "hardcoded-value-rules.sh"
 _BASELINE = Path(__file__).with_name("hardcoded_values_baseline.txt")
+# Kept in step with SCAN_DIRS in detect-hardcoded-values.sh; the guard below
+# asserts the two lists have not drifted, so a new scan directory cannot make
+# every hermetic test start refusing without anyone noticing why.
+_SCAN_DIRS = (
+    "autobot-backend",
+    "autobot-frontend/src",
+    "autobot_shared",
+    "autobot-slm-backend",
+    "autobot-slm-frontend/src",
+    "autobot-infrastructure",
+)
 
 _BAD_ACCOUNT = "ka" + "li"
 _FLEET_IP = ".".join(("172", "16", "168", "77"))
@@ -48,14 +61,19 @@ _FLEET_IP = ".".join(("172", "16", "168", "77"))
 def _hermetic_repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
     scripts_dir = root / "pipeline-scripts"
-    scripts_dir.mkdir(parents=True)
+    scripts_dir.mkdir(parents=True, exist_ok=True)
     target = scripts_dir / "detect-hardcoded-values.sh"
     shutil.copy(_SCRIPT, target)
     target.chmod(target.stat().st_mode | stat.S_IEXEC)
     lib_dir = root / "scripts" / "lib"
-    lib_dir.mkdir(parents=True)
+    lib_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(_LIB, lib_dir / "hardcoded-value-rules.sh")
     shutil.copy(_BASELINE, scripts_dir / "hardcoded_values_baseline.txt")
+    # Every SCAN_DIRS entry must exist, or the script now refuses to scan a
+    # partial tree (#14912 review). The fixture creates them all empty; tests
+    # that care about content write into the ones they need.
+    for scan_dir in _SCAN_DIRS:
+        (root / scan_dir).mkdir(parents=True, exist_ok=True)
     return root
 
 
@@ -105,7 +123,7 @@ def test_a_sudoers_line_in_a_shell_script_is_now_flagged(tmp_path):
     """The exact shape from #14316: a bare ``kali ALL=(ALL) NOPASSWD: ...`` line."""
     root = _hermetic_repo(tmp_path)
     infra = root / "autobot-infrastructure" / "shared" / "scripts" / "setup"
-    infra.mkdir(parents=True)
+    infra.mkdir(parents=True, exist_ok=True)
     (infra / "setup_passwordless_sudo.sh").write_text(
         f"#!/bin/bash\n{_BAD_ACCOUNT} ALL=(ALL) NOPASSWD: /usr/bin/lsof\n",
         encoding="utf-8",
@@ -121,7 +139,7 @@ def test_a_systemd_user_directive_in_a_shell_script_is_now_flagged(tmp_path):
     """The ``fix-vnc-desktop.sh`` shape: ``User=kali`` inside a heredoc unit file."""
     root = _hermetic_repo(tmp_path)
     infra = root / "autobot-infrastructure" / "shared" / "scripts" / "utilities"
-    infra.mkdir(parents=True)
+    infra.mkdir(parents=True, exist_ok=True)
     (infra / "fix-vnc-desktop.sh").write_text(
         "#!/bin/bash\n"
         "cat > /etc/systemd/system/tigervnc.service << EOF\n"
@@ -141,7 +159,7 @@ def test_the_fixed_variable_form_stays_clean(tmp_path):
     literal, and must not become a new false positive."""
     root = _hermetic_repo(tmp_path)
     infra = root / "autobot-infrastructure" / "shared" / "scripts" / "utilities"
-    infra.mkdir(parents=True)
+    infra.mkdir(parents=True, exist_ok=True)
     (infra / "fix-vnc-desktop.sh").write_text(
         "#!/bin/bash\n"
         'VNC_USER="${AUTOBOT_VNC_USER:-autobot}"\n'
@@ -161,7 +179,7 @@ def test_a_hardcoded_fleet_ip_in_a_shell_script_is_now_flagged(tmp_path):
     """The IP scan has the same blind spot -- shell/ansible were never included."""
     root = _hermetic_repo(tmp_path)
     shared = root / "autobot_shared"
-    shared.mkdir(parents=True)
+    shared.mkdir(parents=True, exist_ok=True)
     (shared / "deploy.sh").write_text(f"HOST={_FLEET_IP}\n", encoding="utf-8")
 
     report = _run(root)
@@ -173,7 +191,7 @@ def test_a_hardcoded_fleet_ip_in_a_shell_script_is_now_flagged(tmp_path):
 def test_a_hardcoded_fleet_ip_in_an_ansible_yaml_file_is_now_flagged(tmp_path):
     root = _hermetic_repo(tmp_path)
     ansible_dir = root / "autobot-slm-backend" / "ansible"
-    ansible_dir.mkdir(parents=True)
+    ansible_dir.mkdir(parents=True, exist_ok=True)
     (ansible_dir / "inventory.yml").write_text(f"host: {_FLEET_IP}\n", encoding="utf-8")
 
     report = _run(root)
@@ -185,7 +203,7 @@ def test_an_unrelated_extension_is_still_ignored(tmp_path):
     """Scope check: the fix targets sh/yml/yaml, not every file in the tree."""
     root = _hermetic_repo(tmp_path)
     shared = root / "autobot_shared"
-    shared.mkdir(parents=True)
+    shared.mkdir(parents=True, exist_ok=True)
     (shared / "notes.txt").write_text(f"{_BAD_ACCOUNT} ALL=(ALL) NOPASSWD: x\n{_FLEET_IP}\n", encoding="utf-8")
 
     report = _run(root)
@@ -263,7 +281,7 @@ def test_prune_removes_a_stranded_entry_and_the_audit_then_passes(tmp_path):
     """The recovery loop the audit message now names."""
     root = _hermetic_repo(tmp_path)
     scanned = root / "autobot-backend"
-    scanned.mkdir(parents=True)
+    scanned.mkdir(parents=True, exist_ok=True)
     (scanned / "svc.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
     _write_baseline(
         root,
@@ -282,7 +300,7 @@ def test_prune_cannot_add_a_key(tmp_path):
     """The property that stops prune becoming the bypass the no-growth guard prevents."""
     root = _hermetic_repo(tmp_path)
     scanned = root / "autobot-backend"
-    scanned.mkdir(parents=True)
+    scanned.mkdir(parents=True, exist_ok=True)
     (scanned / "known.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
     # A violation that is NOT baselined — prune must leave it a violation.
     (scanned / "brand_new.py").write_text('HOST = "' + ".".join(("172", "16", "168", "91")) + '"\n', encoding="utf-8")
@@ -300,7 +318,7 @@ def test_prune_cannot_raise_a_count(tmp_path):
     """min(baseline, found): a key baselined at 1 and found twice stays at 1."""
     root = _hermetic_repo(tmp_path)
     scanned = root / "autobot-backend"
-    scanned.mkdir(parents=True)
+    scanned.mkdir(parents=True, exist_ok=True)
     (scanned / "svc.py").write_text(f'A = "{_FLEET_IP}"\nB = "{_FLEET_IP}"\n', encoding="utf-8")
     _write_baseline(root, [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
 
@@ -314,7 +332,7 @@ def test_prune_preserves_the_header(tmp_path):
     """The header carries the rules governing the file, including 'only shrinks'."""
     root = _hermetic_repo(tmp_path)
     scanned = root / "autobot-backend"
-    scanned.mkdir(parents=True)
+    scanned.mkdir(parents=True, exist_ok=True)
     (scanned / "svc.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
     _write_baseline(root, [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
     assert _run_flag(root, "--prune-baseline").returncode == 0
@@ -326,9 +344,109 @@ def test_prune_preserves_the_header(tmp_path):
 def test_the_audit_failure_names_the_recovery_command(tmp_path):
     """#14912: most of this guard's cost was discoverability, not the rule."""
     root = _hermetic_repo(tmp_path)
-    (root / "autobot-backend").mkdir(parents=True)
+    (root / "autobot-backend").mkdir(parents=True, exist_ok=True)
     _write_baseline(root, [f"1|ssot|autobot-backend/gone.py|{_FLEET_IP}"])
     result = _run_flag(root, "--audit-baseline")
     assert result.returncode == 1
     assert "--prune-baseline" in result.stdout, "the failure does not say how to recover"
     assert "gone.py" in result.stdout, "the failure does not name the entries"
+
+
+def test_a_noop_prune_leaves_the_file_byte_identical(tmp_path):
+    """#14912 review: the PR claimed this property with no committed test.
+
+    A no-op prune is the common case — most runs find nothing stale — so a
+    regression in the sort order, the collation, or the header `awk` would
+    turn every such run into a whole-file diff, and nothing would have caught
+    it. Asserted on bytes, not on entry counts, because that is the claim.
+    """
+    root = _hermetic_repo(tmp_path)
+    scanned = root / "autobot-backend"
+    (scanned / "svc.py").write_text(f'A = "{_FLEET_IP}"\nB = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(root, [f"2|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
+
+    baseline = root / "pipeline-scripts" / "hardcoded_values_baseline.txt"
+    before = baseline.read_bytes()
+    result = _run_flag(root, "--prune-baseline")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "0 removed" in result.stdout, result.stdout
+    assert baseline.read_bytes() == before, "a no-op prune rewrote the file"
+
+
+def test_a_second_noop_prune_is_also_byte_identical(tmp_path):
+    """Idempotence: running it twice must not drift the file either."""
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend" / "svc.py").write_text(f'A = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(root, [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
+    baseline = root / "pipeline-scripts" / "hardcoded_values_baseline.txt"
+
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    once = baseline.read_bytes()
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    assert baseline.read_bytes() == once
+
+
+@pytest.mark.parametrize("missing", _SCAN_DIRS)
+def test_a_missing_scan_dir_refuses_instead_of_pruning(tmp_path, missing):
+    """#14912 review, HIGH: a PARTIAL scan silently gutted the baseline.
+
+    ``hv_scan_tree`` treats a missing root as a no-op, so one moved directory
+    yields nothing while the others still yield plenty. The total stays
+    non-zero, the empty-scan refusal never fires, and every baseline key under
+    the unreached directory is dropped by ``min(kept, 0)`` — exit 0, in the
+    same voice a one-entry cleanup uses.
+
+    Parametrized over every entry so the guard cannot cover five of six.
+    """
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend" / "svc.py").write_text(f'A = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(
+        root,
+        [
+            f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}",
+            f"1|ssot|{missing}/deep/thing.py|{_FLEET_IP}",
+        ],
+    )
+    baseline = root / "pipeline-scripts" / "hardcoded_values_baseline.txt"
+    before = baseline.read_bytes()
+
+    shutil.rmtree(root / missing)
+
+    result = _run_flag(root, "--prune-baseline")
+    assert result.returncode != 0, result.stdout
+    assert missing in result.stderr
+    assert baseline.read_bytes() == before, "the baseline was rewritten from a partial scan"
+
+
+@pytest.mark.parametrize("missing", _SCAN_DIRS)
+def test_a_missing_scan_dir_also_refuses_to_report_or_audit(tmp_path, missing):
+    """A partial scan corrupts every mode, not just prune.
+
+    --json under-reports the counts ssot-coverage.yml decides pass/fail from,
+    and --audit-baseline calls the unreached directory's entries STALE, which
+    is a false accusation that sends an author to prune away real records.
+    """
+    root = _hermetic_repo(tmp_path)
+    shutil.rmtree(root / missing)
+    for flag in ("--json", "--audit-baseline"):
+        result = _run_flag(root, flag)
+        assert result.returncode != 0, f"{flag} reported on a partial tree: {result.stdout}"
+        assert "does not exist" in result.stderr
+
+
+def test_the_tests_scan_dir_list_matches_the_script(tmp_path):
+    """The fixture duplicates SCAN_DIRS; assert it has not drifted.
+
+    A new entry in the script and not here would leave every hermetic test
+    refusing, with a failure that points at the fixture rather than the cause.
+    """
+    text = _SCRIPT.read_text(encoding="utf-8")
+    block = text.split("SCAN_DIRS=(", 1)[1].split(")", 1)[0]
+    in_script = tuple(
+        line.strip().strip('"')
+        for line in block.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    )
+    assert in_script == _SCAN_DIRS, (
+        f"SCAN_DIRS drifted — script has {in_script}, this file has {_SCAN_DIRS}"
+    )

--- a/pipeline-scripts/detect-hardcoded-values_test.py
+++ b/pipeline-scripts/detect-hardcoded-values_test.py
@@ -215,3 +215,120 @@ def test_the_real_repository_has_no_new_blocking_ssot_violations():
         "a real fleet IP is now reachable through *.sh/*.yml/*.yaml scanning and must be "
         f"fixed at the source (or noqa'd if a documented example), not allow-listed: {report}"
     )
+
+
+# ── #14912: --prune-baseline, and the audit message that sends you to it ─────
+
+
+def _write_baseline(root, lines: list[str]) -> None:
+    """Replace the baseline body, keeping its header (which carries the rules)."""
+    path = root / "pipeline-scripts" / "hardcoded_values_baseline.txt"
+    header = [ln for ln in path.read_text(encoding="utf-8").splitlines(keepends=True) if ln.startswith("#")]
+    path.write_text("".join(header) + "".join(f"{ln}\n" for ln in lines), encoding="utf-8")
+
+
+def _baseline_keys(root) -> set:
+    path = root / "pipeline-scripts" / "hardcoded_values_baseline.txt"
+    return {
+        ln.split("|", 1)[1]
+        for ln in path.read_text(encoding="utf-8").splitlines()
+        if ln[:1].isdigit()
+    }
+
+
+def _run_flag(root, flag: str) -> subprocess.CompletedProcess:
+    return subprocess.run(  # nosec B603  # fixed argv, no shell
+        ["bash", str(root / "pipeline-scripts" / "detect-hardcoded-values.sh"), flag],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_prune_refuses_when_the_scan_found_nothing(tmp_path):
+    """An empty scan and a broken detector are indistinguishable, and this path WRITES.
+
+    A rules file that failed to load, or scan directories that moved, would take
+    every baselined entry with it — and the no-growth guard would not object,
+    because shrinking is allowed by design.
+    """
+    root = _hermetic_repo(tmp_path)  # no scan directories exist here
+    before = (root / "pipeline-scripts" / "hardcoded_values_baseline.txt").read_bytes()
+    result = _run_flag(root, "--prune-baseline")
+    assert result.returncode != 0
+    assert "refusing to rewrite the baseline" in result.stderr
+    assert (root / "pipeline-scripts" / "hardcoded_values_baseline.txt").read_bytes() == before
+
+
+def test_prune_removes_a_stranded_entry_and_the_audit_then_passes(tmp_path):
+    """The recovery loop the audit message now names."""
+    root = _hermetic_repo(tmp_path)
+    scanned = root / "autobot-backend"
+    scanned.mkdir(parents=True)
+    (scanned / "svc.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(
+        root,
+        [
+            f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}",
+            "1|ssot|autobot-backend/gone.py|" + _FLEET_IP,
+        ],
+    )
+    assert _run_flag(root, "--audit-baseline").returncode == 1
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    assert _baseline_keys(root) == {f"ssot|autobot-backend/svc.py|{_FLEET_IP}"}
+    assert _run_flag(root, "--audit-baseline").returncode == 0
+
+
+def test_prune_cannot_add_a_key(tmp_path):
+    """The property that stops prune becoming the bypass the no-growth guard prevents."""
+    root = _hermetic_repo(tmp_path)
+    scanned = root / "autobot-backend"
+    scanned.mkdir(parents=True)
+    (scanned / "known.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
+    # A violation that is NOT baselined — prune must leave it a violation.
+    (scanned / "brand_new.py").write_text('HOST = "' + ".".join(("172", "16", "168", "91")) + '"\n', encoding="utf-8")
+    _write_baseline(root, [f"1|ssot|autobot-backend/known.py|{_FLEET_IP}"])
+
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    keys = _baseline_keys(root)
+    assert not any("brand_new.py" in k for k in keys), f"prune ADDED a key: {sorted(keys)}"
+    assert json.loads(_run_flag(root, "--json").stdout)["ssot_violations"] >= 1, (
+        "prune silenced a finding it was never allowed to absorb"
+    )
+
+
+def test_prune_cannot_raise_a_count(tmp_path):
+    """min(baseline, found): a key baselined at 1 and found twice stays at 1."""
+    root = _hermetic_repo(tmp_path)
+    scanned = root / "autobot-backend"
+    scanned.mkdir(parents=True)
+    (scanned / "svc.py").write_text(f'A = "{_FLEET_IP}"\nB = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(root, [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
+
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    body = (root / "pipeline-scripts" / "hardcoded_values_baseline.txt").read_text(encoding="utf-8")
+    entry = [ln for ln in body.splitlines() if ln[:1].isdigit()]
+    assert entry == [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"], entry
+
+
+def test_prune_preserves_the_header(tmp_path):
+    """The header carries the rules governing the file, including 'only shrinks'."""
+    root = _hermetic_repo(tmp_path)
+    scanned = root / "autobot-backend"
+    scanned.mkdir(parents=True)
+    (scanned / "svc.py").write_text(f'HOST = "{_FLEET_IP}"\n', encoding="utf-8")
+    _write_baseline(root, [f"1|ssot|autobot-backend/svc.py|{_FLEET_IP}"])
+    assert _run_flag(root, "--prune-baseline").returncode == 0
+    text = (root / "pipeline-scripts" / "hardcoded_values_baseline.txt").read_text(encoding="utf-8")
+    assert text.startswith("#")
+    assert "only ever shrinks" in text.lower() or "only ever shrink" in text.lower()
+
+
+def test_the_audit_failure_names_the_recovery_command(tmp_path):
+    """#14912: most of this guard's cost was discoverability, not the rule."""
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend").mkdir(parents=True)
+    _write_baseline(root, [f"1|ssot|autobot-backend/gone.py|{_FLEET_IP}"])
+    result = _run_flag(root, "--audit-baseline")
+    assert result.returncode == 1
+    assert "--prune-baseline" in result.stdout, "the failure does not say how to recover"
+    assert "gone.py" in result.stdout, "the failure does not name the entries"

--- a/scripts/lib/hardcoded-value-rules.sh
+++ b/scripts/lib/hardcoded-value-rules.sh
@@ -681,8 +681,19 @@ hv_stale_baseline_entries() {
 # baselined at 2 and now found 3 times prunes to 2, not 3.
 #
 # Requires a completed hv_partition over a FULL tree scan. Pruning against a
-# partial scan drops every key the scan did not reach, which is why the caller
-# must refuse to write the result of an empty one.
+# partial scan drops every key the scan did not reach.
+#
+# The live risk is a scan DIRECTORY that has moved or been renamed, because
+# hv_scan_tree treats a missing root as a silent no-op: the other directories
+# still produce hundreds of findings, so the total stays non-zero and an
+# empty-scan check cannot see it. Reproduced during review -- one absent
+# directory silently removed every baseline key beneath it, exit 0.
+#
+# An earlier version of this comment also cited "a rules file that failed to
+# load". That path was never reachable: detect-hardcoded-values.sh fails fatally
+# on an unsourceable library before any scanning begins. Naming a risk the code
+# already forecloses makes the remaining, real one look handled -- so the
+# caller now asserts every SCAN_DIRS entry exists before it scans.
 hv_pruned_baseline() {
     local key kept seen
     for key in "${!HV_BASELINE[@]}"; do

--- a/scripts/lib/hardcoded-value-rules.sh
+++ b/scripts/lib/hardcoded-value-rules.sh
@@ -659,3 +659,37 @@ hv_stale_baseline_entries() {
     done
     return 0
 }
+
+# The baseline rewritten to what the last scan actually found -- REMOVAL ONLY.
+#
+# WHY THIS IS SAFE, structurally rather than by inspection. Two properties, and
+# both come from the shape of the loop rather than from a check that could be
+# forgotten:
+#
+#   * it iterates "${!HV_BASELINE[@]}" -- keys ALREADY in the baseline -- so it
+#     cannot introduce one. Findings are never iterated here.
+#   * it emits min(baseline_count, seen_count), so it cannot raise one.
+#
+# That matters because a prune that could add or increment would BE the bypass
+# check_baseline_no_growth.sh exists to prevent: fix nothing, run prune, and
+# every new finding becomes "known". The two guards are complementary only
+# while this direction is closed by construction.
+#
+# hv_partition increments HV_BASELINE_SEEN BEFORE testing it against the
+# allowance, so `seen` is the true number of findings for that key, including
+# any beyond what the baseline permits. That is what makes min() correct: a key
+# baselined at 2 and now found 3 times prunes to 2, not 3.
+#
+# Requires a completed hv_partition over a FULL tree scan. Pruning against a
+# partial scan drops every key the scan did not reach, which is why the caller
+# must refuse to write the result of an empty one.
+hv_pruned_baseline() {
+    local key kept seen
+    for key in "${!HV_BASELINE[@]}"; do
+        kept="${HV_BASELINE[$key]}"
+        seen="${HV_BASELINE_SEEN[$key]:-0}"
+        [ "$seen" -lt "$kept" ] && kept="$seen"
+        [ "$kept" -gt 0 ] && printf '%s|%s\n' "$kept" "$key"
+    done
+    return 0
+}


### PR DESCRIPTION
## Thinking Path

The stale-baseline audit shipped in #14883 was **not defective** — it fired on real drift and reported accurately on the change that caused it. What it did not do was tell the person who hit it what to do next, and that person is almost always the one who just *fixed* a hardcoded value, being sent to hand-edit a 1410-entry file unrelated to their change.

Measured, because the rate is the whole argument: the baseline covers **776 distinct files of 9510 tracked (~8% of the repo)**, concentrated in `autobot-slm-backend/ansible` (328) and `autobot-infrastructure/shared` (297). Any change that edits, moves, or fixes a baselined line strands its entry. This taxes exactly the behaviour the guard exists to encourage.

The audit stays blocking (#14912 point 3). A stranded entry naming a moved path exempts nothing today but silently re-permits the value the moment that path returns — a known recurrence class here. The answer is one-command recovery, not a downgrade to a warning.

## What Changed

**`--prune-baseline`, removal-only by construction.** `hv_pruned_baseline` iterates `"${!HV_BASELINE[@]}"` — keys already in the baseline, so it cannot introduce one — and emits `min(baseline_count, seen_count)`, so it cannot raise one. Two properties from the shape of the loop, not from a check that could be forgotten.

`hv_partition` increments `HV_BASELINE_SEEN` *before* testing it against the allowance, which is what makes `min()` correct rather than accidentally lossy: a key baselined at 2 and now found 3 times prunes to **2**, not 3.

That property is load-bearing. A prune that could add or increment **would be** the bypass `check_baseline_no_growth.sh` exists to prevent — fix nothing, run prune, and every new finding becomes "known". The two guards are complementary only while this direction is closed.

**The audit message now names the entries *and* the command**, and says why the command is safe to run (#14912 point 2). Most of this guard's cost was discoverability, not the rule.

**Prune refuses when the scan found nothing.** Found by prototyping, not review: prune drops every key the scan did not see, so a rules file that failed to load or a scan directory that moved would take all 1410 entries with it — and the no-growth guard would not object, because shrinking is allowed by design. An empty result and a broken detector are indistinguishable, and this is the one path that *rewrites* the record. It also refuses to write a baseline whose header was lost, since the rules governing the file live in that header.

**Docs**: `HARDCODING_PREVENTION.md` gains the recovery, so the next person to hit the red finds the answer.

This change does **not** modify `hardcoded_values_baseline.txt`.

### Review round: partial-scan gutting (HIGH) — fixed

The empty-scan refusal only caught a *whole-tree* zero. `hv_scan_tree` treats a missing root as a silent no-op, so one moved `SCAN_DIRS` entry yields nothing while the other five yield hundreds: the total stays non-zero, the refusal never fires, and every baseline key under the unreached directory is dropped by `min(kept, 0)` — `exit 0`, in the same voice a one-entry cleanup uses. `--audit-baseline` then passes (every survivor still matches) and `check_baseline_no_growth.sh` stays silent (shrinking is allowed by design). **Nothing between them checked magnitude.**

Reproduced before fixing: with `autobot-slm-backend` absent, `pruned — 5 key(s) -> 2 key(s), 3 removed`, exit 0. Real blast radius: **554** entries under `autobot-backend`, **405** under `autobot-slm-backend`, **337** under `autobot-infrastructure`.

Every `SCAN_DIRS` entry must now exist before anything is scanned — **for every mode, not just prune**, because a partial scan also makes `--json` under-report the counts `ssot-coverage.yml` gates on and makes `--audit-baseline` call the unreached directory's entries `STALE`, a false accusation that sends an author to prune away real records.

**No proportional-loss guard**, deliberately and stated in the code: a percentage threshold has no non-arbitrary value, would block the one legitimate large prune, and would still pass any loss under it. The existence check removes the cause rather than rationing the symptom.

Also: the library comment cited "a rules file that failed to load" — already fatal before any scanning, so unreachable; it now names the real (directory-move) risk. `LC_ALL=C` pins the prune sort's collation. `"${BASELINE}.tmp"` added to the cleanup trap.

Eight tests added this round, **455 passing**: byte-identical no-op prune (the property this body claimed with no committed test), idempotence, missing-scan-dir refusal for prune **and** for `--json`/`--audit-baseline` — each parametrized over all six entries so the guard cannot cover five of six — plus a drift test pinning the fixture's `SCAN_DIRS` copy to the script's.

## Verification

Mutation-proved, both directions. Nothing committed; source probes were removed and the baseline restored byte-for-byte.

| Proof | Result |
|---|---|
| real unbaselined violation in tree, then prune | key **not** added; still reported `ssot_violations: 1`; no-growth **green** |
| key baselined 1, found twice | stays **1** — cannot raise |
| strand an entry → audit | **RED**, names the entry and `--prune-baseline` |
| → prune → audit | **GREEN**; baseline **byte-identical** to pre-mutation |
| empty scan (hermetic tree, no scan dirs) | **refuses**, baseline unwritten |
| clean tree → prune | byte-identical **no-op** (also proves sort order and header round-trip) |

Suites: **440 passed** across `pipeline-scripts/`, `scripts/lib/hardcoded_value_rules_test.py`, `repo_tests/shell_lib_test.py`, `repo_tests/shell_lib_sources_resolve_test.py`, and the hardcoded-values hook suite — including **6 new tests** covering each property above. `check_script_exec_bits` clean, SPDX clean, `lint-conventions` clean, 0 commit trailers.

Local runs are Python 3.10.12 / pytest 9.0.2; the CI runner is 3.14.

### Two findings raised while doing this, not bundled

- **#14914 — 8 of 12 rule classes never block.** `STATUS="fail"` and `ssot-coverage`'s exit condition are both keyed on `ssot_violations` alone, so `other`-class findings (paths, DSNs, URLs, accounts, roles, categories, timeouts, magic numbers) are computed, printed, and read by nothing that can fail. The merged base carries **9 unbaselined violations right now** under `"status": "pass"` — all from #14890's ansible work. #14883 is what made those eight rules actually run against the tree, so the surface grew and the sink did not.
- **Required-context gap** (recorded in #14912): `SSOT Configuration Compliance` is not one of the ten required contexts on `Dev_new_gui`, so every step in that workflow is advisory at the protection layer. Promotion needs a required-context shim because of the `paths:` filter (#13388) — an owner decision, deliberately out of scope here.

## Model Used

Claude Opus 5 (1M context), model id `claude-opus-5[1m]`.

Closes #14912
