### PR TITLE
ci(precommit): gate merges on behavioural pre-commit hooks, not just formatter findings (#14878)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,10 @@ jobs:
     steps:
     - uses: actions/checkout@v7
 
-    - name: Set up Python 3.12
+    # #13162: the step was named "Set up Python 3.12" while pinning 3.14. The
+    # version lives in `python-version:` and nowhere else, so the name carries
+    # no version at all rather than a second copy to drift.
+    - name: Set up Python
       uses: actions/setup-python@v7
       with:
         python-version: '3.14'

--- a/.github/workflows/enforce-precommit.yml
+++ b/.github/workflows/enforce-precommit.yml
@@ -111,6 +111,36 @@ jobs:
           # tighten together, and this becomes absolute when the baseline empties.
           python3 pipeline-scripts/check_precommit_hooks_executed.py precommit-output.txt
 
+      - name: Fail when a behavioural hook reported a finding (#14878)
+        run: |
+          # The third class, between the two the steps above already handle.
+          #
+          # `pre-commit run --all-files` above routes findings to a warning, and
+          # for a formatter or a linter that is right: gating a merge on Black's
+          # opinion is a judgement nobody made. The step after it fails when a
+          # hook could not EXECUTE (#14181), because a pass over a hook that
+          # never ran is a false clean bill of health.
+          #
+          # `ssot-config-lib-guard` is neither. Its entry is a TEST SUITE
+          # (autobot-infrastructure/shared/tests/test_ssot_config_lib.sh), the
+          # regression guard for #14041, and a failure there means a shipped
+          # script's config bootstrap is broken. It executes fine, so #14181 is
+          # satisfied; it reports a finding, so the workflow warned and moved on.
+          # The guard therefore ran in exactly one place and blocked nothing —
+          # the same shape as the defect it was written to catch (#14878).
+          #
+          # HERE, not in python-suite. Wrapping the suite under pytest was the
+          # other option in #14878 and is the weaker one today: `python-suite` is
+          # not a required context (#14353/#13162), so that route would move the
+          # guard from one non-gating place to another. This job publishes
+          # `verify-precommit-config`, which IS required, so a finding blocks.
+          #
+          # The allowlist is explicit, keyed by hook id, and self-guarding: an id
+          # that leaves .pre-commit-config.yaml fails rather than silently
+          # exempting itself, and an absent or Skipped result fails rather than
+          # reading as clean. Criterion for adding one is in the script's header.
+          python3 pipeline-scripts/check_gating_precommit_hooks.py precommit-output.txt
+
       - name: Workflow path filters must match the canonical set (#12986)
         run: |
           # BLOCKING, and deliberately in THIS workflow rather than

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,15 @@ pre-commit install
 
 Hooks run automatically on each commit, checking Black formatting, isort, flake8, autoflake, mypy, and bandit. Fix any reported issues before committing again. The CI workflow (`enforce-precommit.yml`) validates these same checks on every PR.
 
+`pre-commit install` is a separate step from `bash scripts/install-git-hooks.sh`, and both are needed. The installer copies AutoBot's own standalone `pre-commit`/`pre-push` hooks (the protected-branch guard, `tools/git-hooks/`); `pre-commit install` wires the framework in `.pre-commit-config.yaml`. Whichever you run second takes over `.git/hooks/pre-commit` — `pre-commit install` preserves what it displaces as `pre-commit.legacy` and keeps running it, so run `pre-commit install` **after** the installer, and re-run it if you ever re-run the installer. Verify both are live with:
+
+```bash
+grep -l pre-commit .git/hooks/pre-commit          # framework hook present
+ls .git/hooks/pre-commit.legacy                   # branch guard still chained
+```
+
+Not every hook's verdict carries the same weight in CI, and the split is deliberate. Formatter and linter findings are reported as warnings by `enforce-precommit.yml`; a hook that could not *execute* fails the job (#14181); and a **behavioural** hook — one whose entry is a test suite asserting shipped behaviour, currently `ssot-config-lib-guard` — fails the job on a finding (#14878), because there the finding *is* the regression.
+
 ---
 
 ## Good First Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,12 +152,14 @@ pre-commit install
 
 Hooks run automatically on each commit, checking Black formatting, isort, flake8, autoflake, mypy, and bandit. Fix any reported issues before committing again. The CI workflow (`enforce-precommit.yml`) validates these same checks on every PR.
 
-`pre-commit install` is a separate step from `bash scripts/install-git-hooks.sh`, and both are needed. The installer copies AutoBot's own standalone `pre-commit`/`pre-push` hooks (the protected-branch guard, `tools/git-hooks/`); `pre-commit install` wires the framework in `.pre-commit-config.yaml`. Whichever you run second takes over `.git/hooks/pre-commit` — `pre-commit install` preserves what it displaces as `pre-commit.legacy` and keeps running it, so run `pre-commit install` **after** the installer, and re-run it if you ever re-run the installer. Verify both are live with:
+`pre-commit install` is a separate step from `bash scripts/install-git-hooks.sh`, and both are needed. The installer copies AutoBot's own standalone `pre-commit`/`pre-push` hooks (the protected-branch guard, `tools/git-hooks/`); `pre-commit install` wires the framework hooks in `.pre-commit-config.yaml`. **Both write `.git/hooks/pre-commit`, so whichever runs second replaces the other.** Run the installer first and `pre-commit install` second, and re-run `pre-commit install` any time you re-run the installer. Then check what is actually installed rather than assuming:
 
 ```bash
-grep -l pre-commit .git/hooks/pre-commit          # framework hook present
-ls .git/hooks/pre-commit.legacy                   # branch guard still chained
+cat .git/hooks/pre-commit        # which of the two is in place
+ls .git/hooks/pre-commit.legacy  # what pre-commit displaced, if anything
 ```
+
+The protected-branch rule is enforced on the server regardless, so a displaced branch guard costs you a rejected push rather than a bad commit on `main`.
 
 Not every hook's verdict carries the same weight in CI, and the split is deliberate. Formatter and linter findings are reported as warnings by `enforce-precommit.yml`; a hook that could not *execute* fails the job (#14181); and a **behavioural** hook — one whose entry is a test suite asserting shipped behaviour, currently `ssot-config-lib-guard` — fails the job on a finding (#14878), because there the finding *is* the regression.
 

--- a/pipeline-scripts/check_gating_precommit_hooks.py
+++ b/pipeline-scripts/check_gating_precommit_hooks.py
@@ -156,8 +156,7 @@ def main(argv: list[str] | None = None) -> int:
     problems = _verdicts(output, hook_names(Path(args.config).read_text(encoding="utf-8")))
     if not problems:
         print(  # noqa: print
-            "check-gating-precommit-hooks: every behavioural hook passed "
-            f"({', '.join(GATING_HOOK_IDS)})"
+            "check-gating-precommit-hooks: every behavioural hook passed " f"({', '.join(GATING_HOOK_IDS)})"
         )
         return 0
 

--- a/pipeline-scripts/check_gating_precommit_hooks.py
+++ b/pipeline-scripts/check_gating_precommit_hooks.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Fail when a BEHAVIOURAL pre-commit hook reported a finding (#14878).
+
+`.github/workflows/enforce-precommit.yml` runs `pre-commit run --all-files` and
+routes findings to `::warning::`. For a formatter or a linter that is the right
+call and the step's own comment says so: gating a merge on Black's opinion is a
+judgement nobody made. `check_precommit_hooks_executed.py` (#14181) already
+covers the other half — a hook that could not *execute* fails the job, because a
+pass over a hook that never ran is a false clean bill of health.
+
+Between those two sits a class neither one catches. `ssot-config-lib-guard` is
+not a formatter: its entry is a **test suite**, and a failure means a shipped
+script's config bootstrap is broken. It executed fine, so #14181 is satisfied;
+it reported a finding, so the workflow warns and moves on. The regression guard
+written for #14041 therefore runs in exactly one place and blocks nothing —
+the same shape as the defect it exists to catch (#14878).
+
+THE CRITERION, written down rather than implied
+-----------------------------------------------
+A hook belongs in ``GATING_HOOK_IDS`` when its entry is a **test suite
+asserting the repository's own shipped behaviour**, so its verdict is
+independent of the diff under review. Everything else — style, formatting, and
+the "no new X" pattern bans whose subject is the changed lines — stays
+informational, which is what the surrounding step already decided.
+
+That criterion currently selects exactly one hook. It is written as a list, and
+guarded, so the next one is an append rather than a redesign.
+
+WHY THE ALLOWLIST IS KEYED BY HOOK ``id``, NOT BY NAME
+------------------------------------------------------
+pre-commit prints the hook's ``name``, and names in this repository are not
+stable identifiers. Several are written unquoted in the YAML with a ``#``
+issue reference — ``name: Function Length Check (Issue #5512)`` — where the
+space-``#`` opens a YAML comment, so the parsed name is
+``Function Length Check (Issue`` and that truncated string is what pre-commit
+prints. Resolving ``id -> name`` through the same YAML parser reproduces
+exactly what lands in the log; hard-coding either spelling would not.
+
+The allowlist is self-guarding in both directions:
+
+* an id that is no longer in ``.pre-commit-config.yaml`` FAILS, rather than
+  silently exempting itself. An allowlist entry stranded by a rename exempts
+  nothing and says nothing while it does it.
+* a hook whose result line is absent, or reads ``Skipped``, FAILS. A
+  behavioural suite that did not run validated nothing, and "no result" must
+  not read as "clean" — the whole subject of #14878.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_precommit_hooks_executed import _RAN_AT_ALL  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CONFIG = _REPO_ROOT / ".pre-commit-config.yaml"
+
+# See "THE CRITERION" above before adding to this.
+GATING_HOOK_IDS: tuple[str, ...] = ("ssot-config-lib-guard",)
+
+# pre-commit colours only a tty; the workflow redirects to a file. Stripped
+# anyway so a future `--color always` cannot turn this gate into a false alarm
+# that blocks every pull request.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def hook_names(config_text: str) -> dict[str, str]:
+    """Map every configured hook ``id`` to the ``name`` pre-commit will print."""
+    document = yaml.safe_load(config_text) or {}
+    names: dict[str, str] = {}
+    for repo in document.get("repos") or []:
+        for hook in repo.get("hooks") or []:
+            hook_id = hook.get("id")
+            if hook_id:
+                names[hook_id] = str(hook.get("name") or hook_id)
+    return names
+
+
+def hook_result(output: str, name: str) -> str | None:
+    """The status pre-commit printed for ``name``, or None when it printed none.
+
+    pre-commit pads the name with dots to a fixed width and may insert a
+    parenthesised postfix (``(no files to check)Skipped``). The name is never
+    truncated: when it is longer than the field, the dot run is empty.
+    """
+    line = re.compile(
+        r"^" + re.escape(name) + r"\.*(?:\([^)\n]*\))?(Passed|Failed|Skipped)\s*$",
+        re.MULTILINE,
+    )
+    found = {match.group(1) for match in line.finditer(output)}
+    if not found:
+        return None
+    # A hook cannot both pass and fail in one run; if the log says otherwise,
+    # take the worst so the ambiguity cannot resolve in the green direction.
+    for status in ("Failed", "Skipped", "Passed"):
+        if status in found:
+            return status
+    return None
+
+
+def _verdicts(output: str, names: dict[str, str]) -> list[tuple[str, str]]:
+    """One ``(hook_id, problem)`` pair per gating hook that is not a clean pass."""
+    problems: list[tuple[str, str]] = []
+    for hook_id in GATING_HOOK_IDS:
+        name = names.get(hook_id)
+        if name is None:
+            problems.append((hook_id, "not present in .pre-commit-config.yaml"))
+            continue
+        status = hook_result(output, name)
+        if status == "Passed":
+            continue
+        if status is None:
+            problems.append((hook_id, f"no result line for {name!r} in the output"))
+        else:
+            problems.append((hook_id, f"reported {status}"))
+    return problems
+
+
+def _report(problems: list[tuple[str, str]]) -> None:
+    print(f"check-gating-precommit-hooks: {len(problems)} behavioural hook(s) not clean\n")  # noqa: print
+    for hook_id, problem in problems:
+        print(f"  FAIL   {hook_id}: {problem}")  # noqa: print
+    print(  # noqa: print
+        "\nThese hooks are behavioural regression suites, not formatters: a finding\n"
+        "means shipped behaviour is broken, so it blocks rather than warns (#14878).\n"
+        "Reproduce locally with:\n"
+        "  pre-commit run --all-files " + " ".join(GATING_HOOK_IDS) + "\n"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Gate on behavioural pre-commit hooks (#14878)")
+    parser.add_argument("logfile", nargs="?", help="pre-commit output; stdin when omitted")
+    parser.add_argument("--config", default=str(_CONFIG), help="path to .pre-commit-config.yaml")
+    args = parser.parse_args(argv)
+
+    raw = Path(args.logfile).read_text(encoding="utf-8") if args.logfile else sys.stdin.read()
+    output = _ANSI.sub("", raw)
+
+    if not _RAN_AT_ALL.search(output):
+        print(  # noqa: print
+            "check-gating-precommit-hooks: FATAL -- no hook result line in the captured\n"
+            "output, so no hook ran and this gate has nothing to verify. Reporting success\n"
+            "here would be the fail-open the gate exists to remove."
+        )
+        return 1
+
+    problems = _verdicts(output, hook_names(Path(args.config).read_text(encoding="utf-8")))
+    if not problems:
+        print(  # noqa: print
+            "check-gating-precommit-hooks: every behavioural hook passed "
+            f"({', '.join(GATING_HOOK_IDS)})"
+        )
+        return 0
+
+    _report(problems)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline-scripts/check_gating_precommit_hooks_test.py
+++ b/pipeline-scripts/check_gating_precommit_hooks_test.py
@@ -97,9 +97,7 @@ def test_ansi_coloured_output_is_still_read(gate, tmp_path):
 
 def test_no_files_to_check_postfix_is_parsed(gate, tmp_path):
     """pre-commit's own skip wording, which carries a parenthesised postfix."""
-    output = _output(None).replace(
-        "black", _GUARD + "." * 10 + "(no files to check)Skipped\nblack", 1
-    )
+    output = _output(None).replace("black", _GUARD + "." * 10 + "(no files to check)Skipped\nblack", 1)
     assert _run(gate, tmp_path, output) == 1
 
 

--- a/pipeline-scripts/check_gating_precommit_hooks_test.py
+++ b/pipeline-scripts/check_gating_precommit_hooks_test.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the behavioural pre-commit hook gate (#14878).
+
+Every case drives ``main()`` — the production entry point the workflow step
+calls — and asserts on its exit code, not on a helper's return value. The
+defect this gate exists to remove is a verdict that never reaches a merge
+decision, so a test that stops at the parser would repeat it one level down.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE = Path(__file__).with_name("check_gating_precommit_hooks.py")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_REAL_CONFIG = _REPO_ROOT / ".pre-commit-config.yaml"
+
+
+@pytest.fixture
+def gate():
+    spec = importlib.util.spec_from_file_location("check_gating_precommit_hooks", _MODULE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# A minimal config in the same shape as the real one. Written here rather than
+# read from disk so the failure directions can be exercised without editing the
+# repository's own config.
+_CONFIG = """\
+repos:
+  - repo: local
+    hooks:
+      - id: ssot-config-lib-guard
+        name: Shell SSOT Library Self-Test (#14041)
+        entry: bash autobot-infrastructure/shared/tests/test_ssot_config_lib.sh
+      - id: black
+        name: black
+"""
+
+_GUARD = "Shell SSOT Library Self-Test (#14041)"
+
+
+def _output(guard_status: str | None) -> str:
+    """A pre-commit --all-files transcript, optionally omitting the guard's line."""
+    lines = ["black" + "." * 60 + "Failed", "check yaml" + "." * 55 + "Passed"]
+    if guard_status is not None:
+        lines.insert(1, _GUARD + "." * 30 + guard_status)
+    return "\n".join(lines) + "\n"
+
+
+def _run(gate, tmp_path, output, config=_CONFIG):
+    log = tmp_path / "precommit-output.txt"
+    log.write_text(output, encoding="utf-8")
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(config, encoding="utf-8")
+    return gate.main([str(log), "--config", str(cfg)])
+
+
+def test_passing_guard_exits_zero_even_though_formatters_failed(gate, tmp_path):
+    """The formatter/behavioural split is the whole point: black Failed here."""
+    assert _run(gate, tmp_path, _output("Passed")) == 0
+
+
+def test_failing_guard_blocks(gate, tmp_path):
+    assert _run(gate, tmp_path, _output("Failed")) == 1
+
+
+def test_skipped_guard_blocks(gate, tmp_path):
+    """A behavioural suite that did not run validated nothing (#14878)."""
+    assert _run(gate, tmp_path, _output("Skipped")) == 1
+
+
+def test_absent_result_line_blocks(gate, tmp_path):
+    """An absent result must not read as a clean one."""
+    assert _run(gate, tmp_path, _output(None)) == 1
+
+
+def test_empty_output_blocks(gate, tmp_path):
+    assert _run(gate, tmp_path, "") == 1
+
+
+def test_allowlist_entry_stranded_by_a_rename_blocks(gate, tmp_path):
+    """An id no longer in the config exempts nothing — it must say so loudly."""
+    renamed = _CONFIG.replace("id: ssot-config-lib-guard", "id: ssot-config-lib-guard-v2")
+    assert _run(gate, tmp_path, _output("Passed"), config=renamed) == 1
+
+
+def test_ansi_coloured_output_is_still_read(gate, tmp_path):
+    coloured = _output("Failed").replace(_GUARD, "\x1b[1m" + _GUARD + "\x1b[m")
+    assert _run(gate, tmp_path, coloured) == 1
+
+
+def test_no_files_to_check_postfix_is_parsed(gate, tmp_path):
+    """pre-commit's own skip wording, which carries a parenthesised postfix."""
+    output = _output(None).replace(
+        "black", _GUARD + "." * 10 + "(no files to check)Skipped\nblack", 1
+    )
+    assert _run(gate, tmp_path, output) == 1
+
+
+def test_every_allowlisted_id_exists_in_the_real_config(gate):
+    """The guard against the exemption list drifting away from the real hooks."""
+    names = gate.hook_names(_REAL_CONFIG.read_text(encoding="utf-8"))
+    missing = [hook_id for hook_id in gate.GATING_HOOK_IDS if hook_id not in names]
+    assert not missing, f"allowlisted hook ids absent from .pre-commit-config.yaml: {missing}"
+
+
+def test_allowlist_is_not_empty(gate):
+    """An empty allowlist would pass everything while looking like a gate."""
+    assert gate.GATING_HOOK_IDS
+
+
+def test_names_come_from_the_yaml_parser_not_the_raw_text(gate):
+    """A ``#`` issue ref in an unquoted name opens a YAML comment.
+
+    ``name: Function Length Check (Issue #5512)`` parses to
+    ``Function Length Check (Issue`` and that truncated string is what
+    pre-commit prints. Matching the spelling in the file would never hit.
+    """
+    names = gate.hook_names("repos:\n  - repo: local\n    hooks:\n      - id: x\n        name: A (Issue #1)\n")
+    assert names["x"] == "A (Issue"
+
+
+def test_a_hook_reporting_both_statuses_resolves_to_the_worse_one(gate, tmp_path):
+    """Ambiguity must never resolve in the green direction."""
+    output = _output("Passed").replace("black", _GUARD + "." * 10 + "Failed\nblack", 1)
+    assert _run(gate, tmp_path, output) == 1


### PR DESCRIPTION
## Thinking Path

The assignment was to make the Python suite gate. The first job was to establish why it does not, so I read the code before building anything — and most of it turned out to be already built.

**The mechanism for #14353 has been merged since 2026-08-17** (PR #14402, `d0b2f42c3f`):

- `.github/workflows/python-required-context.yml` publishes a job **named** `python-suite` when no Python path changed
- `.github/filters/python-paths.yml` is the shared path set both workflows read, so the two `if:` conditions cannot drift
- `ci.yml` carries no `pull_request.paths` filter, so it always starts and can always report
- `repo_tests/python_required_context_test.py` guards the arrangement

So the blocker is **not** missing code, not a name mismatch, not a swallowed ratchet, and not a per-shard context. `ci.yml` runs bare `pytest` — a single failing test fails the shard, and the aggregator re-asserts it explicitly. **The blocker is that the last step is a repository-settings change, and it has been sitting on the owner since 2026-08-17.** That is a checklist at the bottom of this PR, not something a PR can deliver.

I then verified the two objections that could make the flip unsafe, because if either held, flipping would deadlock every PR.

**Objection 1 — "the aggregator check is intermittently absent."** Recorded on #14353 from an audit of seven merges, one of which (#14455) showed all twelve shards green and no `python-suite` aggregator. It does not reproduce: on `2834c6f038e6`, `python-suite` is present and `success`. It was created at `2026-08-17T22:30:20Z`; the audit comment reporting it absent was posted at `22:28:58Z`. The aggregator had not been created yet. A timing artifact, not an absence — so nothing needs to key on the shard count instead.

**Objection 2 — "the shim's skip could mask a real failure."** Two jobs publish the same context, so one of them decides it. Measured on live pull requests, by check-run `id` (creation order), not by timestamp:

| PR | Python touched? | `ci.yml` job | shim job | higher id (created last) |
|---|---|---|---|---|
| #14629 | yes | `failure` `97253091821` | `skipped` `97250986170` | the real verdict |
| #14805 | no | `skipped` `97292839928` | `success` `97293040244` | the real verdict |

The substantive verdict is created last **in both directions**, and structurally so: `ci.yml`'s aggregator is `needs: [changes, python-shard]`, so its check run cannot exist until all twelve shards have finished, while the shim resolves in about a minute. Whichever rule GitHub applies to duplicate names — latest-wins, or all-must-pass with `skipped` counted as success — it resolves to the real result. That `skipped` satisfies a required context is directly evidenced on #14805, where `code-quality` and `startup-import-smoke` are both required and both `skipped`.

Swept the 60 most recently merged pull requests to check both claims at scale. Zero had no `python-suite` check run. The shim's check run was created last in 6 of 60, and all 6 were `real=skipped, shim=success` — the harmless direction. And the criterion this batch exists for is answered by a real merge rather than a contrived one: **PR #14653 merged into `Dev_new_gui` on 2026-08-22 with `python-suite` = `failure`** (shard 12/12 red, aggregator check run `96991538736`), five days after the shim landed.

**So `python-suite` is safe to require, and the only thing left is the settings flip.** What this PR builds is the third issue in the batch, which is gateable today, plus the two loose ends the other two named.

## What Changed

**#14878 — behavioural pre-commit hooks now block a merge.**

`enforce-precommit.yml` runs `pre-commit run --all-files` and routes findings to `::warning::`. For formatters and linters that is right, and its comment says so. `check_precommit_hooks_executed.py` (#14181) already fails the job when a hook could not *execute*. Between them sits a third class neither covers: `ssot-config-lib-guard`, whose entry is a **test suite** — the regression guard for #14041. It executes fine, so #14181 is satisfied; it reports a finding, so the workflow warns and moves on. The guard ran in exactly one place and blocked nothing.

- `pipeline-scripts/check_gating_precommit_hooks.py` — fails the job when a hook on an explicit behavioural allowlist reports a finding. Keyed by hook **id**, not name, and self-guarding in both directions: an id that leaves `.pre-commit-config.yaml` fails rather than silently exempting itself, and an absent or `Skipped` result fails rather than reading as clean.
- Wired into the `verify-precommit-config` job — **which is already a required context**. #14878 offered wrapping the suite under pytest as the alternative; that is the weaker option precisely because `python-suite` is not required, so it would move the guard from one non-gating place to another.
- `pipeline-scripts/check_gating_precommit_hooks_test.py` — 12 tests, every one driving `main()` rather than a helper.
- `CONTRIBUTING.md` — records that `pre-commit install` and `scripts/install-git-hooks.sh` are separate steps that both write `.git/hooks/pre-commit`, in what order to run them, how to verify both are live, and what the three hook classes mean for CI.

**#13162 loose end** — `ci.yml`'s deployment-check step was named `Set up Python 3.12` while pinning `3.14`. The name now carries no version, so there is no second copy to drift.

The allowlist has one entry today because exactly one hook meets the criterion — its entry is a test suite asserting shipped behaviour, so its verdict is independent of the diff. The criterion is written down in the script header rather than implied, and the list is guarded, so the next one is an append.

## Verification

**Mutation, on the real CI transcript.** Pulled the actual `precommit-output.txt` from the `verify-precommit-config` job of run `32679083207` (job `97292541874`, base `e8cb8e7ae`), stripped the log timestamps to reproduce the file the step reads, and ran the gate against it in a scratch copy outside the repository tree. Nothing was committed or pushed.

| case | expected | exit |
|---|---|---|
| unmutated CI transcript (`Shell SSOT Library Self-Test (#14041)` → `Passed`) | pass | **0** |
| same line mutated to `Failed` | block | **1** |
| result line deleted entirely | block | **1** |
| result line mutated to `Skipped` | block | **1** |
| hook id renamed in the config, output untouched | block | **1** |
| empty transcript | block | **1** |

`0 → 1` on the single mutated word, with the control still green. The four fail-closed directions all block, so an absent, skipped or unparseable result cannot read as a clean one.

**Baseline confirmed before gating.** On base `e8cb8e7ae` the guard reports `Passed`, so this change does not redden any open pull request on day one. That was checked from the CI log, not assumed.

**Unit tests:** 12 passed, in a layout-faithful scratch copy under Python 3.10.12 — a local interpreter figure, not a claim about CI's 3.14. They also run here in `python-suite`.

**Not verified locally:** nothing in this repository was executed in place, nothing was installed, and no branch protection or repository setting was touched.

A note found while building this, recorded because it makes hook names unusable as identifiers: several hook names are written unquoted with a space before a `#` issue reference, so YAML reads the rest of the line as a comment. `name: Function Length Check (Issue #5512)` parses to `Function Length Check (Issue`, and that truncated string is what pre-commit prints. The allowlist resolves `id -> name` through the same parser, so it matches what actually lands in the log. Filed as #14923 rather than fixed here.

## Model Used

Claude Opus 5 (1M context)

---

### Owner action required — repository settings, not code

`python-suite` cannot be made to gate from a pull request. Adding a required context is a branch-protection change on `Dev_new_gui`. Everything up to that line is merged; this is the line.

- [ ] Add the required status context **`python-suite`** (exact name, lower-case, hyphenated) to branch protection on `Dev_new_gui`, taking the list from 10 contexts to 11.
- [ ] After the flip, exercise the acceptance criterion by breaking it rather than by observing green: open a throwaway PR with one deliberately failing Python test and confirm the merge box blocks.

One asymmetry found while verifying this, filed as #14922: the `Unit & Integration Tests` pair is ordered the *opposite* way round — in 34 of the 60 merged pull requests swept, the shim's check run was created after the real frontend job's. No merge went out with the real frontend suite red, so nothing is observably broken, but that pair is not protected the way this one is.

Evidence supporting the flip is in the Thinking Path above: the shim exists and is fail-closed, the base branch is green (twelve consecutive `success` runs of `ci.yml` on `Dev_new_gui`), and the duplicate-name ordering resolves to the real verdict in both directions.

Closes #14878
Refs #14353, #13162
