### PR TITLE
fix(auth): establish the canonical role vocabulary (#13854, #12786, #14024, #13957)

### DIFF
--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -676,12 +676,12 @@ async def add_text_to_knowledge(
 
     # GH#8598: block sub-company agents from writing to parent-company KB
     if organization_id:
-        from llc.kb.write_guard import assert_not_writing_to_ancestor_kb
+        from llc.kb.write_guard import CROSS_ORG_KB_ROLES, assert_not_writing_to_ancestor_kb
         from user_management.database import get_async_session_factory
 
         _requester = get_auth_middleware().get_user_from_request(req)
         _requester_role = (_requester or {}).get("role", "")
-        if _requester_role not in ("platform_admin", "superadmin"):
+        if _requester_role not in CROSS_ORG_KB_ROLES:  # #12786: the guard's own set, not a third copy
             _requester_org_id = (_requester or {}).get("org_id")
             _session_factory = get_async_session_factory()
             async with _session_factory() as _session:
@@ -3138,8 +3138,17 @@ def _resolve_target_org_id(current_user: dict, override_org_id: str | None) -> s
     mode — the service uses the ``__default__`` sentinel.
     """
     if override_org_id:
+        from llc.kb.write_guard import CROSS_ORG_KB_ROLES  # noqa: PLC0415
+
+        from autobot_shared.auth.permissions import is_admin_role  # noqa: PLC0415
+
         role = (current_user or {}).get("role", "")
-        if role not in ("admin", "platform_admin", "superadmin"):
+        # #12786: the same two sets this file already depends on, unioned
+        # explicitly rather than re-spelled as a third literal tuple that
+        # nothing keeps in step. Membership is unchanged:
+        # {admin, superadmin} | {platform_admin, superadmin}
+        #     = {admin, platform_admin, superadmin}.
+        if not (is_admin_role(role) or role in CROSS_ORG_KB_ROLES):
             raise HTTPException(status_code=403, detail="Only admins may target another org")
         return override_org_id
     return (current_user or {}).get("org_id")

--- a/autobot-backend/api/knowledge.py
+++ b/autobot-backend/api/knowledge.py
@@ -3138,9 +3138,8 @@ def _resolve_target_org_id(current_user: dict, override_org_id: str | None) -> s
     mode — the service uses the ``__default__`` sentinel.
     """
     if override_org_id:
-        from llc.kb.write_guard import CROSS_ORG_KB_ROLES  # noqa: PLC0415
-
         from autobot_shared.auth.permissions import is_admin_role  # noqa: PLC0415
+        from llc.kb.write_guard import CROSS_ORG_KB_ROLES  # noqa: PLC0415
 
         role = (current_user or {}).get("role", "")
         # #12786: the same two sets this file already depends on, unioned

--- a/autobot-backend/api/user_management/users.py
+++ b/autobot-backend/api/user_management/users.py
@@ -131,7 +131,7 @@ async def _search_users_from_db(q: str, limit: int) -> UserSearchResponse:
             results = [
                 UserSearchResult(
                     id=str(user.id),
-                    name=user.display_name or user.username,
+                    name=user.full_name,  # #13957: the canonical rule, not a sixth copy of it
                     type="user",
                 )
                 for user in users

--- a/autobot-backend/auth_rbac_admin_guard_test.py
+++ b/autobot-backend/auth_rbac_admin_guard_test.py
@@ -16,9 +16,18 @@ and #12717 (a superadmin silently *downgraded* rather than denied).
 the class from returning: a new ``role == "admin"`` comparison fails here rather
 than becoming the next incident.
 
-Adding ``superadmin``/``platform_admin`` to the shared ``Role`` enum is the
-deeper fix and is still open on #12786 — that enum drives ``ROLE_PERMISSIONS``
-for both backends, so it needs a cross-backend review rather than a drive-by.
+#13854/#12786 did the deeper fix for ``superadmin``: it is a first-class
+``Role`` member with an explicit (empty) ``ROLE_PERMISSIONS`` entry, and
+``ADMIN_ROLES`` is now derived from the enum, so it can no longer name a role
+the enum does not have.
+
+``platform_admin`` is deliberately NOT in that enum. Nothing anywhere mints it
+as a role string — the platform-level signal the codebase actually uses is the
+boolean ``users.is_platform_admin`` — so adding it would invent a role rather
+than canonicalise one. It stays in ``ADMIN_ROLE_LITERALS`` below because this
+guard's job is to catch hand-rolled comparisons against ANY administrative
+literal, and a comparison against a role nothing mints is still a bug worth
+failing on.
 """
 
 import ast

--- a/autobot-backend/llc/api/companies.py
+++ b/autobot-backend/llc/api/companies.py
@@ -38,6 +38,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.user_management.dependencies import _parse_uuid_safe, get_current_user, require_org_context
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.user_management.models.user import resolve_display_name
 from llc.deps import assert_company_access, get_session, service_dep
 from llc.kb.collections import KbCollectionManager
 from llc.models.company import (
@@ -589,15 +590,18 @@ async def list_members(
     # a member, and which of them can take an assignment.
     active: Dict[uuid.UUID, bool] = {}
     if user_ids:
+        # #13957: ``User.full_name`` is a hybrid property, so the canonical
+        # "display_name, else username" rule is selected in SQL here rather than
+        # re-spelled in the comprehension below. This is an inner select on
+        # ``users``, so a returned row always has the NOT NULL ``username`` to
+        # fall back to and the two-rung rule is complete.
         rows = (
             await session.execute(
-                select(User.id, User.display_name, User.username, User.is_active, User.deleted_at).where(
-                    User.id.in_(user_ids)
-                )
+                select(User.id, User.full_name, User.is_active, User.deleted_at).where(User.id.in_(user_ids))
             )
         ).all()
-        names = {uid: (dn or un) for uid, dn, un, _ia, _da in rows}
-        active = {uid: _person_is_active(ia, da) for uid, _dn, _un, ia, da in rows}
+        names = {uid: name for uid, name, _ia, _da in rows}
+        active = {uid: _person_is_active(ia, da) for uid, _name, ia, da in rows}
     return [
         {
             **_to_member_read(m),
@@ -1038,7 +1042,11 @@ async def _compose_human_nodes(session: AsyncSession, company_id: uuid.UUID) -> 
                 # ``assignee_user_id`` references.
                 id=f"user:{user_id}",
                 node_id=str(user_id),
-                name=display_name or username or str(user_id),
+                # #13957: the canonical rule plus the third rung this site
+                # needs -- the join below is a LEFT OUTER JOIN, so a membership
+                # whose user row is gone yields NULL for both names and must
+                # still render something the caller can key on.
+                name=resolve_display_name(display_name, username, str(user_id)),
                 title=role_label,
                 # ``idle`` is exactly what ``_heartbeat_status_to_org_status``
                 # returns for an agent with no run, so it asserts no liveness we

--- a/autobot-backend/llc/api/work_items.py
+++ b/autobot-backend/llc/api/work_items.py
@@ -39,6 +39,7 @@ from api.user_management.dependencies import get_current_user, require_org_conte
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.user_management.models.user import resolve_display_name
 from llc.deps import assert_company_access, get_session, service_dep
 from models.agent_org import AgentOrgNode
 from user_management.models.user import User
@@ -270,7 +271,7 @@ async def _assignee_display(item: Any, session: AsyncSession) -> Optional[Dict[s
         row = (
             await session.execute(select(User.display_name, User.username).where(User.id == item.assignee_user_id))
         ).one_or_none()
-        name = (row.display_name or row.username) if row else None
+        name = resolve_display_name(row.display_name, row.username) if row else None
         return {
             "type": AssigneeType.USER.value,
             "id": str(item.assignee_user_id),

--- a/autobot-backend/llc/kb/write_guard.py
+++ b/autobot-backend/llc/kb/write_guard.py
@@ -20,7 +20,28 @@ from user_management.models.organization import Organization
 
 logger = get_logger(__name__)
 
-_SUPERADMIN_ROLES: frozenset[str] = frozenset({"platform_admin", "superadmin"})
+# "May write KB content across an organisation boundary" (#12786).
+#
+# This is a DIFFERENT question from ``is_admin_role`` and the member sets differ
+# on purpose — compare them rather than the names:
+#
+#     ADMIN_ROLES         : admin, superadmin
+#     CROSS_ORG_KB_ROLES  : platform_admin, superadmin
+#
+# ``admin`` is administrative *within its own organisation* and is deliberately
+# absent here: the whole point of the guard below is that an org admin must not
+# reach a parent org's KB namespace. Folding this into ``ADMIN_ROLES`` would add
+# ``admin`` and delete the property the guard exists to enforce, so it stays a
+# separate, named set.
+#
+# ``platform_admin``: no code path anywhere mints this role string — the
+# platform-level flag the rest of the codebase uses is the boolean
+# ``users.is_platform_admin`` / ``TenantContext.is_platform_admin``, not a role
+# named ``platform_admin``. It is preserved rather than dropped (removing it
+# would silently change this guard's behaviour if any deployment does set it),
+# and reconciling the two spellings is tracked separately — see the PR for
+# #12786.
+CROSS_ORG_KB_ROLES: frozenset[str] = frozenset({"platform_admin", "superadmin"})
 
 
 async def assert_not_writing_to_ancestor_kb(

--- a/autobot-backend/llc/models/enums.py
+++ b/autobot-backend/llc/models/enums.py
@@ -308,6 +308,18 @@ class BoardType(str, Enum):
 class MembershipRole(str, Enum):
     """Role of a human user within an LLC company (GH#8223).
 
+    NOT the platform RBAC vocabulary. Three unrelated enums use the word "role"
+    and share string values with nothing at the type level keeping them apart
+    (#14024) — this one answers "what is this person within this company?",
+    ``autobot_shared.auth.permissions.Role`` answers "what may this account do
+    on the platform?", and ``CategoryDefaults.ROLE_*`` answers "who wrote this
+    chat message?".
+
+    ``"admin"`` is in this vocabulary AND in ``auth.permissions.Role``, so a
+    company admin and a platform admin are the same string and different
+    authority. Never pass one where the other is expected; the overlap is
+    asserted in ``security/roles_do_not_collide_test.py``.
+
     Member order matches the deployed (migration-built) enum label order so a
     create_all-built ``membershiprole`` sorts identically to a migration-built
     one (GH#10076): migration 031 created ('owner','admin','member','guest') and

--- a/autobot-backend/middleware/builtin/permission_enforcement_test.py
+++ b/autobot-backend/middleware/builtin/permission_enforcement_test.py
@@ -42,9 +42,31 @@ class TestRoleSatisfies:
         assert _role_satisfies("admin", _WRITE_PERM) is True
         assert _role_satisfies("admin", _ADMIN_ONLY_PERM) is True
 
-    def test_superadmin_holds_every_permission(self):
-        """`superadmin` is administrative but not a `Role` enum member (#12704/#12717)."""
-        assert _role_satisfies("superadmin", _ADMIN_ONLY_PERM) is True
+    def test_superadmin_holds_no_permission(self):
+        """The inversion #13854 made deliberately, at the gate that enforces it.
+
+        This asserted the opposite until #13854, and it passed for a reason that
+        was never a decision: ``role_has_permission`` short-circuited on
+        ``is_admin_role``, so being in ``ADMIN_ROLES`` — a *predicate* — silently
+        granted every permission in the system. ``SecurityLayer.check_permission``
+        denied superadmin those same permissions at the same time.
+
+        ``superadmin`` is now a first-class ``Role`` whose ``ROLE_PERMISSIONS``
+        entry is explicitly empty, and every resolver reads that one mapping. It
+        remains administrative (``require_role`` at 17 endpoints, ``is_admin_role``
+        at the imperative checks) — it simply holds no granular grant, so this
+        extension refuses it a tool that requires one.
+        """
+        assert _role_satisfies("superadmin", _ADMIN_ONLY_PERM) is False
+        assert _role_satisfies("superadmin", _READ_PERM) is False
+
+    def test_superadmin_is_still_administrative(self):
+        """The tightening above is about grants, not about retiring the role."""
+        from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role
+
+        assert is_admin_role("superadmin") is True
+        assert Role("superadmin") is Role.SUPERADMIN
+        assert ROLE_PERMISSIONS[Role.SUPERADMIN] == []
 
     def test_operator_lacks_an_admin_only_permission(self):
         assert _role_satisfies("operator", _ADMIN_ONLY_PERM) is False

--- a/autobot-backend/security/auth_rbac_test.py
+++ b/autobot-backend/security/auth_rbac_test.py
@@ -275,10 +275,12 @@ class TestPermissionIntegration:
 class TestIsAdminRole:
     """#12717: the single answer to "is this role administrative?".
 
-    "superadmin" is passed as a raw string to require_role() at 17 call sites
-    but is NOT a member of the canonical Role enum, so hand-rolled
+    "superadmin" is passed as a raw string to require_role() at 17 call sites.
+    It was not a member of the canonical Role enum, so hand-rolled
     ``role == "admin"`` checks silently locked superadmins out of read paths
-    whose write paths already allowed them.
+    whose write paths already allowed them. #13854 made it a first-class Role
+    member; ``is_admin_role`` remains the answer for imperative checks, and this
+    class pins that it still admits both administrative roles.
     """
 
     def test_accepts_both_administrative_roles(self):

--- a/autobot-backend/security/canonical_permissions_test.py
+++ b/autobot-backend/security/canonical_permissions_test.py
@@ -85,19 +85,33 @@ def test_an_unknown_role_is_denied(gate):
 # ------------------------------------------- superadmin and case, at the root
 
 
-def test_superadmin_is_not_a_role_member_and_is_not_silently_treated_as_one():
-    """``Role("superadmin")`` raises, and this resolver does not paper over it.
+def test_superadmin_is_a_role_member_that_resolves_to_no_permissions():
+    """#13854 landed the first-class member; the answer it gives is unchanged.
 
-    An earlier version of this change mapped it onto admin's set via
-    ``ADMIN_ROLES``. That reads as a fix and is an authorisation expansion: it
-    granted 54 permissions including shell execution to a role that held none of
-    them. The genuine fix is a first-class ``Role`` member with its own
-    ``ROLE_PERMISSIONS`` entry — #13854.
+    This test used to assert ``Role("superadmin")`` *raises*. That was the
+    defect, not the contract: the empty permission list was produced by a failed
+    enum lookup, so superadmin was indistinguishable from a typo, and
+    ``role_has_permission`` — reading a different source — granted it everything
+    at the same time.
+
+    It is now a member with an explicitly empty ``ROLE_PERMISSIONS`` entry. The
+    resolved answer here is byte-identical to before; what changed is that it is
+    now stated in the canonical mapping rather than inferred from an exception.
     """
-    with pytest.raises(ValueError):
-        Role("superadmin")
-
+    assert Role("superadmin") is Role.SUPERADMIN
+    assert ROLE_PERMISSIONS[Role.SUPERADMIN] == []
     assert canonical_role_permissions("superadmin") == []
+
+
+def test_an_unrecognised_role_is_still_distinguishable_from_superadmin():
+    """Both resolve to ``[]``; only one of them is a role.
+
+    The point of the change is that these two cases stopped being the same
+    event. If superadmin were dropped from the enum again, this fails.
+    """
+    assert Role("superadmin") is Role.SUPERADMIN
+    with pytest.raises(ValueError):
+        Role("not-a-role")
 
 
 @pytest.mark.parametrize("role", ["Admin", "ADMIN", "  admin  ", "aDmIn"])
@@ -191,9 +205,10 @@ def test_a_role_that_may_not_run_a_shell_command_is_denied_at_the_gate(gate, rol
 def test_superadmin_gains_no_permissions_from_this_change(gate):
     """It is administrative via ``ADMIN_ROLES`` but holds no canonical grants.
 
-    Mapping it onto admin's set would hand it 54 permissions including shell
-    execution that it did not previously have — an authorisation expansion, not
-    the resolver fix #13820 decided. Tracked separately in #13854.
+    Still true after #13854 made it a ``Role`` member: the entry it gained is
+    an explicitly empty one. Mapping it onto admin's set would hand it 54
+    permissions including shell execution — an authorisation expansion, which
+    neither #13820 nor #13854 decided to make.
     """
     assert gate.check_permission("superadmin", "allow_shell_execute") is False
     assert gate.check_permission("superadmin", "admin.system") is False

--- a/autobot-backend/security/roles_do_not_collide_test.py
+++ b/autobot-backend/security/roles_do_not_collide_test.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Three 'role' vocabularies share literals; the overlap must stay deliberate (#14024).
+
+Three unrelated vocabularies use the word "role" and share string values, with
+nothing at the type level keeping them apart:
+
+    platform RBAC       autobot_shared.auth.permissions.Role
+    company membership  llc.models.enums.MembershipRole
+    chat message role   autobot_shared.ssot_constants.CategoryDefaults.ROLE_*
+
+**They are correctly separate concepts and are deliberately not merged.** This
+file is not a step toward collapsing them — it is the guard that keeps the
+collision surface from growing silently.
+
+The failure mode is real and already happened. ``tools/tool_registry`` set
+``"user_role": "user"`` — an RBAC input read by ``worker_node._validate_user_role``.
+The hardcoded-value guard suggested ``CategoryDefaults.ROLE_USER``, the *chat*
+constant, which holds ``"user"`` too. Applying that suggestion would have tied
+an authorization decision to a presentation constant, gone green, and been
+invisible in review (#13934). Any later re-tuning of the chat vocabulary would
+then have silently changed an authz value.
+
+A same-NAME search finds nothing here: the three types have different names. The
+comparison that matters is between their MEMBER SETS, which is what this file
+does.
+"""
+
+from llc.models.enums import MembershipRole
+
+from autobot_shared.auth.permissions import Role
+from autobot_shared.ssot_constants import CategoryDefaults
+
+RBAC_ROLES = frozenset(role.value for role in Role)
+MEMBERSHIP_ROLES = frozenset(role.value for role in MembershipRole)
+CHAT_ROLES = frozenset(
+    {
+        CategoryDefaults.ROLE_USER,
+        CategoryDefaults.ROLE_ASSISTANT,
+        CategoryDefaults.ROLE_SYSTEM,
+    }
+)
+
+# The overlaps that exist today, each one reviewed and accepted. A new collision
+# fails the tests below with the offending value named, instead of waiting for
+# someone to notice.
+KNOWN_RBAC_MEMBERSHIP_OVERLAP = frozenset({"admin"})
+KNOWN_RBAC_CHAT_OVERLAP = frozenset({"user"})
+KNOWN_MEMBERSHIP_CHAT_OVERLAP = frozenset()
+
+
+# ------------------------------------------- the subjects exist and are whole
+#
+# Without these, every overlap assertion below is satisfiable by an empty set —
+# an import that silently resolved to nothing would read as "no collisions".
+
+
+def test_each_vocabulary_is_populated():
+    assert RBAC_ROLES, "platform RBAC vocabulary resolved empty"
+    assert MEMBERSHIP_ROLES, "company membership vocabulary resolved empty"
+    assert CHAT_ROLES, "chat message vocabulary resolved empty"
+
+
+def test_each_vocabulary_holds_the_members_it_is_supposed_to():
+    """Written out, so a rename or a removal is caught here and not downstream."""
+    assert RBAC_ROLES == {"admin", "superadmin", "operator", "analyst", "editor", "user", "readonly"}
+    assert MEMBERSHIP_ROLES == {"owner", "admin", "member", "guest", "lead"}
+    assert CHAT_ROLES == {"user", "assistant", "system"}
+
+
+# ------------------------------------------------ the overlap is exactly known
+
+
+def test_rbac_and_membership_share_only_the_known_value():
+    """``admin`` means "platform administrator" in one and "company admin" in the other."""
+    overlap = RBAC_ROLES & MEMBERSHIP_ROLES
+    assert overlap == KNOWN_RBAC_MEMBERSHIP_OVERLAP, (
+        f"platform RBAC and company membership now share {sorted(overlap)}; "
+        f"previously {sorted(KNOWN_RBAC_MEMBERSHIP_OVERLAP)}. A value in both type-checks in "
+        "either position. Confirm the new collision is deliberate and add it here, or rename it."
+    )
+
+
+def test_rbac_and_chat_share_only_the_known_value():
+    """``user`` is an authorization subject in one and a message author in the other."""
+    overlap = RBAC_ROLES & CHAT_ROLES
+    assert overlap == KNOWN_RBAC_CHAT_OVERLAP, (
+        f"platform RBAC and chat message roles now share {sorted(overlap)}; "
+        f"previously {sorted(KNOWN_RBAC_CHAT_OVERLAP)}. This is the pair that produced #13934 — "
+        "a chat constant suggested for an RBAC field. Confirm and record it here, or rename it."
+    )
+
+
+def test_membership_and_chat_do_not_collide_at_all():
+    overlap = MEMBERSHIP_ROLES & CHAT_ROLES
+    assert overlap == KNOWN_MEMBERSHIP_CHAT_OVERLAP, (
+        f"company membership and chat message roles now share {sorted(overlap)}, "
+        "which they never did before. Confirm and record it here, or rename it."
+    )
+
+
+def test_the_new_rbac_member_collides_with_nothing():
+    """``superadmin`` was added by #13854 into a namespace with two neighbours.
+
+    Stated separately so the addition is visibly checked against both other
+    vocabularies rather than only against the aggregate overlap.
+    """
+    assert "superadmin" in RBAC_ROLES
+    assert "superadmin" not in MEMBERSHIP_ROLES
+    assert "superadmin" not in CHAT_ROLES
+
+
+# ------------------------------------------------ the values stay distinguishable
+
+
+def test_a_chat_role_is_not_a_valid_rbac_role_except_where_known():
+    """The concrete consequence, asserted as behaviour rather than as set algebra.
+
+    ``assistant`` and ``system`` must not resolve as RBAC roles at all. ``user``
+    does, and that is the known collision — asserted explicitly so it stays a
+    recorded fact rather than an accident.
+    """
+    for chat_role in (CategoryDefaults.ROLE_ASSISTANT, CategoryDefaults.ROLE_SYSTEM):
+        try:
+            Role(chat_role)
+        except ValueError:
+            continue
+        raise AssertionError(f"chat role {chat_role!r} now resolves as a platform RBAC role")
+
+    assert Role(CategoryDefaults.ROLE_USER) is Role.USER

--- a/autobot-backend/security/roles_do_not_collide_test.py
+++ b/autobot-backend/security/roles_do_not_collide_test.py
@@ -28,10 +28,9 @@ comparison that matters is between their MEMBER SETS, which is what this file
 does.
 """
 
-from llc.models.enums import MembershipRole
-
 from autobot_shared.auth.permissions import Role
 from autobot_shared.ssot_constants import CategoryDefaults
+from llc.models.enums import MembershipRole
 
 RBAC_ROLES = frozenset(role.value for role in Role)
 MEMBERSHIP_ROLES = frozenset(role.value for role in MembershipRole)

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -113,13 +113,15 @@ def canonical_role_permissions(user_role: str) -> List[str]:
     lookups always agree on who a role is — a normalisation applied to one source
     of three creates a second identity that holds some grants and not others.
 
-    ``superadmin`` deliberately resolves to ``[]`` here. It is administrative per
-    ``ADMIN_ROLES`` and is **not** a ``Role`` member, so mapping it onto admin's
-    set would hand it 54 permissions including shell execution that it did not
-    previously hold — a live authorisation expansion, which is not what #13820
-    decided. The real fix is making it a first-class ``Role`` with its own
-    ``ROLE_PERMISSIONS`` entry (see the TODO in ``autobot_shared.auth.permissions``);
-    tracked in #13854.
+    ``superadmin`` resolves to ``[]`` here, and since #13854 it does so for a
+    stated reason rather than by accident. It is now a first-class ``Role``
+    member whose ``ROLE_PERMISSIONS`` entry is explicitly empty: administrative
+    as a predicate (``require_role``, ``is_admin_role``), holder of no granular
+    permission. Before #13854 this ``[]`` came from ``Role("superadmin")``
+    *raising* — the same answer, but indistinguishable from an unrecognised
+    role, and contradicted by ``role_has_permission``, which granted superadmin
+    everything. Both paths now agree, and they agree because one mapping says
+    so.
 
     An unrecognised role yields ``[]`` — no grant, and no exception either.
     """

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -28,7 +28,7 @@ import uuid
 
 import aiohttp
 
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
@@ -174,13 +174,16 @@ class MCPDispatcher:
         if declared is None:
             return "undeclared"
 
-        # superadmin is administrative but is not a Role enum member (see
-        # ADMIN_ROLES in autobot_shared.auth.permissions), so resolving it
-        # through Role() would report the most privileged role in the system as
-        # denied on every tool. is_admin_role is the canonical, case-insensitive
-        # answer.
-        if is_admin_role(role):
-            return None
+        # #13854 removed an ``is_admin_role`` short-circuit that stood here. It
+        # existed because ``superadmin`` was not a ``Role`` member, so resolving
+        # it through ``Role()`` raised and reported the most privileged role in
+        # the system as denied on every tool. It is a Role member now, so the
+        # canonical mapping answers for it like any other role — and what that
+        # mapping says is that superadmin holds no granular permission, so an
+        # MCP tool requiring one is refused. That is the deliberate reading of
+        # an empty ROLE_PERMISSIONS entry, not an accident of resolution: the
+        # short-circuit was the last place where being in ``ADMIN_ROLES``
+        # granted access that ``ROLE_PERMISSIONS`` never wrote down.
         try:
             held = _ROLE_PERMISSION_VALUES[Role(str(role or "").lower())]
         except (ValueError, KeyError):

--- a/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
+++ b/autobot-backend/services/mcp_dispatch_rbac_shadow_test.py
@@ -97,16 +97,49 @@ def test_a_malformed_cache_entry_does_not_raise():
 
 @pytest.mark.parametrize("role", ["superadmin", "SUPERADMIN", "Admin", "ADMIN"])
 def test_administrative_roles_are_not_reported_as_unknown(role):
-    """``superadmin`` is administrative but is not a ``Role`` enum member.
+    """The original point of this test, preserved across #13854.
 
-    Resolving it through ``Role()`` reported the most privileged role in the system
-    as denied on every tool — and a stage 3 built on that inventory would have
-    stripped a superadmin of all MCP access. ``is_admin_role`` is the canonical,
-    case-insensitive answer, and it is what the legacy gate already uses.
+    ``superadmin`` used not to be a ``Role`` member, so ``Role()`` raised on it and
+    the shadow log reported the most privileged role in the system as an
+    *unrecognised string*. That was the defect: an administrative role and a typo
+    produced the same verdict.
+
+    It is a ``Role`` member now, so it resolves — and what it resolves to is a role
+    holding no granular permission. The verdict is therefore about a missing
+    grant, never about an unknown role. That distinction is the one this test
+    exists to protect, and it is asserted directly below rather than inferred from
+    ``is None``.
     """
     d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
 
+    verdict = d._would_deny("click", role)
+
+    assert verdict is None or not verdict.startswith("unknown-role"), (
+        f"{role!r} resolved as an unrecognised role ({verdict!r}) — it is administrative "
+        "and must resolve through the canonical vocabulary"
+    )
+
+
+@pytest.mark.parametrize("role", ["admin", "ADMIN", "Admin"])
+def test_admin_is_permitted_every_declared_tool(role):
+    """``admin`` holds all 54 permissions, so it is never denied a declared tool."""
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
     assert d._would_deny("click", role) is None
+
+
+@pytest.mark.parametrize("role", ["superadmin", "SUPERADMIN"])
+def test_superadmin_is_refused_a_tool_whose_permission_it_does_not_hold(role):
+    """#13854: this gate stopped short-circuiting on the administrative predicate.
+
+    Before, ``is_admin_role`` waved superadmin through every tool while the
+    canonical mapping said it held nothing — ``ADMIN_ROLES`` acting as a
+    permission source. The refusal names the missing grant, so the reason is
+    actionable rather than a bare denial.
+    """
+    d = _dispatcher({"click": _tool("click", "mcp.browser.control")})
+
+    assert d._would_deny("click", role) == "missing:mcp.browser.control"
 
 
 def test_a_known_role_in_the_wrong_case_still_resolves():

--- a/autobot-backend/tests/integration/test_cross_service_auth_parity.py
+++ b/autobot-backend/tests/integration/test_cross_service_auth_parity.py
@@ -50,7 +50,7 @@ for p in (_AUTOBOT_BACKEND, str(_AUTOBOT_SHARED)):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role, is_admin_role
 
 # ---------------------------------------------------------------------------
 # Helpers — replicate each backend's enforcement path without FastAPI imports
@@ -253,14 +253,58 @@ class TestPermissionCompleteness:
             f"Add them to the appropriate role(s) in autobot_shared/auth/permissions.py."
         )
 
-    @pytest.mark.parametrize("role", list(Role))
-    def test_role_has_at_least_one_permission(self, role: Role):
-        """Every Role must have at least one permission (no empty-set roles)."""
+    # #13854: the invariant is "a role authorised by GRANT must grant
+    # something" — not "every role must". Administrative roles are authorised
+    # by PREDICATE: ``require_role`` and ``is_admin_role`` admit them directly,
+    # so ``superadmin``'s empty entry is a deliberate statement of policy, not a
+    # wiring omission. Asserting the old, broader form here would contradict
+    # ``roles_are_canonical_test``, which asserts the opposite on purpose.
+    #
+    # The exemption is DERIVED from ``is_admin_role`` — the same predicate the
+    # live gates use — rather than a second hand-written list of administrative
+    # roles. Such a list is exactly the fork #13854/#12786 removed, and it would
+    # silently stop exempting the right roles the moment ``ADMIN_ROLES`` changed.
+    # ``role.value`` (not the member) is passed deliberately: ``str()`` on a
+    # ``(str, Enum)`` member yields "Role.ADMIN", not "admin" — see #14944.
+    @pytest.mark.parametrize("role", [r for r in Role if not is_admin_role(r.value)])
+    def test_non_administrative_role_has_at_least_one_permission(self, role: Role):
+        """Every role that grants access through ROLE_PERMISSIONS must grant something."""
         perms = ROLE_PERMISSIONS.get(role, [])
         assert perms, (
             f"Role {role.value!r} has no permissions in ROLE_PERMISSIONS — "
-            f"every role must grant at least one permission."
+            f"every non-administrative role must grant at least one permission."
         )
+
+    def test_the_permissionless_roles_are_exactly_the_administrative_ones(self):
+        """The contrapositive, so the exemption above cannot quietly widen.
+
+        Stated as a property over every role rather than as an allowlist: ANY
+        role with an empty grant list must be administrative. A new empty
+        NON-administrative role is excluded from the parametrisation above and
+        would therefore never be checked there — this is the hole that leaves,
+        closed.
+        """
+        ungranted = {r.value for r in Role if not ROLE_PERMISSIONS.get(r, [])}
+
+        assert ungranted == {"superadmin"}, (
+            f"the set of roles holding zero permissions changed to {sorted(ungranted)}. "
+            "Only an administrative, predicate-authorised role may hold none (#13854). "
+            "Confirm the change is deliberate and record it here."
+        )
+        for value in ungranted:
+            assert is_admin_role(value), f"role {value!r} holds no permissions and is not administrative"
+
+    def test_the_parametrisation_above_is_not_empty(self):
+        """Guard against vacuity.
+
+        If the derived filter ever excluded every role, each parametrised case
+        would silently vanish rather than fail — an absent result reading as a
+        clean one.
+        """
+        graded = [r for r in Role if not is_admin_role(r.value)]
+
+        assert len(graded) >= 5, f"expected the non-administrative roles to be graded, got {graded}"
+        assert Role.ADMIN not in graded and Role.SUPERADMIN not in graded
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -82648,6 +82648,18 @@ export interface components {
          * MembershipRole
          * @description Role of a human user within an LLC company (GH#8223).
          *
+         *     NOT the platform RBAC vocabulary. Three unrelated enums use the word "role"
+         *     and share string values with nothing at the type level keeping them apart
+         *     (#14024) — this one answers "what is this person within this company?",
+         *     ``autobot_shared.auth.permissions.Role`` answers "what may this account do
+         *     on the platform?", and ``CategoryDefaults.ROLE_*`` answers "who wrote this
+         *     chat message?".
+         *
+         *     ``"admin"`` is in this vocabulary AND in ``auth.permissions.Role``, so a
+         *     company admin and a platform admin are the same string and different
+         *     authority. Never pass one where the other is expected; the overlap is
+         *     asserted in ``security/roles_do_not_collide_test.py``.
+         *
          *     Member order matches the deployed (migration-built) enum label order so a
          *     create_all-built ``membershiprole`` sorts identically to a migration-built
          *     one (GH#10076): migration 031 created ('owner','admin','member','guest') and

--- a/autobot-slm-backend/api/scim.py
+++ b/autobot-slm-backend/api/scim.py
@@ -105,7 +105,7 @@ def _scim_error(detail: str, scim_type: str = "invalidValue", status_code: int =
 
 def _user_to_scim(user: User, base_url: str) -> dict:
     """Serialise a User ORM instance to a SCIM 2.0 User resource dict."""
-    name_parts = (user.display_name or user.username).split(" ", 1)
+    name_parts = user.full_name.split(" ", 1)  # #13957: the canonical rule
     given = name_parts[0]
     family = name_parts[1] if len(name_parts) > 1 else ""
     return {

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -127,9 +127,38 @@ class Permission(str, Enum):
 
 
 class Role(str, Enum):
-    """Standard roles in the AutoBot system."""
+    """Platform RBAC roles — the vocabulary that answers "what may this account do?".
+
+    This is one of **three** unrelated vocabularies in the codebase that use the
+    word "role", and they share string values with nothing at the type level
+    keeping them apart (#14024). They are correctly separate concepts and are
+    deliberately **not** merged; the hazard is that a value from the wrong one
+    type-checks, passes tests, and reads correctly at a glance:
+
+    ===================== ============================================= =========================================
+    vocabulary            defined in                                    members
+    ===================== ============================================= =========================================
+    platform RBAC (here)  ``autobot_shared.auth.permissions.Role``      admin, superadmin, operator, analyst,
+                                                                        editor, user, readonly
+    company membership    ``llc.models.enums.MembershipRole``           owner, admin, member, guest, lead
+    chat message role     ``ssot_constants.CategoryDefaults.ROLE_*``    user, assistant, system
+    ===================== ============================================= =========================================
+
+    Shared literals: ``"admin"`` with ``MembershipRole``, ``"user"`` with the
+    chat constants. ``roles_do_not_collide_test.py`` asserts that overlap is
+    exactly this and fails when a new value collides.
+
+    Never substitute across the three. ``tools/tool_registry`` nearly tied an
+    authorization decision to ``CategoryDefaults.ROLE_USER`` — a presentation
+    constant that merely happens to hold ``"user"`` too (#13934).
+
+    ``SUPERADMIN`` (#13854/#12786) is administrative — it is admitted by
+    ``require_role`` at 17 endpoints and by :func:`is_admin_role` — and holds
+    **no** granular permissions. See ``ROLE_PERMISSIONS`` for why.
+    """
 
     ADMIN = "admin"
+    SUPERADMIN = "superadmin"
     OPERATOR = "operator"
     ANALYST = "analyst"
     EDITOR = "editor"
@@ -137,20 +166,31 @@ class Role(str, Enum):
     READONLY = "readonly"
 
 
-# ``require_role(*roles: Role | str)`` accepts raw strings, so 17 call sites
-# pass ``require_role("admin", "superadmin")`` even though ``superadmin`` is not
-# a member of Role above. Every such guard admits a superadmin, while any
-# hand-rolled ``role == "admin"`` check rejects one -- so a superadmin could
-# perform the write but not the read (#12704, #12717).
+# The roles that answer "is this role administrative?" -- declared as *enum
+# members*, not as loose strings (#13854).
 #
-# This set is the single place that answers "is this role administrative?".
-# It lives here rather than in autobot-backend's auth_rbac because that module
+# It used to be ``frozenset({"admin", "superadmin"})``, a literal set naming a
+# role that was not in the enum above. That shape had a specific hazard, named
+# on #13854: because ``role_has_permission`` short-circuited on it, **adding a
+# member to this frozenset silently granted that member every permission in the
+# system**, shell execution included, with no edit to ROLE_PERMISSIONS and no
+# review of the security layer. A predicate ("is this administrative?") was
+# doubling as a permission source, which is not what it is for.
+#
+# Deriving it from the enum closes that structurally. A role cannot be named
+# here unless it is a Role member, and a Role member cannot exist without a
+# ROLE_PERMISSIONS entry (asserted by ``test_permission_parity`` and by
+# ``roles_are_canonical_test``), so its grants are always written down in the
+# one place a reader looks -- and adding one is an edit a reviewer sees.
+#
+# This lives here rather than in autobot-backend's auth_rbac because that module
 # imports auth_middleware, which needs this answer too -- importing it back the
 # other way closes a cycle (#12786).
-#
-# Making superadmin a first-class Role member is the deeper fix and is still
-# open: this enum drives ROLE_PERMISSIONS for BOTH backends.
-ADMIN_ROLES: frozenset = frozenset({"admin", "superadmin"})
+_ADMINISTRATIVE_ROLES: frozenset = frozenset({Role.ADMIN, Role.SUPERADMIN})
+
+# The string form, for the many callers that hold a raw role string. Derived, so
+# the two can never drift.
+ADMIN_ROLES: frozenset = frozenset(role.value for role in _ADMINISTRATIVE_ROLES)
 
 
 def is_admin_role(role) -> bool:
@@ -226,6 +266,35 @@ ROLE_PERMISSIONS: Dict[Role, List[Permission]] = {
         Permission.MCP_HTTP_WRITE,
         Permission.MCP_DESKTOP_CONTROL,
     ],
+    # superadmin holds NO granular permissions. This is deliberate, it is the
+    # decision #13854 asked for, and it is written as an explicit empty entry
+    # rather than an omission so that a reader who looks here finds an answer
+    # instead of a gap (#13854, #12786).
+    #
+    # What superadmin IS: an administrative *predicate*. It is admitted by
+    # ``require_role("admin", "superadmin")`` at 17 endpoints and by
+    # ``is_admin_role`` at the imperative checks that cannot use a dependency.
+    # Those are unchanged by this entry.
+    #
+    # What it is NOT: a permission holder. Granting it admin's set would have
+    # added 54 permissions — ``admin.system``, ``security.manage``,
+    # ``admin.users.write`` and ``allow_shell_execute`` among them — none of
+    # which it held through the SecurityLayer gate before. #13820 measured that
+    # expansion and refused to let it ride along inside a resolver fix; nothing
+    # since has decided to widen the role, so this change does not either. An
+    # authorization change is a separate, deliberate act.
+    #
+    # The effect is that superadmin now resolves the SAME WAY through every
+    # path — Role(), ROLE_PERMISSIONS, canonical_role_permissions,
+    # SecurityLayer.check_permission, role_has_permission and SYSTEM_ROLES all
+    # say "administrative, zero granular grants". Before this it resolved four
+    # different ways, including allow-all at one gate and deny-all at another.
+    #
+    # If superadmin should instead be operational, the change is one line here:
+    #     Role.SUPERADMIN: list(ROLE_PERMISSIONS[Role.ADMIN]),
+    # It is an authorization expansion and needs a security review and a data
+    # migration for the ``roles`` table, which an empty entry does not.
+    Role.SUPERADMIN: [],
     Role.OPERATOR: [
         Permission.API_READ,
         Permission.API_WRITE,
@@ -353,20 +422,32 @@ def role_has_permission(role: str | None, permission: str) -> bool:
     ``ROLE_PERMISSIONS`` — added here so a second consumer (#14420's
     ``PermissionEnforcementExtension``) does not need its own copy.
 
-    Administrative roles (see ``is_admin_role``) hold every permission. An
-    absent, unrecognised, or non-administrative role that does not carry
-    *permission* is denied — this fails closed rather than defaulting to
-    permissive for a role string this module cannot resolve.
+    Every role is answered from ``ROLE_PERMISSIONS`` and nowhere else. There is
+    no administrative short-circuit: this used to return True for anything
+    :func:`is_admin_role` accepted, which quietly made ``ADMIN_ROLES`` — a
+    predicate — the most permissive permission source in the system, and put
+    this function in direct contradiction with
+    ``SecurityLayer.check_permission``, which denied superadmin the very
+    permissions this granted it (#13854).
+
+    Removing it costs ``admin`` nothing: ``ROLE_PERMISSIONS[Role.ADMIN]``
+    contains every member of ``Permission`` (asserted in
+    ``roles_are_canonical_test``), so the short-circuit never decided an admin
+    call. It changes exactly one role — ``superadmin``, from allow-all to the
+    empty set its ROLE_PERMISSIONS entry declares.
+
+    An absent, unrecognised, or unmapped role is denied — this fails closed
+    rather than defaulting to permissive for a role this module cannot resolve.
+    A ``Role`` member with no ROLE_PERMISSIONS entry likewise denies instead of
+    raising ``KeyError`` at request time, which a bare subscript here did.
     """
-    if is_admin_role(role):
-        return True
     if not role:
         return False
     try:
         role_enum = Role(str(role).lower())
     except ValueError:
         return False
-    return permission in _ROLE_PERMISSION_VALUES[role_enum]
+    return permission in _ROLE_PERMISSION_VALUES.get(role_enum, frozenset())
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +507,12 @@ def _build_system_permissions() -> List[tuple]:
 
 _ROLE_META: Dict[Role, Dict] = {
     Role.ADMIN: {"description": "Full administrative access", "priority": 100},
+    # Priority stated explicitly: the ``_ROLE_META.get`` fallback below would
+    # otherwise hand superadmin priority 0, sorting the most privileged role in
+    # the system BELOW readonly (10). 110 keeps the ordering honest — it is
+    # administrative at every gate that admits admin. The empty permission list
+    # in ROLE_PERMISSIONS is what limits it; priority is not a grant.
+    Role.SUPERADMIN: {"description": "Administrative role; holds no granular permissions (#13854)", "priority": 110},
     Role.OPERATOR: {"description": "Operator access for day-to-day service management", "priority": 80},
     Role.ANALYST: {"description": "Analytics and read-heavy access", "priority": 60},
     Role.EDITOR: {"description": "Content and knowledge editing access", "priority": 55},

--- a/autobot_shared/auth/permissions_test.py
+++ b/autobot_shared/auth/permissions_test.py
@@ -14,7 +14,13 @@ than only through one caller's delegate.
 
 import pytest
 
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role, role_has_permission
+from autobot_shared.auth.permissions import (
+    ROLE_PERMISSIONS,
+    Permission,
+    Role,
+    is_admin_role,
+    role_has_permission,
+)
 
 # A permission every non-readonly role holds, and one only admin holds —
 # picked from the real enum/mapping rather than invented values, so a
@@ -41,11 +47,46 @@ def test_admin_holds_every_permission():
         assert role_has_permission("admin", perm.value) is True, perm.value
 
 
-def test_superadmin_holds_every_permission():
-    """`superadmin` is administrative but not a `Role` enum member (#12704/#12717) —
-    `is_admin_role` is the canonical, case-insensitive answer."""
+def test_superadmin_holds_no_permission():
+    """The inversion #13854 made deliberately, asserted as the whole set.
+
+    This test previously asserted the exact opposite — superadmin held every
+    permission — and it passed for a reason that was never a decision:
+    `role_has_permission` short-circuited on `is_admin_role`, so `ADMIN_ROLES`
+    was silently the most permissive permission source in the system. Meanwhile
+    `SecurityLayer.check_permission` denied superadmin those same permissions.
+    Two canonical resolvers, opposite answers, for the most privileged role.
+
+    Superadmin is now a `Role` member with an explicitly empty
+    `ROLE_PERMISSIONS` entry, and every resolver reads that one mapping. It is
+    administrative as a predicate (see `is_admin_role`) and holds no granular
+    grant.
+    """
     for perm in Permission:
-        assert role_has_permission("superadmin", perm.value) is True, perm.value
+        assert role_has_permission("superadmin", perm.value) is False, perm.value
+
+
+def test_superadmin_is_still_administrative():
+    """The predicate is unchanged — this is not a retirement of the role.
+
+    The 17 `require_role("admin", "superadmin")` endpoints and every
+    `is_admin_role` caller admit it exactly as before.
+    """
+    assert is_admin_role("superadmin") is True
+    assert Role("superadmin") is Role.SUPERADMIN
+    assert ROLE_PERMISSIONS[Role.SUPERADMIN] == []
+
+
+def test_being_administrative_does_not_grant_permissions():
+    """#13854 AC: `ADMIN_ROLES` must not be a permission source.
+
+    Membership of ADMIN_ROLES and possession of a permission are now decided by
+    different data. Asserted through a role that is in one and not the other, so
+    a reintroduced short-circuit fails here rather than being invisible.
+    """
+    assert is_admin_role("superadmin") is True
+    assert role_has_permission("superadmin", Permission.SHELL_EXECUTE.value) is False
+    assert role_has_permission("superadmin", Permission.ADMIN_SYSTEM.value) is False
 
 
 def test_admin_role_is_case_insensitive():

--- a/autobot_shared/auth/roles_are_canonical_test.py
+++ b/autobot_shared/auth/roles_are_canonical_test.py
@@ -26,9 +26,9 @@ assertion here.
 import pytest
 
 from autobot_shared.auth.permissions import (
+    _ROLE_META,
     ADMIN_ROLES,
     ROLE_PERMISSIONS,
-    _ROLE_META,
     Permission,
     Role,
     is_admin_role,

--- a/autobot_shared/auth/roles_are_canonical_test.py
+++ b/autobot_shared/auth/roles_are_canonical_test.py
@@ -1,0 +1,163 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The canonical role vocabulary has no members outside it (#13854, #12786).
+
+``superadmin`` was administrative — ``ADMIN_ROLES`` held it, ``is_admin_role``
+returned True for it, 17 ``require_role`` guards admitted it — while not being a
+``Role`` member and holding no ``ROLE_PERMISSIONS`` entry. It therefore resolved
+four different ways at once: allow-all through ``role_has_permission``, deny-all
+through ``SecurityLayer.check_permission``, admitted by ``require_role``, and
+``ValueError`` through ``Role()``.
+
+These tests pin the properties that made that state possible, so it cannot
+reassemble itself:
+
+1. every administrative role is a real ``Role`` with a real grant list;
+2. being administrative is not, by itself, a grant;
+3. every ``Role`` member has an entry, so no lookup falls off the mapping.
+
+Each test asserts the PRESENCE of what it expects, never merely the absence of a
+failure — an empty vocabulary would otherwise satisfy every "nothing is wrong"
+assertion here.
+"""
+
+import pytest
+
+from autobot_shared.auth.permissions import (
+    ADMIN_ROLES,
+    ROLE_PERMISSIONS,
+    _ROLE_META,
+    Permission,
+    Role,
+    is_admin_role,
+    role_has_permission,
+)
+
+# The vocabulary as of #13854, written out. A rename or a removal fails here
+# first, with a message naming the member — rather than silently shrinking the
+# sets every other test in this file derives from the enum.
+EXPECTED_ROLE_VALUES = {
+    "admin",
+    "superadmin",
+    "operator",
+    "analyst",
+    "editor",
+    "user",
+    "readonly",
+}
+EXPECTED_ADMIN_ROLE_VALUES = {"admin", "superadmin"}
+
+
+# --------------------------------------------------- the vocabulary is present
+
+
+def test_the_role_enum_holds_exactly_the_expected_members():
+    """Presence, not absence. Guards against both a dropped and an added role."""
+    assert {role.value for role in Role} == EXPECTED_ROLE_VALUES
+
+
+def test_superadmin_is_a_member():
+    """Stated on its own because it is the member #13854 exists to add.
+
+    A regression that removes it would still pass a test comparing two derived
+    sets to each other.
+    """
+    assert Role.SUPERADMIN in Role
+    assert Role("superadmin") is Role.SUPERADMIN
+    assert Role.SUPERADMIN.value == "superadmin"
+
+
+# ------------------------------------- AC: every ADMIN_ROLES member is canonical
+
+
+def test_admin_roles_is_not_empty():
+    """The guard below is vacuous over an empty set — check the subject exists."""
+    assert ADMIN_ROLES == EXPECTED_ADMIN_ROLE_VALUES
+    assert len(ADMIN_ROLES) == 2
+
+
+@pytest.mark.parametrize("role_value", sorted(EXPECTED_ADMIN_ROLE_VALUES))
+def test_every_administrative_role_is_a_role_member_with_a_grant_list(role_value):
+    """#13854 AC: ``ADMIN_ROLES`` may not name a role the enum does not have.
+
+    This is the assertion that would have failed before #13854 —
+    ``Role("superadmin")`` raised — and it is parametrised over the literal
+    expected set rather than over ``ADMIN_ROLES`` itself, so an ADMIN_ROLES that
+    lost a member cannot make its own guard pass by shrinking.
+    """
+    role = Role(role_value)
+    assert role in ROLE_PERMISSIONS, f"{role_value} is administrative but has no ROLE_PERMISSIONS entry"
+    assert is_admin_role(role_value) is True
+
+
+def test_admin_roles_cannot_name_a_non_role():
+    """Derived from the enum, so a bare string cannot be added to it."""
+    for value in ADMIN_ROLES:
+        assert Role(value) in Role
+
+
+# ------------------------------ AC: ADMIN_ROLES is not a permission source
+
+
+def test_being_administrative_grants_nothing_by_itself():
+    """The core #13854 AC, asserted through the role that separates the two.
+
+    ``superadmin`` is in ``ADMIN_ROLES`` and holds an empty grant list. If any
+    resolver ever again short-circuits on the administrative predicate, this
+    fails. Asserted over the WHOLE Permission enum, not a sample, so a partial
+    reintroduction cannot slip through.
+    """
+    assert is_admin_role("superadmin") is True
+    assert ROLE_PERMISSIONS[Role.SUPERADMIN] == []
+
+    granted = [p.value for p in Permission if role_has_permission("superadmin", p.value)]
+    assert granted == [], f"ADMIN_ROLES membership leaked {len(granted)} permissions: {granted}"
+
+
+def test_admin_holds_every_permission_from_its_own_entry():
+    """The invariant that made removing the short-circuit safe (#13854).
+
+    ``role_has_permission`` used to return True for anything ``is_admin_role``
+    accepted. Removing that is only behaviour-preserving for ``admin`` because
+    admin's own ROLE_PERMISSIONS entry already covers every Permission member.
+    That was measured once; this asserts it continuously, because a future
+    permission added to the enum but not granted to admin would silently make
+    the removal a regression.
+    """
+    admin_grants = {p.value for p in ROLE_PERMISSIONS[Role.ADMIN]}
+    every_permission = {p.value for p in Permission}
+
+    assert every_permission, "Permission enum is empty — this guard would be vacuous"
+    assert every_permission - admin_grants == set(), "admin no longer holds every Permission"
+
+    for permission in Permission:
+        assert role_has_permission("admin", permission.value) is True, permission.value
+
+
+# ------------------------------------------- no member falls off the mapping
+
+
+def test_every_role_has_a_role_permissions_entry():
+    """A missing entry used to raise ``KeyError`` at request time.
+
+    ``role_has_permission`` subscripted ``_ROLE_PERMISSION_VALUES`` directly, so
+    a ``Role`` member added without a grant list crashed the permission check
+    instead of denying it.
+    """
+    assert set(Role), "Role enum is empty — this guard would be vacuous"
+    missing = {role.value for role in Role if role not in ROLE_PERMISSIONS}
+    assert missing == set(), f"Role members with no ROLE_PERMISSIONS entry: {missing}"
+
+
+def test_every_role_has_role_metadata():
+    """A missing ``_ROLE_META`` entry silently seeds priority 0 — below readonly."""
+    missing = {role.value for role in Role if role not in _ROLE_META}
+    assert missing == set(), f"Role members with no _ROLE_META entry: {missing}"
+
+
+@pytest.mark.parametrize("unknown", ["not-a-role", "", None, "platform_admin", "guest"])
+def test_an_unresolvable_role_is_denied_rather_than_raising(unknown):
+    """Fail closed, and fail quietly — never a 500 from the permission gate."""
+    assert role_has_permission(unknown, Permission.API_READ.value) is False

--- a/autobot_shared/auth/test_slm_permission_parity.py
+++ b/autobot_shared/auth/test_slm_permission_parity.py
@@ -162,14 +162,11 @@ def test_slm_role_permissions_align_with_shared(slm_role):
     to ROLE_PERMISSIONS[Role.X] in the shared module but forgets to update
     SYSTEM_ROLES['x'] in the SLM backend → this test fails immediately.
     """
-    role_name_map = {
-        Role.ADMIN: "admin",
-        Role.OPERATOR: "operator",
-        Role.ANALYST: "analyst",
-        Role.EDITOR: "editor",
-        Role.USER: "user",
-        Role.READONLY: "readonly",
-    }
+    # Derived, not hand-listed (#13854). This was a hardcoded dict of the six
+    # members that existed when it was written; a seventh would have been
+    # skipped silently, which is exactly the drift the test exists to catch.
+    # Every Role member's SLM key is its own value.
+    role_name_map = {role: role.value for role in Role}
     gaps: dict[str, set[str]] = {}
     for shared_role, slm_key in role_name_map.items():
         if slm_key not in slm_role.SYSTEM_ROLES:

--- a/autobot_shared/ssot_constants.py
+++ b/autobot_shared/ssot_constants.py
@@ -848,6 +848,19 @@ class CategoryDefaults:
     CONTEXT_TYPE_GENERAL: str = "general"
     CONTEXT_TYPE_SECURITY: str = "security"
     CONTEXT_TYPE_RESEARCH: str = "research"
+    # CHAT MESSAGE authorship — who wrote a message. NOT an authorization role.
+    #
+    # Two other vocabularies use the word "role" and share values with this one
+    # (#14024): ``autobot_shared.auth.permissions.Role`` (platform RBAC) and
+    # ``llc.models.enums.MembershipRole`` (company membership). ``ROLE_USER``
+    # holds the same string as ``Role.USER``, and this class is a bare string
+    # constant holder, so a value from here satisfies an RBAC parameter with no
+    # type error and no test failure.
+    #
+    # ``tools/tool_registry`` came within one applied lint suggestion of tying an
+    # authorization decision to ``ROLE_USER`` (#13934). If a field is consumed by
+    # a permission check, it wants ``auth.permissions.Role`` — not these. The
+    # overlap is asserted in ``security/roles_do_not_collide_test.py``.
     ROLE_USER: str = "user"
     ROLE_ASSISTANT: str = "assistant"
     ROLE_SYSTEM: str = "system"

--- a/autobot_shared/user_management/models/user.py
+++ b/autobot_shared/user_management/models/user.py
@@ -42,8 +42,9 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from autobot_shared.time_utils import now_utc
@@ -56,6 +57,42 @@ if TYPE_CHECKING:
     from user_management.models.role import UserRole
     from user_management.models.sso import UserSSOLink
     from user_management.models.team import TeamMembership
+
+
+def resolve_display_name(
+    display_name: str | None,
+    username: str | None,
+    fallback: str | None = None,
+) -> str | None:
+    """The display-label rule for callers that hold columns, not an entity (#13957).
+
+    :attr:`UserCore.full_name` is the same rule and is preferred wherever a
+    loaded ``User`` (or a ``select(User.full_name)`` column) is available. This
+    function exists for the case ``full_name`` genuinely cannot serve: a LEFT
+    OUTER JOIN onto ``users`` where the user row may be absent entirely, so
+    ``username`` — ``NOT NULL`` in the table — still arrives as ``NULL``.
+
+    It carries the **union** of the fallback depths the five copies had drifted
+    to, rather than picking one and silently shortening the others:
+
+    - ``display_name``, then ``username`` — every copy agreed this far;
+    - then *fallback*, the extra rung ``llc.api.companies._compose_human_nodes``
+      needed so an orphaned membership renders its user id instead of nothing;
+    - then ``None``, which ``llc.api.work_items._assignee_display`` relies on to
+      distinguish "no assignee" from a named one.
+
+    Passing no *fallback* therefore reproduces the two-rung behaviour exactly;
+    no call site loses a rung it had.
+
+    Args:
+        display_name: The user's optional display name.
+        username: The user's username; ``None`` only when the row is absent.
+        fallback: Final rung when neither name is present — e.g. ``str(user_id)``.
+
+    Returns:
+        The first non-empty value of the three, or ``None`` if all are empty.
+    """
+    return display_name or username or fallback or None
 
 
 class UserCore(Base):
@@ -269,10 +306,38 @@ class UserCore(Base):
         current[keys[-1]] = value
         self.preferences = preferences
 
-    @property
+    @hybrid_property
     def full_name(self) -> str:
-        """Return display name or username as fallback."""
+        """The person's display label: ``display_name``, falling back to ``username``.
+
+        A ``hybrid_property`` rather than a plain ``property`` (#13957). The rule
+        was re-implemented at five call sites for one reason: a plain property is
+        only reachable from a loaded entity, so any ``select(User.display_name,
+        User.username)`` column tuple had to spell the fallback out again. Three
+        of those copies had already drifted to different fallback depths. The
+        ``expression`` half below makes the identical rule usable directly in a
+        column select, so there is one place to change how a person is named.
+
+        ``username`` is ``NOT NULL``, so this is non-``None`` for any row that
+        exists. It is **not** safe for an outer join, where the whole user row
+        may be absent and both columns arrive as ``NULL`` — that case needs a
+        third fallback rung and belongs to :func:`resolve_display_name`.
+        """
         return self.display_name or self.username
+
+    @full_name.expression  # type: ignore[no-redef]
+    def full_name(cls):  # noqa: N805 - SQLAlchemy hybrid expression takes the class
+        """SQL half of :meth:`full_name`, usable inside ``select(...)``.
+
+        ``coalesce`` and Python's ``or`` are not the same test: ``coalesce``
+        returns the first non-NULL, while ``or`` skips any falsy value. They
+        differ only for an empty-string ``display_name``, which the Python half
+        skips and this would return. ``display_name`` is normalised to ``None``
+        rather than ``""`` on write (see ``user_service.create_user``), so no
+        stored row distinguishes them; ``NULLIF`` keeps the two halves identical
+        even if one ever does.
+        """
+        return func.coalesce(func.nullif(cls.display_name, ""), cls.username)
 
     def record_login(self) -> None:
         """Record a successful login."""

--- a/scripts/lib/hardcoded-value-rules.sh
+++ b/scripts/lib/hardcoded-value-rules.sh
@@ -381,12 +381,38 @@ _hv_rule_account() {
 }
 
 # Role strings (detector 3).
+#
+# #14024: THREE unrelated vocabularies use the word "role" and share literals —
+# platform RBAC (auth.permissions.Role), company membership
+# (llc.models.enums.MembershipRole) and chat message roles
+# (CategoryDefaults.ROLE_*). This rule detects the chat vocabulary's values, but
+# "user" is in the RBAC one as well, so naming a chat constant for it is a coin
+# flip that a reader then applies mechanically.
+#
+# That is not hypothetical. `tools/tool_registry` had `"user_role": "user"`, an
+# RBAC input read by `worker_node._validate_user_role`. This rule suggested
+# `CategoryDefaults.ROLE_USER`. Applying it would have tied an authorization
+# decision to a presentation constant, gone green, and been invisible in review
+# (#13934); a later re-tuning of the chat vocabulary would then have silently
+# changed an authz value.
+#
+# So for an ambiguous value the guard now REPORTS the ambiguity instead of
+# picking a side. "assistant" and "system" belong to the chat vocabulary alone
+# and keep the concrete suggestion. The detection set is unchanged — only the
+# advice — so this adds no findings and needs no baseline change.
+_HV_ROLE_AMBIGUOUS_VALUES_RE='(user)'
+_HV_ROLE_CHAT_SUGGESTION="CategoryDefaults.ROLE_ASSISTANT/ROLE_SYSTEM (chat message vocabulary)"
+_HV_ROLE_AMBIGUOUS_SUGGESTION="AMBIGUOUS (#14024): this value is in more than one role vocabulary \
+- chat (CategoryDefaults.ROLE_USER) and platform RBAC (auth.permissions.Role.USER). \
+Trace the consumer before replacing it; do not apply a suggestion blind."
 _hv_rule_role() {
     [[ $3 =~ $_HV_ROLE_SKIP_RE ]] && return 0
     [[ $3 =~ $_HV_UNION_TYPE_RE ]] && return 0
     [[ $3 =~ $_HV_ROLE_KEYWORD_RE ]] || _hv_get_call_argument "$3" 'role' "$_HV_ROLE_VALUE_RE" || return 0
     _hv_match "$3" "$_HV_ROLE_VALUE_RE" || return 0
-    _hv_emit VIOLATION other "$1" "$2" "$HV_MATCH" "CategoryDefaults.ROLE_USER/ROLE_ASSISTANT/ROLE_SYSTEM"
+    local _hv_role_suggestion="$_HV_ROLE_CHAT_SUGGESTION"
+    [[ $HV_MATCH =~ $_HV_ROLE_AMBIGUOUS_VALUES_RE ]] && _hv_role_suggestion="$_HV_ROLE_AMBIGUOUS_SUGGESTION"
+    _hv_emit VIOLATION other "$1" "$2" "$HV_MATCH" "$_hv_role_suggestion"
 }
 
 # Category / search-mode strings (detector 3, #14005).

--- a/scripts/lib/hardcoded_value_rules_test.py
+++ b/scripts/lib/hardcoded_value_rules_test.py
@@ -177,3 +177,73 @@ def test_the_severity_distinction_survived() -> None:
     """offset=0 is a WARNING, not a VIOLATION — a rule in its own right."""
     assert _scan("offset = 0").startswith("WARNING|")
     assert _scan("limit = 10").startswith("VIOLATION|")
+
+
+# ---------------------------------------------------------------------------
+# #14024: the ROLE rule's suggestion must not name one vocabulary for a value
+# that lives in several. The near-miss this prevents is recorded in #13934:
+# an RBAC field was about to be pointed at a chat presentation constant because
+# both hold "user".
+# ---------------------------------------------------------------------------
+
+_SUGGESTION_FIELD = 5  # VIOLATION|class|file|lineno|value|suggestion
+
+
+def _suggestions(line: str) -> list[str]:
+    """The suggestion field of every record `line` produces."""
+    records = [r for r in _scan(line).splitlines() if r]
+    return [r.split("|")[_SUGGESTION_FIELD] for r in records]
+
+
+def test_an_ambiguous_role_value_is_not_given_a_single_vocabularys_constant() -> None:
+    """`user` is in the chat vocabulary AND in platform RBAC.
+
+    Naming either one is advice that is wrong half the time and looks
+    authoritative both times.
+    """
+    suggestions = _suggestions('TASK = {"role": "user"}')
+
+    assert suggestions, "the role rule stopped firing on its own ambiguous value"
+    for suggestion in suggestions:
+        assert "AMBIGUOUS" in suggestion, suggestion
+        assert "ROLE_USER" not in suggestion.replace("CategoryDefaults.ROLE_USER)", ""), suggestion
+
+
+def test_the_ambiguous_suggestion_names_both_vocabularies() -> None:
+    """Reporting "ambiguous" is only useful if it says ambiguous between what."""
+    suggestions = _suggestions('TASK = {"role": "user"}')
+
+    assert suggestions
+    for suggestion in suggestions:
+        assert "CategoryDefaults" in suggestion, suggestion
+        assert "Role" in suggestion, suggestion
+        assert "#14024" in suggestion, suggestion
+
+
+@pytest.mark.parametrize("value", ["assistant", "system"])
+def test_an_unambiguous_chat_role_still_gets_the_concrete_suggestion(value: str) -> None:
+    """Only the shared literal loses its suggestion; the rest keep working.
+
+    Blanking the advice for every role value would be a regression dressed as a
+    fix, so this pins the half that must not change.
+    """
+    suggestions = _suggestions(f'MSG = {{"role": "{value}"}}')
+
+    assert suggestions, f"the role rule stopped firing on {value!r}"
+    for suggestion in suggestions:
+        assert "CategoryDefaults" in suggestion, suggestion
+        assert "AMBIGUOUS" not in suggestion, suggestion
+
+
+def test_the_role_rule_still_detects_the_same_values_as_before() -> None:
+    """#14024 changed the ADVICE, not the detection set.
+
+    If this rule started firing on more or fewer lines, the baseline of known
+    findings would need regenerating — which is exactly the kind of coupled
+    change that hides a real new violation among the churn.
+    """
+    assert _suggestions('MSG = {"role": "user"}')
+    assert _suggestions('MSG = {"role": "assistant"}')
+    assert _suggestions('MSG = {"role": "system"}')
+    assert not _scan("MSG = {'role': CategoryDefaults.ROLE_USER}")
+    assert not _scan('ROLE_USER = "user"')


### PR DESCRIPTION
Closes #13854, #12786, #14024, #13957

## Thinking Path

The four issues are one problem seen from four sides: the canonical role vocabulary had a member living outside it, so every consumer invented its own answer.

**First question asked, before changing anything: is any of these a deliberate fork?** Yes — one of them is, explicitly, and it is **not** collapsed here.

#14024 states it in its own body: the three "role" vocabularies "are correctly separate concepts — this is not a request to merge them". Comparing **member sets** rather than names confirms it:

```
auth.Role      : admin analyst editor operator readonly user
MembershipRole : admin guest lead member owner
chat ROLE_*    : assistant system user
```

Three different questions — "what may this account do on the platform?", "what is this person within this company?", "who wrote this message?". They are kept apart and given a guard, not merged. A second deliberate fork surfaced during the sweep and is also kept (see the union table's `CROSS_ORG_KB_ROLES` row).

The security carve-out drove every remaining call. For an authorization fork, "more functionality" is the union of **checks**, never the union of **allowances**.

### The contradiction found on the way

`superadmin` did not resolve two ways. It resolved **four**, simultaneously:

| resolver | verdict on `superadmin` |
|---|---|
| `require_role("admin","superadmin")` (17 endpoints) | **admitted** |
| `is_admin_role()` (~15 imperative checks) | **admitted** |
| `role_has_permission()` → `permission_enforcement` | **allow-all — every one of the 54 permissions** |
| `SecurityLayer.check_permission` / `canonical_role_permissions` | **deny-all — zero permissions** |
| `Role("superadmin")` | **`ValueError`** |

`role_has_permission` short-circuited on `is_admin_role`, which made `ADMIN_ROLES` — documented as a *predicate* — silently the most permissive permission source in the system. That is exactly what #13854's AC 2 forbids, and it put two canonical resolvers in direct opposition for the most privileged role in the product.

### What `superadmin` now holds, and why

**`Role.SUPERADMIN` exists, and its `ROLE_PERMISSIONS` entry is explicitly empty (`[]`).**

It is #13854's option 1 (first-class member) carrying option 3's policy (predicate-only) — deliberately, not as a compromise:

- **Not one permission is added anywhere.** Granting it admin's set is **+54 permissions** including `allow_shell_execute`, `admin.system`, `security.manage` and `admin.users.write`. #13820 measured that expansion and refused to let it ride along inside a resolver fix. Nothing since has decided to widen the role, so this change does not either.
- **The empty entry is written down**, not inferred from a raised `ValueError`. Before, "superadmin" and "typo" produced the same `[]` from the same failed lookup.
- **The alternative is one line**, recorded in the source next to the entry: `Role.SUPERADMIN: list(ROLE_PERMISSIONS[Role.ADMIN])`. It is an authorization expansion and needs a security review plus a `roles` data migration, which an empty entry does not.

**The 17 `require_role("admin", "superadmin")` call sites are unchanged and resolve exactly as before** — `require_role` compares lowercased strings, and `superadmin` is still one of the accepted ones. Same for every `is_admin_role` caller. The role keeps its entire administrative reach; what it gains is a written-down grant list, and what it loses is an allowance no mapping ever declared.

### The one behaviour change, stated plainly

Removing the `is_admin_role` short-circuits **tightens `superadmin` at two granular-permission gates** — `middleware.builtin.permission_enforcement` and `services.mcp_dispatch._would_deny` (stage 3, enforcing). A superadmin previously passed both by predicate; it is now refused any MCP tool whose declared permission it does not hold, which — with an empty entry — is all of them.

This is a restriction, never a widening, and it is the strictest reading of the union-of-checks rule: three of the five resolvers already denied it. It is called out here rather than buried because it is the one thing in this PR a superadmin user would notice. If superadmin is meant to be operational rather than a gate-passing predicate, the one-line alternative above is the change — and it belongs in its own reviewed PR.

Both gates' own test suites asserted the old contract and are updated here — `middleware/builtin/permission_enforcement_test.py` and `services/mcp_dispatch_rbac_shadow_test.py`. The shadow test's original purpose is **preserved rather than deleted**: its point was that an administrative role must never be reported as an *unrecognised string*, and that is now asserted directly (`not verdict.startswith("unknown-role")`) instead of being inferred from `is None`. Superadmin's refusal names the missing grant (`missing:mcp.browser.control`), so it is actionable rather than a bare denial, and `admin` keeps a dedicated test proving it is still permitted every declared tool.

`admin` is unaffected, and that is measured rather than assumed: `ROLE_PERMISSIONS[Role.ADMIN]` contains **all 54** `Permission` members, so the short-circuit never decided an admin call. `roles_are_canonical_test` now asserts that continuously, because a permission added to the enum but not granted to admin would silently turn the removal into a regression.

### Wire / persistence surface

Checked before touching the enum, since a stored literal changes meaning when the enum changes:

- **No schema migration is required.** There is no `role` column on `users` and no Postgres ENUM for platform roles — roles are rows in `roles` keyed by `name String(100)`. (The only `role`-named PG enum is `membershiprole`, a different vocabulary.) No migration anywhere mentions `superadmin`.
- **No data migration is required *because the entry is empty*.** Nothing at runtime consumes `SYSTEM_ROLES`; the only writer was a frozen one-shot migration. A role with zero grants needs no row. Option 1 *would* have needed one — a further reason it is a separate change.
- **JWT / session:** `role` is an opaque string claim, never validated against the enum at the token boundary. Already-issued tokens carrying `superadmin` keep passing the same 17 endpoints.
- **One live token behaviour change, and it is a tightening:** `autobot-slm-backend/services/auth.py::_resolve_role` caught `ValueError` and silently downgraded an unknown `superadmin` to `Role.USER` — i.e. it *granted* superadmin USER's 15 permissions. It now resolves to `Role.SUPERADMIN` and its 0. Restriction, not expansion.
- `GET /api/auth/roles/{role}/permissions` returns 200 with an empty list for `superadmin` instead of 404.

## What Changed

**#13854 / #12786 — the canonical vocabulary**

- `Role.SUPERADMIN` added, with an explicit empty `ROLE_PERMISSIONS` entry and an explicit `_ROLE_META` entry (the `.get` fallback would otherwise have seeded priority `0`, sorting the most privileged role *below* `readonly`).
- `ADMIN_ROLES` is now **derived** from `_ADMINISTRATIVE_ROLES: frozenset[Role]`. It can no longer name a role the enum does not have, so a future addition necessarily comes with a reviewed `ROLE_PERMISSIONS` entry — #13854 AC 2, closed structurally rather than by convention.
- `role_has_permission` reads `ROLE_PERMISSIONS` and nothing else. Also fixes a latent **`KeyError` at request time**: it subscripted `_ROLE_PERMISSION_VALUES` bare, so any `Role` member without an entry crashed the permission gate instead of denying. Now fails closed.
- `services/mcp_dispatch._would_deny`: the #13228 stage-2 consumer workaround removed (#13854 AC 4).
- Three copies of the `platform_admin`/`superadmin` literal consolidated onto one named `CROSS_ORG_KB_ROLES` (#12786's "also worth reconciling"). Membership is unchanged at all three sites, including the union at `knowledge.py:3147`.
- #12786's third ask — a gate rejecting new `role == "admin"` comparisons — **already exists** (`auth_rbac_admin_guard_test.py`); its header is corrected to match reality.

**#14024 — three vocabularies, kept apart**

- `security/roles_do_not_collide_test.py`: compares the three as **member sets** and pins the overlap exactly. A new colliding value fails with the value named.
- The hardcoded-value guard no longer suggests `CategoryDefaults.ROLE_USER` for `"user"`. That value is in two vocabularies, so the suggestion was a coin flip a reader applies mechanically — the near-miss in #13934. It now reports the ambiguity and names both. `assistant`/`system` are unambiguous and keep their concrete suggestion. **Detection set unchanged**, so no baseline churn (the baseline key is `count|class|file|value` — the suggestion is not part of it).
- Each of the three definitions now names the other two and the literals they share.

**#13957 — one display-name rule**

- `UserCore.full_name` becomes a `hybrid_property`, so the identical rule works from an ORM entity *and* inside `select(...)`. Its SQL half uses `coalesce(nullif(display_name,''), username)` so both halves agree on an empty string.
- `resolve_display_name()` added for the case `full_name` genuinely cannot serve: a LEFT OUTER JOIN where the whole user row is absent and `username` — `NOT NULL` in the table — still arrives `NULL`.
- All five copies converged. The canonical property had **zero call sites** before this: it was dead code while five copies of its body were live, and three of them had already drifted to different fallback depths.

## Union Table

Every role-shaped vocabulary in the repo, as member sets. Nothing was dropped; the two rows marked *deliberate fork* are kept apart on purpose.

| # | vocabulary | member set (before) | covered by (after) |
|---|---|---|---|
| 1 | `auth.permissions.Role` | admin, operator, analyst, editor, user, readonly | **`Role`** — unchanged, **+ superadmin** |
| 2 | `ADMIN_ROLES` literal | admin, **superadmin** | **`Role`** — both are now members; `ADMIN_ROLES` derived from them |
| 3 | `write_guard._SUPERADMIN_ROLES` | platform_admin, superadmin | **`CROSS_ORG_KB_ROLES`** — *deliberate fork, kept* |
| 4 | `knowledge.py:684` tuple | platform_admin, superadmin | **`CROSS_ORG_KB_ROLES`** — identical set, deduplicated |
| 5 | `knowledge.py:3142` tuple | admin, platform_admin, superadmin | `is_admin_role(role) or role in CROSS_ORG_KB_ROLES` — same union |
| 6 | `MembershipRole` | owner, admin, member, guest, lead | **unchanged** — *deliberate fork, kept + guarded* |
| 7 | `CategoryDefaults.ROLE_*` | user, assistant, system | **unchanged** — *deliberate fork, kept + guarded* |
| 8 | `DEPRECATED_PRIVILEGED_ROLES` | god, superuser, root | **unchanged** — already normalised to `admin`; not administrative, not touched |
| 9 | frontend `useUserStore` union | admin, operator, analyst, editor, user, **viewer**, readonly | **unchanged** — drift filed, see Residuals |
| 10 | `router.d.ts` `minRole` | admin, user, readonly, **guest** | **unchanged** — drift filed |
| 11 | `RoleUpdateRequest` pattern | admin, user, readonly | **unchanged** — superadmin stays non-assignable via API |
| 12 | `SecurityLayer._get_default_role_permissions` | admin, operator, **developer**, user, readonly, editor | **unchanged** — `developer` is a separate finding, filed as #14940 |

**Nothing lost.** Row 2's `superadmin` was the only member of any set that had no canonical home; it now has one. Rows 3–5 collapse to one *named* constant with byte-identical membership — `admin` is deliberately **absent** from row 3, because the guard exists to stop an org admin reaching a *parent* org's KB; folding it into `ADMIN_ROLES` would have added `admin` and deleted the property the guard enforces. That is the union-of-checks rule doing its job: a narrower set wins where it is a restriction.

Row 12 is a separate finding the sweep turned up, filed as **#14940**. `developer` is not a `Role` member and grants `files.*`, KB write and `allow_shell_execute_safe` from `SecurityLayer._get_default_role_permissions`. It shares only the shape "a role string the canonical enum does not know about" — the mechanism is different and there is no common fix: `superadmin` held *nothing* and its grant list came from a raised `ValueError`, whereas `developer`'s grants come from a legacy defaults dict this PR never touches. It is left alone because narrowing it **revokes live access** — and `validate-security-config.py:53` lists `developer` among the accounts a valid security config is expected to provision, so it is not an orphan. That is its own authorization decision with its own host evidence to gather.

**Deliberate forks, raised not collapsed:** rows 3, 6 and 7. Rows 6 and 7 are documented as such by #14024 itself; row 3 is documented in `write_guard.py` with its member-set comparison.

## Verification

**Static, on the committed source** (no repo code executed; CI runs the suites):

```
Permission members : 54
ADMIN     holds 54   Permission members NOT held by ADMIN: NONE
SUPERADMIN holds 0
Role members: ADMIN SUPERADMIN OPERATOR ANALYST EDITOR USER READONLY
Roles missing a ROLE_PERMISSIONS entry: none
Roles missing a _ROLE_META entry      : none
```

**Mutation evidence, both directions.** A stdlib-only copy of `permissions.py` was mutated in a scratch directory and the guard assertions re-run. Every mutation asserts its target is present *before* applying — a mutation whose target is missing reports a false PASS.

| mutation | guard | verdict |
|---|---|---|
| *(baseline, no mutation)* | all 7 guards | **PASS** |
| **remove** the `SUPERADMIN` member | module fails to import | **RED** |
| **rename** `superadmin` → `super_admin` | `exact_member_set`, `superadmin_is_a_member`, `every_admin_role_has_a_grant_list` | **RED — the guard follows the rename** |
| **reintroduce** the `is_admin_role` short-circuit | `admin_roles_is_not_a_permission_source` | **RED** |
| **add** a colliding member (`guest`, already in `MembershipRole`) | `rbac_vs_membership`, `exact_member_set` | **RED** |
| **revoke** `ADMIN_SYSTEM` from admin | `admin_holds_every_permission` | **RED** |

The removal *and* rename pair is the point: a guard that only pinned the name would survive the rename, and one that only counted members would survive the removal.

**Guards are asserted non-vacuous.** Every collision test asserts its vocabularies are populated and hold their expected members first — an import silently resolving to nothing would otherwise read as "no collisions", and a guard whose subject is missing reports a false PASS.

## Residuals

Filed, not fixed here — each is a different risk profile from this change:

- **#14937 — frontend role drift.** `useUserStore` carries a phantom `viewer`, `router.d.ts` carries a `guest` that #744 removed, and `isAdmin` is a hard `role === 'admin'` equality that excludes `superadmin` — #12786's exact bug class, on the UI side. Fixing it changes what the UI offers and belongs in a reviewed frontend PR.
- **#14938 — `platform_admin` has no producer.** Nothing anywhere mints it as a role string; the platform signal in actual use is the boolean `users.is_platform_admin`. Preserved (removing it would silently change the KB guard for any deployment that does set it) and documented; wire-or-retire tracked separately.
- **#14944 — `is_admin_role(Role.ADMIN)` returns `False`.** `str()` on a `(str, Enum)` member yields `"Role.ADMIN"`, not `"admin"`. Pre-existing and latent: `ADMIN_ROLES`'s value and the function body are byte-identical before and after this PR (verified by loading both revisions side by side), and all 20 live call sites pass plain strings. Fails in the unsafe direction and is sprung by doing the *more* type-safe thing, so it gets likelier as the canonical vocabulary sees proper use.
- **#14940 — `developer` is not a `Role` member** but holds real grants in the SecurityLayer defaults table, a legacy source this PR does not touch. Adjacent to #13854, not the same mechanism: narrowing it revokes live access, and it appears to be provisioned. Needs its own decision and host evidence.
- **#14939 — display-name rule, frontend half.** Five more copies in Vue/TS with a fourth and fifth fallback depth (`|| user_id`, `|| email ||`, `|| '—'`), caused by the two LLC endpoints disagreeing about who owns the last rung. Out of #13957's stated scope, which is the Python sites.

## Model Used

Claude Opus 5 (1M context) — `claude-opus-5[1m]`
