### PR TITLE
fix(ci): make every hardcoded-value class block, not one of two (#14914)

### DIFF
--- a/.github/workflows/ssot-coverage.yml
+++ b/.github/workflows/ssot-coverage.yml
@@ -7,7 +7,9 @@
 #
 # Runs hardcoded value detection with SSOT validation on PRs
 # Reports compliance percentage and highlights violations
-# SSOT violations are blocking — merges require compliance (Issue #2874)
+# Every VIOLATION-severity finding is blocking — both the `ssot` class and the
+# `other` class — and the verdict is the detector's own `status` field, not a
+# count re-interpreted here (Issue #2874, #14914).
 
 name: SSOT Coverage
 
@@ -162,7 +164,12 @@ jobs:
           let body = `## ${emoji} SSOT Configuration Compliance: ${statusText}\n\n`;
 
           if (status === 'pass') {
-            body += '🎉 No hardcoded values detected that have SSOT config equivalents!\n\n';
+            // #14914: state precisely what green means. It used to say "no
+            // hardcoded values that have SSOT config equivalents", which was
+            // true of the `ssot` class only — the other eight rule classes were
+            // reported in this very comment and blocked nothing.
+            body += '🎉 No new hardcoded values of either class — `ssot` and `other` both block.\n\n';
+            body += '_Known backlog in `pipeline-scripts/hardcoded_values_baseline.txt` is suppressed and tracked in #14371._\n\n';
           } else {
             body += `| Metric | Count |\n`;
             body += `|--------|-------|\n`;
@@ -216,12 +223,40 @@ jobs:
           }
 
     - name: Set job status
+      shell: bash
       run: |
+        set -euo pipefail
+        # #14914: this used to re-derive the verdict here, from
+        # `ssot_violations` alone, in a second copy of a policy the detector
+        # already owns. Two consequences, both live on the merged base:
+        #
+        #   * the eight `other`-class rules blocked nothing, so nine hardcoded
+        #     /opt/autobot paths sat on Dev_new_gui under a green check;
+        #   * the parse above falls back to "0" when the JSON is missing, so a
+        #     detector that died (a missing scan directory is FATAL by design)
+        #     reported clean. An absent result read as a clean result.
+        #
+        # Now there is one verdict, computed once, in
+        # pipeline-scripts/detect-hardcoded-values.sh, and this step only
+        # enforces it. `status` has no numeric fallback: an unparseable JSON
+        # yields "unknown", which is not "pass", which fails.
+        STATUS="${{ steps.ssot_check.outputs.status }}"
+        EXIT_CODE="${{ steps.ssot_check.outputs.exit_code }}"
+        TOTAL_VIOLATIONS="${{ steps.ssot_check.outputs.total_violations }}"
         SSOT_VIOLATIONS="${{ steps.ssot_check.outputs.ssot_violations }}"
+        OTHER_VIOLATIONS="${{ steps.ssot_check.outputs.other_violations }}"
 
-        # Fail the job if there are SSOT violations (Issue #2874)
-        if [ "$SSOT_VIOLATIONS" -gt "0" ]; then
-          echo "::error::Found $SSOT_VIOLATIONS hardcoded values that have SSOT config equivalents"
+        if [ "$EXIT_CODE" != "0" ]; then
+          echo "::error::detect-hardcoded-values.sh exited ${EXIT_CODE} — it reports no"
+          echo "::error::verdict on a run it could not complete. Refusing to report clean."
+          exit 1
+        fi
+
+        if [ "$STATUS" != "pass" ]; then
+          echo "::error::SSOT compliance status '${STATUS}': ${TOTAL_VIOLATIONS} new hardcoded value(s)"
+          echo "::error::(ssot=${SSOT_VIOLATIONS}, other=${OTHER_VIOLATIONS}). Both classes block (#14914)."
           echo "::error::Run './pipeline-scripts/detect-hardcoded-values.sh --report' locally for details"
           exit 1
         fi
+
+        echo "SSOT compliance: pass — 0 new violations of either class"

--- a/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
@@ -50,6 +50,13 @@
 #   - A directory holding data/ is REPORTED and left alone, never removed
 #   - All removals use state: absent (idempotent, no error if already gone)
 #   - Run with --check first to preview changes
+#
+# #14914: the removal paths below are built from `{{ autobot.base_dir }}`
+# (inventory/group_vars/all.yml), not from a `/opt/autobot` literal. They were
+# part of the nine hardcoded-value findings sitting unbaselined on Dev_new_gui
+# while the gate that reported them keyed its verdict on a different class.
+# The prose in this file still says /opt/autobot where it describes the deployed
+# layout to a reader; the paths the code ACTS on come from the variable.
 
 # ---------------------------------------------------------------------------
 # Pre-cleanup: snapshot /opt/autobot/ on all nodes
@@ -98,7 +105,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: SLM
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------
@@ -125,7 +132,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: Backend
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
     - name: "Backend | Find flat Python files at /opt/autobot root"
@@ -175,7 +182,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: Frontend
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------
@@ -202,7 +209,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: NPU
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------
@@ -229,7 +236,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: "AI Stack"
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------
@@ -259,7 +266,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: Databases
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------
@@ -286,7 +293,7 @@
         label: "{{ _cleanup_target.dir }}"
       vars:
         caller_role: Browser
-        remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"
         remove_reason: "{{ _cleanup_target.why }}"
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
+++ b/autobot-slm-backend/ansible/playbooks/cleanup-nodes.yml
@@ -51,12 +51,25 @@
 #   - All removals use state: absent (idempotent, no error if already gone)
 #   - Run with --check first to preview changes
 #
-# #14914: the removal paths below are built from `{{ autobot.base_dir }}`
-# (inventory/group_vars/all.yml), not from a `/opt/autobot` literal. They were
-# part of the nine hardcoded-value findings sitting unbaselined on Dev_new_gui
-# while the gate that reported them keyed its verdict on a different class.
-# The prose in this file still says /opt/autobot where it describes the deployed
-# layout to a reader; the paths the code ACTS on come from the variable.
+# #14914: the removal paths below resolve their install root from
+# `{{ autobot.base_dir }}` (inventory/group_vars/all.yml), not from a
+# `/opt/autobot` literal. They were the nine hardcoded-value findings sitting
+# unbaselined on Dev_new_gui while the gate that reported them keyed its verdict
+# on a different class.
+#
+# This indirection is load-bearing in BOTH directions, and the second one is
+# easy to miss: tests/test_cleanup_never_destroys_data_14856.py is a static
+# guard that expands these loops and resolves each removal target to a concrete
+# path, so it can assert no component directory is deleted outside the guarded
+# primitive and that /opt/autobot/config is never scheduled at all. It matches
+# on a literal `/opt/` prefix. A first attempt at this change routed the paths
+# through the variable WITHOUT teaching that guard to resolve it, and every
+# target here collapsed to a non-`/opt/` placeholder: the protected-config check
+# kept passing with nothing left to match.
+#
+# So the guard now resolves autobot.base_dir out of group_vars, and both
+# directions are mutation-proved. If this root ever moves again, change it in
+# group_vars — and re-run that guard, do not assume it followed.
 
 # ---------------------------------------------------------------------------
 # Pre-cleanup: snapshot /opt/autobot/ on all nodes

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -23,12 +23,25 @@
 #     --limit <node_id> \
 #     -e "role_name=redis systemd_service=redis-stack-server role_target_dir=autobot-redis backup_before_removal=true"
 #
-# #14914: the removal paths below are built from `{{ autobot.base_dir }}`
-# (inventory/group_vars/all.yml), not from a `/opt/autobot` literal. They were
-# part of the nine hardcoded-value findings sitting unbaselined on Dev_new_gui
-# while the gate that reported them keyed its verdict on a different class.
-# The prose in this file still says /opt/autobot where it describes the deployed
-# layout to a reader; the paths the code ACTS on come from the variable.
+# #14914: the removal paths below resolve their install root from
+# `{{ autobot.base_dir }}` (inventory/group_vars/all.yml), not from a
+# `/opt/autobot` literal. They were the nine hardcoded-value findings sitting
+# unbaselined on Dev_new_gui while the gate that reported them keyed its verdict
+# on a different class.
+#
+# This indirection is load-bearing in BOTH directions, and the second one is
+# easy to miss: tests/test_cleanup_never_destroys_data_14856.py is a static
+# guard that expands these loops and resolves each removal target to a concrete
+# path, so it can assert no component directory is deleted outside the guarded
+# primitive and that /opt/autobot/config is never scheduled at all. It matches
+# on a literal `/opt/` prefix. A first attempt at this change routed the paths
+# through the variable WITHOUT teaching that guard to resolve it, and every
+# target here collapsed to a non-`/opt/` placeholder: the protected-config check
+# kept passing with nothing left to match.
+#
+# So the guard now resolves autobot.base_dir out of group_vars, and both
+# directions are mutation-proved. If this root ever moves again, change it in
+# group_vars — and re-run that guard, do not assume it followed.
 
 - name: "Remove role {{ role_name }} from node"
   hosts: all
@@ -204,13 +217,19 @@
       become: true
 
     - name: "Record what the disk cleanup actually did (#14856)"
+      # #14914: the install root was spelled out twice inside the expression
+      # below, once per branch. Hoisted to a single task-scoped var so the path
+      # this summary NAMES is the same string in both branches and cannot drift
+      # between them. It stays a literal on purpose -- see this file's header.
+      vars:
+        _role_dir: "{{ autobot.base_dir }}/{{ role_target_dir | default('') }}"
       ansible.builtin.set_fact:
         _disk_cleanup_summary: >-
           {{ 'skipped (no target dir)'
              if not (role_target_dir is defined and role_target_dir | length > 0)
-             else (autobot.base_dir + '/' + role_target_dir + ' removed'
+             else (_role_dir + ' removed'
                    if not (_role_dir_after.stat.exists | default(true))
-                   else autobot.base_dir + '/' + role_target_dir + ' KEPT - it holds data, see the REFUSING message above') }}
+                   else _role_dir + ' KEPT - it holds data, see the REFUSING message above') }}
 
     - name: "Clean orphan user-level Python packages"
       ansible.builtin.file:

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -22,6 +22,13 @@
 #     -i inventory/production.yml -i inventory/slm-nodes.yml \
 #     --limit <node_id> \
 #     -e "role_name=redis systemd_service=redis-stack-server role_target_dir=autobot-redis backup_before_removal=true"
+#
+# #14914: the removal paths below are built from `{{ autobot.base_dir }}`
+# (inventory/group_vars/all.yml), not from a `/opt/autobot` literal. They were
+# part of the nine hardcoded-value findings sitting unbaselined on Dev_new_gui
+# while the gate that reported them keyed its verdict on a different class.
+# The prose in this file still says /opt/autobot where it describes the deployed
+# layout to a reader; the paths the code ACTS on come from the variable.
 
 - name: "Remove role {{ role_name }} from node"
   hosts: all
@@ -181,7 +188,7 @@
       when: role_target_dir is defined and role_target_dir | length > 0
       vars:
         caller_role: "Remove role"
-        remove_dir_path: "/opt/autobot/{{ role_target_dir }}"
+        remove_dir_path: "{{ autobot.base_dir }}/{{ role_target_dir }}"
         remove_reason: "role {{ role_target_dir }} is being removed from this node"
 
     # #14856: this line used to read "<dir> removed" whenever a target dir was
@@ -191,7 +198,7 @@
     # does not implement. So it reports what the filesystem says afterwards.
     - name: "Re-check the role directory after removal (#14856)"
       ansible.builtin.stat:
-        path: "/opt/autobot/{{ role_target_dir }}"
+        path: "{{ autobot.base_dir }}/{{ role_target_dir }}"
       register: _role_dir_after
       when: role_target_dir is defined and role_target_dir | length > 0
       become: true
@@ -201,9 +208,9 @@
         _disk_cleanup_summary: >-
           {{ 'skipped (no target dir)'
              if not (role_target_dir is defined and role_target_dir | length > 0)
-             else ('/opt/autobot/' + role_target_dir + ' removed'
+             else (autobot.base_dir + '/' + role_target_dir + ' removed'
                    if not (_role_dir_after.stat.exists | default(true))
-                   else '/opt/autobot/' + role_target_dir + ' KEPT - it holds data, see the REFUSING message above') }}
+                   else autobot.base_dir + '/' + role_target_dir + ' KEPT - it holds data, see the REFUSING message above') }}
 
     - name: "Clean orphan user-level Python packages"
       ansible.builtin.file:

--- a/autobot-slm-backend/ansible/playbooks/remove-role.yml
+++ b/autobot-slm-backend/ansible/playbooks/remove-role.yml
@@ -220,7 +220,7 @@
       # #14914: the install root was spelled out twice inside the expression
       # below, once per branch. Hoisted to a single task-scoped var so the path
       # this summary NAMES is the same string in both branches and cannot drift
-      # between them. It stays a literal on purpose -- see this file's header.
+      # between them.
       vars:
         _role_dir: "{{ autobot.base_dir }}/{{ role_target_dir | default('') }}"
       ansible.builtin.set_fact:

--- a/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
+++ b/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
@@ -65,10 +65,65 @@ _CALL_SITES = (
 # explicitly-named operation, not a cleanup. That is a boundary, not an
 # exception: nothing here exempts a component directory from the rule.
 #
-# `{{ ... }}` is collapsed first so that "/opt/autobot/{{ role_target_dir }}" is
-# recognised as one of these and a fully-templated "{{ some_path }}" is not.
+# `{{ ... }}` is collapsed AFTER the install root is resolved, so that both
+# "<root>/{{ role_target_dir }}" and "{{ autobot.base_dir }}/{{ dir }}" are
+# recognised, while a fully-templated "{{ some_path }}" is not.
 _TEMPLATE = re.compile(r"\{\{.*?\}\}")
-_INSTALL_ROOT = "/opt/autobot"
+
+# #14914: `{{ autobot.base_dir }}`, in any spacing. Substituted for its SSOT
+# value BEFORE the generic collapse, because a path built from the variable
+# otherwise flattens to a placeholder that is under no root at all — and this
+# classifier answers False for everything it cannot place, so the tree-wide
+# sweep below would pass over an empty set. Rendering the WHOLE string instead
+# would be worse: the unknown vars would blank too, turning
+# "<root>/{{ role_target_dir }}" into the bare root and un-classifying a real
+# component removal.
+_BASE_DIR_REF = re.compile(r"\{\{\s*autobot\.base_dir\s*\}\}")
+
+# Roots under which a single trailing segment is a component directory.
+#
+# Deliberately NOT "whatever base_dir happens to be" alone, and not a frozen
+# literal either — the two shapes have different natures:
+#
+#   * the canonical install root comes from the inventory SSOT. It is a setting,
+#     it can move, and this follows it.
+#   * the historical roots are a fact about hosts that already exist, not a
+#     setting. /opt/slm-agent and friends predate the rename and are still
+#     cleaned up by this file's own subject; they do not move when base_dir
+#     does. /opt/autobot stays in this set for the same reason even when it is
+#     no longer the configured base: a host mid-migration still carries one and
+#     the playbooks still target it, so dropping it would lose coverage at
+#     exactly the moment the tree is most dangerous.
+_HISTORICAL_ROOTS = ("/opt/autobot", "/opt")
+
+
+def _base_dir() -> str:
+    return str(_inventory_vars()["autobot"]["base_dir"]).rstrip("/")
+
+
+def _component_roots() -> tuple[str, ...]:
+    """Every root, longest first.
+
+    Order matters: "/opt/autobot/backend" must be read as <root>/backend and not
+    as the flat /opt/<autobot/backend>, whose tail contains a slash and would be
+    dismissed.
+    """
+    return tuple(sorted({_base_dir(), *_HISTORICAL_ROOTS}, key=len, reverse=True))
+
+
+def _normalised_path(raw: str) -> str:
+    return _TEMPLATE.sub("TPL", _BASE_DIR_REF.sub(_base_dir(), raw)).strip().rstrip("/")
+
+
+def _under_a_known_root(raw: str) -> bool:
+    """Whether the classifier had a subject to adjudicate at all.
+
+    Distinct from being a component directory: "<root>/backend/data" is under a
+    root and is NOT a component directory. Counting these is what tells the
+    sweep apart from a sweep that classified nothing.
+    """
+    path = _normalised_path(raw)
+    return any(path == root or path.startswith(root + "/") for root in _component_roots())
 
 
 _GROUP_VARS_ALL = _ANSIBLE / "inventory" / "group_vars" / "all.yml"
@@ -107,13 +162,16 @@ def _inventory_vars() -> dict[str, Any]:
 
 
 def _is_component_dir(raw: str) -> bool:
-    path = _TEMPLATE.sub("TPL", raw).strip().rstrip("/")
-    if not path.startswith("/opt/") or path == _INSTALL_ROOT:
-        return False
-    tail = path[len("/opt/") :]
-    if tail.startswith("autobot/"):
-        tail = tail[len("autobot/") :]
-    return bool(tail) and "/" not in tail
+    path = _normalised_path(raw)
+    for root in _component_roots():
+        if path == root:
+            # The root itself contains component directories; removing it is
+            # decommissioning a node, a different and explicitly-named operation.
+            return False
+        if path.startswith(root + "/"):
+            tail = path[len(root) + 1 :]
+            return bool(tail) and "/" not in tail
+    return False
 
 
 # --------------------------------------------------------------------------
@@ -329,6 +387,7 @@ def test_no_component_directory_is_removed_outside_the_primitive() -> None:
     """
     files_scanned = 0
     deletions_seen = 0
+    candidates_seen = 0
     offenders: list[str] = []
 
     for path in sorted(_ANSIBLE.rglob("*.yml")) + sorted(_ANSIBLE.rglob("*.yaml")):
@@ -343,16 +402,73 @@ def test_no_component_directory_is_removed_outside_the_primitive() -> None:
             deletions_seen += 1
             spec = _module(task, "ansible.builtin.file", "file") or {}
             raw = str(spec.get("path") or spec.get("dest") or "")
+            if _under_a_known_root(raw):
+                candidates_seen += 1
             if _is_component_dir(raw):
                 offenders.append(f"{path.relative_to(_ANSIBLE)}: {task.get('name')} -> {raw}")
 
     # Presence, not absence of failure: an empty scan reads as a clean scan.
     assert files_scanned > 100, f"only {files_scanned} ansible files scanned — the sweep is not reaching the tree"
     assert deletions_seen > 50, f"only {deletions_seen} state=absent tasks found — the sweep is not finding deletions"
+    # #14914: the two assertions above prove the sweep READ the tree. This one
+    # proves the classifier was actually asked something. `offenders` is empty in
+    # a healthy tree, so it can never evidence that — a classifier that answered
+    # False for every path in the repository would produce exactly the same empty
+    # list as a clean tree. That is not hypothetical: before this change
+    # `_is_component_dir` matched a hardcoded "/opt/" prefix, so moving
+    # autobot.base_dir (or writing a deletion path from the variable, which the
+    # playbooks now do) placed every target outside every root it knew, and this
+    # whole sweep would have passed over nothing at all.
+    assert candidates_seen > 0, (
+        "no state=absent path resolved to anything under a known install root, so the "
+        f"component-directory classifier adjudicated nothing across {deletions_seen} deletions. "
+        f"Roots it recognised: {list(_component_roots())}. Either the tree stopped removing "
+        "anything under the install root, or the roots have drifted from what the playbooks "
+        "actually build — and the second one is a silent hole in this guard."
+    )
     assert not offenders, (
         "these tasks remove a whole component directory themselves instead of delegating to "
         f"{_PRIMITIVE.name}, so nothing checks whether the directory holds data/:\n  " + "\n  ".join(offenders)
     )
+
+
+def test_the_component_classifier_recognises_every_root_shape() -> None:
+    """#14914: the sweep's classifier, exercised directly on every shape it claims.
+
+    The tree-wide sweep asserts an EMPTY result, so it cannot tell a working
+    classifier from one that answers False for everything. This is the positive
+    half: every root shape the classifier documents is fed to it, and a fixture
+    that stops being recognised fails here by name instead of quietly shrinking
+    what the sweep covers.
+
+    Fixtures are built from the inventory SSOT, not written out, so they follow a
+    moved base_dir the same way the classifier does. A hardcoded "/opt/autobot"
+    here would keep testing the old root after the real one moved — which is the
+    exact defect this test exists to pin.
+    """
+    base = _base_dir()
+    assert base.startswith("/") and base != "/", f"the SSOT install root is unusable: {base!r}"
+
+    must_classify = {
+        f"{base}/autobot-backend": "a component directory at the configured root",
+        "{{ autobot.base_dir }}/autobot-backend": "the same, written through the SSOT variable",
+        f"{base}/{{{{ role_target_dir }}}}": "a templated component, root spelled out",
+        "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}": "a templated component, root from the variable",
+        "/opt/slm-agent": "a flat pre-rename root, a historical fact that does not move",
+        "/opt/autobot/autobot-backend": "the historical canonical root, still on deployed hosts",
+    }
+    must_not_classify = {
+        base: "the install root itself — removing it is decommissioning, not cleanup",
+        "/opt": "the parent of the flat legacy roots",
+        f"{base}/autobot-backend/data": "a path INSIDE a component, not the component",
+        "{{ remove_dir_path }}": "a fully-templated path that names no root",
+        "/var/lib/redis": "not an AutoBot install path at all",
+    }
+
+    for raw, why in must_classify.items():
+        assert _is_component_dir(raw), f"classifier no longer recognises {raw!r} — {why}"
+    for raw, why in must_not_classify.items():
+        assert not _is_component_dir(raw), f"classifier wrongly claims {raw!r} — {why}"
 
 
 def _delegated_targets(task: dict) -> list[str]:
@@ -794,10 +910,18 @@ def test_legacy_data_probe_defaults_to_assuming_data() -> None:
     looked. The probe must now answer "assume data" when it has no result.
     """
     tasks = [t for t in _load(_LEGACY) if isinstance(t, dict)]
+    # #14914: matched after resolving `{{ autobot.base_dir }}`, and against a
+    # path built from the SSOT rather than a literal. The exact-string form was
+    # the third site in this file keyed to "/opt/autobot"; it fails loudly rather
+    # than quietly (the presence assertion below catches it), but it would have
+    # failed saying "nothing probes the legacy directory" when the truth was that
+    # the probe had simply adopted the variable.
+    expected_probe = _base_dir() + "/{{ dir_name }}/data"
     probes = [
         t
         for t in tasks
-        if (_module(t, "ansible.builtin.stat", "stat") or {}).get("path") == "/opt/autobot/{{ dir_name }}/data"
+        if _BASE_DIR_REF.sub(_base_dir(), str((_module(t, "ansible.builtin.stat", "stat") or {}).get("path") or ""))
+        == expected_probe
     ]
     assert probes, "nothing probes the legacy directory for data/"
     assert "when" not in probes[0], (

--- a/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
+++ b/autobot-slm-backend/tests/test_cleanup_never_destroys_data_14856.py
@@ -71,6 +71,41 @@ _TEMPLATE = re.compile(r"\{\{.*?\}\}")
 _INSTALL_ROOT = "/opt/autobot"
 
 
+_GROUP_VARS_ALL = _ANSIBLE / "inventory" / "group_vars" / "all.yml"
+
+
+def _inventory_vars() -> dict[str, Any]:
+    """The facts `group_vars/all.yml` supplies to every play in this inventory.
+
+    #14914: the playbooks build their removal paths from `{{ autobot.base_dir }}`
+    rather than a `/opt/autobot` literal, so this guard has to resolve that
+    variable or every target below renders with an empty install root.
+
+    Read out of the SSOT file rather than restated here, deliberately. A copy of
+    `/opt/autobot` in this test would keep resolving after the real value moved,
+    and these guards would then be checking paths no playbook produces — which
+    is the same shape as the literal the playbooks just stopped carrying, one
+    layer up.
+
+    Asserted on PRESENCE: if the key disappears, that is a loud failure here,
+    not a silent one in a comparison that stops matching.
+    """
+    assert _GROUP_VARS_ALL.is_file(), f"the inventory SSOT is missing: {_GROUP_VARS_ALL}"
+    loaded = yaml.safe_load(_GROUP_VARS_ALL.read_text(encoding="utf-8")) or {}
+    autobot = loaded.get("autobot")
+    assert isinstance(autobot, dict), (
+        f"{_GROUP_VARS_ALL.name} no longer defines an `autobot` mapping, so every removal "
+        "target in this file would render without its install root and the checks below "
+        "would compare paths no playbook produces"
+    )
+    base_dir = str(autobot.get("base_dir") or "")
+    assert base_dir.startswith("/"), (
+        f"{_GROUP_VARS_ALL.name} defines autobot.base_dir as {base_dir!r}, which is not an "
+        "absolute path; the removal targets built from it cannot be checked"
+    )
+    return {"autobot": autobot}
+
+
 def _is_component_dir(raw: str) -> bool:
     path = _TEMPLATE.sub("TPL", raw).strip().rstrip("/")
     if not path.startswith("/opt/") or path == _INSTALL_ROOT:
@@ -323,19 +358,27 @@ def test_no_component_directory_is_removed_outside_the_primitive() -> None:
 def _delegated_targets(task: dict) -> list[str]:
     """The concrete paths one delegation can remove, loop expanded.
 
-    Callers pass `remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"` over
-    a loop, so the literal string says nothing about what is actually scheduled.
-    Expanding it is the difference between a guard that reads the code and one
-    that reads what the code will do.
+    Callers pass `remove_dir_path: "{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"`
+    over a loop, so the raw string says nothing about what is actually scheduled.
+    Expanding it — the install root from the inventory SSOT, the component from
+    the loop — is the difference between a guard that reads the code and one that
+    reads what the code will do.
     """
     spec = str((task.get("vars") or {}).get("remove_dir_path", ""))
     if not spec:
         return []
+    # #14914: the inventory facts belong in EVERY render scope here, including
+    # the loop-less one. Without them `{{ autobot.base_dir }}/{{ x }}` renders
+    # as `/x`, which is not a `/opt/` path and never equals the protected
+    # directory — so the caller's check keeps passing with nothing left to
+    # match. That is not a hypothetical: it is how the first attempt at #14914
+    # disarmed the protected-config guard while every test stayed green.
+    scope = _inventory_vars()
     items = task.get("loop")
     if not isinstance(items, list):
-        return [spec]
+        return [str(_render_value(spec, dict(scope)))]
     loop_var = ((task.get("loop_control") or {}).get("loop_var")) or "item"
-    return [str(_render_value(spec, {loop_var: item})) for item in items]
+    return [str(_render_value(spec, {**scope, loop_var: item})) for item in items]
 
 
 def test_the_protected_config_dir_is_never_scheduled_for_removal() -> None:
@@ -347,7 +390,11 @@ def test_the_protected_config_dir_is_never_scheduled_for_removal() -> None:
     unpinned decision regrows, so it is pinned here rather than left as a
     comment.
     """
-    protected = "/opt/autobot/config"
+    # Built from the same SSOT the playbooks build their targets from (#14914).
+    # Hardcoding it here would leave this comparison matching the old location
+    # the moment autobot.base_dir moved — the guard would go quiet rather than
+    # red, which is the failure mode this whole file exists to prevent.
+    protected = f"{str(_inventory_vars()['autobot']['base_dir']).rstrip('/')}/config"
     targets_seen = 0
     offenders: list[str] = []
     for candidate in sorted(_ANSIBLE.rglob("*.yml")) + sorted(_ANSIBLE.rglob("*.yaml")):
@@ -426,11 +473,30 @@ def test_the_removal_summary_reports_what_happened_not_what_was_asked() -> None:
     summaries = [t for t in tasks if "_disk_cleanup_summary" in str(_module(t, "ansible.builtin.debug", "debug") or {})]
     assert summaries, "the summary no longer reports the computed disk-cleanup result"
 
+    # #14914: the install root moved to a task-scoped `vars:` entry, so it has to
+    # be rendered into scope here too. Read out of the task rather than restated,
+    # because a hardcoded copy would keep rendering after the task stopped
+    # defining it — and the wording assertions below would then be judging a
+    # message with the path silently missing from it.
+    render_scope = {**_inventory_vars(), "role_target_dir": "autobot-backend"}
+    task_vars = {k: _render_value(v, render_scope) for k, v in (decisions[0].get("vars") or {}).items()}
+    assert task_vars, "the summary task defines no vars — the expression's operands cannot be resolved"
+
     # Removed for real -> says removed. Still there -> must NOT say removed.
-    base = {"role_target_dir": "autobot-backend"}
+    base = {**render_scope, **task_vars}
     gone = str(_render_value(expr, {**base, "_role_dir_after": _stat(False)}))
     kept = str(_render_value(expr, {**base, "_role_dir_after": _stat(True)}))
     unknown = str(_render_value(expr, base))
+
+    # The summary must NAME the directory, in both directions. Without this the
+    # wording checks below pass just as well over a message whose path rendered
+    # empty, which is exactly what an unresolved operand produces.
+    expected_dir = f"{str(render_scope['autobot']['base_dir']).rstrip('/')}/autobot-backend"
+    for label, text in (("gone", gone), ("kept", kept)):
+        assert expected_dir in text, (
+            f"the {label} summary does not name the directory it is reporting on. "
+            f"Expected {expected_dir!r} (built from the inventory SSOT), got: {text!r}"
+        )
 
     assert "removed" in gone.lower(), f"a directory that IS gone is not reported as removed: {gone!r}"
     assert "removed" not in kept.lower(), f"a directory still on disk is reported as removed: {kept!r}"

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -143,7 +143,7 @@ entry points read it:
 
 | Entry point | Scope | On a violation |
 |---|---|---|
-| `pipeline-scripts/detect-hardcoded-values.sh` | a tree | always exits 0; `ssot-coverage.yml` decides pass/fail from the reported counts |
+| `pipeline-scripts/detect-hardcoded-values.sh` | a tree | always exits 0 on a completed scan; the verdict travels in the JSON `status` field, which `ssot-coverage.yml` enforces as-is. A non-zero exit means the scan did not finish, and that also fails the job |
 | `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values` | staged files, or an explicit argv list from CI | exits 1 — this is the one that stops a commit |
 
 They differ only in where the lines come from and what they do with the
@@ -154,6 +154,26 @@ points pick it up.
 already existed when the three former detectors were merged. It only ever
 shrinks: a finding that is not in it fails the build, and every run prints how
 many baselined findings it suppressed.
+
+### What blocks a build (#14914)
+
+**Severity decides, not class.** Every `VIOLATION` blocks — both the `ssot`
+class and the `other` class. The two classes differ in what the fix *looks
+like*: an `ssot` finding names the exact config key that replaces the value, an
+`other` finding names the family. They do not differ in whether the value
+belongs in the source, so they do not differ in whether they block.
+
+`WARNING` is the advisory severity and does not block. There is exactly one
+today — `offset=0` — and it is advisory because the shape is too common to gate
+on, not because of the class it happens to carry. Warnings are counted
+separately and are not part of `total_violations`.
+
+So: **an advisory rule emits `WARNING` from the rule itself.** Do not park a
+rule outside the gate by choosing a class the verdict does not read — that was
+the #14914 defect. Eight of the twelve emit sites (paths, DSNs, URLs, accounts,
+roles, categories, timeouts, magic numbers) were detected, counted, JSON-encoded
+and printed while the verdict read `ssot_violations` alone, so nine hardcoded
+`/opt/autobot` paths sat on the merged base under a green check.
 
 ### "STALE baseline entry" — what to do (#14912)
 

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -158,7 +158,12 @@ many baselined findings it suppressed.
 ### What blocks a build (#14914)
 
 **Severity decides, not class.** Every `VIOLATION` blocks — both the `ssot`
-class and the `other` class. The two classes differ in what the fix *looks
+class and the `other` class, and this is now true at *both* entry points. The
+pre-commit hook has always counted `^VIOLATION|` class-agnostically and exited
+1; the tree scan keyed its verdict on `ssot_violations` alone. The same finding,
+from the same rule in the same library, blocked a commit and passed CI — the
+commit-time gate was stricter than the merge-time one, which is backwards, since
+the local one is the one a developer can skip. The two classes differ in what the fix *looks
 like*: an `ssot` finding names the exact config key that replaces the value, an
 `other` finding names the family. They do not differ in whether the value
 belongs in the source, so they do not differ in whether they block.

--- a/pipeline-scripts/detect-hardcoded-values.sh
+++ b/pipeline-scripts/detect-hardcoded-values.sh
@@ -17,8 +17,12 @@
 # This one differs from the hook in exactly two ways, and both are entry-point
 # policy rather than rule content:
 #   * it scans a tree rather than the staged file list;
-#   * it always exits 0. ssot-coverage.yml decides pass/fail from the reported
-#     counts, and has done since #2874.
+#   * it always exits 0 on a completed scan, pass or fail. The verdict travels
+#     in the `status` field, which ssot-coverage.yml enforces as-is (#14914);
+#     a non-zero exit from here therefore means the scan did NOT complete, and
+#     that workflow treats it as a failure rather than as a clean result.
+#     Keep those two facts together: making this script exit 1 on violations
+#     would make a real verdict indistinguishable from a crashed run.
 #
 # Usage: detect-hardcoded-values.sh [--json|--report|--audit-baseline|--prune-baseline|--help]
 
@@ -112,8 +116,35 @@ SSOT_VIOLATIONS=$(count_of '^VIOLATION|ssot|')
 OTHER_VIOLATIONS=$(count_of '^VIOLATION|other|')
 WARNINGS=$(count_of '^WARNING|')
 
+# The verdict, and the ONE place that decides it (#14914).
+#
+# This used to read `[ "$SSOT_VIOLATIONS" -gt 0 ]`, which meant the eight
+# `other`-class rules — AutoBot paths, DB DSNs, URLs, account identities, roles,
+# categories, timeouts, magic numbers — were detected, counted, written into the
+# JSON, printed to the report, and gated on by nothing. Two thirds of the merged
+# rule set was surface with no sink. The merged base carried nine `other`
+# findings under a green `SSOT Configuration Compliance` while that was true.
+#
+# The enforcement axis is SEVERITY, not class:
+#
+#   VIOLATION  blocks. Both classes. `ssot` and `other` differ in what the fix
+#              LOOKS like — an `ssot` finding names the exact config key that
+#              replaces it, an `other` one names the family — not in whether the
+#              value belongs in the source. A hardcoded DSN is not less wrong
+#              for having no `config.vm.*` entry to point at.
+#   WARNING    is advisory and deliberately does not block. There is exactly one
+#              (`offset=0`, _hv_rule_magic_number), and that carve-out predates
+#              this change: detector 3 chose it because the shape is common
+#              enough to be noise. WARNINGS are counted separately and are not
+#              part of TOTAL_VIOLATIONS, so the intent is expressed by the
+#              severity a rule emits, in the rule, rather than by which counter
+#              this line happens to read.
+#
+# Adding an advisory rule therefore means emitting WARNING from it. It does not
+# mean parking a class outside the gate, because that is indistinguishable from
+# the bug above.
 STATUS="pass"
-[ "$SSOT_VIOLATIONS" -gt 0 ] && STATUS="fail"
+[ "$TOTAL_VIOLATIONS" -gt 0 ] && STATUS="fail"
 
 if [ "$AUDIT_BASELINE" = true ]; then
     STALE=$(hv_stale_baseline_entries)

--- a/pipeline-scripts/detect-hardcoded-values_test.py
+++ b/pipeline-scripts/detect-hardcoded-values_test.py
@@ -26,6 +26,7 @@ fleet IP by an unrelated scanner walking test sources.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import stat
 import subprocess  # nosec B404  # fixed argv, no shell
@@ -132,7 +133,10 @@ def test_a_sudoers_line_in_a_shell_script_is_now_flagged(tmp_path):
     report = _run(root)
 
     assert report["other_violations"] >= 1
-    assert report["status"] == "pass", "an account violation alone must not block the SSOT gate"
+    # #14914 flipped this assertion, and it was the bug in one line: an account
+    # identity baked into a deployment script is a hardcoded value whether or
+    # not `config.vm.*` has a key for it. It used to read `== "pass"`.
+    assert report["status"] == "fail", "an `other`-class violation must block the gate (#14914)"
 
 
 def test_a_systemd_user_directive_in_a_shell_script_is_now_flagged(tmp_path):
@@ -211,15 +215,16 @@ def test_an_unrelated_extension_is_still_ignored(tmp_path):
     assert report["total_violations"] == 0
 
 
-def test_the_real_repository_has_no_new_blocking_ssot_violations():
-    """End-to-end against the real tree.
+def test_the_real_repository_has_no_new_blocking_violations():
+    """End-to-end against the real tree, on the number that actually blocks.
 
-    Enabling ``*.sh``/``*.yml``/``*.yaml`` scanning must surface an
-    ``other_violations`` backlog (expected, per #14316) without turning up a
-    NEW ``ssot_violations`` hit -- that category blocks the CI gate
-    (ssot-coverage.yml's job-status step), so a real fleet IP reachable only
-    once shell/yaml scanning was enabled would silently redden every future
-    PR touching an unrelated file that happens to share this workflow.
+    This asserted ``ssot_violations == 0`` until #14914 — which is why it was
+    green on a base carrying nine unbaselined ``other`` findings. A test that
+    measures a different number from the gate is not a test of the gate.
+
+    Both halves are asserted: the count, so a regression names how many; and
+    ``status``, so a change that keys the verdict off some third quantity is
+    caught rather than passing on a count nobody reads any more.
     """
     result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
         ["bash", str(_SCRIPT), "--json"],
@@ -229,10 +234,11 @@ def test_the_real_repository_has_no_new_blocking_ssot_violations():
     )
     report = json.loads(result.stdout)
 
-    assert report["ssot_violations"] == 0, (
-        "a real fleet IP is now reachable through *.sh/*.yml/*.yaml scanning and must be "
-        f"fixed at the source (or noqa'd if a documented example), not allow-listed: {report}"
+    assert report["total_violations"] == 0, (
+        "a hardcoded value reachable through *.sh/*.yml/*.yaml scanning must be fixed at "
+        f"the source (or noqa'd if a documented example), not left to the gate: {report}"
     )
+    assert report["status"] == "pass", report
 
 
 # ── #14912: --prune-baseline, and the audit message that sends you to it ─────
@@ -450,3 +456,151 @@ def test_the_tests_scan_dir_list_matches_the_script(tmp_path):
     assert in_script == _SCAN_DIRS, (
         f"SCAN_DIRS drifted — script has {in_script}, this file has {_SCAN_DIRS}"
     )
+
+
+# ── #14914: what the verdict is keyed on, and that something consumes it ─────
+#
+# The detector detected, counted, JSON-encoded and printed every `other`-class
+# finding, and then nothing gated on any of it: `STATUS` and ssot-coverage.yml's
+# job-status step were both keyed on `ssot_violations`. Eight of the twelve emit
+# sites — paths, DSNs, URLs, accounts, roles, categories, timeouts, magic
+# numbers — could not fail a build. Full surface, no sink.
+#
+# These tests cover BOTH halves, because either one alone is the same defect
+# again: the producer's verdict, and the workflow step that acts on it.
+
+
+def test_an_other_class_violation_alone_blocks(tmp_path):
+    """The mutation, committed. A DSN literal is `other` and nothing else."""
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend" / "db.py").write_text(
+        'ENGINE = "' + "sqlite" + ':///./app.db"\n', encoding="utf-8"
+    )
+
+    report = _run(root)
+
+    assert report["other_violations"] >= 1, f"the fixture did not trip the rule at all: {report}"
+    assert report["ssot_violations"] == 0, f"fixture must isolate the `other` class: {report}"
+    assert report["total_violations"] == report["other_violations"], report
+    assert report["status"] == "fail", (
+        "an `other`-class violation was found, counted and reported, and the gate "
+        f"still said pass — the #14914 defect: {report}"
+    )
+
+
+def test_a_clean_tree_still_passes(tmp_path):
+    """The other direction. A gate that fails everything is not a gate."""
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend" / "db.py").write_text(
+        "ENGINE = create_engine(config.database.url)\n", encoding="utf-8"
+    )
+
+    report = _run(root)
+
+    assert report == {
+        "status": "pass",
+        "total_violations": 0,
+        "ssot_violations": 0,
+        "other_violations": 0,
+        "warnings": 0,
+        "baselined": report["baselined"],
+    }, report
+
+
+def test_a_warning_only_tree_stays_advisory(tmp_path):
+    """WARNING is the advisory severity, and that is deliberate and unchanged.
+
+    ``offset=0`` is the one WARNING the merged rule set emits; detector 3 chose
+    it because the shape is too common to block on. Keying the gate on
+    ``total_violations`` must not sweep it in — the advisory axis is severity,
+    not class, and this asserts the distinction survives rather than assuming it.
+    """
+    root = _hermetic_repo(tmp_path)
+    (root / "autobot-backend" / "query.py").write_text("offset = 0\n", encoding="utf-8")
+
+    report = _run(root)
+
+    assert report["warnings"] >= 1, f"the advisory fixture emitted nothing to assert on: {report}"
+    assert report["total_violations"] == 0, report
+    assert report["status"] == "pass", f"a WARNING blocked the gate: {report}"
+
+
+_WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ssot-coverage.yml"
+_GATE_STEP = "Set job status"
+
+
+def _gate_step_script(outputs: dict) -> list[str]:
+    """The workflow's enforcement step, with its step outputs substituted in.
+
+    Extracted and executed rather than read for the string ``total_violations``:
+    a source-text assertion passes just as well over a step that computes the
+    right value and then ignores it.
+    """
+    yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflow")
+    doc = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["ssot-coverage"]["steps"]
+    matching = [s for s in steps if s.get("name") == _GATE_STEP]
+    # Assert the target EXISTS before asserting anything about it: a renamed or
+    # deleted step would otherwise make every case below vacuously pass.
+    assert len(matching) == 1, (
+        f"expected exactly one '{_GATE_STEP}' step in {_WORKFLOW.name}; found {len(matching)}. "
+        "If it was renamed, rename it here — do not let this test go quiet."
+    )
+    script = matching[0]["run"]
+
+    expr = re.compile(r"\$\{\{\s*steps\.ssot_check\.outputs\.(\w+)\s*\}\}")
+    referenced = set(expr.findall(script))
+    assert "status" in referenced, (
+        f"the gate step no longer reads the detector's verdict; it reads {sorted(referenced)}. "
+        "#14914: the verdict is computed once, in detect-hardcoded-values.sh."
+    )
+    unknown = referenced - set(outputs)
+    assert not unknown, f"the gate step reads outputs this test does not supply: {sorted(unknown)}"
+
+    return ["bash", "-eo", "pipefail", "-c", expr.sub(lambda m: outputs[m.group(1)], script)]
+
+
+_PASSING_OUTPUTS = {
+    "status": "pass",
+    "exit_code": "0",
+    "total_violations": "0",
+    "ssot_violations": "0",
+    "other_violations": "0",
+}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expect_failure", "why"),
+    [
+        ({}, False, "a clean run must not be failed by the gate step"),
+        (
+            {"status": "fail", "total_violations": "9", "other_violations": "9"},
+            True,
+            "nine `other`-class findings and status=fail must fail the job — this is the "
+            "exact shape that sat green on the merged base",
+        ),
+        (
+            {"status": "fail", "total_violations": "1", "ssot_violations": "1"},
+            True,
+            "an ssot finding must still block, as it has since #2874",
+        ),
+        (
+            {"status": "unknown", "total_violations": "0"},
+            True,
+            "an unparseable detector result is not a clean result",
+        ),
+        (
+            {"exit_code": "1"},
+            True,
+            "a detector that did not complete reports no verdict; a FATAL scan-dir "
+            "refusal used to be swallowed and read as pass",
+        ),
+    ],
+)
+def test_the_workflow_step_enforces_the_detectors_verdict(overrides, expect_failure, why):
+    outputs = dict(_PASSING_OUTPUTS, **overrides)
+    result = subprocess.run(  # nosec B603  # fixed argv, no shell injection
+        _gate_step_script(outputs), capture_output=True, text=True
+    )
+    failed = result.returncode != 0
+    assert failed is expect_failure, f"{why} (exit={result.returncode}, out={result.stdout!r})"

--- a/pipeline-scripts/detect-hardcoded-values_test.py
+++ b/pipeline-scripts/detect-hardcoded-values_test.py
@@ -525,6 +525,53 @@ def test_a_warning_only_tree_stays_advisory(tmp_path):
     assert report["status"] == "pass", f"a WARNING blocked the gate: {report}"
 
 
+_HOOK_REL = Path("autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values")
+_HOOK = Path(__file__).resolve().parent.parent / _HOOK_REL
+
+
+def test_both_entry_points_agree_on_what_blocks(tmp_path):
+    """#14914: the two entry points onto ONE rule set disagreed about the verdict.
+
+    The pre-commit hook counts ``^VIOLATION|`` — class-agnostic, keyed on
+    severity — and exits 1. The tree scan keyed its verdict on
+    ``ssot_violations`` alone. So the same finding, produced by the same rule
+    from the same library, blocked a commit and passed CI. The commit-time gate
+    was strictly stricter than the merge-time one, which is backwards: the
+    stricter check is the one a developer can skip locally.
+
+    Driven end-to-end through BOTH real entry points on the same fixture rather
+    than compared as source text, because the claim is about their verdicts.
+    """
+    root = _hermetic_repo(tmp_path)
+    hook = root / _HOOK_REL
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(_HOOK, hook)
+    hook.chmod(hook.stat().st_mode | stat.S_IEXEC)
+    shutil.copytree(_HOOK.parent / "lib", hook.parent / "lib")
+
+    target = root / "autobot-backend" / "db.py"
+    target.write_text('ENGINE = "' + "sqlite" + ':///./app.db"\n', encoding="utf-8")
+
+    hook_result = subprocess.run(  # nosec B603  # fixed argv, no shell
+        ["bash", str(hook), "autobot-backend/db.py"],
+        capture_output=True, text=True, cwd=root,
+    )
+    report = _run(root)
+
+    # Assert the fixture reached BOTH before comparing verdicts: two entry points
+    # that each found nothing also "agree", and that agreement proves nothing.
+    assert report["other_violations"] >= 1, f"the tree scan never saw the fixture: {report}"
+    assert "VIOLATION" in hook_result.stdout, (
+        f"the hook never saw the fixture, so its exit code says nothing: {hook_result.stdout!r}"
+    )
+
+    assert hook_result.returncode == 1, "the hook stopped blocking on an `other`-class violation"
+    assert report["status"] == "fail", (
+        "the tree scan passes a finding the commit-time hook blocks — the two entry points "
+        f"onto one rule set disagree again: {report}"
+    )
+
+
 _WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ssot-coverage.yml"
 _GATE_STEP = "Set job status"
 

--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -1168,8 +1168,6 @@
 2|other|autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml|'/opt/autobot/autobot-slm-frontend
 1|other|autobot-slm-backend/ansible/playbooks/provision-fleet-roles.yml|https://github.com/mrveiss/AutoBot-AI.git
 3|other|autobot-slm-backend/ansible/playbooks/recover_host.yml|/home/autobot
-1|other|autobot-slm-backend/ansible/playbooks/remove-role.yml|"/opt/autobot/{{ role_target_dir }}
-1|other|autobot-slm-backend/ansible/playbooks/remove-role.yml|'/opt/autobot/
 1|other|autobot-slm-backend/ansible/playbooks/remove-role.yml|'/opt/autobot/autobot-db-stack/chromadb/data
 3|other|autobot-slm-backend/ansible/playbooks/rollback-dependencies.yml|'/opt/autobot/backups
 1|other|autobot-slm-backend/ansible/playbooks/rotate-certs.yml|120


### PR DESCRIPTION
Closes #14914

## Thinking Path

The issue recommended baselining the nine existing findings and then keying the gate on `total_violations`. I checked the first half against the guards that landed alongside this code and did not follow it.

`pipeline-scripts/check_baseline_no_growth.sh` fails on any new key or increased count, and it has **no sanctioned override** — no env var, no allowlist, no reviewer-approval path. Its own failure text says an unfixable violation "is a decision for a reviewer to take deliberately, not something an appended line should buy silently", but there is no mechanism by which a reviewer takes that decision. So baselining the nine had exactly two routes: weaken the guard, or fix the values. The task forbade the first and the issue itself offered the second ("or fix them — they are `/opt/autobot` literals in ansible playbooks").

Fixing them was also strictly better. All nine are quoted `/opt/autobot` literals in two ansible playbooks, and `inventory/group_vars/all.yml` already defines `autobot.base_dir: "/opt/autobot"` as the SSOT for that tree, used by every `group_vars/*.yml` file. Reuse, not a new variable.

Second question the issue raised, and the one that actually settles the design: should all twelve emit classes block equally, or are some advisory by intent? They should all block, because **the advisory axis already exists and it is severity, not class.** `_hv_rule_magic_number` emits `WARNING` for `offset=0` — a carve-out detector 3 made deliberately because the shape is too common to gate on — and `WARNING` records are counted separately and are not part of `total_violations`. So a rule that should not block says so *in the rule*, by the severity it emits. `ssot` vs `other` was never that: it describes what the fix *looks like* (a named config key vs a named family), not whether the value belongs in the source. A hardcoded DSN is not less wrong for having no `config.vm.*` entry to point at. Keying the verdict on `total_violations` therefore enforces the intent that was already written into the rules, and sweeps in no warning.

There is a second, independent corroboration I missed on the first pass and verified rather than took on trust: **the pre-commit hook already blocked on both classes.** `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values` computes `violations=$(grep -c '^VIOLATION|' "$newfile")` — class-agnostic, keyed on severity — and exits 1. So the same finding, produced by the same rule in the same library, *blocked a commit and passed CI*. The two thin entry points onto one rule set disagreed about the verdict, and the commit-time gate was the stricter of the two — backwards, since that is the one a developer can skip locally. This change makes them agree, and `test_both_entry_points_agree_on_what_blocks` drives both real entry points on one fixture so they cannot diverge again silently.

Third: the issue names two places keyed on `ssot_violations`, the script and the workflow. Two copies of one policy is how they drifted apart from the rules in the first place, so I did not fix both — I removed one. The workflow now enforces the detector's `status` field rather than re-deriving a verdict from a count. That closed a fail-open I found while doing it: the workflow's count parse ends in `|| echo "0"`, so a detector that *died* (a missing scan directory is FATAL by design, as of #14912) produced no JSON, parsed as zero violations, and passed. `status` has no numeric fallback — an unparseable result yields `unknown`, which is not `pass` — and the captured `exit_code`, which was previously written to `$GITHUB_OUTPUT` and read by nothing, is now checked.

## What Changed

**Which classes block:** both. Every `VIOLATION`-severity finding now fails the gate — the 4 `ssot` emit sites (VM IPs, infra ports, model names) and all 8 `other` emit sites (AutoBot paths, DB DSNs, URLs, account identities, roles, categories, timeouts, magic numbers).

**Which do not, and why:** `WARNING`-severity findings stay advisory and do not block. There is exactly one today — `offset=0` in `_hv_rule_magic_number` — and that predates this change. Warnings are counted separately and are excluded from `total_violations`, so the exemption is stated by the severity the rule emits rather than by which counter the verdict happens to read. This is now written down in the script, in `docs/developer/HARDCODING_PREVENTION.md`, and asserted by a test.

**Violations baselined: zero.** The nine were fixed instead, for the reason in the Thinking Path. They are:

| # | file:line | literal | fix |
|---|---|---|---|
| 1 | `remove-role.yml:194` | `"/opt/autobot/{{ role_target_dir }}"` (the post-removal `stat` probe) | `"{{ autobot.base_dir }}/{{ role_target_dir }}"` |
| 2 | `remove-role.yml:206` | `'/opt/autobot/' + role_target_dir` (the "KEPT" summary string) | hoisted: the install root was spelled out once per branch inside the expression, so both branches now read a single task-scoped `_role_dir` built from `autobot.base_dir` — one string, and it cannot drift between the two branches |
| 3-9 | `cleanup-nodes.yml:101,128,178,205,232,262,289` | `remove_dir_path: "/opt/autobot/{{ _cleanup_target.dir }}"`, once per play (SLM, Backend, Frontend, NPU, AI Stack, Databases, Browser) | `"{{ autobot.base_dir }}/{{ _cleanup_target.dir }}"` |

Two further occurrences in `remove-role.yml` (line 184's `remove_dir_path`, line 204's "removed" summary string) were *already baselined* and so were not reported. I fixed them too: leaving an identical literal one line from its replacement is not a fix, and it means the file no longer spells the same path two ways. That stranded their two baseline entries, which `--prune-baseline` then removed — 1410 keys to 1408, removal-only, no key added and no count raised. **That is how a baseline change got past `check_baseline_no_growth.sh`: it shrank.** The guard was neither disabled nor weakened, and the growth direction remains completely closed.

Three literals in `remove-role.yml` are deliberately untouched and out of scope: `backup_dir: /opt/autobot/backups` and `- /opt/autobot/autobot-backend/data` (unquoted, so no rule matches them) and the `chromadb_data_dir` default on line 46 (baselined, still matching).

**Files:**
- `pipeline-scripts/detect-hardcoded-values.sh` — `STATUS` keyed on `TOTAL_VIOLATIONS`; the severity-vs-class rule written down where the verdict is computed; the header's entry-point contract updated to say the verdict travels in `status` and that a non-zero exit means the scan did not finish.
- `.github/workflows/ssot-coverage.yml` — `Set job status` enforces `status` and `exit_code` instead of re-deriving from `ssot_violations`; `set -euo pipefail` added; the PR comment's pass line no longer claims something narrower than what was checked.
- `autobot-slm-backend/ansible/playbooks/{remove-role,cleanup-nodes}.yml` — 11 literals to `{{ autobot.base_dir }}`.
- `pipeline-scripts/hardcoded_values_baseline.txt` — 2 stranded entries pruned, 0 added.
- `pipeline-scripts/detect-hardcoded-values_test.py` — see Verification.
- `docs/developer/HARDCODING_PREVENTION.md` — a "What blocks a build" section.

## Verification

**Mutation, both directions, producer.** Run against a copy of the tree outside the repo, never committed. The mutation is one real `other`-class finding: a quoted `/opt/autobot` path in an ansible playbook, the same shape as the nine.

```
### clean tree, this branch's script
{ "status": "pass",  "total_violations": 0, "ssot_violations": 0, "other_violations": 0 }

### mutated tree, this branch's script
{ "status": "fail",  "total_violations": 1, "ssot_violations": 0, "other_violations": 1 }

### the SAME mutated tree, the script at origin/Dev_new_gui (c83c2e39e)
{ "status": "pass",  "total_violations": 1, "ssot_violations": 0, "other_violations": 1 }
```

Same tree, same finding, opposite verdicts — the change is what moved it, not the fixture.

**Mutation, both directions, sink.** The `Set job status` step extracted from the workflow YAML and executed with each run's real outputs substituted in:

```
mutation present:  exit 1  ::error::SSOT compliance status 'fail': 1 new hardcoded value(s)
                           ::error::(ssot=0, other=1). Both classes block (#14914).
mutation removed:  exit 0  SSOT compliance: pass — 0 new violations of either class
```

**The base, before and after.** `origin/Dev_new_gui` at `c83c2e39e` reports `{"status": "pass", "total_violations": 9, "ssot_violations": 0, "other_violations": 9, "baselined": 1976}` — the issue's evidence, still reproducing on a base 4 commits newer. This branch reports `{"status": "pass", "total_violations": 0, ..., "baselined": 1974}`, and `--audit-baseline` prints `every baseline entry still matches something`.

**Tests** — `78 passed` across `pipeline-scripts/detect-hardcoded-values_test.py` (38) and `scripts/lib/hardcoded_value_rules_test.py` (40), run against the out-of-repo copy. New and changed:

- `test_an_other_class_violation_alone_blocks` — the mutation, committed. Asserts the fixture actually tripped the rule (`other_violations >= 1`) *before* asserting the verdict, so a fixture that stopped matching cannot report a false pass; asserts `ssot_violations == 0` so the case cannot pass through the old path.
- `test_a_clean_tree_still_passes` — the other direction, asserted as a whole-dict equality rather than "no failure".
- `test_a_warning_only_tree_stays_advisory` — `offset=0` gives `warnings >= 1`, `total_violations == 0`, `status == "pass"`. The advisory carve-out is asserted, not assumed.
- `test_the_workflow_step_enforces_the_detectors_verdict` — five cases against the real workflow step, extracted and **executed**, not grepped: a source-text assertion passes just as well over a step that computes the right number and ignores it. Cases: clean passes; `status=fail` with 9 `other` findings fails (the exact shape that sat green on the base); an `ssot` finding still fails; `status=unknown` fails; `exit_code=1` fails. It asserts the step exists exactly once and that it still reads `status` before running anything, so a rename cannot make five cases vacuously pass.
- `test_both_entry_points_agree_on_what_blocks` — runs the real pre-commit hook (argv mode) and the real tree scan over one `other`-class fixture and asserts both block. It asserts each entry point actually *saw* the fixture first, because two entry points that each find nothing also "agree". Mutation: restoring `[ "$SSOT_VIOLATIONS" -gt 0 ]` fails this test and `test_an_other_class_violation_alone_blocks`, and nothing else.
- `test_a_sudoers_line_in_a_shell_script_is_now_flagged` — its `assert report["status"] == "pass"` encoded the old policy in one line. Flipped to `"fail"`.
- `test_the_real_repository_has_no_new_blocking_ssot_violations` → `..._no_new_blocking_violations` — it asserted `ssot_violations == 0`, which is why it was green on a base carrying nine unbaselined `other` findings. Now asserts `total_violations == 0` **and** `status == "pass"`: a test that measures a different number from the gate is not a test of the gate.

**Fail-closed, confirmed by CI rather than asserted (#14856 interaction).** The first push of this branch (`8aa9eacbb`) reddened `python-suite shard 11/12`:

```
test_cleanup_never_destroys_data_14856.py::test_the_removal_summary_reports_what_happened_not_what_was_asked
jinja2.exceptions.UndefinedError: 'autobot' is undefined
```

That is the review's central claim demonstrated on the real playbook text: an undefined `autobot` raises rather than silently resolving to `/`. It is stronger evidence than anything written by hand, and it is why the guard — not the playbook — was what needed changing.

**The second regression, which CI did NOT catch.** Chasing that failure surfaced a worse one in the same file, and it was silent. `test_cleanup_never_destroys_data_14856.py` is a *static* guard: it expands these loops and resolves each removal target to a concrete path so it can assert that `/opt/autobot/config` is never scheduled for deletion (#3873 — it holds `permission_rules.yaml`, read at runtime). It matches on a literal `/opt/` prefix, after collapsing `{{ ... }}` to a placeholder. Routing the paths through `{{ autobot.base_dir }}` without teaching the guard to resolve it made every target render as `TPL/TPL` — not a `/opt/` path, never equal to the protected directory. **The protected-config check kept passing with nothing left to match.** Green, and blind.

The fix is the one the review asked for, extended to the render scope that failed quietly: `_inventory_vars()` loads `autobot` from `inventory/group_vars/all.yml` and is injected into **both** render scopes — the summary expression *and* `_delegated_targets`, including its loop-less branch. Nothing in the test hardcodes `/opt/autobot`: the protected path and the expected summary path are both built from the loaded SSOT, so a real drift in `base_dir` moves the guard with it instead of stranding it.

Mutation-proved, four ways, on the out-of-repo copy:

| mutation | expected | observed |
|---|---|---|
| schedule `config` for removal | guard FIRES | `AssertionError: /opt/autobot/config is scheduled for removal by:` |
| move `base_dir` to `/srv/autobot` | guard FOLLOWS, stays green | 49 passed |
| move `base_dir` **and** schedule `config` | guard FIRES at the new root | `AssertionError: /srv/autobot/config is scheduled for removal by:` |
| delete `autobot.base_dir` | loud, specific failure | `all.yml defines autobot.base_dir as '', which is not an absolute path` |

Row 2 alone would have been a false comfort — "green after the root moved" is also what going blind looks like. Row 3 is the one that proves it followed.

I also added an assertion that the summary message actually *names* the directory, in both branches, built from the SSOT. Without it the existing removed/KEPT wording checks pass just as well over `'/autobot-backend removed'` — a message that quietly lost its install root. Verified by mutation: re-introducing the unresolved indirection now fails with `assert '/opt/autobot/autobot-backend' in '/autobot-backend removed'`.

**The same blindness in the sweep's classifier, and a design call.** Fixing the protected-config check left a sibling stranded: `_is_component_dir` — which powers `test_no_component_directory_is_removed_outside_the_primitive`, the tree-wide sweep that is the whole point of #14856 — classified on hardcoded literals (`path.startswith("/opt/")`). It answers `False` for anything it cannot place, and the sweep asserts an *empty* result, so a classifier that recognised nothing produced exactly the same empty list as a clean tree.

Measured before deciding: only **3 of 68** `state: absent` paths in the ansible tree resolve under any known root today, and **none** use the variable. So this was not a present miss — it was a latent forward trap, and this PR is what arms it: the playbooks now build removal paths from `{{ autobot.base_dir }}`, and the header notes I added tell future authors to do the same. The first person to write `path: "{{ autobot.base_dir }}/foo", state: absent` would have been invisible to the sweep.

**Design call: not "replace `/opt/` with `base_dir`".** The classifier deliberately covers two shapes with different natures, and collapsing them would have lost coverage:

- the **canonical** root is a *setting* — it comes from the inventory SSOT, it can move, and the classifier now follows it;
- the **historical** roots are a *fact about hosts that already exist* — `/opt/slm-agent` and friends predate the rename and are still cleaned up by this file's own subject. They do not move when `base_dir` does.

`/opt/autobot` stays in the historical set even when it is no longer the configured base, for the same reason: a host mid-migration still carries one and the playbooks still target it. Dropping it would lose coverage at exactly the moment the tree is most dangerous. Roots are matched longest-first so `/opt/autobot/backend` reads as `<root>/backend` rather than the flat `/opt/<autobot/backend>`, whose tail contains a slash and would be dismissed.

The base-dir reference is resolved *textually* before the generic `{{ ... }}` collapse, not by rendering the whole string — rendering would blank the unknown vars too, turning `<root>/{{ role_target_dir }}` into the bare root and **un**-classifying a real component removal.

**Presence, not absence of failure.** Two additions, because `offenders` is empty in a healthy tree and can never evidence that the classifier works:

- `test_the_component_classifier_recognises_every_root_shape` — feeds every documented shape to the classifier directly, with fixtures built from the SSOT rather than written out, plus negative cases. A shape that stops being recognised fails here *by name*.
- `candidates_seen` in the sweep — counts paths that resolved under a known root at all (distinct from being a component: `<root>/backend/data` is under a root and is not one), and fails loudly if the classifier adjudicated nothing across all 68 deletions.

Mutation-proved, and against the pre-fix classifier for contrast:

| mutation | pre-fix | post-fix |
|---|---|---|
| unguarded removal written `{{ autobot.base_dir }}/autobot-backend` | **PASSED — blind** | FAILED (caught) |
| root moved to `/srv/autobot`, unguarded removal at the new root | **PASSED — blind** | FAILED (caught) |
| root moved, legacy `/opt/slm-agent` removal | caught | FAILED (caught) |
| root moved, historical `/opt/autobot/autobot-backend` removal | caught | FAILED (caught) — no coverage lost |
| control: `/srv/autobot/autobot-backend/data` (inside a component) | — | PASSED (correctly not an offender) |
| `_HISTORICAL_ROOTS = ()` | — | fails: `classifier no longer recognises '/opt/slm-agent'` |
| base-dir resolution disabled | — | fails: `classifier no longer recognises '{{ autobot.base_dir }}/autobot-backend'` |

Row 4 is the one that justifies the historical set: dropping `/opt/autobot` from it would have turned a caught removal into a missed one.

**Third literal site, also fixed.** `test_legacy_data_probe_defaults_to_assuming_data` matched a stat path by exact string against `"/opt/autobot/{{ dir_name }}/data"`. It fails *loudly* rather than quietly (its `assert probes` presence check catches it), but it would have failed saying "nothing probes the legacy directory" when the truth was that the probe had adopted the variable. Now resolved from the SSOT.

**Two `/opt` literals deliberately left:** the fabricated `remove_dir_path` scenario inputs at lines 709/717. They are inputs fed to the primitive's `when:`, which does not reference the path at all (it tests `_remove_dir_data.stat.exists`), so the value is arbitrary and deriving it would add coupling for nothing.

**Sibling guards checked:** `_render_value`/`_evaluate` have 8 call sites in that file; only the two above touch the playbooks changed here (the rest evaluate `roles/_shared/` task files). The only other Python file referencing these playbooks is `autobot-slm-backend/api/nodes.py`, which names `playbooks/remove-role.yml` as a string and evaluates no template text. So nothing else is latent-broken on another shard.

**Not verified here:** nothing was run against a host. The ansible change is a variable substitution whose value is defined in `inventory/group_vars/all.yml`, in scope for both playbooks' documented invocations (`-i inventory/...`, so `inventory/group_vars/` applies). If `autobot` were somehow undefined the tasks fail loudly rather than resolving to `/` — fail-closed, which is the correct direction for a destructive playbook, but it is a behaviour change on a path CI cannot exercise and deserves a reviewer's eye.

**Finding, filed separately:** `check_baseline_no_growth.sh` has no sanctioned path for a legitimate, reviewed baseline addition, while its own failure message implies one exists. Today every appended line is a bypass attempt by construction; the day one is genuinely correct, the only routes are to weaken the guard or to fix the value. Not changed here — adding an override to a guard is a decision, not a side effect of this fix. Filed as #14919.

## Model Used

Claude Opus 5 (1M context)