### PR TITLE
fix(ci): triage every failure and error in the marker-excluded suite, and make it report an executed count (#14930)

### DIFF
--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -30,6 +30,33 @@
 #     Redis, so one is provided below rather than letting the first night fail
 #     for infrastructure reasons and calling it "the point". #13286 stays open
 #     until a run is green or its remaining failures have been triaged.
+#
+#     TRIAGED under #14930. The run on 2026-08-24 read
+#     `19 failed, 35 passed, 12 skipped, 19 errors`. All 38 non-passes were one
+#     defect class in two disguises: a live service the runner does not have,
+#     reported as a hard result instead of a stated non-result.
+#       * 19 errors — `redis_service_api_integration_test.py` had no
+#         `backend_url` fixture on this tree at all, so every test in it errored
+#         at setup. The fixture is now defined in the module.
+#       * 16 failures — `infrastructure_integration_test.py` (6) and
+#         `voice_integration_test.py` (10) dial a backend on :8001 and a TTS
+#         worker on :8083 over real HTTP. Both now skip, naming the absent
+#         service, via `autobot_shared.live_service_probe`.
+#       * 2 failures — the two knowledge-base tests. NOT an infrastructure gap:
+#         the Redis below is healthy, but `autobot-backend/conftest.py` replaces
+#         `autobot_shared.redis_client` with a socket-free stand-in for every
+#         backend item, markers included, so `get_redis_client()` returns None
+#         whatever Redis is running. Tracked as #14932; they skip on that
+#         structural condition until it lands, then run for real.
+#       * 1 failure — `performance_benchmarks_test.py` asserted absolute process
+#         RSS under 500 MB. A worker sits at ~1.6 GB from imports alone before
+#         the first benchmark, so the budget was spent before the test started.
+#         Now measured as the RSS delta across the operation, which is what the
+#         assertion always meant.
+#
+#     A skip is a real outcome here, not a pass. "Report marker coverage" below
+#     prints the counts and fails the job if the selection collected nothing, so
+#     the difference is on the run page instead of inferred from a log.
 #   * No coverage gate. Coverage is measured by the PR gate; adding tracing here
 #     would roughly double the runtime for no added assertion.
 #   * Two invocations, same reason as ci.yml: autobot-backend/ and
@@ -48,17 +75,16 @@ on:
   # workflows named marker-tests.yml" because GitHub had never registered it.
   #
   # That changes the moment the integration branch is promoted to the default
-  # branch — the cron would start firing immediately. Its one observed run is
-  # RED (11 failed, 7 passed, 40 errors), so registering it as-is would install
-  # a nightly that fails every night against the default branch. A permanently
-  # red scheduled workflow is not a signal; it is noise that trains everyone to
+  # branch — the cron would start firing immediately. A permanently red
+  # scheduled workflow is not a signal; it is noise that trains everyone to
   # ignore the one place marker-excluded regressions would show up.
   #
   # So the cron is commented rather than deleted — it is correct, and it is what
-  # #13286 exists to deliver. Restore it as the closing step of that issue, once
-  # the 11 failures and 40 collection errors are triaged and the suite is green.
-  # `workflow_dispatch` below stays live, so the suite remains runnable on demand
-  # to verify exactly that.
+  # #13286 exists to deliver. #14930 triaged every failure and error the suite
+  # was carrying (see the block above); restore the cron as the closing step of
+  # #13286, and raise MARKER_MIN_PASSED to the figure the run then reports so a
+  # later collapse cannot pass unnoticed. `workflow_dispatch` below stays live,
+  # so the suite remains runnable on demand to verify exactly that.
   #
   # schedule:
   #   # 03:20 UTC daily — off the */15 dispatch-watchdog and */30 runner-health
@@ -118,6 +144,17 @@ jobs:
       # Single source for the marker expression: the schedule uses the default,
       # a manual dispatch may narrow it to one marker while triaging.
       MARKER_EXPRESSION: ${{ github.event.inputs.markers || 'integration or slow or distributed or performance' }}
+      # Floor for the number of marker-carrying tests that must PASS (#14930).
+      # This is a ratchet, not a target: raise it when the suite genuinely
+      # covers more, and lower it only with a stated reason for which tests
+      # stopped running. A silent drop is the failure mode it exists to catch —
+      # the suite ran 35 passing tests while reading as an undifferentiated red,
+      # so nobody would have noticed the number falling to 3.
+      #
+      # Kept at the presence floor (1) until the first run under this workflow
+      # reports a real post-fix figure; #13286 raises it to that number as part
+      # of turning the schedule on.
+      MARKER_MIN_PASSED: '1'
 
     steps:
       - uses: actions/checkout@v7
@@ -175,13 +212,17 @@ jobs:
       - name: Run marked tests — backend, shared, tts-worker, repo_tests
         run: |
           echo "Selecting: $MARKER_EXPRESSION"
-          # Exit 5 is pytest's "no tests collected". For a marker selection that
-          # is a legitimate outcome (no test currently carries the marker in this
-          # tree), not a failure — anything else propagates.
+          # Exit 5 is pytest's "no tests collected". Tolerated here ONLY so the
+          # second invocation still runs and the report step still gets both
+          # files — it is NOT accepted as an outcome: "Report marker coverage"
+          # below fails the job when the two invocations collected nothing
+          # between them. Before #14930 this line was the whole story, and an
+          # empty selection was indistinguishable from a passing one.
           python -m pytest \
             autobot-backend autobot_shared autobot-tts-worker repo_tests \
             -n auto --dist loadscope \
             -m "$MARKER_EXPRESSION" \
+            --junitxml=marker-report-backend.xml \
             --tb=short \
             --durations=25 \
             -q || [ $? -eq 5 ]
@@ -196,6 +237,37 @@ jobs:
             autobot-slm-backend \
             -n auto --dist loadscope \
             -m "$MARKER_EXPRESSION" \
+            --junitxml=marker-report-slm.xml \
             --tb=short \
             --durations=25 \
             -q || [ $? -eq 5 ]
+
+      # The one verdict pytest cannot give: "the selection still matches the
+      # tests it is supposed to match" (#14930).
+      #
+      # Runs on failure too — deliberately. A red pytest step that skipped this
+      # would hide exactly the case worth seeing: a suite whose coverage
+      # collapsed AND whose remainder failed. The counts are printed here and
+      # written to the run summary, so a drop from the recorded baseline is
+      # visible on the run page rather than buried in 4,000 lines of log.
+      #
+      # A missing report file is a hard failure inside the script, not a zero:
+      # a pytest that died before writing its XML must never read as "collected
+      # nothing", let alone as clean.
+      - name: Report marker coverage
+        if: ${{ !cancelled() }}
+        run: |
+          python pipeline-scripts/marker_suite_report.py \
+            backend=marker-report-backend.xml \
+            slm=marker-report-slm.xml \
+            --min-collected 1 \
+            --min-passed "$MARKER_MIN_PASSED"
+
+      - name: Upload marker reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: marker-suite-reports
+          path: marker-report-*.xml
+          if-no-files-found: error
+          retention-days: 14

--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -20,12 +20,27 @@ import requests
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from autobot_shared.live_service_probe import require_live_endpoint
 from autobot_shared.paths import project_root
 from constants.network_constants import ServiceURLs
 
 pytestmark = pytest.mark.integration
 
 BASE_URL = f"{ServiceURLs.BACKEND_API}/api/iac"
+
+
+@pytest.fixture(autouse=True)
+def _require_live_backend() -> None:
+    """Skip when no backend is listening, instead of failing on a refused socket (#14930).
+
+    Every check in this module dials ``BASE_URL`` over real HTTP. On a runner
+    with no backend up, all six reported ``ConnectionRefusedError`` as test
+    failures — a red result that says nothing about the code under test and
+    trained the whole marker-excluded suite to be ignored. A skip naming the
+    absent service is the honest report; the tests still run, and still fail
+    for real, wherever a backend is actually up.
+    """
+    require_live_endpoint(ServiceURLs.BACKEND_API, what="the AutoBot backend API")
 
 
 def test_health():

--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -29,17 +29,35 @@ pytestmark = pytest.mark.integration
 BASE_URL = f"{ServiceURLs.BACKEND_API}/api/iac"
 
 
+# ``test_celery_worker_status`` reads ``logs/celery-worker.log`` off disk and
+# issues no HTTP at all, so a backend that is down does not stop it — it was
+# passing before #14930 and must keep passing. A module-wide guard would have
+# traded a red result for lost coverage, which is the wrong trade and was caught
+# by comparing the skip count (7) against the number of tests that actually
+# failed on a refused connection (6).
+_NEEDS_NO_BACKEND = ("test_celery_worker_status",)
+
+
 @pytest.fixture(autouse=True)
-def _require_live_backend() -> None:
+def _require_live_backend(request) -> None:
     """Skip when no backend is listening, instead of failing on a refused socket (#14930).
 
-    Every check in this module dials ``BASE_URL`` over real HTTP. On a runner
-    with no backend up, all six reported ``ConnectionRefusedError`` as test
-    failures — a red result that says nothing about the code under test and
-    trained the whole marker-excluded suite to be ignored. A skip naming the
-    absent service is the honest report; the tests still run, and still fail
-    for real, wherever a backend is actually up.
+    The six checks that dial ``BASE_URL`` over real HTTP reported
+    ``ConnectionRefusedError`` as test failures on a runner with no backend up —
+    a red result that says nothing about the code under test and trained the
+    whole marker-excluded suite to be ignored. A skip naming the absent service
+    is the honest report; they still run, and still fail for real, wherever a
+    backend is actually up.
     """
+    stranded = [name for name in _NEEDS_NO_BACKEND if name not in globals()]
+    assert not stranded, (
+        f"_NEEDS_NO_BACKEND names {stranded}, which no longer exist in this module. "
+        f"A rename stranded the exemption: it now exempts nothing, silently."
+    )
+
+    if request.node.name in _NEEDS_NO_BACKEND:
+        return
+
     require_live_endpoint(ServiceURLs.BACKEND_API, what="the AutoBot backend API")
 
 

--- a/autobot-backend/api/voice_integration_test.py
+++ b/autobot-backend/api/voice_integration_test.py
@@ -19,6 +19,7 @@ import wave
 import pytest
 import requests
 
+from autobot_shared.live_service_probe import require_live_endpoint
 from autobot_shared.ssot_config import config
 
 # #12510: these tests hit a live backend + TTS worker over real HTTP, so they
@@ -31,6 +32,21 @@ pytestmark = pytest.mark.integration
 BACKEND_URL = config.backend_url
 TTS_WORKER_URL = config.tts_worker_url
 LATENCY_BUDGET_SEC = 5.0  # STT → TTS round-trip target
+
+
+@pytest.fixture(autouse=True)
+def _require_live_voice_stack() -> None:
+    """Skip when the backend or the TTS worker is absent (#14930).
+
+    All ten tests here drive the real pipeline over HTTP. On a GitHub-hosted
+    runner neither service exists, so each failed with a refused connection —
+    ten red results that measured the runner's inventory, not the voice
+    pipeline. Both endpoints are checked because the module drives both
+    directly, and a skip that named only one would misreport which half of the
+    stack was missing.
+    """
+    require_live_endpoint(BACKEND_URL, what="the AutoBot backend API")
+    require_live_endpoint(TTS_WORKER_URL, what="the AutoBot TTS worker")
 
 
 # ------------------------------------------------------------------ #

--- a/autobot-backend/knowledge/gpu_kb_integration_test.py
+++ b/autobot-backend/knowledge/gpu_kb_integration_test.py
@@ -23,7 +23,35 @@ They now assert instead of returning, so a regression fails the run.
 
 import pytest
 
+from autobot_shared.live_service_probe import require_real_redis_client
 from utils.semantic_chunker_gpu import get_gpu_semantic_chunker
+
+
+@pytest.fixture(autouse=True)
+def _require_real_redis(request) -> None:
+    """Skip while the backend conftest's Redis stand-in is installed (#14930, #14932).
+
+    ``get_knowledge_base()`` initialises Redis first (``knowledge/base.py``
+    step 1) and raises ``RuntimeError: Failed to initialize knowledge base``
+    when it cannot. In the marker-excluded run that is not an infrastructure
+    gap — the workflow provides a healthy Redis — it is
+    ``autobot-backend/conftest.py`` replacing ``autobot_shared.redis_client``
+    with a socket-free stand-in whose ``get_redis_client`` returns ``None`` for
+    every item under ``autobot-backend/``, markers included. #14932 owns that.
+
+    The condition checked is structural (is the real module installed?), not the
+    test's own failure, so this stops skipping by itself the moment #14932
+    lands — and a knowledge base that then fails to initialise fails the test,
+    which is the point.
+
+    Scoped to ``integration``-marked items only. Both files in this directory
+    pair the marked test with a hermetic one that needs no Redis at all and runs
+    on the PR unit gate; guarding those too would silently disable a passing
+    gate test, which is the same class of damage this change exists to undo.
+    """
+    if request.node.get_closest_marker("integration") is None:
+        return
+    require_real_redis_client("the knowledge base")
 
 # Long enough that chunking has something to divide, short enough to stay fast.
 SAMPLE_TEXT = (

--- a/autobot-backend/knowledge/gpu_kb_integration_test.py
+++ b/autobot-backend/knowledge/gpu_kb_integration_test.py
@@ -53,6 +53,7 @@ def _require_real_redis(request) -> None:
         return
     require_real_redis_client("the knowledge base")
 
+
 # Long enough that chunking has something to divide, short enough to stay fast.
 SAMPLE_TEXT = (
     "AutoBot is an advanced Linux administration platform designed for intelligent automation. "

--- a/autobot-backend/knowledge/kb_optimization_test.py
+++ b/autobot-backend/knowledge/kb_optimization_test.py
@@ -13,12 +13,40 @@ import time
 
 import pytest
 
+from autobot_shared.live_service_probe import require_real_redis_client
 from autobot_shared.ssot_config import config
 
 # Add AutoBot to path
 sys.path.insert(0, config.project_root)
 
 from knowledge_base import get_knowledge_base
+
+
+@pytest.fixture(autouse=True)
+def _require_real_redis(request) -> None:
+    """Skip while the backend conftest's Redis stand-in is installed (#14930, #14932).
+
+    ``get_knowledge_base()`` initialises Redis first (``knowledge/base.py``
+    step 1) and raises ``RuntimeError: Failed to initialize knowledge base``
+    when it cannot. In the marker-excluded run that is not an infrastructure
+    gap — the workflow provides a healthy Redis — it is
+    ``autobot-backend/conftest.py`` replacing ``autobot_shared.redis_client``
+    with a socket-free stand-in whose ``get_redis_client`` returns ``None`` for
+    every item under ``autobot-backend/``, markers included. #14932 owns that.
+
+    The condition checked is structural (is the real module installed?), not the
+    test's own failure, so this stops skipping by itself the moment #14932
+    lands — and a knowledge base that then fails to initialise fails the test,
+    which is the point.
+
+    Scoped to ``integration``-marked items only. Both files in this directory
+    pair the marked test with a hermetic one that needs no Redis at all and runs
+    on the PR unit gate; guarding those too would silently disable a passing
+    gate test, which is the same class of damage this change exists to undo.
+    """
+    if request.node.get_closest_marker("integration") is None:
+        return
+    require_real_redis_client("the knowledge base")
 
 # Test document content
 TEST_DOCUMENT_CONTENT = """

--- a/autobot-backend/knowledge/kb_optimization_test.py
+++ b/autobot-backend/knowledge/kb_optimization_test.py
@@ -48,6 +48,7 @@ def _require_real_redis(request) -> None:
         return
     require_real_redis_client("the knowledge base")
 
+
 # Test document content
 TEST_DOCUMENT_CONTENT = """
 AutoBot System Architecture and Design Philosophy

--- a/autobot-backend/performance_benchmarks_test.py
+++ b/autobot-backend/performance_benchmarks_test.py
@@ -49,20 +49,42 @@ class PerformanceBenchmark:
         self.metrics = []
         self.start_time = None
         self.end_time = None
+        self.start_rss_mb = None
 
     def start_measurement(self):
         """Start performance measurement"""
         self.start_time = time.perf_counter()
+        # #14930: record the baseline so end_measurement can report the memory
+        # THIS operation cost. See end_measurement for why the absolute figure
+        # was the wrong number.
+        self.start_rss_mb = psutil.Process().memory_info().rss / 1024 / 1024
 
     def end_measurement(self):
-        """End performance measurement and record metrics"""
+        """End performance measurement and record metrics.
+
+        ``memory_usage`` is the RSS *delta* across the measured region, not the
+        process's absolute RSS (#14930).
+
+        The absolute figure made ``assert stats["max_memory_mb"] < 500`` a
+        measurement of the interpreter's import footprint rather than of the
+        operation under test: importing the orchestrator, knowledge base,
+        memory manager and LLM service leaves a pytest-xdist worker at ~1.6 GB
+        before the first benchmark runs, so the assertion reported
+        ``1644.55 > 500`` and named it "Memory usage too high" on every run. It
+        could not have passed, and it could not have caught a regression in the
+        code it names — a budget that is spent before the test starts is not a
+        budget. The delta is the quantity the assertion always meant.
+        """
         self.end_time = time.perf_counter()
         duration = self.end_time - self.start_time
+        rss_mb = psutil.Process().memory_info().rss / 1024 / 1024
+        baseline_mb = getattr(self, "start_rss_mb", rss_mb)
         self.metrics.append(
             {
                 "duration": duration,
                 "timestamp": time.time(),
-                "memory_usage": psutil.Process().memory_info().rss / 1024 / 1024,  # MB
+                "memory_usage": rss_mb - baseline_mb,  # MB grown during this measurement
+                "rss_mb": rss_mb,  # absolute, kept for reporting only
                 "cpu_percent": psutil.Process().cpu_percent(),
             }
         )
@@ -145,7 +167,13 @@ class TestLLMServicePerformance:
 
             # Performance assertions
             assert stats["avg_duration"] < 2.0, f"LLM response too slow for prompt length {len(prompt)}"
-            assert stats["max_memory_mb"] < 500, "Memory usage too high"
+            # #14930: a delta budget. 500 MB of GROWTH from one mocked chat()
+            # call would be a genuine leak; 500 MB of absolute RSS is just
+            # AutoBot being imported.
+            assert stats["max_memory_mb"] < 500, (
+                f"one measured operation grew RSS by {stats['max_memory_mb']:.1f} MB "
+                f"(budget 500 MB) for prompt length {len(prompt)}"
+            )
 
         # Log results for analysis
         print("\nLLM Performance Results:")  # noqa: print

--- a/autobot-backend/services/redis_service_api_integration_test.py
+++ b/autobot-backend/services/redis_service_api_integration_test.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.live_service_probe import require_live_endpoint
 from autobot_shared.logging_manager import get_logger
 
 try:
@@ -37,6 +38,44 @@ logger = get_logger(__name__)
 
 
 # Fixtures
+@pytest.fixture(scope="session")
+def backend_url() -> str:
+    """Base URL of the backend API these tests drive (#14930).
+
+    Nothing under ``autobot-backend/`` defined this fixture, so every test in
+    the module errored at setup with ``fixture 'backend_url' not found`` — 19
+    of the 19 collection errors in the marker-excluded suite came from this one
+    file. The only conftest that provided it,
+    ``autobot-infrastructure/shared/tests/conftest.py``, is not on this tree's
+    conftest chain.
+
+    Providing it rather than deselecting the module is deliberate: the tests are
+    well-formed and *should* run — see ``_require_live_backend`` below for the
+    condition under which they can.
+    """
+    from constants.network_constants import ServiceURLs
+
+    return ServiceURLs.BACKEND_API
+
+
+@pytest.fixture(autouse=True)
+def _require_live_backend(backend_url) -> None:
+    """These tests issue real HTTP; skip when no backend is listening.
+
+    Unlike ``knowledge_api_integration_test.py`` — which patches
+    ``aiohttp.ClientSession.get`` and therefore only needs a syntactically valid
+    URL — every request here goes over the wire to ``backend_url`` through a
+    genuine ``httpx.AsyncClient``. Patching ``api.service_management.redis_service_manager``
+    affects this process, not the server being dialled. So a live backend is a
+    real precondition, and without one the correct report is "not exercised
+    here", not ``ConnectionRefusedError`` dressed up as a test failure.
+
+    Autouse rather than module-level: a deselected test never runs the fixture,
+    so the PR unit gate pays nothing for this.
+    """
+    require_live_endpoint(backend_url, what="the AutoBot backend API")
+
+
 @pytest.fixture
 async def api_client(backend_url):
     """Create async HTTP client for API testing."""

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -1926,3 +1926,21 @@ register_env_var(
         component="backend",
     )
 )
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LIVE_PROBE_TIMEOUT_SECONDS",
+        type=float,
+        default=1.0,
+        description=(
+            "Seconds a test's live-service precondition probe waits for a TCP connect "
+            "before reporting the service as absent and skipping "
+            "(autobot_shared/live_service_probe.py, #14930). Short by default: a "
+            "refused loopback connect returns immediately, and this runs once per "
+            "endpoint per process. Raise it when probing a fleet host across a link "
+            "slow enough that a live service could be mistaken for a missing one."
+        ),
+        component="testing",
+        range=(0.1, 60.0),
+    )
+)

--- a/autobot_shared/live_service_probe.py
+++ b/autobot_shared/live_service_probe.py
@@ -1,0 +1,131 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Precondition probes for tests that drive a *live* AutoBot service (#14930).
+
+Several suites under the ``integration`` / ``performance`` markers issue real
+HTTP to a running backend, TTS worker or embedding provider. On a GitHub-hosted
+runner none of those are up, so the tests did not report "not exercised here" —
+they reported ``ConnectionRefusedError`` as a test failure, or (when the URL
+fixture did not exist at all) as a setup error. 38 such results made the
+marker-excluded suite permanently red and therefore unread.
+
+The distinction this module draws is deliberately narrow:
+
+* **Nothing is listening on the endpoint** — the service under test is absent,
+  so the test was never exercised. That is a ``skip`` with a stated reason.
+* **Anything else** — a connected service answering wrongly, a bad URL, a
+  programming error — is a real result and propagates untouched.
+
+That boundary is the whole point. A guard that swallowed *any* exception would
+be a test that cannot fail, which is the defect class this repo keeps paying
+for; ``endpoint_is_listening`` therefore catches ``OSError`` (every network
+condition: refused, unreachable, timed out, DNS failure) and nothing wider.
+A ``TypeError`` from a malformed argument still raises.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from urllib.parse import urlsplit
+
+__all__ = [
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "endpoint_is_listening",
+    "reset_probe_cache",
+    "require_live_endpoint",
+    "split_endpoint",
+]
+
+# Env-var-backed module constant rather than a literal at the call site: a
+# fleet run may need longer than a loopback run, and no caller should hardcode
+# its own budget. Kept short — this runs before every guarded test, and a
+# refused loopback connect returns in well under a millisecond.
+DEFAULT_PROBE_TIMEOUT_SECONDS = float(os.getenv("AUTOBOT_LIVE_PROBE_TIMEOUT_SECONDS", "1.0"))
+
+_DEFAULT_PORTS = {"http": 80, "https": 443, "redis": 6379, "rediss": 6379, "ws": 80, "wss": 443}
+
+# Probing once per endpoint per process keeps an autouse guard from opening a
+# socket for every test in a 19-test module.
+_PROBE_CACHE: dict[tuple[str, int], bool] = {}
+
+
+def reset_probe_cache() -> None:
+    """Forget every cached probe result.
+
+    Exposed for tests of this module itself: without it a cached ``False`` from
+    one case would decide the next one.
+    """
+    _PROBE_CACHE.clear()
+
+
+def split_endpoint(target: str, port: int | None = None) -> tuple[str, int]:
+    """Return ``(host, port)`` for a URL or a bare host.
+
+    Raises ``ValueError`` when no port can be determined, rather than guessing —
+    a probe against the wrong port would report a live service as absent and
+    silently skip a suite that should have run.
+    """
+    if not isinstance(target, str) or not target.strip():
+        raise ValueError(f"endpoint target must be a non-empty string, got {target!r}")
+
+    target = target.strip()
+    parts = urlsplit(target if "//" in target else f"//{target}")
+    host = parts.hostname
+    if not host:
+        raise ValueError(f"could not determine a host from endpoint {target!r}")
+
+    resolved_port = port or parts.port or _DEFAULT_PORTS.get((parts.scheme or "").lower())
+    if not resolved_port:
+        raise ValueError(f"could not determine a port from endpoint {target!r}; pass port= explicitly")
+
+    return host, int(resolved_port)
+
+
+def endpoint_is_listening(
+    target: str,
+    port: int | None = None,
+    timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
+    use_cache: bool = True,
+) -> bool:
+    """True when a TCP connection to *target* is accepted.
+
+    This asks exactly one question — *is a process accepting connections here* —
+    and answers it without sending a byte of protocol. It says nothing about
+    whether that process is healthy, which is the tests' job to assert.
+
+    Only ``OSError`` is treated as "not listening". ``ValueError`` from
+    :func:`split_endpoint` propagates: a target this module cannot parse is a
+    bug in the caller, and reporting it as "absent" would skip a live suite.
+    """
+    host, resolved_port = split_endpoint(target, port)
+    key = (host, resolved_port)
+
+    if use_cache and key in _PROBE_CACHE:
+        return _PROBE_CACHE[key]
+
+    try:
+        with socket.create_connection((host, resolved_port), timeout=timeout):
+            listening = True
+    except OSError:
+        listening = False
+
+    if use_cache:
+        _PROBE_CACHE[key] = listening
+    return listening
+
+
+def require_live_endpoint(target: str, what: str, port: int | None = None) -> None:
+    """Skip the calling test iff nothing is listening on *target*.
+
+    *what* names the missing service in the skip reason, so a skipped run says
+    which part of the stack was absent instead of reading as an unexplained
+    non-result.
+    """
+    host, resolved_port = split_endpoint(target, port)
+    if endpoint_is_listening(target, port):
+        return
+
+    import pytest
+
+    pytest.skip(f"{what} is not listening on {host}:{resolved_port} — this test drives a live service")

--- a/autobot_shared/live_service_probe.py
+++ b/autobot_shared/live_service_probe.py
@@ -27,15 +27,20 @@ from __future__ import annotations
 
 import os
 import socket
+import sys
 from urllib.parse import urlsplit
 
 __all__ = [
     "DEFAULT_PROBE_TIMEOUT_SECONDS",
     "endpoint_is_listening",
-    "reset_probe_cache",
+    "redis_client_is_stubbed",
     "require_live_endpoint",
+    "require_real_redis_client",
+    "reset_probe_cache",
     "split_endpoint",
 ]
+
+REDIS_CLIENT_MODULE = "autobot_shared.redis_client"
 
 # Env-var-backed module constant rather than a literal at the call site: a
 # fleet run may need longer than a loopback run, and no caller should hardcode
@@ -129,3 +134,47 @@ def require_live_endpoint(target: str, what: str, port: int | None = None) -> No
     import pytest
 
     pytest.skip(f"{what} is not listening on {host}:{resolved_port} — this test drives a live service")
+
+
+def redis_client_is_stubbed() -> bool:
+    """True when ``autobot_shared.redis_client`` is a stand-in, not the real module.
+
+    ``autobot-backend/conftest.py`` owns ``sys.modules[REDIS_CLIENT_MODULE]`` for
+    the whole backend directory and installs a socket-free stand-in whose
+    ``get_redis_client`` returns ``None`` unconditionally. That is correct for
+    the PR unit gate, which must never dial Redis, but it is applied to every
+    backend item including the ``integration`` ones that exist *because* they
+    need a real Redis — see #14932.
+
+    The stand-in is a bare ``types.ModuleType`` built in memory, so it has no
+    ``__file__``; the genuine module was loaded from disk and has one. File
+    location is the only thing that separates them, which is exactly the
+    distinction relied on elsewhere in this repo for hand-installed stubs.
+
+    A module that is not imported at all reads as *not* stubbed: the caller has
+    not reached the point where it would matter, and reporting "stubbed" for an
+    absent module would skip on a condition nobody established.
+    """
+    module = sys.modules.get(REDIS_CLIENT_MODULE)
+    if module is None:
+        return False
+    return getattr(module, "__file__", None) is None
+
+
+def require_real_redis_client(what: str) -> None:
+    """Skip the calling test iff the Redis client module is a stand-in.
+
+    This is a *structural* precondition — "is the real module installed" — not an
+    observation of the test's own failure. When #14932 removes the stand-in for
+    marked items, this stops skipping on its own and the test runs for real.
+    """
+    if not redis_client_is_stubbed():
+        return
+
+    import pytest
+
+    pytest.skip(
+        f"{what} needs a real Redis client, but {REDIS_CLIENT_MODULE} is the "
+        f"backend conftest's socket-free stand-in (get_redis_client() always "
+        f"returns None) — tracked as #14932"
+    )

--- a/autobot_shared/live_service_probe_test.py
+++ b/autobot_shared/live_service_probe_test.py
@@ -1,0 +1,155 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The live-service probe must not fail open (#14930).
+
+This guard exists to convert "the service is not running here" into a skip.
+The failure mode that would make it worthless is the opposite of a false skip:
+a probe that answers "not listening" for *any* problem would turn a genuinely
+broken suite into a silently skipped one — the known-red-workflow habit, moved
+one layer down. Every test below pins the boundary rather than the happy path.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from autobot_shared import live_service_probe
+from autobot_shared.live_service_probe import (
+    endpoint_is_listening,
+    require_live_endpoint,
+    reset_probe_cache,
+    split_endpoint,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    reset_probe_cache()
+    yield
+    reset_probe_cache()
+
+
+@pytest.fixture
+def listening_port():
+    """A real socket accepting connections, closed when the test ends."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    try:
+        yield server.getsockname()[1]
+    finally:
+        server.close()
+
+
+@pytest.fixture
+def closed_port():
+    """A port number nothing is bound to: bind, read the port, then release it."""
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()
+    return port
+
+
+class TestEndpointIsListening:
+    def test_true_for_a_socket_that_is_actually_accepting(self, listening_port):
+        assert endpoint_is_listening(f"http://127.0.0.1:{listening_port}") is True
+
+    def test_false_when_nothing_is_bound(self, closed_port):
+        assert endpoint_is_listening(f"http://127.0.0.1:{closed_port}") is False
+
+    def test_a_non_network_error_propagates_rather_than_reading_as_absent(self, monkeypatch, listening_port):
+        """The one assertion that keeps this from becoming a test that cannot fail.
+
+        If ``endpoint_is_listening`` caught ``Exception`` instead of ``OSError``,
+        this would return False and every guarded suite would skip forever on a
+        bug that has nothing to do with the service being down.
+        """
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("not a network condition")
+
+        monkeypatch.setattr(live_service_probe.socket, "create_connection", _boom)
+
+        with pytest.raises(RuntimeError, match="not a network condition"):
+            endpoint_is_listening(f"http://127.0.0.1:{listening_port}", use_cache=False)
+
+    def test_result_is_cached_per_endpoint(self, monkeypatch, listening_port):
+        calls: list[tuple] = []
+        real = live_service_probe.socket.create_connection
+
+        def _counting(address, **kwargs):
+            calls.append(address)
+            return real(address, **kwargs)
+
+        monkeypatch.setattr(live_service_probe.socket, "create_connection", _counting)
+
+        endpoint_is_listening(f"http://127.0.0.1:{listening_port}")
+        endpoint_is_listening(f"http://127.0.0.1:{listening_port}")
+
+        assert len(calls) == 1, "the probe reopened a socket it had already answered"
+
+    def test_reset_probe_cache_actually_forgets(self, monkeypatch, listening_port):
+        calls: list[tuple] = []
+        real = live_service_probe.socket.create_connection
+
+        def _counting(address, **kwargs):
+            calls.append(address)
+            return real(address, **kwargs)
+
+        monkeypatch.setattr(live_service_probe.socket, "create_connection", _counting)
+
+        endpoint_is_listening(f"http://127.0.0.1:{listening_port}")
+        reset_probe_cache()
+        endpoint_is_listening(f"http://127.0.0.1:{listening_port}")
+
+        assert len(calls) == 2
+
+
+class TestSplitEndpoint:
+    def test_parses_a_url_with_an_explicit_port(self):
+        assert split_endpoint("http://10.0.0.5:8001/api/iac") == ("10.0.0.5", 8001)
+
+    def test_parses_a_bare_host_and_port(self):
+        assert split_endpoint("localhost:6379") == ("localhost", 6379)
+
+    def test_falls_back_to_the_scheme_default_port(self):
+        assert split_endpoint("https://example.invalid/x") == ("example.invalid", 443)
+
+    def test_explicit_port_argument_wins(self):
+        assert split_endpoint("example.invalid", port=9999) == ("example.invalid", 9999)
+
+    @pytest.mark.parametrize("bad", ["", "   ", "http://", "///nope"])
+    def test_unparseable_targets_raise_rather_than_guessing(self, bad):
+        """A target we cannot parse must never be reported as 'absent'.
+
+        Guessing here would skip a live suite on a typo, which is exactly the
+        silent-non-result this whole change exists to remove.
+        """
+        with pytest.raises(ValueError):
+            split_endpoint(bad)
+
+    def test_a_host_with_no_derivable_port_raises(self):
+        with pytest.raises(ValueError, match="port"):
+            split_endpoint("some-host-with-no-scheme")
+
+
+class TestRequireLiveEndpoint:
+    def test_does_not_skip_when_the_service_is_up(self, listening_port):
+        # Reaching the next statement is the assertion: pytest.skip raises.
+        require_live_endpoint(f"http://127.0.0.1:{listening_port}", what="a test double")
+
+    def test_skips_with_a_reason_naming_the_service_and_endpoint(self, closed_port):
+        with pytest.raises(Exception) as excinfo:
+            require_live_endpoint(f"http://127.0.0.1:{closed_port}", what="the AutoBot backend API")
+
+        assert excinfo.typename == "Skipped", f"expected a skip, got {excinfo.typename}"
+        message = str(excinfo.value)
+        assert "the AutoBot backend API" in message
+        assert f"127.0.0.1:{closed_port}" in message
+
+    def test_an_unparseable_target_raises_instead_of_skipping(self):
+        with pytest.raises(ValueError):
+            require_live_endpoint("", what="nothing")

--- a/autobot_shared/live_service_probe_test.py
+++ b/autobot_shared/live_service_probe_test.py
@@ -12,6 +12,8 @@ one layer down. Every test below pins the boundary rather than the happy path.
 from __future__ import annotations
 
 import socket
+import sys
+import types
 
 import pytest
 
@@ -153,3 +155,42 @@ class TestRequireLiveEndpoint:
     def test_an_unparseable_target_raises_instead_of_skipping(self):
         with pytest.raises(ValueError):
             require_live_endpoint("", what="nothing")
+
+
+class TestRedisClientIsStubbed:
+    """The stand-in detector must key on module identity, not on a symptom."""
+
+    def test_false_for_the_genuine_module_loaded_from_disk(self, monkeypatch):
+        import autobot_shared.redis_client as real
+
+        monkeypatch.setitem(sys.modules, live_service_probe.REDIS_CLIENT_MODULE, real)
+        assert real.__file__, "the genuine module must have a __file__ for this check to mean anything"
+        assert live_service_probe.redis_client_is_stubbed() is False
+
+    def test_true_for_an_in_memory_stand_in(self, monkeypatch):
+        standin = types.ModuleType(live_service_probe.REDIS_CLIENT_MODULE)
+        standin.get_redis_client = lambda *a, **k: None
+        assert getattr(standin, "__file__", None) is None
+        monkeypatch.setitem(sys.modules, live_service_probe.REDIS_CLIENT_MODULE, standin)
+
+        assert live_service_probe.redis_client_is_stubbed() is True
+
+    def test_an_absent_module_is_not_reported_as_stubbed(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, live_service_probe.REDIS_CLIENT_MODULE, raising=False)
+        assert live_service_probe.redis_client_is_stubbed() is False
+
+    def test_require_real_redis_client_skips_only_under_the_stand_in(self, monkeypatch):
+        standin = types.ModuleType(live_service_probe.REDIS_CLIENT_MODULE)
+        monkeypatch.setitem(sys.modules, live_service_probe.REDIS_CLIENT_MODULE, standin)
+
+        with pytest.raises(Exception) as excinfo:
+            live_service_probe.require_real_redis_client("the knowledge base")
+
+        assert excinfo.typename == "Skipped"
+        assert "#14932" in str(excinfo.value), "the skip reason must name the tracking issue"
+
+        import autobot_shared.redis_client as real
+
+        monkeypatch.setitem(sys.modules, live_service_probe.REDIS_CLIENT_MODULE, real)
+        # Reaching the next statement is the assertion.
+        live_service_probe.require_real_redis_client("the knowledge base")

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -493,6 +493,7 @@ To add a new variable:
 | `AUTOBOT_INJECTION_HARDBLOCK_THRESHOLD` | auth | float | `0.75` | Confidence in [0.0, 1.0] at or above which a detected injection is hard-blocked. 0.75 maps to HIGH; 1.0 would block only CRITICAL. |
 | `AUTOBOT_INTERNAL_API_KEY` | auth | str | `""` | Shared secret used to authenticate internal service-to-service calls. |
 | `AUTOBOT_KB_TIMEOUT` | kb | int | `30` | Timeout in seconds for knowledge-base HTTP requests. Range: 1–300. |
+| `AUTOBOT_LIVE_PROBE_TIMEOUT_SECONDS` | testing | float | `1.0` | Seconds a test's live-service precondition probe waits for a TCP connect before reporting the service as absent and skipping (autobot_shared/live_service_probe.py, #14930). Short by default: a refused loopback connect returns immediately, and this runs once per endpoint per process. Raise it when probing a fleet host across a link slow enough that a live service could be mistaken for a missing one. Range: 0.1–60.0. |
 | `AUTOBOT_LLC_H2A_BRIEF_CACHE_TTL` | orchestrator | int | `86400` | Cache lifetime in seconds for a human-to-agent handoff brief (llc/services/handoff.py). One day. |
 | `AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS` | ai | float | `30.0` | Cap applied to a provider's `Retry-After`. Without it a provider advertising a long back-off would stall a request for that whole period (services/llm_service.py). |
 | `AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN` | ai | int | `0` | Cumulative token ceiling (input plus output) for one run. Zero disables the gate, which is the shipped default (#11541). |
@@ -584,5 +585,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*146 variables registered as of last generation.*
+*147 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->

--- a/pipeline-scripts/marker_suite_report.py
+++ b/pipeline-scripts/marker_suite_report.py
@@ -137,7 +137,7 @@ def render(per_report: dict[str, Counts], total: Counts, marker_expression: str)
 
 def _emit_summary(text: str) -> None:
     """Print, and append to the GitHub step summary when running in Actions."""
-    print(text)
+    print(text)  # noqa: print
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
         return
@@ -194,7 +194,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             per_report[name] = parse_report(Path(raw_path))
         except ReportError as exc:
-            print(f"::error::marker-suite report: {exc}", file=sys.stderr)
+            print(f"::error::marker-suite report: {exc}", file=sys.stderr)  # noqa: print
             return 1
 
     total = Counts()
@@ -205,7 +205,7 @@ def main(argv: list[str] | None = None) -> int:
 
     problems = check(per_report, args.min_collected, args.min_passed)
     for problem in problems:
-        print(f"::error::marker-suite report: {problem}", file=sys.stderr)
+        print(f"::error::marker-suite report: {problem}", file=sys.stderr)  # noqa: print
     return 1 if problems else 0
 
 

--- a/pipeline-scripts/marker_suite_report.py
+++ b/pipeline-scripts/marker_suite_report.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Report how many marker-carrying tests actually ran, and fail if none did (#14930).
+
+`.github/workflows/marker-tests.yml` runs the complement of the PR gate's
+exclusion — `integration or slow or distributed or performance`. Until this
+script existed the workflow's only signal was pytest's exit code, and its two
+steps ended in ``|| [ $? -eq 5 ]``: exit 5 is "no tests collected", which was
+swallowed as a legitimate outcome. That is the exact shape this repository has
+been bitten by repeatedly — **an empty result reading as a clean result**. A
+run in which the marker selection silently stopped matching anything was
+indistinguishable, from the outside, from a run in which everything passed.
+
+So this script asserts PRESENCE rather than absence of failure:
+
+* Every report file it is told to expect must exist. A missing file is a hard
+  failure, never "nothing to check" — a pytest that died before writing its XML
+  is precisely the case that must not read as clean.
+* The aggregate collected count must clear ``--min-collected`` (at least 1).
+* The passed count must clear ``--min-passed``, so a collapse from today's
+  baseline is caught rather than merely being visible in a log nobody opens.
+
+It intentionally does NOT decide whether the run passed — pytest's own exit
+status still governs that. This adds the one verdict pytest cannot give: "the
+selection still matches the tests it is supposed to match."
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+# The names pytest writes on <testsuite>. Kept as a constant so a pytest change
+# that renames one surfaces as a parse failure rather than a silent zero.
+_REQUIRED_ATTRS = ("tests", "failures", "errors", "skipped")
+
+
+@dataclass(frozen=True)
+class Counts:
+    """One invocation's outcome, as pytest's JUnit XML reports it."""
+
+    collected: int = 0
+    failures: int = 0
+    errors: int = 0
+    skipped: int = 0
+
+    @property
+    def passed(self) -> int:
+        return self.collected - self.failures - self.errors - self.skipped
+
+    @property
+    def executed(self) -> int:
+        """Tests that ran a body — everything collected that was not skipped."""
+        return self.collected - self.skipped
+
+    def __add__(self, other: "Counts") -> "Counts":
+        return Counts(
+            collected=self.collected + other.collected,
+            failures=self.failures + other.failures,
+            errors=self.errors + other.errors,
+            skipped=self.skipped + other.skipped,
+        )
+
+
+class ReportError(RuntimeError):
+    """A report could not be read or understood. Never downgraded to zero."""
+
+
+def parse_report(path: Path) -> Counts:
+    """Read one JUnit XML file into :class:`Counts`.
+
+    Raises rather than returning zeros for a missing or malformed file. A parse
+    failure that returned ``Counts()`` would be reported as "collected nothing",
+    which is a different — and much more alarming — claim than "could not read
+    the report", and the two must not be confused.
+    """
+    if not path.exists():
+        raise ReportError(
+            f"expected JUnit report {path} does not exist — pytest did not reach the end of the run. "
+            f"This is a failure, not an empty result."
+        )
+
+    try:
+        root = ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        raise ReportError(f"{path} is not parseable JUnit XML: {exc}") from exc
+
+    suites = list(root.iter("testsuite"))
+    if not suites:
+        raise ReportError(f"{path} contains no <testsuite> element")
+
+    total = Counts()
+    for suite in suites:
+        missing = [attr for attr in _REQUIRED_ATTRS if attr not in suite.attrib]
+        if missing:
+            raise ReportError(f"{path}: <testsuite> is missing attribute(s) {missing}; cannot count reliably")
+        total = total + Counts(
+            collected=int(suite.attrib["tests"]),
+            failures=int(suite.attrib["failures"]),
+            errors=int(suite.attrib["errors"]),
+            skipped=int(suite.attrib["skipped"]),
+        )
+    return total
+
+
+def render(per_report: dict[str, Counts], total: Counts, marker_expression: str) -> str:
+    """Build the markdown block shown on the run page and in the log."""
+    lines = [
+        "## Marker-excluded suite coverage",
+        "",
+        f"Selection: `{marker_expression}`",
+        "",
+        "| Invocation | Collected | Executed | Passed | Failed | Errors | Skipped |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for name, counts in per_report.items():
+        lines.append(
+            f"| {name} | {counts.collected} | {counts.executed} | {counts.passed} "
+            f"| {counts.failures} | {counts.errors} | {counts.skipped} |"
+        )
+    lines.append(
+        f"| **total** | **{total.collected}** | **{total.executed}** | **{total.passed}** "
+        f"| **{total.failures}** | **{total.errors}** | **{total.skipped}** |"
+    )
+    lines.append("")
+    lines.append(
+        "A skip here means the test was not exercised — usually an absent live service. "
+        "It is a real outcome, not a pass: read the count."
+    )
+    return "\n".join(lines)
+
+
+def _emit_summary(text: str) -> None:
+    """Print, and append to the GitHub step summary when running in Actions."""
+    print(text)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write(text + "\n")
+
+
+def check(per_report: dict[str, Counts], min_collected: int, min_passed: int) -> list[str]:
+    """Return every floor violation. An empty list means the floors held."""
+    total = Counts()
+    for counts in per_report.values():
+        total = total + counts
+
+    problems: list[str] = []
+    if total.collected < min_collected:
+        problems.append(
+            f"the marker selection collected {total.collected} test(s), below the floor of {min_collected}. "
+            f"The suite is selecting nothing — that is a broken selection, not a clean run."
+        )
+    if total.passed < min_passed:
+        problems.append(
+            f"{total.passed} test(s) passed, below the floor of {min_passed}. "
+            f"Marker-carrying tests that used to run no longer do; find out which before lowering this floor."
+        )
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("reports", nargs="+", help="JUnit XML files, as NAME=PATH or PATH")
+    parser.add_argument(
+        "--min-collected",
+        type=int,
+        default=1,
+        help="fail when fewer than this many tests were collected in total (default: 1)",
+    )
+    parser.add_argument(
+        "--min-passed",
+        type=int,
+        default=1,
+        help="fail when fewer than this many tests passed in total (default: 1)",
+    )
+    parser.add_argument("--marker-expression", default=os.environ.get("MARKER_EXPRESSION", "(unset)"))
+    args = parser.parse_args(argv)
+
+    if args.min_collected < 1:
+        parser.error("--min-collected must be at least 1: a floor of 0 is not a presence assertion")
+
+    per_report: dict[str, Counts] = {}
+    for entry in args.reports:
+        name, _, raw_path = entry.partition("=")
+        if not raw_path:
+            name, raw_path = Path(entry).stem, entry
+        try:
+            per_report[name] = parse_report(Path(raw_path))
+        except ReportError as exc:
+            print(f"::error::marker-suite report: {exc}", file=sys.stderr)
+            return 1
+
+    total = Counts()
+    for counts in per_report.values():
+        total = total + counts
+
+    _emit_summary(render(per_report, total, args.marker_expression))
+
+    problems = check(per_report, args.min_collected, args.min_passed)
+    for problem in problems:
+        print(f"::error::marker-suite report: {problem}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline-scripts/marker_suite_report.py
+++ b/pipeline-scripts/marker_suite_report.py
@@ -26,7 +26,17 @@ status still governs that. This adds the one verdict pytest cannot give: "the
 selection still matches the tests it is supposed to match."
 """
 
-from __future__ import annotations
+# NOTE: deliberately NO ``from __future__ import annotations`` here.
+#
+# On Python 3.14, ``@dataclass`` resolves *string* annotations by looking its own
+# module up in ``sys.modules`` (``dataclasses._is_type`` ->
+# ``sys.modules.get(cls.__module__).__dict__``). The future import turns every
+# annotation into a string, so a module executed WITHOUT a ``sys.modules`` entry —
+# which is how this repo's guard tests load their subject, to avoid tripping the
+# sys.modules leak guard — dies at class-creation time with
+# ``AttributeError: 'NoneType' object has no attribute '__dict__'``.
+#
+# Real annotations cost nothing here and keep the module loadable by any loader.
 
 import argparse
 import os

--- a/pipeline-scripts/marker_suite_report_test.py
+++ b/pipeline-scripts/marker_suite_report_test.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The marker-suite presence assertion must not be satisfiable by nothing (#14930).
+
+Two halves, and both are needed:
+
+* **The script.** Its whole reason to exist is that an empty or absent result
+  must not read as a clean one, so most of these tests feed it exactly that and
+  assert it fails.
+* **The wiring.** A guard that is correct and unreferenced guards nothing. The
+  last class asserts `.github/workflows/marker-tests.yml` actually invokes it,
+  on the report paths pytest is actually told to write — so moving or renaming
+  either end breaks a test instead of silently disarming the check.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from marker_suite_report import Counts, ReportError, check, main, parse_report  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "marker-tests.yml"
+SCRIPT = Path(__file__).parent / "marker_suite_report.py"
+
+
+def write_report(path: Path, tests: int, failures: int = 0, errors: int = 0, skipped: int = 0) -> Path:
+    path.write_text(
+        f'<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuites><testsuite name="pytest" tests="{tests}" failures="{failures}" '
+        f'errors="{errors}" skipped="{skipped}" time="1.0"></testsuite></testsuites>\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestParseReport:
+    def test_reads_the_four_counts(self, tmp_path):
+        report = write_report(tmp_path / "r.xml", tests=85, failures=19, errors=19, skipped=12)
+        counts = parse_report(report)
+
+        assert counts.collected == 85
+        assert counts.failures == 19
+        assert counts.errors == 19
+        assert counts.skipped == 12
+        assert counts.passed == 35
+        assert counts.executed == 73
+
+    def test_a_missing_report_raises_instead_of_counting_zero(self, tmp_path):
+        """The trap this script exists for: an absent result must not read as clean.
+
+        Returning ``Counts()`` here would make a pytest that died before writing
+        its XML indistinguishable from a run that collected nothing, and both
+        indistinguishable from a healthy run once the floors were relaxed.
+        """
+        with pytest.raises(ReportError, match="does not exist"):
+            parse_report(tmp_path / "never-written.xml")
+
+    def test_malformed_xml_raises(self, tmp_path):
+        bad = tmp_path / "bad.xml"
+        bad.write_text("<testsuites><testsuite tests=", encoding="utf-8")
+
+        with pytest.raises(ReportError, match="not parseable"):
+            parse_report(bad)
+
+    def test_a_file_with_no_testsuite_raises(self, tmp_path):
+        empty = tmp_path / "empty.xml"
+        empty.write_text("<testsuites></testsuites>", encoding="utf-8")
+
+        with pytest.raises(ReportError, match="no <testsuite>"):
+            parse_report(empty)
+
+    def test_a_missing_attribute_raises_rather_than_defaulting_to_zero(self, tmp_path):
+        """A pytest that renames an attribute must break loudly, not count zero."""
+        partial = tmp_path / "partial.xml"
+        partial.write_text(
+            '<testsuites><testsuite name="pytest" tests="10" failures="0" errors="0"/></testsuites>',
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ReportError, match="missing attribute"):
+            parse_report(partial)
+
+    def test_multiple_testsuites_are_summed(self, tmp_path):
+        multi = tmp_path / "multi.xml"
+        multi.write_text(
+            '<testsuites>'
+            '<testsuite name="a" tests="4" failures="1" errors="0" skipped="1"/>'
+            '<testsuite name="b" tests="6" failures="0" errors="2" skipped="0"/>'
+            '</testsuites>',
+            encoding="utf-8",
+        )
+        counts = parse_report(multi)
+
+        assert counts.collected == 10
+        assert counts.failures == 1
+        assert counts.errors == 2
+        assert counts.skipped == 1
+
+
+class TestFloors:
+    def test_zero_collected_is_a_violation(self):
+        problems = check({"backend": Counts(collected=0)}, min_collected=1, min_passed=1)
+        assert problems, "collecting nothing must never read as a clean run"
+        assert "selecting nothing" in problems[0]
+
+    def test_a_healthy_run_reports_no_violation(self):
+        problems = check({"backend": Counts(collected=85, skipped=49)}, min_collected=1, min_passed=1)
+        assert problems == []
+
+    def test_a_run_that_only_skips_violates_the_passed_floor(self):
+        """All-skipped is the failure mode a naive 'no failures' check would miss."""
+        problems = check({"backend": Counts(collected=85, skipped=85)}, min_collected=1, min_passed=1)
+
+        assert problems
+        assert "passed" in problems[0]
+
+    def test_the_floors_are_summed_across_invocations(self):
+        problems = check(
+            {"backend": Counts(collected=0), "slm": Counts(collected=4, skipped=3)},
+            min_collected=1,
+            min_passed=1,
+        )
+        assert problems == [], "a legitimately empty second invocation must not fail the run on its own"
+
+
+class TestMain:
+    def test_exit_zero_on_a_healthy_pair(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        a = write_report(tmp_path / "a.xml", tests=85, skipped=49)
+        b = write_report(tmp_path / "b.xml", tests=0)
+
+        assert main([f"backend={a}", f"slm={b}", "--min-collected", "1", "--min-passed", "1"]) == 0
+
+    def test_exit_one_when_nothing_was_collected(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        a = write_report(tmp_path / "a.xml", tests=0)
+        b = write_report(tmp_path / "b.xml", tests=0)
+
+        assert main([f"backend={a}", f"slm={b}"]) == 1
+
+    def test_exit_one_when_a_report_is_absent(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        a = write_report(tmp_path / "a.xml", tests=85, skipped=49)
+
+        assert main([f"backend={a}", f"slm={tmp_path / 'gone.xml'}"]) == 1
+
+    def test_exit_one_when_the_passed_floor_is_missed(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        a = write_report(tmp_path / "a.xml", tests=85, skipped=60)
+
+        assert main([f"backend={a}", "--min-passed", "35"]) == 1
+
+    def test_a_zero_min_collected_is_rejected(self, tmp_path):
+        """The presence assertion must not be disableable from the call site."""
+        a = write_report(tmp_path / "a.xml", tests=1)
+
+        with pytest.raises(SystemExit) as excinfo:
+            main([f"backend={a}", "--min-collected", "0"])
+        assert excinfo.value.code != 0
+
+    def test_the_summary_is_written_to_the_github_step_summary(self, tmp_path, monkeypatch):
+        summary = tmp_path / "summary.md"
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+        a = write_report(tmp_path / "a.xml", tests=85, failures=0, errors=0, skipped=49)
+
+        assert main([f"backend={a}"]) == 0
+
+        written = summary.read_text(encoding="utf-8")
+        assert "Marker-excluded suite coverage" in written
+        assert "85" in written and "36" in written
+
+    def test_runs_as_a_script(self, tmp_path):
+        """The workflow invokes it through the interpreter, so prove that path works."""
+        a = write_report(tmp_path / "a.xml", tests=0)
+        result = subprocess.run(  # nosec B603
+            [sys.executable, str(SCRIPT), f"backend={a}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "selecting nothing" in result.stderr
+
+
+class TestWorkflowWiring:
+    """A guard nothing calls is not a guard. Pin both ends of the wire."""
+
+    @pytest.fixture(scope="class")
+    def marker_job(self):
+        parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        return parsed["jobs"]["marker-tests"]
+
+    @pytest.fixture(scope="class")
+    def run_steps(self, marker_job):
+        return [step for step in marker_job["steps"] if "run" in step]
+
+    def test_the_workflow_invokes_this_script(self, run_steps):
+        invocations = [step for step in run_steps if "marker_suite_report.py" in step["run"]]
+        assert invocations, (
+            "marker-tests.yml no longer runs marker_suite_report.py — the presence "
+            "assertion is disarmed and an empty collection would read as clean again"
+        )
+
+    def test_the_script_path_the_workflow_uses_exists(self, run_steps):
+        """Catches the rename half of the pair: move the script, this fails."""
+        for step in run_steps:
+            for token in step["run"].split():
+                if token.endswith("marker_suite_report.py"):
+                    assert (REPO_ROOT / token).exists(), f"workflow references a script that does not exist: {token}"
+
+    def test_every_junitxml_pytest_writes_is_checked_by_the_report_step(self, run_steps):
+        """The report step must consume exactly the files pytest is told to produce.
+
+        A junitxml path that nothing checks is an invocation whose emptiness
+        nobody would notice — the original defect, one file over.
+        """
+        produced = set()
+        consumed = set()
+        for step in run_steps:
+            for token in step["run"].replace("=", " ").split():
+                if token.endswith(".xml"):
+                    if "marker_suite_report.py" in step["run"]:
+                        consumed.add(token)
+                    else:
+                        produced.add(token)
+
+        assert produced, "no --junitxml path found in the pytest steps; nothing can be counted"
+        assert produced <= consumed, f"junit reports written but never checked: {sorted(produced - consumed)}"
+
+    def test_the_report_step_runs_even_when_a_pytest_step_failed(self, run_steps):
+        """Otherwise a failing suite skips the count and the collapse stays hidden."""
+        report_steps = [step for step in run_steps if "marker_suite_report.py" in step["run"]]
+        for step in report_steps:
+            condition = str(step.get("if", ""))
+            assert "cancelled" in condition or "always" in condition, (
+                "the marker-suite report step must run on failure too, or a red pytest "
+                f"run hides the coverage count entirely; got if: {condition!r}"
+            )
+
+    def test_the_marker_expression_is_not_narrowed(self, marker_job):
+        """Nobody may quietly shrink the selection to make the run green."""
+        expression = marker_job["env"]["MARKER_EXPRESSION"]
+        for marker in ("integration", "slow", "distributed", "performance"):
+            assert marker in expression, f"the {marker!r} marker is no longer selected by this suite"

--- a/pipeline-scripts/marker_suite_report_test.py
+++ b/pipeline-scripts/marker_suite_report_test.py
@@ -29,16 +29,38 @@ WORKFLOW = REPO_ROOT / ".github" / "workflows" / "marker-tests.yml"
 SCRIPT = Path(__file__).with_name("marker_suite_report.py")
 
 
-def _load_script():
-    """Load the checker without registering it in ``sys.modules``.
+_MODULE_NAME = "marker_suite_report"
 
-    Same pattern as this directory's other guard tests: the repo-wide
-    sys.modules leak guard (#13337) fails a shard that leaves a synthetic entry
-    behind, and a sibling import via ``sys.path`` would leave one.
+
+def _load_script():
+    """Load the checker, leaving no ``sys.modules`` entry behind.
+
+    Same intent as this directory's other guard tests — the repo-wide sys.modules
+    leak guard (#13337) fails a shard that strands a synthetic entry, and a
+    sibling import via ``sys.path`` would strand one.
+
+    The entry is installed for the duration of ``exec_module`` and removed in a
+    ``finally``. Executing with NO entry at all is what the first version did,
+    and it broke collection on Python 3.14: ``@dataclass`` resolves string
+    annotations through ``sys.modules[cls.__module__]``, which was ``None``.
+    The module no longer uses ``from __future__ import annotations`` so it does
+    not depend on this, but a future edit that re-adds it must not silently
+    resurrect a collection error.
     """
-    spec = importlib.util.spec_from_file_location("marker_suite_report", SCRIPT)
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, SCRIPT)
+    assert spec is not None and spec.loader is not None, f"cannot build an import spec for {SCRIPT}"
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+
+    had_previous = _MODULE_NAME in sys.modules
+    previous = sys.modules.get(_MODULE_NAME)
+    sys.modules[_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if had_previous:
+            sys.modules[_MODULE_NAME] = previous
+        else:
+            sys.modules.pop(_MODULE_NAME, None)
     return module
 
 

--- a/pipeline-scripts/marker_suite_report_test.py
+++ b/pipeline-scripts/marker_suite_report_test.py
@@ -16,6 +16,7 @@ Two halves, and both are needed:
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -23,13 +24,30 @@ from pathlib import Path
 import pytest
 import yaml
 
-sys.path.insert(0, str(Path(__file__).parent))
-
-from marker_suite_report import Counts, ReportError, check, main, parse_report  # noqa: E402
-
-REPO_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "marker-tests.yml"
-SCRIPT = Path(__file__).parent / "marker_suite_report.py"
+SCRIPT = Path(__file__).with_name("marker_suite_report.py")
+
+
+def _load_script():
+    """Load the checker without registering it in ``sys.modules``.
+
+    Same pattern as this directory's other guard tests: the repo-wide
+    sys.modules leak guard (#13337) fails a shard that leaves a synthetic entry
+    behind, and a sibling import via ``sys.path`` would leave one.
+    """
+    spec = importlib.util.spec_from_file_location("marker_suite_report", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_report = _load_script()
+Counts = _report.Counts
+ReportError = _report.ReportError
+check = _report.check
+main = _report.main
+parse_report = _report.parse_report
 
 
 def write_report(path: Path, tests: int, failures: int = 0, errors: int = 0, skipped: int = 0) -> Path:
@@ -210,12 +228,22 @@ class TestWorkflowWiring:
             "assertion is disarmed and an empty collection would read as clean again"
         )
 
-    def test_the_script_path_the_workflow_uses_exists(self, run_steps):
-        """Catches the rename half of the pair: move the script, this fails."""
-        for step in run_steps:
-            for token in step["run"].split():
-                if token.endswith("marker_suite_report.py"):
-                    assert (REPO_ROOT / token).exists(), f"workflow references a script that does not exist: {token}"
+    def test_every_script_path_the_workflow_references_exists(self, run_steps):
+        """Catches the rename half of the pair, from either end.
+
+        Deliberately NOT keyed on the name ``marker_suite_report.py``. A first
+        draft of this test was, and it passed vacuously when the workflow was
+        mutated to call ``moved_elsewhere.py`` — no token matched, so the loop
+        body never ran and the check reported success. A guard whose subject can
+        disappear must assert on what IS there, not iterate over what might be.
+        """
+        referenced = {
+            token for step in run_steps for token in step["run"].split() if token.endswith(".py") and "/" in token
+        }
+        assert referenced, "no run step references a script path; the coverage report is not wired to anything"
+
+        missing = sorted(token for token in referenced if not (REPO_ROOT / token).exists())
+        assert not missing, f"marker-tests.yml references script(s) that do not exist: {missing}"
 
     def test_every_junitxml_pytest_writes_is_checked_by_the_report_step(self, run_steps):
         """The report step must consume exactly the files pytest is told to produce.
@@ -246,8 +274,30 @@ class TestWorkflowWiring:
                 f"run hides the coverage count entirely; got if: {condition!r}"
             )
 
-    def test_the_marker_expression_is_not_narrowed(self, marker_job):
-        """Nobody may quietly shrink the selection to make the run green."""
-        expression = marker_job["env"]["MARKER_EXPRESSION"]
-        for marker in ("integration", "slow", "distributed", "performance"):
-            assert marker in expression, f"the {marker!r} marker is no longer selected by this suite"
+    @pytest.mark.parametrize("marker", ["integration", "slow", "distributed", "performance"])
+    def test_the_marker_expression_is_not_narrowed(self, marker_job, marker):
+        """Nobody may quietly shrink the selection to make the run green.
+
+        Narrowing the selection is the one "fix" #14930 explicitly rules out: a
+        suite that passes because it stopped selecting the failing tests is the
+        inert-suite defect wearing a green tick.
+        """
+        assert marker in marker_job["env"]["MARKER_EXPRESSION"], (
+            f"the {marker!r} marker is no longer selected by the scheduled run"
+        )
+
+    @pytest.mark.parametrize("marker", ["integration", "slow", "distributed", "performance"])
+    def test_the_dispatch_default_is_not_narrowed(self, marker):
+        """The manual-dispatch default is a second way to shrink the selection.
+
+        ``MARKER_EXPRESSION`` is ``inputs.markers || <default>``, so both strings
+        decide what runs and guarding only the first leaves the other open. A
+        mutation of the dispatch default alone slipped past an earlier version
+        of this class, which is why it is pinned separately.
+        """
+        parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        # `on:` parses as the boolean True under YAML 1.1, not the string "on".
+        triggers = parsed.get("on", parsed.get(True))
+        default = triggers["workflow_dispatch"]["inputs"]["markers"]["default"]
+
+        assert marker in default, f"the workflow_dispatch default no longer offers the {marker!r} marker"


### PR DESCRIPTION
Closes #14930

## Thinking Path

The issue's corrected framing was right: the suite partially works. 35 marker-carrying
tests execute and pass. The question was what the other 38 results actually are, and
the answer is that **37 of 38 are one defect class in two disguises** — a live service
the runner does not have, reported as a hard result instead of a stated non-result.

**The 19 errors** are not 19 problems. They are one file:
`autobot-backend/services/redis_service_api_integration_test.py`. It has no
`backend_url` fixture anywhere on its conftest chain — the only definition lives in
`autobot-infrastructure/shared/tests/conftest.py`, which this tree never reaches — so
all 19 error at setup. Nothing else in the run raised that error.

**The 19 failures** are three causes, not one:

| Count | Where | Cause |
| ---: | --- | --- |
| 6 | `api/infrastructure_integration_test.py` | `ConnectionRefused` dialling the backend on :8001 |
| 10 | `api/voice_integration_test.py` | `ConnectionRefused` dialling :8001 and the TTS worker on :8083 |
| 2 | `knowledge/gpu_kb_integration_test.py`, `knowledge/kb_optimization_test.py` | `RuntimeError: Failed to initialize knowledge base` |
| 1 | `performance_benchmarks_test.py` | `AssertionError: Memory usage too high` — `1644.55 < 500` |

The 16 connection failures are the same shape as the 19 errors: real HTTP to services
that do not exist on a GitHub-hosted runner.

The two knowledge-base failures looked like the same thing and are not. The workflow
provides a healthy Redis specifically for these, and its header says so. They fail
anyway because `autobot-backend/conftest.py` replaces `autobot_shared.redis_client`
with a socket-free stand-in whose `get_redis_client()` returns `None` for **every**
item under `autobot-backend/`, gated on directory membership and not on markers. So
the marker suite provisions a Redis that no backend test can reach — a service
configured, health-checked, and structurally unconsumable. That is filed as **#14932**
with the root cause and a proposed fix, and deliberately not fixed here: the change
flips Redis behaviour for every backend `integration` test at once, and 35 of them
currently pass. Landing it alongside the guard work would make the resulting count
unattributable.

The one genuine assertion defect is the benchmark. It asserted **absolute process
RSS** under 500 MB, but a pytest-xdist worker sits at ~1.6 GB from importing the
orchestrator, knowledge base, memory manager and LLM service before the first
benchmark runs. The budget was spent before the test started: it could not pass, and
it could not have caught a regression in the code it names.

**On the decision the issue asks for** — provide the fixture, or deselect. Both, and
they are not alternatives. The tests are well-formed and *should* run, so
`backend_url` is defined rather than the module being marked out; but every request
goes over the wire through a real `httpx.AsyncClient`, so a live backend is a genuine
precondition. `knowledge_api_integration_test.py` is the contrast that settles it:
it patches `aiohttp.ClientSession.get`, needs only a syntactically valid URL string,
and correctly just defines the fixture.

Nothing here narrows what the suite selects. Two tests assert that, on both the
scheduled expression and the dispatch default.

## What Changed

**`autobot_shared/live_service_probe.py`** (new) — the canonical precondition probe.
`endpoint_is_listening()` opens a TCP socket and catches `OSError` and nothing wider,
so "the service is absent" skips while a connected-but-wrong service, a malformed
target, or a programming error still fails. `redis_client_is_stubbed()` detects the
backend stand-in structurally, by the absence of `__file__` on an in-memory
`ModuleType`, so the knowledge-base skips clear themselves the moment #14932 lands
rather than being permanent by construction.

**Four test modules** now report absent services as skips naming the missing service,
via autouse fixtures — so a deselected test on the PR gate pays nothing. The
knowledge-base guards are scoped to `integration`-marked items only: both files pair
the marked test with a hermetic one that runs on the PR gate, and guarding those too
would have silently disabled a passing gate test.

**`performance_benchmarks_test.py`** measures the RSS *delta* across the measured
region. 500 MB of growth from one mocked `chat()` call is a real leak; 500 MB of
absolute RSS is AutoBot being imported.

**`pipeline-scripts/marker_suite_report.py`** (new) + the workflow's new **Report
marker coverage** step. Both pytest invocations now write JUnit XML, and the script
aggregates collected / executed / passed / failed / errors / skipped into the run
summary and fails the job when the selection collected nothing. A **missing** report
file is a hard failure inside the script, never a zero — a pytest that died before
writing its XML must not read as "collected nothing", let alone as clean. The step
runs on `!cancelled()` so a red pytest cannot hide the coverage count.

The `|| [ $? -eq 5 ]` lines stay, but no longer decide anything: they exist so the
second invocation still runs and the report step still receives both files. Exit 5 is
now caught by the floor instead of being accepted.

**Header.** The file's triage record is written into it, and the stale "one observed
run is RED (11 failed, 7 passed, 40 errors)" paragraph is corrected.

## Verification

**Before**, run `32702629146` on PR #14929's head `4d050db81`:

```
19 failed, 35 passed, 12 skipped, 19 errors in 695.40s
```

**After**, run `32713266629` on head `b3096ed86` — the workflow is **green**, the first
green run in its history (every prior run, on any branch, was red):

```
35 passed, 49 skipped in 697.15s
```

and its own new report step, on the run summary page:

```
| Invocation | Collected | Executed | Passed | Failed | Errors | Skipped |
| backend    |        84 |       35 |     35 |      0 |      0 |      49 |
| slm        |         0 |        0 |      0 |      0 |      0 |       0 |
| **total**  |    **84** |   **35** | **35** |  **0** |  **0** |  **49** |
```

| | before | after |
| --- | ---: | ---: |
| failed | 19 | **0** |
| errors | 19 | **0** |
| passed | 35 | 35 |
| skipped | 12 | 49 |
| collected | 85 | 84 |

Every one of the 38 failures and errors became a skip with a stated reason, counted by
the new report step. From the run's own summary table and the uploaded JUnit artifact:

| Skip reason | Count |
| --- | ---: |
| `the AutoBot backend API is not listening on 127.0.0.1:8001` | 36 |
| `Chromium is not downloaded for Playwright` (pre-existing) | 10 |
| `the knowledge base needs a real Redis client … tracked as #14932` | 2 |
| `collection skipped` (pre-existing) | 1 |
| `AUTOBOT_SUMMARIZATION_PROVIDER is not set` (pre-existing) | 1 |

(Counts above are from the intermediate run `32709235066`; the final run's 49 skips are
the same set less the over-reach fixed below.) `19 + 6 + 10 + 2 = 37` former
failures/errors became skips. The 12 pre-existing skips are unchanged.
`TestLLMServicePerformance::test_llm_response_time_benchmark` now **passes** — the RSS
delta fix — confirmed test-by-test in the artifact.

**The two count deltas, both explained rather than waved at:**

*85 → 84 collected.* Not a lost test. The "before" run was on #14929's head, which adds
`tools scripts pipeline-scripts autobot-infrastructure/shared/scripts/hooks` to the
pytest roots; this branch is on base, which has four roots. #14929's own comment names
the extra test: *"`scripts/check_script_exec_bits_test.py`'s `@pytest.mark.integration`
case was selected by NO workflow at all."* Nothing here removes a root, and that test
returns to the selection when #14929 lands.

*35 → 34 passed — a real over-reach in this PR, found and fixed.* The infrastructure
guard was module-wide, but only **6** of that module's 7 tests dial the backend;
`test_celery_worker_status` reads `logs/celery-worker.log` off disk and was passing. The
7-skips-vs-6-failures mismatch is what exposed it. It is now exempted by an explicit
constant that **self-checks**: the fixture asserts every exempted name still resolves in
the module, so a rename fails loudly instead of stranding the exemption silently. An AST
check confirms the exemption set equals exactly the tests containing no `requests.` call.
With that fix the measured figures are **35 passed, 49 skipped, 0 failed, 0 errors**
(run `32713266629`) — a net `+1` pass over base, from the benchmark repair.

**Full PR CI, deduped to the latest entry per check name:** 50 SUCCESS, 1 SUCCESS
(StatusContext), 9 SKIPPED, **0 failing, 0 cancelled, 0 pending**. `mergeStateStatus`
is `BLOCKED` on `REVIEW_REQUIRED` — the ruleset review gate, not a check.

**One further defect found and filed, not fixed: #14935.** Run `32710575293` went red on
`test_system_startup_performance` at `537.86ms` against a `500.0ms` budget, while the
run before and after it passed — a boundary flake on runner contention. Underneath it is
a real bug: every `MultiModalProcessor()` logs
`Failed to load vision models: CLIPModel.__init__() got an unexpected keyword argument 'resume_download'`
and continues, so **no vision model loads at all** and the benchmark is largely timing a
failing `transformers` call. Pre-existing (it passed by luck in the "before" run) and
unrelated to this PR's subject, but it will redden this suite about half the time, so it
must be fixed before the cron in #13286 is enabled. Relaxing the budget to clear the
board is explicitly rejected there.

**Mutation pairs.** Seven mutations were applied to the workflow, each verified
present in the source *before* mutating so a missing target could not report a false
pass. All seven were caught:

```
CAUGHT  delete the report step entirely        -> invokes=False
CAUGHT  workflow calls a renamed script        -> script_exists=False
CAUGHT  script moved on disk, workflow stale   -> script_exists=False
CAUGHT  junit report nothing checks            -> all_reports_checked=False
CAUGHT  narrow MARKER_EXPRESSION               -> expr_not_narrowed=False
CAUGHT  narrow the dispatch default            -> dispatch_not_narrowed=False
CAUGHT  skip the report on failure             -> runs_on_failure=False
```

Two of those exist because the exercise found real holes in this PR's own tests:

- The rename check was keyed on the filename `marker_suite_report.py`, so renaming the
  script in the workflow left **no token matching** and the loop passed vacuously. It
  now asserts that every `.py` path the workflow references exists, which catches the
  rename from either end.
- Narrowing the **dispatch default** slipped past entirely: `MARKER_EXPRESSION` is
  `inputs.markers || <default>`, so two strings decide what runs and only one was
  pinned.

**Two regressions this PR introduced and fixed before merge**, both caught by CI rather
than assumed away:

- `marker_suite_report_test.py` failed collection on **all 12** python-suite shards.
  On Python 3.14 `@dataclass` resolves string annotations through
  `sys.modules[cls.__module__]`, which is `None` for a module executed without a
  `sys.modules` entry — the loader pattern this repo uses to avoid the sys.modules leak
  guard. Fixed at the source by dropping `from __future__ import annotations` from the
  script, plus a register/`finally`-pop loader so re-adding it cannot resurrect the
  error. Verified against a scratchpad copy, including that the loader leaves no entry.
- `AUTOBOT_LIVE_PROBE_TIMEOUT_SECONDS` was unregistered. Added to
  `autobot_shared/env_registry.py` with its range, and the autogenerated table in
  `docs/developer/CLAUDE_RULES.md` regenerated — verified by rebuilding the whole
  147-row table from the registry via AST and diffing it against the committed section.

**Presence assertions.** `pipeline-scripts/marker_suite_report_test.py` feeds the
checker the empty and absent cases and asserts it fails: zero collected, an all-skipped
run, a missing report file, malformed XML, a `<testsuite>` missing an attribute, and
`--min-collected 0` (rejected at the argument parser — the presence assertion is not
disableable from the call site). `autobot_shared/live_service_probe_test.py` pins the
probe's boundary: a non-`OSError` from `create_connection` propagates rather than
reading as "absent", and an unparseable target raises instead of skipping a live suite.

No code from the codebase was executed locally; the mutation and wiring checks above
read YAML and re-implement the assertions rather than importing the repo.

**Residuals, filed not dropped:** #14932 — the conftest Redis stand-in, with the root
cause, the proposed one-line window-4 fix, and a note that the marker run also lacks
`config/redis-databases.yaml` so named databases never resolve; and #14935 above.
`Closes` names only #14930, which is fully delivered.

**Note for #14929:** it also edits `marker-tests.yml` (appending pytest roots) and will
conflict with the restructured run steps here. Its roots re-apply cleanly onto the new
step bodies; nothing in this PR removes them.

## Model Used

Claude Opus 5 (1M context)
