### PR TITLE
fix(ci): close two gate escapes — a missing route and an accidental skip (#14919, #14885)

### DIFF
--- a/.github/workflows/verify-generated-types.yml
+++ b/.github/workflows/verify-generated-types.yml
@@ -23,6 +23,38 @@
 # despite zero consumers importing it — see #12662 for the cross-language
 # NodeStatus drift this closes.
 #
+# #14885: both filters also watch autobot_shared/**/*.py, and the per-product
+# split between them is preserved. Neither used to, while BOTH generated files
+# depend on that tree — measured, not assumed:
+#
+#   * autobot_shared/user_management/schemas/user.py is the sole definition of
+#     UserResponse, UserCreate, UserUpdate, UserListResponse, RoleResponse and
+#     PasswordChange. Each backend's user_management/schemas/user.py is a
+#     re-export shim over it (#12647), and both committed api.ts files carry
+#     those component schemas. Editing one field there changes both.
+#   * autobot_shared/openapi_schema.normalize_pattern_anchors is applied to the
+#     spec by scripts/audit_api_wiring.py (used by BOTH dump modes in this
+#     workflow) and by autobot-slm-backend/scripts/dump_openapi.py. It rewrites
+#     the published schema, so a change to it changes both outputs.
+#
+# So a change confined to autobot_shared/ could alter either generated api.ts
+# while this workflow computed "nothing to verify" and self-skipped — and
+# `verify-generated-types` is a REQUIRED context, so that reported green over a
+# check that never ran. 46 of the last 300 first-parent commits on Dev_new_gui
+# touch only autobot_shared/**/*.py; that is the blind spot's size, and it is
+# also the added cost of closing it.
+#
+# The filter widens rather than the check becoming unskippable, because the
+# skip is already safe HERE and only here: the required context is the separate
+# `verify-generated-types` reporting job below (#13862), which always runs and
+# always states a verdict. Making the working job unconditional on a
+# path-filtered workflow is what deadlocks a pull request (#13388/#12934); the
+# defect was the filter's reach, not the existence of a skip.
+#
+# pipeline-scripts/check_workflow_path_filters.py now asserts that both filters
+# and the push trigger still name the shared tree, so this cannot quietly
+# shrink back.
+#
 # Runs on GitHub-hosted ubuntu-latest (not the self-hosted runner) so it adds
 # no load to the single self-hosted runner.
 
@@ -33,6 +65,10 @@ on:
     branches: [ main, Dev_new_gui ]
     paths:
       - 'autobot-backend/**/*.py'
+      # #14885: both products' schemas are dumped by importing the application,
+      # and both applications import from autobot_shared. Measured, not
+      # assumed — see the header.
+      - 'autobot_shared/**/*.py'
       - 'autobot-frontend/src/types/generated/api.ts'
       - 'autobot-frontend/package.json'
       - 'autobot-frontend/package-lock.json'
@@ -71,6 +107,7 @@ jobs:
           filters: |
             types:
               - 'autobot-backend/**/*.py'
+              - 'autobot_shared/**/*.py'
               - 'autobot-frontend/src/types/generated/api.ts'
               - 'autobot-frontend/package.json'
               - 'autobot-frontend/package-lock.json'
@@ -79,6 +116,7 @@ jobs:
               - '.github/workflows/verify-generated-types.yml'
             slm_types:
               - 'autobot-slm-backend/**/*.py'
+              - 'autobot_shared/**/*.py'
               - 'autobot-slm-frontend/src/types/generated/api.ts'
               - 'autobot-slm-frontend/package.json'
               - 'autobot-slm-frontend/package-lock.json'
@@ -174,7 +212,11 @@ jobs:
 
   verify-generated-types-slm:
     needs: changes
-    if: needs.changes.outputs.slm_types == 'true'
+    # `!= 'false'`, matching verify-types-run above and for the same reason
+    # (#14885). With `== 'true'` a paths-filter that succeeded but emitted
+    # nothing skips this job silently — the fail-safe has to point at running
+    # the check, not at skipping it.
+    if: needs.changes.outputs.slm_types != 'false'
     name: verify-generated-types-slm
     runs-on: ubuntu-latest
 

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -235,6 +235,12 @@ The justification is a preceding **comment**, never a suffix on the entry: the
 key is everything after the first `|`, so a trailing `# reviewed: …` would
 change the key until it matched no finding at all.
 
+An entry whose key does not carry **exactly two** `|` separators is refused
+outright rather than parsed. `|` is a legal byte in a filename and the record
+format does not escape it, so a crafted path can make the file field resolve to
+an unrelated, untouched decoy — which was a working bypass of this route until
+the check was added.
+
 Every permitted addition is printed in full and annotated on the run
 (`::warning::`), so growth is loud rather than silent. A **rename** of a file
 carrying a baselined value is deliberately not covered — the new path is absent

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -235,6 +235,12 @@ The justification is a preceding **comment**, never a suffix on the entry: the
 key is everything after the first `|`, so a trailing `# reviewed: …` would
 change the key until it matched no finding at all.
 
+An entry naming a **symlink** is refused. A symlink's content is the target
+path, so "byte-identical to the base ref" stays true however much the file it
+points at was rewritten — and the detector never attributes a finding to a
+symlink path anyway, because its tree walk does not follow them. Baseline the
+real path.
+
 An entry whose key does not carry **exactly two** `|` separators is refused
 outright rather than parsed. `|` is a legal byte in a filename and the record
 format does not escape it, so a crafted path can make the file field resolve to

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -208,6 +208,39 @@ Why the audit blocks rather than warns: an entry naming a path that has moved
 exempts nothing today, but silently re-permits the value the moment that path
 comes back.
 
+### Adding a baseline entry (#14919)
+
+There is exactly one route, and it does not exist for the case the guard was
+built to stop. An entry may be **added** only when both hold:
+
+1. **The file is byte-identical to the base ref.** A detection-rule change that
+   suddenly matches code which was already in the tree is a legitimate
+   addition — nothing in your change wrote that value. A file your change
+   *touches* is the bypass itself (hardcode a value, append its key in the same
+   commit) and has **no override at all**: not an env var, not a label, not a
+   marker. The two cases are separated by the diff, not by permission.
+2. **This change adds a written justification directly above the entry**, of the
+   form:
+
+   ```
+   # reviewed: #<issue> why this cannot be fixed at the source
+   1|ssot|path/to/file.py|value
+   ```
+
+   It must be a *new* line in your diff. A justification already in the file
+   covers the entry it was written for, not a later append that happens to sit
+   under it.
+
+The justification is a preceding **comment**, never a suffix on the entry: the
+key is everything after the first `|`, so a trailing `# reviewed: …` would
+change the key until it matched no finding at all.
+
+Every permitted addition is printed in full and annotated on the run
+(`::warning::`), so growth is loud rather than silent. A **rename** of a file
+carrying a baselined value is deliberately not covered — the new path is absent
+at the base ref, so the addition is refused, and loosening that to "the content
+existed somewhere at base" would also admit a verbatim copy.
+
 ---
 
 ## ConfigRegistry Fallback Pattern (Issue #2671)

--- a/pipeline-scripts/check_baseline_no_growth.sh
+++ b/pipeline-scripts/check_baseline_no_growth.sh
@@ -296,6 +296,29 @@ while IFS= read -r gline; do
         continue
     fi
 
+    # A SYMLINK IS NOT THE CONTENT THE FINDING IS ABOUT.
+    #
+    # A symlink's blob is the target PATH STRING, so `git diff --quiet` below
+    # reports it unchanged however much the file it points at was rewritten.
+    # Found in review: base has `alias.py -> real.py`, the change rewrites
+    # `real.py` to add a secret and baselines `alias.py`, and the byte-identical
+    # test passes on the link object while the value is brand new.
+    #
+    # Refusing costs nothing, because a finding can never legitimately be
+    # attributed to a symlink path in the first place: hv_scan_tree walks the
+    # tree with `grep -r`, which does not follow symlinks during traversal, so
+    # the detector reports the finding under the real path. An entry naming a
+    # symlink is therefore always either a mistake or a decoy.
+    if [ -L "$entry_file" ]; then
+        echo "  REFUSED  ${key}"
+        echo "           ${entry_file} is a symlink. Its content is the target PATH, so"
+        echo "           'byte-identical to the base ref' says nothing about the file the"
+        echo "           value actually lives in. The detector never attributes a finding"
+        echo "           to a symlink path either — baseline the real path."
+        refused=$((refused + 1))
+        continue
+    fi
+
     if ! git rev-parse --verify --quiet "${base}:${entry_file}" >/dev/null; then
         echo "  REFUSED  ${key}"
         echo "           ${entry_file} does not exist at ${base}: this change created it,"

--- a/pipeline-scripts/check_baseline_no_growth.sh
+++ b/pipeline-scripts/check_baseline_no_growth.sh
@@ -26,6 +26,14 @@
 # Shrinking stays silent. Removals and decreases are how a fixed violation
 # leaves, and a guard that blocked those would make the file unmaintainable.
 #
+# ONE addition route exists (#14919), and only one: an entry whose file this
+# change leaves byte-identical to the base ref, carrying a `# reviewed: #<issue>`
+# justification that this change itself adds directly above it. That is the
+# detection-rule case -- a new rule matching code that was already there -- and
+# it is separated from the bypass case mechanically, by the diff, not by a
+# permission an appended line could grant itself. An addition in a file this
+# change touches has no route at all. See the block above the adjudication loop.
+#
 # FAIL-CLOSED EVERYWHERE. An unresolvable base, an unreadable baseline on either
 # side, or a parse failure is a FAILURE, never a skip: a guard that reads
 # "cannot determine" as "clean" is precisely the class being fixed here.
@@ -110,14 +118,217 @@ if [ "$rc" -eq 0 ]; then
     exit 0
 fi
 
+# ── the reviewed-addition route (#14919) ─────────────────────────────────────
+#
+# Until now the guard had exactly two outcomes, "no growth, exit 0" and
+# "growth, exit 1", while its own failure text told the reader that growth was
+# "a decision for a reviewer to take deliberately". No such decision existed.
+# A guard whose message promises a route it does not implement is a guard that
+# acquires an illegitimate one the first time the route is genuinely needed.
+#
+# So there is now one route, and it is deliberately narrow enough that it
+# cannot be the bypass this file exists to close. An addition is permitted only
+# when BOTH hold, and neither can be satisfied by accident:
+#
+#   1. THE CHANGE DID NOT AUTHOR THE CONTENT. The entry's file must exist at
+#      the base ref and be byte-identical to the file in this tree. That is the
+#      mechanical difference between the two kinds of addition:
+#
+#        * a new DETECTION RULE that suddenly matches code which was already
+#          there — the file is untouched, the finding is genuinely pre-existing,
+#          and refusing it would mean "fixing" code this change never wrote;
+#        * a new HARDCODED VALUE — the file necessarily changed, which is the
+#          one-line bypass (hardcode it, append its key in the same commit).
+#
+#      The second can never reach the route at all. No marker, env var or label
+#      opens it, because the test is on the diff rather than on permission.
+#
+#   2. A WRITTEN JUSTIFICATION, NEW IN THIS CHANGE. The nearest non-blank line
+#      above the entry must read `# reviewed: #<issue> <why>`, and that exact
+#      line must be among the lines this change ADDS to the baseline. A comment
+#      that was already in the file cannot be re-used to cover a later append,
+#      and the justification lands as a diff line adjacent to the entry it
+#      justifies, so a reviewer sees both together or neither.
+#
+#      The marker is a preceding COMMENT and not a suffix on the entry itself
+#      because the key is `<count>|<class>|<file>|<value>` and everything after
+#      the first `|` is the key: a trailing `# reviewed: …` would silently
+#      change the key so it matched no finding at all.
+#
+# What this route deliberately does NOT cover: a rename. Moving a file that
+# carries a baselined value changes the entry's path, so the new path is absent
+# at base and the addition is refused. That is the same answer as before this
+# route existed — it is not a regression, and loosening test 1 to "the content
+# existed at base under some name" would also admit a verbatim COPY of a file,
+# which duplicates a hardcoded value rather than inheriting one.
+#
+# FAIL-CLOSED, as everywhere else here: every growth entry must be adjudicated
+# to exactly one of allowed/refused, and the totals are asserted against the
+# number of growth lines before anything exits 0. A growth line this parser
+# failed to understand is a FAILURE, never an unexamined pass.
+
 echo "check-baseline-no-growth: the baseline GREW against ${base}"
 echo "  suppressed findings: ${old_total} -> ${new_total}"
 echo
 printf '%s\n' "$growth" | sed 's/^/  /'
 echo
-echo "The baseline only ever shrinks. Each line above is a finding the detector"
-echo "made and this change would suppress, which is indistinguishable from never"
-echo "having found it. Fix the violation instead; if it genuinely cannot be fixed"
-echo "now, that is a decision for a reviewer to take deliberately, not something"
-echo "an appended line should buy silently."
-exit 1
+
+growth_entries=$(printf '%s\n' "$growth" | grep -c . || true)
+if [ "${growth_entries:-0}" -eq 0 ]; then
+    echo "FATAL: hv_baseline_growth reported growth but emitted no entries —" >&2
+    echo "  refusing to report clean on a verdict this guard cannot read" >&2
+    exit 1
+fi
+# Counted with `wc -l`, NOT with the non-blank count above, and the difference
+# is the point. The loop below skips a blank growth line; counting only
+# non-blank lines here would make that skip agree with itself and the
+# reconciliation at the end would be unfalsifiable. Every line the library
+# emitted has to come back with a verdict.
+growth_lines=$(printf '%s\n' "$growth" | wc -l)
+
+mapfile -t NEW_LINES < "${PROJECT_ROOT}/${BASELINE_REL}"
+if [ "${#NEW_LINES[@]}" -eq 0 ]; then
+    echo "FATAL: ${BASELINE_REL} read as zero lines — refusing to report clean" >&2
+    exit 1
+fi
+
+# Lines this change ADDS to the baseline. Diffed against the working tree, the
+# same side hv_baseline_growth just compared, so the two can never disagree
+# about what "this change" is.
+declare -A ADDED_LINES=()
+while IFS= read -r _added; do
+    # A bare `+` is an added BLANK line. Its key would be the empty string,
+    # which is a bad array subscript under `set -u` and, worse, would make an
+    # entry with no marker at all look like it had one.
+    [ -n "${_added:1}" ] || continue
+    ADDED_LINES["${_added:1}"]=1
+done < <(git diff "$base" -- "$BASELINE_REL" | grep '^+' | grep -v '^+++')
+
+# The nearest non-blank line above the entry whose key is $1, or nothing.
+marker_for_key() {
+    local key="$1" i j
+    for (( i = 0; i < ${#NEW_LINES[@]}; i++ )); do
+        [[ ${NEW_LINES[$i]} =~ ^[0-9] ]] || continue
+        [ "${NEW_LINES[$i]#*|}" = "$key" ] || continue
+        for (( j = i - 1; j >= 0; j-- )); do
+            [[ ${NEW_LINES[$j]} =~ ^[[:space:]]*$ ]] && continue
+            printf '%s\n' "${NEW_LINES[$j]}"
+            return 0
+        done
+        return 1
+    done
+    return 1
+}
+
+allowed=0
+refused=0
+while IFS= read -r gline; do
+    [ -n "$gline" ] || continue
+    # `NEW-KEY  (+2)  ssot|path|value` / `COUNT-UP (1->2)  ssot|path|value`.
+    # The parenthetical never contains `)`, so the first one ends it.
+    key="${gline#*)}"
+    key="${key#"${key%%[![:space:]]*}"}"
+    entry_file="${key#*|}"
+    entry_file="${entry_file%%|*}"
+
+    if [ -z "$key" ] || [ -z "$entry_file" ] || [ "$key" = "$gline" ]; then
+        echo "  REFUSED  ${gline}"
+        echo "           this guard could not parse the entry out of that growth line."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    if [ ! -f "$entry_file" ]; then
+        echo "  REFUSED  ${key}"
+        echo "           ${entry_file} does not exist in this tree, so the entry suppresses"
+        echo "           nothing and is stranded the moment it lands."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    if ! git rev-parse --verify --quiet "${base}:${entry_file}" >/dev/null; then
+        echo "  REFUSED  ${key}"
+        echo "           ${entry_file} does not exist at ${base}: this change created it,"
+        echo "           so the value in it is new, not pre-existing."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    if ! git diff --quiet "$base" -- "$entry_file"; then
+        echo "  REFUSED  ${key}"
+        echo "           ${entry_file} is modified by this change. An addition whose file"
+        echo "           this change touches is the bypass the guard exists to close:"
+        echo "           hardcode a value, append its key in the same commit. There is"
+        echo "           no route for it. Fix the value."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    marker=$(marker_for_key "$key") || marker=""
+    if [ -z "$marker" ] || ! [[ $marker =~ ^#[[:space:]]*reviewed:[[:space:]]*#[0-9]+[[:space:]]+[^[:space:]] ]]; then
+        echo "  REFUSED  ${key}"
+        echo "           ${entry_file} is unchanged by this change, so a detection-rule"
+        echo "           change could legitimately have surfaced this. That still needs a"
+        echo "           written justification on the line above the entry:"
+        echo
+        echo "               # reviewed: #<issue> why this cannot be fixed at the source"
+        echo "               <count>|${key}"
+        echo
+        refused=$((refused + 1))
+        continue
+    fi
+
+    if [ -z "${ADDED_LINES[$marker]+set}" ]; then
+        echo "  REFUSED  ${key}"
+        echo "           its justification was already in the baseline before this change:"
+        echo "             ${marker}"
+        echo "           A justification already in the file covers the entry it was"
+        echo "           written for, not a later append that happens to sit under it."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    echo "  ALLOWED  ${key}"
+    echo "           ${entry_file} is byte-identical to ${base}, and this change adds:"
+    echo "             ${marker}"
+    echo "::warning file=${BASELINE_REL}::reviewed baseline addition: ${key} — ${marker}"
+    allowed=$((allowed + 1))
+done < <(printf '%s\n' "$growth")
+
+# Every growth line must have reached exactly one verdict. Without this, a
+# growth line the parser silently dropped would leave both counters at zero and
+# the run would exit 0 over real growth — an absent result reading as a clean
+# result, which is the class this whole family of guards exists to stop.
+#
+# Reachable, and covered by a test that stubs the library into emitting a line
+# the loop skips. An assertion no input can trigger is one nobody can prove
+# still works.
+if [ $((allowed + refused)) -ne "$growth_lines" ]; then
+    echo >&2
+    echo "FATAL: ${growth_lines} growth entr(ies) but $((allowed + refused)) adjudicated —" >&2
+    echo "  refusing to report clean on a comparison this guard did not finish" >&2
+    exit 1
+fi
+
+echo
+if [ "$refused" -gt 0 ]; then
+    echo "The baseline only shrinks by default. ${refused} of ${growth_entries} addition(s)"
+    echo "above have no route and were refused; fix the violation at the source."
+    echo
+    echo "The one route that exists, and what it costs: an entry may be ADDED only"
+    echo "when its file is byte-identical to the base ref — so this change did not"
+    echo "write the value, a detection-rule change surfaced code that was already"
+    echo "there — AND this change adds a justification line directly above it:"
+    echo
+    echo "    # reviewed: #<issue> why this cannot be fixed at the source"
+    echo "    <count>|<class>|<file>|<value>"
+    echo
+    echo "Nothing opens the route for a file this change touches. That case is the"
+    echo "bypass itself and has no override, by design."
+    exit 1
+fi
+
+echo "check-baseline-no-growth: ${allowed} reviewed addition(s), every one of them in a"
+echo "  file this change leaves byte-identical to ${base} and justified by a line this"
+echo "  change adds. The unreviewed direction stays closed."
+exit 0

--- a/pipeline-scripts/check_baseline_no_growth.sh
+++ b/pipeline-scripts/check_baseline_no_growth.sh
@@ -195,6 +195,19 @@ fi
 # Lines this change ADDS to the baseline. Diffed against the working tree, the
 # same side hv_baseline_growth just compared, so the two can never disagree
 # about what "this change" is.
+# Written to a file first, NOT consumed straight from `<(git diff ...)`. A
+# process substitution's exit status is invisible to `set -e` and `pipefail`, so
+# a failed `git diff` there would leave ADDED_LINES empty and every entry would
+# be refused with the wrong reason ("already in the baseline") instead of the
+# right one. Fail-closed either way, but a guard whose message misdescribes its
+# own failure is one nobody can act on.
+ADDED_DIFF=$(mktemp)
+trap 'rm -f "$OLD_BASELINE" "$ADDED_DIFF"' EXIT
+if ! git diff "$base" -- "$BASELINE_REL" > "$ADDED_DIFF"; then
+    echo "FATAL: cannot diff ${BASELINE_REL} against ${base} — refusing to report clean" >&2
+    exit 1
+fi
+
 declare -A ADDED_LINES=()
 while IFS= read -r _added; do
     # A bare `+` is an added BLANK line. Its key would be the empty string,
@@ -202,7 +215,7 @@ while IFS= read -r _added; do
     # entry with no marker at all look like it had one.
     [ -n "${_added:1}" ] || continue
     ADDED_LINES["${_added:1}"]=1
-done < <(git diff "$base" -- "$BASELINE_REL" | grep '^+' | grep -v '^+++')
+done < <(grep '^+' "$ADDED_DIFF" | grep -v '^+++')
 
 # The nearest non-blank line above the entry whose key is $1, or nothing.
 marker_for_key() {
@@ -228,12 +241,49 @@ while IFS= read -r gline; do
     # The parenthetical never contains `)`, so the first one ends it.
     key="${gline#*)}"
     key="${key#"${key%%[![:space:]]*}"}"
-    entry_file="${key#*|}"
-    entry_file="${entry_file%%|*}"
 
-    if [ -z "$key" ] || [ -z "$entry_file" ] || [ "$key" = "$gline" ]; then
+    if [ -z "$key" ] || [ "$key" = "$gline" ]; then
         echo "  REFUSED  ${gline}"
         echo "           this guard could not parse the entry out of that growth line."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    # THE KEY MUST BE UNAMBIGUOUS BEFORE ITS FILE FIELD MEANS ANYTHING.
+    #
+    # A key is `<class>|<file>|<value>` and both `file` and `value` are raw --
+    # a literal `|` is a legal byte in a Linux filename and nothing in this
+    # toolchain rejects one. With three separators the split below is guesswork,
+    # and the guess is exploitable: for
+    #
+    #     ssot|autobot-backend/decoy.py|evil_new.py|<secret>
+    #
+    # the naive split yields `autobot-backend/decoy.py` -- an untouched,
+    # pre-existing DECOY -- while the finding really belongs to the brand-new
+    # file `autobot-backend/decoy.py|evil_new.py` that this change just wrote.
+    # Every test below then validated the decoy and the guard reported ALLOWED,
+    # exit 0, over exactly the bypass this file exists to close. Reproduced
+    # end-to-end during review before this check existed.
+    #
+    # So an ambiguous key is REFUSED rather than guessed at. All 1408 entries in
+    # the live baseline carry exactly two separators, so this costs nothing
+    # today; a value that genuinely contains `|` needs escaping in the record
+    # format itself, which is a change to the detector, not a guess here.
+    _hv_seps="${key//[^|]/}"
+    if [ "${#_hv_seps}" -ne 2 ]; then
+        echo "  REFUSED  ${key}"
+        echo "           this key has ${#_hv_seps} '|' separator(s), not 2, so which part"
+        echo "           of it is the FILE cannot be determined. Guessing here means"
+        echo "           validating a different file than the finding belongs to."
+        refused=$((refused + 1))
+        continue
+    fi
+
+    entry_file="${key#*|}"
+    entry_file="${entry_file%%|*}"
+    if [ -z "$entry_file" ]; then
+        echo "  REFUSED  ${key}"
+        echo "           its file field is empty."
         refused=$((refused + 1))
         continue
     fi

--- a/pipeline-scripts/check_baseline_no_growth_test.py
+++ b/pipeline-scripts/check_baseline_no_growth_test.py
@@ -35,15 +35,30 @@ def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True)
 
 
+SETTLED_REL = "autobot-backend/settled.py"
+SETTLED_VALUE = "172.16.168.99"
+SETTLED_KEY = f"ssot|{SETTLED_REL}|{SETTLED_VALUE}"
+MARKER = "# reviewed: #14919 vendored fixture; the value is correct where it is"
+
+
 @pytest.fixture()
 def repo(tmp_path: Path) -> tuple[Path, str]:
-    """A two-commit repo whose base commit holds the real baseline."""
+    """A two-commit repo whose base commit holds the real baseline.
+
+    It also carries one SETTLED source file: a tracked file the change under
+    test leaves alone. Without a real file in the tree there is no way to tell
+    the two kinds of baseline addition apart, and every test would exercise the
+    same "file is not there" refusal.
+    """
     root = tmp_path / "repo"
     for rel in (GUARD_REL, BASELINE_REL, *LIBS):
         dest = root / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(REPO_ROOT / rel, dest)
     (root / GUARD_REL).chmod(0o755)
+    settled = root / SETTLED_REL
+    settled.parent.mkdir(parents=True, exist_ok=True)
+    settled.write_text(f'HOST = "{SETTLED_VALUE}"\n', encoding="utf-8")
     _git(root.parent, "init", "--quiet", "-b", "main", str(root))
     _git(root, "config", "user.email", "t@example.invalid")
     _git(root, "config", "user.name", "t")
@@ -182,3 +197,204 @@ def test_an_absent_baseline_at_base_is_the_introduction_not_a_reset(repo) -> Non
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "does not exist at" in result.stdout
+
+
+# ── the reviewed-addition route (#14919) ─────────────────────────────────────
+#
+# The guard used to have no route at all while its failure text told the reader
+# a reviewer could take the decision deliberately. These tests pin BOTH halves
+# of the route that replaced that promise: the legitimate case goes green, and
+# every way of reaching it without paying its price stays red.
+
+
+def _append(root: Path, *lines: str) -> None:
+    with _baseline(root).open("a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line + "\n")
+
+
+def test_a_justified_addition_in_an_untouched_file_is_allowed(repo) -> None:
+    """The legitimate case: a detection rule now matches code already in the tree.
+
+    The file is byte-identical to the base ref, so this change did not write the
+    value — and the justification naming an issue is added by this same change.
+    """
+    root, _ = repo
+    _append(root, MARKER, f"1|{SETTLED_KEY}")
+    result = _run(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert f"ALLOWED  {SETTLED_KEY}" in result.stdout
+    assert "1 reviewed addition(s)" in result.stdout
+    # Loud, not merely permitted: the addition is annotated on the run.
+    assert "::warning file=" in result.stdout
+
+
+def test_the_same_addition_without_a_justification_fails(repo) -> None:
+    """The route is not "an untouched file"; it is "an untouched file AND a reason"."""
+    root, _ = repo
+    _append(root, f"1|{SETTLED_KEY}")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert f"REFUSED  {SETTLED_KEY}" in result.stdout
+    assert "written justification" in result.stdout
+
+
+def test_a_malformed_justification_fails(repo) -> None:
+    """A comment that does not name an issue is a note, not a decision."""
+    root, _ = repo
+    _append(root, "# reviewed: because I say so", f"1|{SETTLED_KEY}")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "written justification" in result.stdout
+
+
+def test_a_justified_addition_in_a_file_this_change_touches_fails(repo) -> None:
+    """The bypass itself, wearing the marker. No route opens for it — ever.
+
+    This is the property the whole guard exists for: hardcode a value and append
+    its key in the same change. Writing a justification above the entry must not
+    buy it, or the route IS the bypass.
+    """
+    root, _ = repo
+    (root / SETTLED_REL).write_text(
+        f'HOST = "{SETTLED_VALUE}"\nOTHER = "10.0.0.1"\n', encoding="utf-8"
+    )
+    _append(root, MARKER, f"1|{SETTLED_KEY}")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert f"REFUSED  {SETTLED_KEY}" in result.stdout
+    assert "is modified by this change" in result.stdout
+
+
+def test_a_justified_addition_in_a_file_this_change_creates_fails(repo) -> None:
+    """A brand-new file cannot hold a pre-existing finding, marker or not."""
+    root, _ = repo
+    fresh = root / "autobot-backend/fresh.py"
+    fresh.write_text('HOST = "10.0.0.2"\n', encoding="utf-8")
+    _git(root, "add", "autobot-backend/fresh.py")
+    _append(root, MARKER, "1|ssot|autobot-backend/fresh.py|10.0.0.2")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "does not exist at" in result.stdout
+
+
+def test_a_justification_that_predates_the_change_cannot_be_reused(repo) -> None:
+    """A marker already in the file covers its own entry, not a later append.
+
+    Otherwise the route degrades into "land one justified entry, then append
+    freely underneath it" — a permission the file grants itself.
+    """
+    root, _ = repo
+    _append(root, MARKER)
+    _git(root, "add", BASELINE_REL)
+    _git(root, "commit", "--quiet", "-m", "land a justification")
+    base = _git(root, "rev-parse", "HEAD").stdout.strip()
+    _append(root, f"1|{SETTLED_KEY}")
+    result = subprocess.run(
+        ["bash", str(root / GUARD_REL)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(root), "BASE_SHA": base},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "already in the baseline before this change" in result.stdout
+
+
+def test_a_justified_count_increase_in_an_untouched_file_is_allowed(repo) -> None:
+    """COUNT-UP takes the same route as NEW-KEY; a rule can match twice in one file."""
+    root, _ = repo
+    lines = _baseline(root).read_text(encoding="utf-8").splitlines()
+    i = _first_entry_index(lines)
+    count, _, rest = lines[i].partition("|")
+    entry_file = rest.split("|", 1)[1].split("|", 1)[0]
+    source = root / entry_file
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("pre-existing\n", encoding="utf-8")
+    _git(root, "add", entry_file)
+    _git(root, "commit", "--quiet", "-m", "settle the entry's file")
+    base = _git(root, "rev-parse", "HEAD").stdout.strip()
+    lines[i : i + 1] = [MARKER, f"{int(count) + 1}|{rest}"]
+    _baseline(root).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(root / GUARD_REL)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(root), "BASE_SHA": base},
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "COUNT-UP" in result.stdout
+    assert "ALLOWED" in result.stdout
+
+
+def test_a_justification_under_a_blank_line_still_counts(repo) -> None:
+    """Blank lines are layout, not a break in the association."""
+    root, _ = repo
+    _append(root, MARKER, "", f"1|{SETTLED_KEY}")
+    result = _run(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ALLOWED" in result.stdout
+
+
+def test_a_mix_of_one_allowed_and_one_refused_addition_fails(repo) -> None:
+    """A justified addition must never launder an unjustified one in the same change."""
+    root, _ = repo
+    _append(root, MARKER, f"1|{SETTLED_KEY}", "1|ssot|autobot-backend/absent.py|10.0.0.3")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "ALLOWED" in result.stdout
+    assert "REFUSED" in result.stdout
+    assert "1 of 2 addition(s)" in result.stdout
+
+
+def test_an_entry_naming_an_absent_file_says_so(repo) -> None:
+    """The fabricated-key refusal has to NAME the reason, not merely exit 1.
+
+    A guard that refuses for an unstated reason gets "fixed" by whatever the
+    next person guesses — here, by inventing a path that happens to exist.
+    """
+    root, _ = repo
+    with _baseline(root).open("a", encoding="utf-8") as handle:
+        handle.write(f"{MARKER}\n1|ssot|autobot-backend/never_existed.py|10.0.0.9\n")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "does not exist in this tree" in result.stdout
+
+
+def _stub_growth(root: Path, body: str) -> None:
+    """Replace the rules library with one whose growth verdict is *body*.
+
+    The guard reads its verdict from `hv_baseline_growth`. Nothing a real
+    baseline can contain makes that function emit a line the adjudication loop
+    skips, so the reconciliation that catches a dropped line is only provable
+    from this side of the seam.
+    """
+    (root / "scripts/lib/hardcoded-value-rules.sh").write_text(
+        "hv_baseline_growth() {\n" + body + "\n    return 1\n}\ntrue\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_growth_line_the_parser_drops_is_fatal_not_a_pass(repo) -> None:
+    """The reconciliation backstop: adjudicated must equal emitted."""
+    root, _ = repo
+    # The blank line has to sit BETWEEN two entries: a trailing one is stripped
+    # by command substitution before the guard ever sees it.
+    _stub_growth(
+        root,
+        f"    printf 'NEW-KEY  (+1)  {SETTLED_KEY}\\n\\nNEW-KEY  (+1)  ssot|a/b.py|x\\n'",
+    )
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "adjudicated" in (result.stdout + result.stderr)
+    assert "refusing to report clean" in (result.stdout + result.stderr)
+
+
+def test_a_growth_verdict_with_no_entries_is_fatal_not_a_pass(repo) -> None:
+    """"The baseline grew" with nothing to show for it is unreadable, not clean."""
+    root, _ = repo
+    _stub_growth(root, "    :")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "emitted no entries" in (result.stdout + result.stderr)

--- a/pipeline-scripts/check_baseline_no_growth_test.py
+++ b/pipeline-scripts/check_baseline_no_growth_test.py
@@ -446,3 +446,31 @@ def test_an_empty_file_field_is_refused(repo) -> None:
     result = _run(repo)
     assert result.returncode == 1, result.stdout + result.stderr
     assert "file field is empty" in result.stdout
+
+
+def test_an_entry_naming_a_symlink_is_refused(repo) -> None:
+    """A symlink's blob is the target PATH, so 'unchanged' says nothing about content.
+
+    Found in review, and reproduced before the check existed: base carries
+    `alias.py -> settled.py`; the change rewrites `settled.py` to add a value
+    and baselines `alias.py`. `git diff --quiet` is silent on the link object,
+    so the byte-identical test passed on the wrong file and the guard exited 0.
+    """
+    root, _ = repo
+    alias = root / "autobot-backend/alias.py"
+    alias.symlink_to("settled.py")
+    _git(root, "add", "autobot-backend/alias.py")
+    _git(root, "commit", "--quiet", "-m", "add the symlink at base")
+    base = _git(root, "rev-parse", "HEAD").stdout.strip()
+    (root / SETTLED_REL).write_text('HOST = "10.0.0.7"\n', encoding="utf-8")
+    _append(root, MARKER, "1|ssot|autobot-backend/alias.py|10.0.0.7")
+    result = subprocess.run(
+        ["bash", str(root / GUARD_REL)],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(root), "BASE_SHA": base},
+    )
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "is a symlink" in result.stdout
+    assert "ALLOWED" not in result.stdout

--- a/pipeline-scripts/check_baseline_no_growth_test.py
+++ b/pipeline-scripts/check_baseline_no_growth_test.py
@@ -398,3 +398,51 @@ def test_a_growth_verdict_with_no_entries_is_fatal_not_a_pass(repo) -> None:
     result = _run(repo)
     assert result.returncode == 1, result.stdout + result.stderr
     assert "emitted no entries" in (result.stdout + result.stderr)
+
+
+def test_a_key_with_an_extra_separator_is_refused_not_guessed_at(repo) -> None:
+    """The bypass found in review, and the reason keys are validated before use.
+
+    `|` is a legal byte in a Linux filename and nothing in this toolchain
+    rejects one. For the key
+
+        ssot|autobot-backend/settled.py|evil_new.py|<secret>
+
+    the naive `<class>|<file>|<value>` split yields `autobot-backend/settled.py`
+    — an untouched DECOY — while the finding really belongs to the brand-new
+    `autobot-backend/settled.py|evil_new.py` this change just wrote. Every other
+    check then validated the decoy and the guard reported ALLOWED, exit 0, over
+    exactly the addition it exists to refuse.
+    """
+    root, _ = repo
+    evil = root / f"{SETTLED_REL}|evil_new.py"
+    evil.write_text('SECRET = "AKIA-EXFIL-1234567890"\n', encoding="utf-8")
+    _append(root, MARKER, f"1|ssot|{SETTLED_REL}|evil_new.py|AKIA-EXFIL-1234567890")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not 2" in result.stdout
+    assert "ALLOWED" not in result.stdout
+
+
+def test_the_decoy_file_is_never_the_one_validated(repo) -> None:
+    """The same key, with the decoy MODIFIED too — the refusal must not depend on it.
+
+    If the ambiguity check were removed and the guard fell back to validating
+    the decoy, this case would still be refused (the decoy changed) and would
+    hide the bug. Asserting the *reason* is what makes the test bite.
+    """
+    root, _ = repo
+    (root / SETTLED_REL).write_text('HOST = "x"\n', encoding="utf-8")
+    (root / f"{SETTLED_REL}|evil_new.py").write_text('S = "v"\n', encoding="utf-8")
+    _append(root, MARKER, f"1|ssot|{SETTLED_REL}|evil_new.py|v")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "not 2" in result.stdout
+
+
+def test_an_empty_file_field_is_refused(repo) -> None:
+    root, _ = repo
+    _append(root, MARKER, "1|ssot||somevalue")
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "file field is empty" in result.stdout

--- a/pipeline-scripts/check_workflow_path_filters.py
+++ b/pipeline-scripts/check_workflow_path_filters.py
@@ -249,12 +249,13 @@ def shared_tree_paths(canonical: list[str]) -> list[str]:
 
 
 def _dorny_filters(parsed: dict, path: Path) -> dict:
-    """The inline `filters:` block of *path*'s dorny/paths-filter step.
+    """The inline `filters:` block of *path*'s single dorny/paths-filter step.
 
-    Every failure to find one is fatal. A restructured workflow whose filters
-    this guard can no longer locate is the case where "found nothing to check"
-    and "checked and it was fine" are indistinguishable.
+    Every failure to find exactly one is fatal. A restructured workflow whose
+    filters this guard can no longer locate is the case where "found nothing to
+    check" and "checked and it was fine" are indistinguishable.
     """
+    found: list[dict] = []
     for job in (parsed.get("jobs") or {}).values():
         if not isinstance(job, dict):
             continue
@@ -270,8 +271,19 @@ def _dorny_filters(parsed: dict, path: Path) -> dict:
                 sys.exit(f"FATAL: {path}'s inline `filters:` block is not parseable YAML: {exc}")
             if not isinstance(block, dict) or not block:
                 sys.exit(f"FATAL: {path}'s inline `filters:` block did not parse to a non-empty mapping")
-            return block
-    sys.exit(f"FATAL: {path} has no dorny/paths-filter step, but this guard's table says it should")
+            found.append(block)
+    if not found:
+        sys.exit(f"FATAL: {path} has no dorny/paths-filter step, but this guard's table says it should")
+    # EXACTLY one, asserted rather than assumed. Returning the first of several
+    # would silently pick a block that may not hold the keys being checked; a
+    # workflow that splits its filter keys across two steps must be looked at,
+    # not guessed at.
+    if len(found) > 1:
+        sys.exit(
+            f"FATAL: {path} has {len(found)} dorny/paths-filter steps. This guard assumes exactly one "
+            "per registered workflow — which block holds a given filter key can no longer be determined"
+        )
+    return found[0]
 
 
 def check_shared_tree_watchers(canonical: list[str]) -> tuple[list[str], int]:
@@ -281,6 +293,18 @@ def check_shared_tree_watchers(canonical: list[str]) -> tuple[list[str], int]:
     checked = 0
     for name, (events, keys) in SHARED_TREE_WATCHERS.items():
         workflow = WORKFLOWS / name
+        # Per ENTRY, not just per table. An entry with empty tuples contributes
+        # nothing to `checked` and validates nothing, while the other entries
+        # keep the global total non-zero — so the run still reports success over
+        # a workflow this table claims to police. That is the same "an empty
+        # result reads as a clean result" shape the global check already guards
+        # against, one level down.
+        if not events or not keys:
+            failures.append(
+                f"{workflow}: declared in SHARED_TREE_WATCHERS with no events and/or no filter keys "
+                "— the table is stale; it would assert nothing about this workflow"
+            )
+            continue
         parsed = _load_yaml(workflow)
         for event in events:
             paths = _event_paths(parsed, workflow, event)

--- a/pipeline-scripts/check_workflow_path_filters.py
+++ b/pipeline-scripts/check_workflow_path_filters.py
@@ -31,6 +31,11 @@ it can pass:
 * every declared location is a superset of the canonical set;
 * every workflow whose dorny step loads the canonical file is declared here
   (reverse check: a new consumer cannot arrive undeclared);
+* every filter in ``SHARED_TREE_WATCHERS`` still names the shared tree (#14885).
+  Those filters deliberately keep a per-product split the canonical set would
+  erase, so they cannot be policed by the superset check above -- but the one
+  entry they all need is the one whose absence made a REQUIRED context report
+  green over work that never ran;
 * ``api-wiring.yml`` still has NO ``pull_request.paths`` (#12934). That absence
   is deliberate -- a path-filtered required check never reports and deadlocks
   the pull request -- and it is exactly the kind of asymmetry a later
@@ -72,10 +77,34 @@ INLINE_CONSUMERS: dict[str, tuple[str, ...]] = {
 NOT_CONSUMERS: dict[str, str] = {
     "verify-generated-types.yml": (
         "its `types` and `slm_types` filters are per-product generated-types "
-        "triggers, deliberately scoped to one backend tree each; collapsing "
-        "them into the canonical set would erase that split. Whether they "
-        "should additionally watch autobot_shared/ is tracked separately."
+        "triggers, deliberately scoped to one backend tree each; the canonical "
+        "set names BOTH backends, so adopting it would erase that split. The "
+        "shared tree they must nonetheless watch (#14885) is asserted by "
+        "SHARED_TREE_WATCHERS below instead."
     ),
+}
+
+# The shared-Python prefix, derived from the canonical set rather than retyped.
+# Hardcoding it here would be a second source of truth for the very thing this
+# guard exists to keep singular.
+SHARED_TREE_PREFIX = "autobot_shared/"
+
+# Filters that cannot adopt the canonical set but must still watch the shared
+# tree (#14885).
+#
+# `verify-generated-types` is a REQUIRED context whose real work self-skipped on
+# an autobot_shared-only change, while BOTH generated api.ts files depend on
+# that tree: autobot_shared/user_management/schemas/user.py is the sole
+# definition of the user schemas both backends re-export, and
+# autobot_shared/openapi_schema.normalize_pattern_anchors rewrites both
+# published specs. A required check reporting green over work that never ran is
+# the #12986 defect class; the per-product split is why it cannot be closed by
+# adopting the canonical list.
+#
+# workflow filename -> (event names whose `paths:` must name it,
+#                       dorny filter keys that must name it)
+SHARED_TREE_WATCHERS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "verify-generated-types.yml": (("push",), ("types", "slm_types")),
 }
 
 # `paths:` on this event must stay ABSENT for these workflows (#12934).
@@ -203,6 +232,82 @@ def check_no_undeclared_consumer() -> list[str]:
     return failures
 
 
+def shared_tree_paths(canonical: list[str]) -> list[str]:
+    """Canonical entries under the shared tree. Dies rather than returning [].
+
+    An empty derivation would make every SHARED_TREE_WATCHERS assertion below
+    vacuously true — a guard that checks nothing is silent in exactly the same
+    way as a guard over a clean tree.
+    """
+    shared = [p for p in canonical if p.startswith(SHARED_TREE_PREFIX)]
+    if not shared:
+        sys.exit(
+            f"FATAL: the canonical '{CANONICAL_KEY}' set names nothing under "
+            f"{SHARED_TREE_PREFIX!r} — SHARED_TREE_WATCHERS would assert nothing"
+        )
+    return shared
+
+
+def _dorny_filters(parsed: dict, path: Path) -> dict:
+    """The inline `filters:` block of *path*'s dorny/paths-filter step.
+
+    Every failure to find one is fatal. A restructured workflow whose filters
+    this guard can no longer locate is the case where "found nothing to check"
+    and "checked and it was fine" are indistinguishable.
+    """
+    for job in (parsed.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict) or "dorny/paths-filter" not in str(step.get("uses", "")):
+                continue
+            raw = (step.get("with") or {}).get("filters")
+            if not isinstance(raw, str):
+                sys.exit(f"FATAL: {path}'s dorny/paths-filter step has no inline `filters:` block")
+            try:
+                block = yaml.safe_load(raw)
+            except yaml.YAMLError as exc:
+                sys.exit(f"FATAL: {path}'s inline `filters:` block is not parseable YAML: {exc}")
+            if not isinstance(block, dict) or not block:
+                sys.exit(f"FATAL: {path}'s inline `filters:` block did not parse to a non-empty mapping")
+            return block
+    sys.exit(f"FATAL: {path} has no dorny/paths-filter step, but this guard's table says it should")
+
+
+def check_shared_tree_watchers(canonical: list[str]) -> tuple[list[str], int]:
+    """Per-product filters that keep their split must still watch the shared tree."""
+    shared = shared_tree_paths(canonical)
+    failures: list[str] = []
+    checked = 0
+    for name, (events, keys) in SHARED_TREE_WATCHERS.items():
+        workflow = WORKFLOWS / name
+        parsed = _load_yaml(workflow)
+        for event in events:
+            paths = _event_paths(parsed, workflow, event)
+            if paths is None:
+                failures.append(f"{workflow}: `on.{event}` declares no `paths:` at all, but must watch {shared}")
+                continue
+            missing = [p for p in shared if p not in paths]
+            checked += 1
+            if missing:
+                failures.append(f"{workflow}: `on.{event}.paths` is missing {missing}")
+            else:
+                print(f"  OK     {workflow} on.{event}.paths watches the shared tree")  # noqa: print
+        block = _dorny_filters(parsed, workflow)
+        for key in keys:
+            entries = block.get(key)
+            if not isinstance(entries, list):
+                failures.append(f"{workflow}: dorny filter '{key}' is absent or is not a list — the table is stale")
+                continue
+            missing = [p for p in shared if p not in entries]
+            checked += 1
+            if missing:
+                failures.append(f"{workflow}: dorny filter '{key}' is missing {missing}")
+            else:
+                print(f"  OK     {workflow} filter '{key}' watches the shared tree")  # noqa: print
+    return failures, checked
+
+
 def check_declarations_resolve() -> list[str]:
     """Every declared workflow must exist.
 
@@ -211,7 +316,12 @@ def check_declarations_resolve() -> list[str]:
     """
     return [
         f"{WORKFLOWS / name}: declared in this guard's table but does not exist — the table is stale"
-        for name in sorted(set(INLINE_CONSUMERS) | set(NOT_CONSUMERS) | set(REQUIRED_ABSENT_PATHS))
+        for name in sorted(
+            set(INLINE_CONSUMERS)
+            | set(NOT_CONSUMERS)
+            | set(REQUIRED_ABSENT_PATHS)
+            | set(SHARED_TREE_WATCHERS)
+        )
         if not (WORKFLOWS / name).is_file()
     ]
 
@@ -232,18 +342,26 @@ def main(argv: list[str] | None = None) -> int:
 
     inline_failures, checked = check_inline_consumers(canonical)
     failures += inline_failures
+    shared_failures, shared_checked = check_shared_tree_watchers(canonical)
+    failures += shared_failures
     failures += check_required_absences()
     failures += check_no_undeclared_consumer()
 
-    if checked == 0:
-        print("\n  FAIL   0 inline path lists were checked — the guard scanned nothing")  # noqa: print
+    if checked == 0 or shared_checked == 0:
+        print(  # noqa: print
+            f"\n  FAIL   {checked} inline path list(s) and {shared_checked} shared-tree "
+            "watcher(s) were checked — a zero on either side means the guard scanned nothing"
+        )
         return 1
 
     for name, reason in sorted(NOT_CONSUMERS.items()):
         print(f"  NOTE   {WORKFLOWS / name} is deliberately not a consumer: {reason}")  # noqa: print
 
     if not failures:
-        print(f"\ncheck-workflow-path-filters: {checked} inline path list(s) match the canonical set")  # noqa: print
+        print(  # noqa: print
+            f"\ncheck-workflow-path-filters: {checked} inline path list(s) match the canonical set, "
+            f"{shared_checked} shared-tree watcher(s) still name it"
+        )
         return 0
 
     print(f"\ncheck-workflow-path-filters: {len(failures)} drift(s)\n")  # noqa: print

--- a/pipeline-scripts/check_workflow_path_filters_test.py
+++ b/pipeline-scripts/check_workflow_path_filters_test.py
@@ -221,3 +221,57 @@ def test_a_canonical_set_naming_no_shared_tree_is_fatal_not_a_pass(tmp_path: Pat
     result = _run(root)
     assert result.returncode != 0
     assert "would assert nothing" in (result.stdout + result.stderr)
+
+
+def test_two_dorny_steps_are_fatal_not_a_guess(tmp_path: Path) -> None:
+    """Returning the first of several blocks would silently check the wrong one."""
+    root = _sandbox(tmp_path)
+    text = (root / VGT).read_text(encoding="utf-8")
+    marker = "      - uses: dorny/paths-filter@"
+    assert marker in text
+    extra = (
+        "  second-filter-job:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d\n"
+        "        with:\n"
+        "          filters: |\n"
+        "            other:\n"
+        "              - 'x/**'\n"
+    )
+    (root / VGT).write_text(text.replace("jobs:\n", "jobs:\n" + extra, 1), encoding="utf-8")
+    result = _run(root)
+    assert result.returncode != 0
+    assert "dorny/paths-filter steps" in (result.stdout + result.stderr)
+
+
+def test_a_watcher_entry_with_empty_tuples_fails(tmp_path: Path) -> None:
+    """An entry that validates nothing must not ride on the other entries' totals.
+
+    The global "zero checked" fallback only fires when the whole table is inert.
+    A single entry declared with empty tuples contributes nothing while the
+    others keep the totals non-zero, so the run would report success over a
+    workflow this table claims to police. Nothing a `.github/` mutation can
+    produce reaches that state, so the table itself is patched in a copy of the
+    guard — the same seam the library stub uses in the baseline guard's tests.
+    """
+    root = _sandbox(tmp_path)
+    src = GUARD.read_text(encoding="utf-8")
+    old = '"verify-generated-types.yml": (("push",), ("types", "slm_types")),'
+    assert old in src, "SHARED_TREE_WATCHERS entry not found — the patch target moved"
+    # A SECOND, valid entry is essential: with only the inert one, the global
+    # "zero checked" fallback fires and the mutation would look killed for the
+    # wrong reason. The copy is byte-identical, so its filters really do pass.
+    shutil.copy(root / VGT, root / ".github/workflows/zz-vgt-copy.yml")
+    patched = root / "patched_guard.py"
+    patched.write_text(
+        src.replace(
+            old,
+            '"verify-generated-types.yml": ((), ()),\n'
+            '    "zz-vgt-copy.yml": (("push",), ("types", "slm_types")),',
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run([sys.executable, str(patched)], cwd=root, capture_output=True, text=True)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "would assert nothing about this workflow" in result.stdout

--- a/pipeline-scripts/check_workflow_path_filters_test.py
+++ b/pipeline-scripts/check_workflow_path_filters_test.py
@@ -148,3 +148,76 @@ def test_every_declared_consumer_is_actually_reached(tmp_path: Path, workflow: s
     result = _run(root)
     assert result.returncode == 1, result.stdout
     assert workflow in result.stdout
+
+
+# ── shared-tree watchers (#14885) ────────────────────────────────────────────
+#
+# `verify-generated-types` is a required context whose real work self-skipped on
+# an autobot_shared-only change, while both generated api.ts files depend on
+# that tree. It keeps a per-product filter split the canonical set would erase,
+# so it is policed by SHARED_TREE_WATCHERS rather than by the superset check —
+# and a second table is a second thing that can go quietly vacuous.
+
+VGT = ".github/workflows/verify-generated-types.yml"
+SHARED = "autobot_shared/**/*.py"
+
+
+@pytest.mark.parametrize("marker", ["types", "slm_types"])
+def test_dropping_the_shared_tree_from_a_dorny_filter_fails(tmp_path: Path, marker: str) -> None:
+    """Each per-product filter is reached individually, not as a pair."""
+    root = _sandbox(tmp_path)
+    _edit(
+        root / VGT,
+        f"            {marker}:\n              - 'autobot",
+        f"            {marker}:\n              - 'REMOVED-MARKER-{marker}'\n              - 'autobot",
+    )
+    # Now delete only this filter's shared entry, leaving the sibling's intact.
+    text = (root / VGT).read_text(encoding="utf-8")
+    head, _, tail = text.partition(f"'REMOVED-MARKER-{marker}'\n")
+    tail = tail.replace(f"              - '{SHARED}'\n", "", 1)
+    (root / VGT).write_text(head + tail, encoding="utf-8")
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert f"dorny filter '{marker}' is missing" in result.stdout
+    assert SHARED in result.stdout
+
+
+def test_dropping_the_shared_tree_from_the_push_trigger_fails(tmp_path: Path) -> None:
+    root = _sandbox(tmp_path)
+    _edit(root / VGT, f"      - '{SHARED}'\n", "")
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert "on.push.paths` is missing" in result.stdout
+
+
+def test_a_renamed_dorny_filter_key_fails_rather_than_exempting_silently(tmp_path: Path) -> None:
+    """A restructure must strand the declaration loudly, not skip past it."""
+    root = _sandbox(tmp_path)
+    _edit(root / VGT, "            slm_types:\n", "            slm_types_v2:\n")
+    result = _run(root)
+    assert result.returncode == 1, result.stdout
+    assert "the table is stale" in result.stdout
+
+
+def test_a_workflow_with_no_dorny_step_is_fatal_not_a_pass(tmp_path: Path) -> None:
+    """"Could not find the filters" and "the filters were fine" are opposite facts."""
+    root = _sandbox(tmp_path)
+    _edit(root / VGT, "      - uses: dorny/paths-filter@", "      - uses: not-dorny/other@")
+    result = _run(root)
+    assert result.returncode != 0
+    assert "has no dorny/paths-filter step" in (result.stdout + result.stderr)
+
+
+def test_a_canonical_set_naming_no_shared_tree_is_fatal_not_a_pass(tmp_path: Path) -> None:
+    """The derivation must die rather than assert nothing.
+
+    Removing the shared tree from the canonical set leaves every inline copy a
+    superset, so the check above stays green — and every shared-tree assertion
+    would pass over an empty list. That is the exact "empty result reads as a
+    clean result" shape, one table over.
+    """
+    root = _sandbox(tmp_path)
+    _edit(root / CANONICAL, f"  - '{SHARED}'\n", "")
+    result = _run(root)
+    assert result.returncode != 0
+    assert "would assert nothing" in (result.stdout + result.stderr)

--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -39,6 +39,13 @@
 # addition in full.
 #
 # Format: <count>|<class>|<file>|<value>
+#
+# THREE `|` PER LINE, EXACTLY. Neither `file` nor `value` is escaped, so a
+# fourth separator makes the record ambiguous -- and the ambiguity is
+# exploitable, not merely untidy: a crafted filename containing `|` lets a
+# reader resolve the FILE field to an unrelated, untouched decoy. The
+# no-growth guard refuses an ambiguous key outright rather than guessing.
+# All 1408 entries below carry exactly three.
 1|other|autobot-backend/a2a/__init__.py|https://a2a-protocol.org/latest/
 1|other|autobot-backend/a2a/agent_card.py|https://backend-host:8443
 1|other|autobot-backend/a2a/agent_card.py|https://github.com/mrveiss/AutoBot-AI

--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -14,11 +14,29 @@
 # prints how many baselined findings it suppressed and the issue that owns the
 # backlog. A backlog nobody is reminded of is indistinguishable from no backlog.
 #
-# THIS FILE ONLY EVER SHRINKS. A finding not listed here fails the build. The
-# count is part of the key, so a SECOND occurrence of an already-known value in
-# an already-known file is a new finding, not a free pass. `--audit-baseline`
-# reports entries that no longer match anything, so a fixed violation cannot
-# leave a stranded exemption behind.
+# THIS FILE ONLY EVER SHRINKS BY DEFAULT. A finding not listed here fails the
+# build. The count is part of the key, so a SECOND occurrence of an
+# already-known value in an already-known file is a new finding, not a free
+# pass. `--audit-baseline` reports entries that no longer match anything, so a
+# fixed violation cannot leave a stranded exemption behind.
+#
+# THE ONE WAY AN ENTRY MAY BE ADDED (#14919). Both halves are required, and the
+# first one cannot be bought:
+#
+#   1. the entry's file is byte-identical to the base ref -- so a detection-rule
+#      change surfaced code that was already here, and this change did not write
+#      the value. An addition in a file the same change TOUCHES is the bypass
+#      this baseline exists to close and has no override of any kind;
+#   2. the change adds a justification line directly above the entry:
+#
+#          # reviewed: #<issue> why this cannot be fixed at the source
+#          1|ssot|path/to/file.py|value
+#
+# The justification is a preceding COMMENT, never a suffix: everything after the
+# first `|` is the key, so a trailing `# reviewed: ...` would change the key
+# until it matched no finding at all. Both halves are enforced by
+# pipeline-scripts/check_baseline_no_growth.sh, which prints every permitted
+# addition in full.
 #
 # Format: <count>|<class>|<file>|<value>
 1|other|autobot-backend/a2a/__init__.py|https://a2a-protocol.org/latest/


### PR DESCRIPTION
Closes #14919, #14885

Two escapes on the same gate shape: one whose escape hatch was missing, one whose escape hatch was accidental.

## Thinking Path

**#14919 — a promise with nothing behind it.** `check_baseline_no_growth.sh` had two outcomes, "no growth, exit 0" and "growth, exit 1", while its own failure text told the reader that growth was "a decision for a reviewer to take deliberately". No such decision existed. The issue offered three options and recommended option 1 (delete the sentence). I took option 2 instead, because the question the issue could not answer turns out to be mechanically answerable.

What makes an addition legitimate? A new detection rule that suddenly matches code already in the tree is legitimate — the change did not write that value. A new hardcoded value is not. Those two are not distinguishable by intent, but they **are** distinguishable by the diff: in the legitimate case the entry's file is untouched; in the bypass case the file necessarily changed, because that is where the value was typed. So the route is keyed on the diff, not on permission. Nothing — no env var, no label, no marker — opens it for a file the same change touches. That case is the bypass itself and stays absolutely closed.

Untouched-file is necessary but not sufficient, or the route degrades into "put your value in a file you also change elsewhere". So it is paired with a written justification (`# reviewed: #<issue> <why>`) that this change must itself add directly above the entry. A justification already in the file covers the entry it was written for, never a later append that happens to sit under it.

The justification is a **preceding comment**, not a suffix on the entry. The baseline key is everything after the first `|`, so a trailing `# reviewed: …` would silently change the key until it matched no finding at all — the guard would pass and the entry would suppress nothing.

**A review of that route found it bypassable twice, which is why there are four commits.** A key is `<class>|<file>|<value>` and neither field is escaped, while `|` is a legal byte in a Linux filename that nothing in this toolchain rejects. For `ssot|autobot-backend/decoy.py|evil_new.py|<secret>` the naive split yields `autobot-backend/decoy.py` — an untouched decoy — while the finding belongs to the brand-new file the change just wrote. Every subsequent test validated the decoy, so the guard printed `ALLOWED` and exited 0 over exactly the addition it exists to refuse. I reproduced it end-to-end before fixing it. An ambiguous key is now **refused rather than parsed**; guessing which part is the file is the whole defect. The producer-side format gap (`_hv_emit` / `hv_partition` split these records positionally too) is filed as #14926 rather than bundled — it is a record-format migration over 1408 entries, not a guard fix.

The second finding, from the re-verification pass: a **symlink** entry. A symlink's blob is the target *path string*, so `git diff --quiet` reports it unchanged however much the file it points at was rewritten — base carries `alias.py -> real.py`, the change rewrites `real.py` to add a secret and baselines `alias.py`, and the byte-identical test passed on the link object. Also reproduced end-to-end. Refusing symlinks costs nothing: `hv_scan_tree` walks with `grep -r`, which does not follow symlinks during traversal, so the detector always reports the finding under the real path. An entry naming a symlink is always a mistake or a decoy. Worth stating plainly: the *wider* gate did not go green over this one — `--audit-baseline` runs unconditionally in the same job, immediately before, and flags the entry as stale — but a guard that validates the wrong object is one nobody can reason about, and neither check asserts that the other will cover it.

Deliberately not covered: a **rename**. Moving a file that carries a baselined value puts the entry on a path absent at base, and it is refused. That is the same answer as before this route existed, so it is not a regression — and loosening test 1 to "the content existed somewhere at base" would also admit a verbatim **copy** of a file, which duplicates a hardcoded value rather than inheriting one.

**#14885 — establishing what can actually alter the generated types.** The issue asked for a measured answer before deciding whether to widen the filter or make the check unskippable. Two independent couplings, read from the code rather than assumed:

- `autobot_shared/user_management/schemas/user.py` is the **sole** definition of `UserResponse`, `UserCreate`, `UserUpdate`, `UserListResponse`, `RoleResponse` and `PasswordChange`. Each backend's `user_management/schemas/user.py` is a re-export shim over it (#12647), and both committed `api.ts` files carry those component schemas (`UserResponse`: 9 references in `autobot-frontend`, 2 in `autobot-slm-frontend`). One field edited there changes both generated files.
- `autobot_shared/openapi_schema.normalize_pattern_anchors` rewrites the published spec, and it is applied by `scripts/audit_api_wiring.py` (used by **both** dump modes this workflow runs) and by `autobot-slm-backend/scripts/dump_openapi.py`.

That settles the direction: **widen the filter, do not make the check unskippable.** The skip here is already safe, and only here, because the required context is the separate `verify-generated-types` reporting job (#13862) — the repo's required-context shim pattern — which always runs and always states a verdict. Making a path-filtered required job unconditional is precisely what deadlocks a pull request (#13388/#12934). The defect was the filter's reach, not the existence of a skip. I verified the pairing rather than assuming it: `verify-generated-types` is `if: always()`, `needs: [changes, verify-types-run]`, and fails when `changes` did not succeed, so it cannot report success over a `changes` job that broke.

**Cost of widening, measured:** 46 of the last 300 first-parent commits on `Dev_new_gui` touch only `autobot_shared/**/*.py`. That is both the size of the blind spot and the added run cost — ~15% more `verify-types-run` executions.

## What Changed

**#14919 — `pipeline-scripts/check_baseline_no_growth.sh`**

- One addition route, gated on two independent tests, each of which must pass for every growth entry: (1) the entry's file exists at the base ref and `git diff --quiet` shows it byte-identical; (2) the nearest non-blank line above the entry matches `# reviewed: #<issue> <why>` **and** is among the lines this change adds to the baseline.
- Every permitted addition is printed in full and emitted as a `::warning file=…::` annotation. Growth is loud, never silent.
- Every growth line must reach exactly one verdict; `allowed + refused` is reconciled against the number of lines the library emitted before anything can exit 0. Counted with `wc -l`, **not** the non-blank count — the loop skips a blank growth line, so counting only non-blank lines here would make that skip agree with itself and leave the assertion unfalsifiable.
- Bug found while testing: an added blank line in the baseline diff produced a bare `+`, whose key is the empty string — a bad array subscript, and worse, an entry with no marker could have read as having one.
- **A symlink entry is refused.** Its blob is the target path, so "byte-identical" says nothing about the content the value lives in.
- **An ambiguous key is refused, not parsed.** A growth key must carry exactly two `|` separators or it is refused with that reason named. All 1408 live baseline entries carry exactly two, so this costs nothing today.
- The `ADDED_LINES` diff is written to a file and its exit status checked, rather than consumed from a `<(...)` process substitution whose failure is invisible to `set -e` and `pipefail`. It was already fail-closed; it now fails with the accurate message rather than "already in the baseline".
- The failure message now describes only what the guard implements, and names the route and its price.
- `docs/developer/HARDCODING_PREVENTION.md` and the baseline file's own header document the route.

**#14885 — `.github/workflows/verify-generated-types.yml`**

- `autobot_shared/**/*.py` added to the `types` filter, the `slm_types` filter, and the `on.push.paths` trigger. The per-product split is preserved intact — the canonical `backend-python` set names *both* backends, so adopting it would have erased the split the guard's own table says must be kept.
- `verify-generated-types-slm` moves from `== 'true'` to `!= 'false'`, matching its sibling. Adjacent instance of the same fail-open shape, found in the same file: an empty filter output must run the check, not skip it.
- Header records the measurement, the cost, and why the answer was "widen" rather than "unskippable".

**#14885 — `pipeline-scripts/check_workflow_path_filters.py`**

- New `SHARED_TREE_WATCHERS` table plus `check_shared_tree_watchers()`: asserts both dorny filter keys and the push trigger still name the shared tree. `NOT_CONSUMERS`' reason is rewritten — the "tracked separately" clause is now resolved, and it says which table does the policing.
- The required entry is **derived** from the canonical set (`shared_tree_paths()`), not retyped, and the derivation `sys.exit`s rather than returning an empty list. An empty derivation would make every assertion vacuously true.
- `_dorny_filters()` exits fatally on a workflow whose filters it cannot locate — "could not find the filters" and "the filters were fine" are opposite facts.
- `SHARED_TREE_WATCHERS` joins the stale-declaration union, and `main()` now fails when either the inline count **or** the shared-tree count is zero.
- Each table entry must declare non-empty `events` **and** `keys`. The global zero-check only fires when the whole table is inert; a single entry with empty tuples would validate nothing while the other entries keep the totals non-zero.
- `_dorny_filters()` refuses a workflow with more than one paths-filter step rather than returning the first. Correct for today's single entry, but which block holds a given key would otherwise be a guess.

## Verification

Both guards were mutated in a scratch copy outside the repository and never committed. Targets were asserted present before each mutation — a mutation whose target is missing reports a false PASS.

**#14919 — `check_baseline_no_growth_test.py`, 25 tests (17 new). Legitimate direction: 25 passed on the unmutated guard; 12 of 12 mutants killed.**

| # | mutation | result |
|---|---|---|
| M1 | drop the modified-file refusal (**the bypass itself**) | RED — `test_a_justified_addition_in_a_file_this_change_touches_fails` |
| M2 | drop the justification requirement | RED — 2 tests |
| M3 | let a pre-existing justification be reused | RED — `test_a_justification_that_predates_the_change_cannot_be_reused` |
| M4 | drop the file-created-by-this-change refusal | RED — `test_a_justified_addition_in_a_file_this_change_creates_fails` |
| M5 | drop the adjudicated-total reconciliation | RED — `test_a_growth_line_the_parser_drops_is_fatal_not_a_pass` |
| M6 | drop the file-presence check | RED — `test_an_entry_naming_an_absent_file_says_so` |
| M7 | drop the empty-growth-verdict FATAL | RED — `test_a_growth_verdict_with_no_entries_is_fatal_not_a_pass` |
| M8 | let a refused addition still exit 0 | RED — 12 tests |
| M9 | drop the empty-file-field refusal | RED — `test_an_empty_file_field_is_refused` |
| M10 | let a failed baseline diff pass silently | RED — 4 tests |
| **M0** | **drop the ambiguous-key refusal (first bypass review found)** | **RED — 2 tests** |
| **M11** | **drop the symlink refusal (second bypass review found)** | **RED — `test_an_entry_naming_a_symlink_is_refused`** |

M5 and M6 **survived the first sweep**, and that is why the code changed rather than the report. M5's reconciliation was unreachable as originally written — nothing the library can emit could trigger it — so it was made reachable (`wc -l` vs the non-blank count) and is now covered by a test that stubs the library into emitting a line the loop skips. M6 was killable only on its message, so the test now asserts the message rather than the exit code.

**#14885 — `check_workflow_path_filters_test.py`, 22 tests (8 new). Legitimate direction: 22 passed on the real, unmutated `.github/` tree, with the guard printing all three new `OK` lines.**

| # | mutation | result |
|---|---|---|
| N1 | stop checking the dorny filters for the shared tree | RED — 3 tests |
| N2 | stop checking the push trigger | RED — 13 tests |
| N3 | let an empty shared derivation through instead of dying | RED — `test_a_canonical_set_naming_no_shared_tree_is_fatal_not_a_pass` |
| N4 | let a missing dorny step read as no filters | RED — `test_a_workflow_with_no_dorny_step_is_fatal_not_a_pass` |
| N7 | accept two dorny steps by returning the first | RED — `test_two_dorny_steps_are_fatal_not_a_guess` |
| N8 | drop the per-entry empty-tuple assertion | RED — `test_a_watcher_entry_with_empty_tuples_fails` |
| N5 | drop `SHARED_TREE_WATCHERS` from the stale-declaration union | **SURVIVED — equivalent** |
| N6 | stop failing when zero shared-tree watchers were checked | **SURVIVED — equivalent** |

N8 also survived its first sweep, and the test that kills it needs a second, *valid* table entry — with only the inert one, the global zero-check fires and the mutant looks killed for the wrong reason.

N5 and N6 are reported as surviving rather than papered over. Both are equivalent mutants *given today's tables*: `verify-generated-types.yml` is in `NOT_CONSUMERS` as well, so the stale-declaration union already covers it (N5); and reaching `shared_checked == 0` with no failures now requires an empty table, since a per-entry empty tuple is caught by name (N6). Both are kept as fail-closed backstops and neither is load-bearing today.

The workflow change is proven in both directions by N1/N2's tests, which mutate the **workflow** (remove the shared-tree entry from one filter at a time) and confirm the guard goes red, while the real tree passes.

Ten adversarial probes were also run directly against the guard in a scratch repository, covering values containing `)` and `|`, paths containing spaces, the bypass wearing a marker, a non-adjacent marker, a marker without an issue number, a deleted file, and a mode-only change. All ten behave as designed.

A `code-reviewer` pass was run on the branch, then a second pass re-verifying the fixes adversarially. Between them they produced: the critical ambiguous-key bypass, the symlink gap, two low findings, and one informational note — **all five fixed here**, each with a regression test and a mutant that proves the test bites. The second pass confirmed the original exploit is closed, that "exactly two separators" is sound rather than heuristic (any embedded `|` pushes the count above two, so a count of two guarantees an unambiguous split), that a filename containing a newline cannot be represented in the record format at all and exits through the designed FATAL, and that the legitimate case still goes green. Its verified-not-a-finding items — submodules, mode-only diffs, and whether widening the filters can deadlock a PR — are reflected above.

`git diff origin/Dev_new_gui -- pipeline-scripts/hardcoded_values_baseline.txt` adds and removes **zero** entry lines — this PR's baseline edit is comment-only, so it does not exercise its own new route.

**Not delivered, and the reason:** #14885's "Ask" bullet 3 wants a CI **run** showing the workflow triggering on an `autobot_shared`-only change. That cannot be produced pre-merge without pushing a throwaway commit whose only purpose is CI evidence, which this repository forbids. The push trigger now names the shared tree, so the first `autobot_shared`-only push to `Dev_new_gui` after merge produces exactly that run — filed as a follow-up and cross-linked on #14885. The issue's four acceptance-criteria checkboxes are all delivered here.

`actionlint` is not installed locally; the workflow parses under `yaml.safe_load` and the CI gate runs `actionlint`.

## Model Used

Claude Opus 5 (1M context)
