### PR TITLE
fix(ops,audit): two failures that reported success — derived memory limits and an audit run that filed nothing (#13765, #13570)

### DIFF
--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -597,12 +597,23 @@ def _dedupe_and_file(
         deferred_count = 0
         _log_unwritable_queue(still_deferred, "the existing queue could not be read")
 
-    # A finding is LOST when it was neither filed nor left in the queue. Derived
-    # from what was observed to happen rather than from a failure flag: both
-    # loss paths above already return 0 for `deferred_count`, and 0 is also the
-    # normal drained state, so a caller reading only that number cannot tell
-    # them apart (#13570).
-    lost = len(still_deferred) if (still_deferred and not deferred_count) else 0
+    # A finding is LOST when it was neither filed nor left in the queue.
+    #
+    # Measured as "how many unique findings went in, minus how many the queue
+    # reports holding" rather than special-casing `deferred_count == 0`. Review
+    # found that earlier form blind at the OTHER boundary: when
+    # `_persist_deferred` sheds past `_MAX_DEFERRED` it returns the POST-shed
+    # count, which is nonzero, so `lost` stayed 0 while findings were dropped
+    # for good and `filed + deferred + lost` undercounted by exactly the shed
+    # amount. Same "0 where loss occurred" defect this issue is about, moved
+    # from the write-failure boundary to the cap boundary.
+    #
+    # Deduped by title first, because `_persist_deferred` dedupes too: two
+    # findings with one title collapsing is intended behaviour, not loss, and
+    # counting the raw list would report a phantom every time a queued finding
+    # was re-discovered.
+    unique_deferred = len({finding["title"] for finding in still_deferred})
+    lost = max(0, unique_deferred - deferred_count)
 
     _report_deferral_outcome(gh_ok, still_deferred, deferred_count)
     outcome = FilingOutcome(filed=filed, deferred=deferred_count, lost=lost, filing_available=gh_ok)

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -23,7 +23,9 @@ import subprocess  # nosec B404  # internal git/gh CLI calls only
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
+
+from celery.signals import beat_init, worker_ready
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
@@ -74,6 +76,104 @@ _MAX_LOG_CHARS = 500
 # truncated finding is still better than none — but an unbounded dump could
 # itself take out the log.
 _MAX_DEFERRED_LOG_CHARS = 100_000
+
+# #13570: a queryable record of whether this worker can file at all, written on
+# every run AND at worker startup. The issue's third fix -- "fail loudly at
+# startup when the worker's filing credential is absent, rather than per-finding
+# at run time" -- was the one that never landed, and the reason it matters is
+# that a log line is not a surface a check can query. The umbrella (#13852) puts
+# it plainly: a service that is running but not working must be distinguishable
+# from one that is working, by something a check can query, not by reading logs.
+_FILING_STATUS_KEY = "audit:filing_status"
+
+# The status key outlives any single run on purpose, but not forever: a stale
+# entry from a worker that has since stopped would answer "filing is broken" for
+# a worker that no longer exists. Refreshed on every run and at startup, so the
+# TTL only has to outlive the longest gap between runs (audit_claims is weekly).
+try:
+    _FILING_STATUS_TTL_S = max(1, int(os.getenv("AUTOBOT_AUDIT_FILING_STATUS_TTL_S", str(86400 * 30))))
+except ValueError:
+    _FILING_STATUS_TTL_S = 86400 * 30
+
+# Task statuses. A run that filed nothing because it COULD not file is not a
+# success, and reporting one is the same defect as the dead-letter queue that
+# claimed to hold findings it never held.
+_STATUS_SUCCESS = "success"
+_STATUS_DEGRADED = "degraded"
+_STATUS_ERROR = "error"
+
+
+class FilingOutcome(NamedTuple):
+    """What actually happened to a run's findings (#13570).
+
+    ``lost`` is the field the old ``(filed, deferred)`` pair could not express:
+    when the dead-letter queue itself cannot be written, ``deferred`` is 0 --
+    identical to a clean run that had nothing to defer. Every caller then
+    reported ``issues_deferred: 0`` and ``status: "success"`` for a run that had
+    just destroyed its own findings.
+
+    Positional so existing unpacking keeps working; named so a caller asking
+    "did anything get lost" does not have to know the order.
+    """
+
+    filed: int
+    deferred: int
+    lost: int
+    filing_available: bool
+
+
+def _filing_status_payload(outcome: "FilingOutcome | None", vault_backed: bool, gh_ok: bool) -> dict:
+    """The queryable shape written to ``audit:filing_status``."""
+    payload = {
+        "checked_at": utc_timestamp(),
+        "filing_available": gh_ok,
+        "credential_source": "system vault" if vault_backed else "ambient CLI auth",
+        "vault_credential_present": vault_backed,
+    }
+    if outcome is not None:
+        payload["last_run_filed"] = outcome.filed
+        payload["last_run_deferred"] = outcome.deferred
+        payload["last_run_lost"] = outcome.lost
+    return payload
+
+
+def _record_filing_status(redis, outcome: "FilingOutcome | None", vault_backed: bool, gh_ok: bool) -> None:
+    """Publish filing health where a check can read it, not only a log reader."""
+    _redis_set(
+        redis,
+        _FILING_STATUS_KEY,
+        _filing_status_payload(outcome, vault_backed, gh_ok),
+        ttl=_FILING_STATUS_TTL_S,
+    )
+
+
+def _vault_backed_now() -> bool:
+    """Did THIS run resolve a vault-owned token? Read, never re-derive.
+
+    Reads the cache `_gh_available` already populated rather than calling
+    `_gh_env()` again. Re-deriving would trigger a second vault round-trip --
+    and, where `_gh_available` is substituted, a lookup that the run itself
+    never made, so the recorded credential source would describe a code path
+    that did not execute. An empty cache means nothing resolved a token, which
+    is exactly "not vault-backed".
+    """
+    return bool(_gh_env_cache[1]) if _gh_env_cache is not None else False
+
+
+def _run_status(outcome: FilingOutcome) -> str:
+    """The status an audit run should report, given what happened to its findings.
+
+    #13570: all three tasks returned ``"success"`` unconditionally. On the live
+    host that meant a run which queued 1,644 findings it could not file -- and a
+    run which lost them outright -- both reported success to Celery, the one
+    machine-readable surface these tasks produce. The log said CRITICAL; the
+    result said success; nothing that polls task results could tell.
+    """
+    if outcome.lost:
+        return _STATUS_ERROR
+    if outcome.deferred or not outcome.filing_available:
+        return _STATUS_DEGRADED
+    return _STATUS_SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -449,7 +549,7 @@ def _dedupe_and_file(
     existing_titles: set[str],
     label: str,
     redis=None,
-) -> tuple[int, int]:
+) -> FilingOutcome:
     """File GitHub issues for new findings; persist any that cannot be filed.
 
     Drains the dead-letter queue first (retrying previously deferred findings),
@@ -458,8 +558,11 @@ def _dedupe_and_file(
     Redis dead-letter queue when filing is impossible (unauthenticated gh) or
     fails. No finding is ever silently discarded (#12319).
 
-    Returns ``(filed, deferred)`` where ``filed + deferred`` accounts for every
-    non-duplicate finding drawn from both the queue and *findings*.
+    Returns a `FilingOutcome`. ``filed + deferred + lost`` accounts for every
+    non-duplicate finding drawn from both the queue and *findings* -- ``lost``
+    being the count the old ``(filed, deferred)`` pair could not express, since
+    a queue that could not be written reported ``deferred == 0``, exactly like a
+    clean run (#13570).
     """
     gh_ok = _gh_available()
     pending, queue_readable = _load_deferred(redis)
@@ -494,8 +597,17 @@ def _dedupe_and_file(
         deferred_count = 0
         _log_unwritable_queue(still_deferred, "the existing queue could not be read")
 
+    # A finding is LOST when it was neither filed nor left in the queue. Derived
+    # from what was observed to happen rather than from a failure flag: both
+    # loss paths above already return 0 for `deferred_count`, and 0 is also the
+    # normal drained state, so a caller reading only that number cannot tell
+    # them apart (#13570).
+    lost = len(still_deferred) if (still_deferred and not deferred_count) else 0
+
     _report_deferral_outcome(gh_ok, still_deferred, deferred_count)
-    return filed, deferred_count
+    outcome = FilingOutcome(filed=filed, deferred=deferred_count, lost=lost, filing_available=gh_ok)
+    _record_filing_status(redis, outcome, _vault_backed_now(), gh_ok)
+    return outcome
 
 
 def _report_deferral_outcome(gh_ok: bool, still_deferred: list[dict], deferred_count: int) -> None:
@@ -520,6 +632,74 @@ def _report_deferral_outcome(gh_ok: bool, still_deferred: list[dict], deferred_c
         "credential and Redis need attention.",
         len(still_deferred),
     )
+
+
+# ---------------------------------------------------------------------------
+# Startup credential guard (#13570 fix 3)
+# ---------------------------------------------------------------------------
+
+
+def check_filing_credential_at_startup(redis=None) -> bool:
+    """Report at STARTUP whether this worker can file issues at all (#13570).
+
+    The issue asks for three things. Two landed in #13860 (the queue reports
+    what it actually stored) and #13859 (a vault-owned credential instead of
+    ambient CLI auth). This is the third, and it never did: *fail loudly at
+    startup when the worker's filing credential is absent, rather than
+    per-finding at run time.*
+
+    Why startup specifically. `_gh_available` runs inside a task, so the first
+    signal that filing is broken arrives whenever an audit next happens to
+    produce a finding -- weekly for `audit_claims`. On the live host the lapse
+    went unnoticed long enough to accumulate 1,644 queued findings, and there is
+    still no way to say when it broke. A worker that cannot file has been unable
+    to file since it started; that fact is available the moment it starts.
+
+    Writes `audit:filing_status` as well as logging. A CRITICAL line is not a
+    surface a check can query, and "the automation reports deferral but nothing
+    is parked" is precisely a story about trusting a reassuring message over an
+    observable fact.
+
+    Returns whether filing is available, so a caller can act on it. Never
+    raises: a broken credential check must not stop a worker from booting, or
+    the audit stops entirely rather than degrading.
+    """
+    try:
+        reset_gh_env_cache()
+        gh_ok = _gh_available()
+        _record_filing_status(redis if redis is not None else _get_redis(), None, _vault_backed_now(), gh_ok)
+        if not gh_ok:
+            logger.critical(
+                "audit worker started WITHOUT a working issue-filing credential. Every "
+                "finding it produces will be queued to %s instead of filed, and the "
+                "backlog is retried automatically once a credential resolves. Store a "
+                "token as '%s' in the system vault. Filing health is queryable at '%s'. "
+                "(#13570)",
+                _DEFERRED_FINDINGS_KEY,
+                _FILING_CREDENTIAL_VAULT_KEY,
+                _FILING_STATUS_KEY,
+            )
+        return gh_ok
+    except Exception as exc:  # noqa: BLE001 - a startup probe must never stop the worker
+        logger.error("audit: startup filing-credential check failed (%s)", type(exc).__name__)
+        return False
+
+
+@worker_ready.connect
+def _audit_worker_ready(**_kwargs) -> None:
+    """Run the startup guard when a Celery worker comes up (#13570)."""
+    check_filing_credential_at_startup()
+
+
+@beat_init.connect
+def _audit_beat_init(**_kwargs) -> None:
+    """Run the startup guard when Beat comes up (#13570).
+
+    Both signals, not just `worker_ready`: Beat and the worker are separate
+    processes with separate deployments, and it is Beat that decides these tasks
+    run at all. A deployment that brings up only one of them must still say so.
+    """
+    check_filing_credential_at_startup()
 
 
 # ---------------------------------------------------------------------------
@@ -627,24 +807,29 @@ def audit_testgaps(self) -> dict:
 
     findings = _testgap_findings(modules, repo_root)
     existing_titles = set(_list_open_issues(label="observability"))
-    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     _redis_set(redis, _TESTGAPS_LAST_RUN_KEY, run_at)
 
     result = {
-        "status": "success",
+        "status": _run_status(outcome),
         "run_at": run_at,
         "modules_checked": len(modules),
         "gaps_found": len(findings),
-        "issues_filed": filed,
-        "issues_deferred": deferred,
+        "issues_filed": outcome.filed,
+        "issues_deferred": outcome.deferred,
+        "issues_lost": outcome.lost,
+        "filing_available": outcome.filing_available,
     }
     logger.info(
-        "audit_testgaps complete: modules_checked=%d gaps_found=%d " "issues_filed=%d issues_deferred=%d",
+        "audit_testgaps complete: status=%s modules_checked=%d gaps_found=%d "
+        "issues_filed=%d issues_deferred=%d issues_lost=%d",
+        result["status"],
         len(modules),
         len(findings),
-        filed,
-        deferred,
+        outcome.filed,
+        outcome.deferred,
+        outcome.lost,
     )
     return result
 
@@ -712,25 +897,30 @@ def audit_dead_code(self) -> dict:
         findings.append({"title": title, "body": body})
 
     existing_titles = set(_list_open_issues(label="observability"))
-    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     # Persist current full inventory for next run's diff
     _redis_set(redis, _DEAD_CODE_INVENTORY_KEY, list(current_fps.keys()))
 
     result = {
-        "status": "success",
+        "status": _run_status(outcome),
         "run_at": utc_timestamp(),
         "total_findings": len(current_lines),
         "new_findings": len(new_findings_raw),
-        "issues_filed": filed,
-        "issues_deferred": deferred,
+        "issues_filed": outcome.filed,
+        "issues_deferred": outcome.deferred,
+        "issues_lost": outcome.lost,
+        "filing_available": outcome.filing_available,
     }
     logger.info(
-        "audit_dead_code complete: total_findings=%d new_findings=%d " "issues_filed=%d issues_deferred=%d",
+        "audit_dead_code complete: status=%s total_findings=%d new_findings=%d "
+        "issues_filed=%d issues_deferred=%d issues_lost=%d",
+        result["status"],
         len(current_lines),
         len(new_findings_raw),
-        filed,
-        deferred,
+        outcome.filed,
+        outcome.deferred,
+        outcome.lost,
     )
     return result
 
@@ -871,7 +1061,7 @@ def audit_claims(self) -> dict:
         findings.append({"title": title, "body": body})
 
     existing_titles = set(_list_open_issues(label="observability"))
-    filed, deferred = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
 
     _redis_set(redis, _CLAIMS_LAST_RUN_KEY, run_at)
     _redis_set(
@@ -881,21 +1071,26 @@ def audit_claims(self) -> dict:
     )
 
     result = {
-        "status": "success",
+        "status": _run_status(outcome),
         "run_at": run_at,
         "claims_checked": len(claims),
         "verified": len(verified),
         "unverified": len(unverified),
-        "issues_filed": filed,
-        "issues_deferred": deferred,
+        "issues_filed": outcome.filed,
+        "issues_deferred": outcome.deferred,
+        "issues_lost": outcome.lost,
+        "filing_available": outcome.filing_available,
         "verification_doc": str(doc_path.relative_to(repo_root)),
     }
     logger.info(
-        "audit_claims complete: claims_checked=%d verified=%d unverified=%d " "issues_filed=%d issues_deferred=%d",
+        "audit_claims complete: status=%s claims_checked=%d verified=%d unverified=%d "
+        "issues_filed=%d issues_deferred=%d issues_lost=%d",
+        result["status"],
         len(claims),
         len(verified),
         len(unverified),
-        filed,
-        deferred,
+        outcome.filed,
+        outcome.deferred,
+        outcome.lost,
     )
     return result

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -13,16 +13,20 @@ from unittest.mock import MagicMock, patch
 
 from workers.audit_tasks import (
     _DEFERRED_FINDINGS_KEY,
+    _FILING_STATUS_KEY,
     _TESTGAPS_LAST_RUN_KEY,
+    FilingOutcome,
     _dead_code_fingerprint,
     _dedupe_and_file,
     _find_test_file,
     _gh_available,
     _persist_deferred,
     _redis_set,
+    _run_status,
     audit_claims,
     audit_dead_code,
     audit_testgaps,
+    check_filing_credential_at_startup,
 )
 
 # ---------------------------------------------------------------------------
@@ -43,7 +47,7 @@ class TestDedupeAndFile:
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue", return_value=True) as mock_file,
         ):
-            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, existing, "enhancement")
 
         assert (filed, deferred) == (1, 0)
         mock_file.assert_called_once_with("discovery: new issue", "body2", "enhancement")
@@ -60,7 +64,7 @@ class TestDedupeAndFile:
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
-            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, existing, "enhancement")
 
         assert (filed, deferred) == (0, 0)
         mock_file.assert_not_called()
@@ -77,7 +81,7 @@ class TestDedupeAndFile:
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue", return_value=True),
         ):
-            filed, deferred = _dedupe_and_file(findings, existing, "enhancement")
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, existing, "enhancement")
 
         assert filed == 1  # second identical title skipped because first added it to set
 
@@ -88,7 +92,7 @@ class TestDedupeAndFile:
             patch("workers.audit_tasks._persist_deferred", return_value=0),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
-            filed, deferred = _dedupe_and_file([], set(), "enhancement")
+            filed, deferred, _lost, _ok = _dedupe_and_file([], set(), "enhancement")
 
         assert (filed, deferred) == (0, 0)
         mock_file.assert_not_called()
@@ -143,7 +147,7 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert filed == 0
         assert deferred == 1
@@ -162,7 +166,7 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue", return_value=False),
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert (filed, deferred) == (0, 1)
         assert store[_DEFERRED_FINDINGS_KEY][0]["title"] == "discovery: flaky"
@@ -182,7 +186,7 @@ class TestNoDropGuarantee:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue", side_effect=_file),
         ):
-            filed, deferred = _dedupe_and_file(findings, set(), "enhancement", client)
+            filed, deferred, _lost, _ok = _dedupe_and_file(findings, set(), "enhancement", client)
 
         assert filed + deferred == len(findings)
         assert (filed, deferred) == (3, 2)
@@ -212,7 +216,7 @@ class TestNoDropGuarantee:
                 side_effect=lambda t, b, lbl: filed_titles.append(t) or True,
             ),
         ):
-            filed, deferred = _dedupe_and_file([], set(), "enh", client)
+            filed, deferred, _lost, _ok = _dedupe_and_file([], set(), "enh", client)
 
         assert filed_titles == ["discovery: retry me"]
         assert (filed, deferred) == (1, 0)
@@ -572,7 +576,7 @@ class TestDeferralIsObservedNotAssumed:
             patch("workers.audit_tasks._file_issue"),
         ):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                filed, deferred = _dedupe_and_file(findings, set(), "enh", client)
+                filed, deferred, _lost, _ok = _dedupe_and_file(findings, set(), "enh", client)
 
         assert (filed, deferred) == (0, 0)
         assert "LOST" in caplog.text
@@ -592,7 +596,7 @@ class TestDeferralIsObservedNotAssumed:
             patch("workers.audit_tasks._file_issue"),
         ):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                filed, deferred = _dedupe_and_file(findings, set(), "enh", client)
+                filed, deferred, _lost, _ok = _dedupe_and_file(findings, set(), "enh", client)
 
         assert (filed, deferred) == (0, 1)
         assert "LOST" not in caplog.text
@@ -682,7 +686,9 @@ class TestQueueIsNeverOverwrittenUnread:
             patch("workers.audit_tasks._file_issue"),
         ):
             with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
-                filed, deferred = _dedupe_and_file([{"title": "discovery: new", "body": "b"}], set(), "enh", client)
+                filed, deferred, _lost, _ok = _dedupe_and_file(
+                    [{"title": "discovery: new", "body": "b"}], set(), "enh", client
+                )
 
         assert (filed, deferred) == (0, 0)
         assert "could not be read" in caplog.text
@@ -700,7 +706,9 @@ class TestQueueIsNeverOverwrittenUnread:
             patch("workers.audit_tasks._redis_set", side_effect=_set),
             patch("workers.audit_tasks._file_issue"),
         ):
-            filed, deferred = _dedupe_and_file([{"title": "discovery: first", "body": "b"}], set(), "e", client)
+            filed, deferred, _lost, _ok = _dedupe_and_file(
+                [{"title": "discovery: first", "body": "b"}], set(), "e", client
+            )
 
         assert (filed, deferred) == (0, 1)
         assert [f["title"] for f in store[_DEFERRED_FINDINGS_KEY]] == ["discovery: first"]
@@ -802,3 +810,319 @@ class TestTruncationIsDeclared:
                 _persist_deferred(client, [{"title": "t", "body": "b", "label": "l"}])
 
         assert "TRUNCATED" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# #13570: a run that filed nothing must not report success, and "cannot file"
+# must be observable somewhere a check can query — not only in a log line.
+# ---------------------------------------------------------------------------
+
+
+class TestRunStatus:
+    """`status` was the string `"success"`, unconditionally, in all three tasks.
+
+    On the live host that meant a run which queued 1,644 findings it could not
+    file reported success to Celery — the one machine-readable surface these
+    tasks produce. The log said CRITICAL, the result said success, and nothing
+    polling task results could tell the difference.
+    """
+
+    def test_a_clean_run_is_still_success(self):
+        assert _run_status(FilingOutcome(filed=3, deferred=0, lost=0, filing_available=True)) == "success"
+
+    def test_nothing_to_do_is_success(self):
+        """An audit with no findings must not be dressed up as a problem."""
+        assert _run_status(FilingOutcome(filed=0, deferred=0, lost=0, filing_available=True)) == "success"
+
+    def test_deferred_findings_are_degraded_not_success(self):
+        assert _run_status(FilingOutcome(filed=0, deferred=1644, lost=0, filing_available=False)) == "degraded"
+
+    def test_unable_to_file_is_degraded_even_with_nothing_to_defer(self):
+        """The gap that hid the lapse for weeks.
+
+        Every clean run during the outage looked identical to a healthy one,
+        because the worker only noticed it could not file when it happened to
+        have a finding to lose. A worker that cannot file is degraded whether or
+        not this particular run produced anything.
+        """
+        assert _run_status(FilingOutcome(filed=0, deferred=0, lost=0, filing_available=False)) == "degraded"
+
+    def test_lost_findings_are_an_error_not_a_degradation(self):
+        """Queued is recoverable; lost is not. They must not share a status."""
+        assert _run_status(FilingOutcome(filed=0, deferred=0, lost=2, filing_available=False)) == "error"
+
+    def test_loss_outranks_a_partial_success(self):
+        assert _run_status(FilingOutcome(filed=9, deferred=1, lost=1, filing_available=True)) == "error"
+
+
+class TestLossIsCounted:
+    def test_lost_findings_are_counted_not_reported_as_zero_deferred(self):
+        """`deferred == 0` is both "nothing to defer" and "the queue ate them".
+
+        The unwritable-queue path already logged the findings in full, but the
+        number it returned was 0 — the same 0 a clean run returns. Every caller
+        then reported `issues_deferred: 0` and `status: success` for a run that
+        had just destroyed its own findings.
+        """
+        _store, _get, _set, client = _fake_redis_backing(writes_succeed=False)
+        findings = [{"title": "discovery: a", "body": "b"}, {"title": "discovery: b", "body": "b"}]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file(findings, set(), "enh", client)
+
+        assert outcome.deferred == 0
+        assert outcome.lost == 2
+        assert _run_status(outcome) == "error"
+
+    def test_a_successful_deferral_counts_as_deferred_not_lost(self):
+        """The fallback working must not be reported as data loss."""
+        _store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file([{"title": "discovery: q", "body": "b"}], set(), "enh", client)
+
+        assert (outcome.deferred, outcome.lost) == (1, 0)
+        assert _run_status(outcome) == "degraded"
+
+    def test_a_drained_queue_is_not_reported_as_loss(self):
+        """The normal drain path writes an empty queue and returns 0.
+
+        Deriving loss from "deferred_count == 0" alone would call every healthy
+        run a data-loss event — a false alarm is the same defect class as a
+        false reassurance.
+        """
+        _store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue", return_value=True),
+        ):
+            outcome = _dedupe_and_file([{"title": "discovery: ok", "body": "b"}], set(), "enh", client)
+
+        assert (outcome.filed, outcome.deferred, outcome.lost) == (1, 0, 0)
+        assert _run_status(outcome) == "success"
+
+
+class TestFilingStatusIsQueryable:
+    """A CRITICAL log line is not a surface a check can query (#13852).
+
+    The umbrella's shared criterion is that a service which is running but not
+    working must be distinguishable from one that is working by something a
+    check can read. `audit:filing_status` is that something.
+    """
+
+    def test_every_run_publishes_filing_health(self):
+        store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            _dedupe_and_file([{"title": "discovery: q", "body": "b"}], set(), "enh", client)
+
+        # Assert PRESENCE. An absent key would read exactly like a healthy one
+        # to anything checking "is filing_available false?".
+        assert _FILING_STATUS_KEY in store
+        status = store[_FILING_STATUS_KEY]
+        assert status["filing_available"] is False
+        assert status["last_run_deferred"] == 1
+        assert status["last_run_lost"] == 0
+        assert status["checked_at"]
+
+    def test_a_healthy_run_publishes_health_too(self):
+        """Written on every run, not only on failure.
+
+        A key that only appears when something is wrong cannot distinguish "the
+        worker is fine" from "the worker never ran" — and the second is how this
+        lapse stayed invisible.
+        """
+        store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue", return_value=True),
+        ):
+            _dedupe_and_file([{"title": "discovery: ok", "body": "b"}], set(), "enh", client)
+
+        assert store[_FILING_STATUS_KEY]["filing_available"] is True
+
+    def test_status_records_that_loss_happened(self):
+        store: dict = {}
+
+        def _set(_redis, key, value, **_kw):
+            store[key] = value
+            return key == _FILING_STATUS_KEY  # the DLQ write fails, the status write lands
+
+        client = MagicMock()
+        client.exists.side_effect = lambda key: 1 if key in store else 0
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file([{"title": "discovery: gone", "body": "b"}], set(), "enh", client)
+
+        assert outcome.lost == 1
+        assert store[_FILING_STATUS_KEY]["last_run_lost"] == 1
+
+
+class TestStartupCredentialGuard:
+    """#13570 fix 3, the one that never landed.
+
+    `_gh_available` runs inside a task, so the first signal that filing is
+    broken arrives whenever an audit next happens to produce a finding — weekly
+    for `audit_claims`. A worker that cannot file has been unable to file since
+    it started, and that fact is available the moment it starts.
+    """
+
+    def test_startup_reports_and_records_a_missing_credential(self, caplog):
+        store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                available = check_filing_credential_at_startup(client)
+
+        assert available is False
+        assert "WITHOUT a working issue-filing credential" in caplog.text
+        assert store[_FILING_STATUS_KEY]["filing_available"] is False
+
+    def test_startup_is_quiet_and_still_records_when_filing_works(self, caplog):
+        """No CRITICAL on a healthy boot — an alarm that always fires is ignored."""
+        store, _get, _set, client = _fake_redis_backing()
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=True),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+        ):
+            with caplog.at_level(logging.CRITICAL, logger="workers.audit_tasks"):
+                available = check_filing_credential_at_startup(client)
+
+        assert available is True
+        assert "WITHOUT a working issue-filing credential" not in caplog.text
+        assert store[_FILING_STATUS_KEY]["filing_available"] is True
+
+    def test_a_broken_check_never_stops_the_worker_booting(self):
+        """Degrading the audit is acceptable; refusing to start is not."""
+        with patch("workers.audit_tasks._gh_available", side_effect=RuntimeError("boom")):
+            assert check_filing_credential_at_startup(MagicMock()) is False
+
+    def test_the_guard_is_actually_wired_to_celery_startup(self):
+        """Assert the WIRING, not just the helper.
+
+        A startup guard nothing calls is exactly the shape of failure this issue
+        is about: present, correct, and never reached. Both signals matter —
+        Beat and the worker are separate processes with separate deployments.
+        """
+        import weakref
+
+        from celery.signals import beat_init, worker_ready
+
+        import workers.audit_tasks as audit_module
+
+        expected = {
+            worker_ready: audit_module._audit_worker_ready,
+            beat_init: audit_module._audit_beat_init,
+        }
+        for signal, handler in expected.items():
+            # Receivers may be stored as weakrefs. Deref only those: a plain
+            # function is callable too, and `r()` on one would INVOKE the
+            # startup guard instead of inspecting it.
+            resolved = [r() if isinstance(r, weakref.ReferenceType) else r for _, r in signal.receivers]
+            names = {getattr(r, "__name__", "") for r in resolved if r is not None}
+            assert handler.__name__ in names, f"{signal.name} has no audit receiver"
+
+    def test_the_module_carrying_the_guard_is_imported_at_worker_startup(self):
+        """Registering is only half the wiring — something has to import it.
+
+        The decorators above run at import time, so a guard in a module Celery
+        never loads is registered on nothing. The chain is
+        `autodiscover_tasks(["workers"], related_name=None)` -> `workers/__init__`
+        -> `.audit_tasks`; break any link and the guard is silently inert while
+        this file's other tests stay green, because they import it themselves.
+        """
+        from pathlib import Path
+
+        backend_root = Path(__file__).resolve().parents[1]
+        assert "from .audit_tasks import" in (backend_root / "workers" / "__init__.py").read_text(encoding="utf-8")
+        celery_src = (backend_root / "celery_app.py").read_text(encoding="utf-8")
+        assert 'autodiscover_tasks(["tasks", "workers", "llc.scheduler"], related_name=None)' in celery_src
+
+
+class TestTaskResultsCarryTheStatus:
+    def test_a_task_that_could_not_file_does_not_report_success(self):
+        """The end-to-end shape: drive the task, read the result it returns."""
+        with (
+            patch("workers.audit_tasks.reset_gh_env_cache"),
+            patch("workers.audit_tasks._get_redis", return_value=None),
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", return_value=True),
+            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._changed_python_modules", return_value=[]),
+            patch(
+                "workers.audit_tasks._dedupe_and_file",
+                return_value=FilingOutcome(filed=0, deferred=7, lost=0, filing_available=False),
+            ),
+        ):
+            result = audit_testgaps()
+
+        assert result["status"] == "degraded"
+        assert result["issues_deferred"] == 7
+        assert result["issues_lost"] == 0
+        assert result["filing_available"] is False
+
+    def test_a_task_that_lost_findings_reports_error(self):
+        with (
+            patch("workers.audit_tasks.reset_gh_env_cache"),
+            patch("workers.audit_tasks._get_redis", return_value=None),
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", return_value=True),
+            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._changed_python_modules", return_value=[]),
+            patch(
+                "workers.audit_tasks._dedupe_and_file",
+                return_value=FilingOutcome(filed=0, deferred=0, lost=3, filing_available=False),
+            ),
+        ):
+            result = audit_testgaps()
+
+        assert result["status"] == "error"
+        assert result["issues_lost"] == 3
+
+    def test_a_healthy_task_still_reports_success(self):
+        with (
+            patch("workers.audit_tasks.reset_gh_env_cache"),
+            patch("workers.audit_tasks._get_redis", return_value=None),
+            patch("workers.audit_tasks._redis_get", return_value=None),
+            patch("workers.audit_tasks._redis_set", return_value=True),
+            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._changed_python_modules", return_value=[]),
+            patch(
+                "workers.audit_tasks._dedupe_and_file",
+                return_value=FilingOutcome(filed=2, deferred=0, lost=0, filing_available=True),
+            ),
+        ):
+            result = audit_testgaps()
+
+        assert result["status"] == "success"
+        assert result["issues_filed"] == 2

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -915,6 +915,75 @@ class TestLossIsCounted:
         assert _run_status(outcome) == "success"
 
 
+class TestLossAtTheCapBoundary:
+    """`_persist_deferred` sheds past the cap and returns the POST-shed count.
+
+    Review found `lost` derived from `deferred_count == 0`, which is only the
+    write-failure boundary. At the cap boundary the count is nonzero, so shed
+    findings — permanently dropped — were reported as `lost: 0` and
+    `filed + deferred + lost` undercounted by exactly the shed amount. The same
+    "0 where loss occurred" defect this issue exists to close, one boundary over.
+    """
+
+    def test_findings_shed_past_the_cap_are_counted_as_lost(self, monkeypatch):
+        store, _get, _set, client = _fake_redis_backing()
+        monkeypatch.setattr("workers.audit_tasks._MAX_DEFERRED", 3)
+        findings = [{"title": f"discovery: {i}", "body": "b"} for i in range(10)]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file(findings, set(), "enh", client)
+
+        assert outcome.deferred == 3, "the queue holds only what fits under the cap"
+        assert outcome.lost == 7, "the seven shed findings are gone and must be counted"
+        assert outcome.filed + outcome.deferred + outcome.lost == len(findings)
+        assert _run_status(outcome) == "error"
+
+    def test_a_run_that_exactly_fills_the_cap_loses_nothing(self, monkeypatch):
+        """The boundary itself must not manufacture a phantom loss."""
+        _store, _get, _set, client = _fake_redis_backing()
+        monkeypatch.setattr("workers.audit_tasks._MAX_DEFERRED", 3)
+        findings = [{"title": f"discovery: {i}", "body": "b"} for i in range(3)]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file(findings, set(), "enh", client)
+
+        assert (outcome.deferred, outcome.lost) == (3, 0)
+        assert _run_status(outcome) == "degraded"
+
+    def test_two_findings_sharing_a_title_are_deduped_not_lost(self):
+        """`_persist_deferred` dedupes by title, so the count must too.
+
+        Measuring loss against the raw list would report a phantom every time a
+        queued finding was re-discovered on a later run — a false alarm is the
+        same defect class as a false reassurance.
+        """
+        _store, _get, _set, client = _fake_redis_backing()
+        findings = [
+            {"title": "discovery: same", "body": "first"},
+            {"title": "discovery: same", "body": "second"},
+        ]
+
+        with (
+            patch("workers.audit_tasks._gh_available", return_value=False),
+            patch("workers.audit_tasks._redis_get", side_effect=_get),
+            patch("workers.audit_tasks._redis_set", side_effect=_set),
+            patch("workers.audit_tasks._file_issue"),
+        ):
+            outcome = _dedupe_and_file(findings, set(), "enh", client)
+
+        assert (outcome.deferred, outcome.lost) == (1, 0)
+
+
 class TestFilingStatusIsQueryable:
     """A CRITICAL log line is not a surface a check can query (#13852).
 

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -51,6 +51,27 @@ backend_core_dir: /var/lib/autobot/cores
 # backend_core_capture is true; the unit omits LimitCORE entirely otherwise.
 backend_core_limit: infinity
 
+# #13765: backend memory limits, DERIVED from detected host memory by
+# autobot-backend.service.j2. Percentages, never byte counts — the owner's
+# decision was explicitly that the number is a property of the box, not a
+# policy, so a literal here would ship one machine's hardware fleet-wide.
+#
+# 50/75 is not arbitrary: the ratio between them is 1.5x, which reproduces the
+# hand-applied MemoryHigh=8G / MemoryMax=12G on the 16 GiB host this issue was
+# filed from. MemoryHigh throttles (escalating reclaim pressure, no kill),
+# MemoryMax kills — so the gap between them is the warning band, and it is
+# derived along with the limits rather than being a second literal.
+backend_memory_high_pct: 50
+backend_memory_max_pct: 75
+
+# Floor below which NO limits are emitted at all, rather than a smaller cap.
+# The backend's observed steady state is ~4.3 GiB, so any watermark near or
+# below that throttles it at idle — the exact failure #13765 documents, which a
+# template would then reproduce on every small install. 6 GiB leaves real
+# headroom above the observed working set; hosts under ~12 GiB total therefore
+# run unlimited, which is the honest answer for a box that cannot afford a cap.
+backend_memory_floor_mb: 6144
+
 # Celery worker settings (Issue #863)
 celery_concurrency: 4  # Number of worker processes
 celery_max_tasks_per_child: 1000  # Restart worker after N tasks (prevents memory leaks)

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -241,6 +241,15 @@
 # out-of-box. Previously the unit was deployed after the MVA-1633 start task, so
 # first-run on a clean node failed: "Could not find the requested service
 # autobot-backend". Tagged backend,config so tag-filtered runs register it too.
+# #13765: the unit below derives MemoryHigh/MemoryMax from ansible_memtotal_mb.
+# A full role run normally has facts, but this role is also reached with
+# gather_facts disabled, and an absent fact renders NO limits while looking
+# exactly like a deliberately-unlimited small host. Same include as
+# unit_only.yml so there is one place that guarantees the fact.
+- name: "Backend | Resolve host memory before rendering the unit (#13765)"
+  ansible.builtin.include_tasks: memory_limits.yml
+  tags: ['backend', 'config']
+
 - name: "Backend | Deploy backend systemd service (#9914)"
   ansible.builtin.template:
     src: autobot-backend.service.j2

--- a/autobot-slm-backend/ansible/roles/backend/tasks/memory_limits.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/memory_limits.yml
@@ -1,0 +1,38 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# #13765: guarantee `ansible_memtotal_mb` before the backend unit is rendered.
+#
+# autobot-backend.service.j2 derives MemoryHigh/MemoryMax from that fact. Every
+# play in playbooks/update-all-nodes.yml — the playbook behind code-sync and
+# self-update — runs `gather_facts: false`, so through the builtin update path
+# the fact is UNDEFINED. The template's `| default(0)` would then compute a
+# derived limit of 0M, fall under the floor, and render no limits at all: a
+# silent no-op that looks identical to a deliberate "this host is too small".
+#
+# That is the failure shape this whole issue is about, so it is closed here
+# rather than left to the template: gather the one fact subset that carries
+# memory, and fail loudly if it still does not resolve.
+---
+- name: "Backend | Gather memory facts for derived limits (#13765)"
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - hardware
+  when: ansible_memtotal_mb is not defined
+  tags: [backend, systemd, unit, config]
+
+# Assert PRESENCE, not the absence of an error. `setup` above can succeed while
+# reporting no memory fact (a container without the expected /proc view), and an
+# absent fact reads exactly like a clean small-host result downstream.
+- name: "Backend | Fail loudly when host memory cannot be detected (#13765)"
+  ansible.builtin.assert:
+    that:
+      - ansible_memtotal_mb is defined
+      - (ansible_memtotal_mb | int) > 0
+    fail_msg: >-
+      Cannot detect host memory, so autobot-backend's MemoryHigh/MemoryMax
+      cannot be derived (#13765). Rendering the unit now would emit no limits
+      and look indistinguishable from a host deliberately left unlimited.
+    success_msg: "Detected {{ ansible_memtotal_mb | default(0) }}M host memory"
+  tags: [backend, systemd, unit, config]

--- a/autobot-slm-backend/ansible/roles/backend/tasks/memory_limits.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/memory_limits.yml
@@ -36,3 +36,24 @@
       and look indistinguishable from a host deliberately left unlimited.
     success_msg: "Detected {{ ansible_memtotal_mb | default(0) }}M host memory"
   tags: [backend, systemd, unit, config]
+
+# MemoryHigh throttles, MemoryMax kills. Inverting them gives a unit that is
+# killed before it is ever throttled -- the warning band silently gone, and the
+# gentler limit unreachable. The shipped defaults are 50/75 and safe; this
+# exists because they are overridable per-inventory and nothing else would
+# notice the swap until a host started dying under load (#13765 review).
+- name: "Backend | Refuse memory limits that would kill before they throttle (#13765)"
+  ansible.builtin.assert:
+    that:
+      - (backend_memory_max_pct | default(75) | int) > (backend_memory_high_pct | default(50) | int)
+      - (backend_memory_high_pct | default(50) | int) > 0
+      - (backend_memory_max_pct | default(75) | int) <= 100
+    fail_msg: >-
+      backend_memory_max_pct ({{ backend_memory_max_pct | default(75) }}) must be
+      greater than backend_memory_high_pct ({{ backend_memory_high_pct | default(50) }})
+      and at most 100. MemoryHigh throttles and MemoryMax kills, so an inverted
+      pair kills the backend before it is ever throttled (#13765).
+    success_msg: >-
+      Memory limits {{ backend_memory_high_pct | default(50) }}%/{{ backend_memory_max_pct | default(75) }}%
+      are correctly ordered
+  tags: [backend, systemd, unit, config]

--- a/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/unit_only.yml
@@ -32,6 +32,10 @@
 #
 # Looped rather than three copied tasks: a fourth unit added to the role should
 # need a list entry, not another block to forget.
+- name: "Backend | Resolve host memory before rendering the unit (#13765)"
+  ansible.builtin.include_tasks: memory_limits.yml
+  tags: [backend, systemd, unit]
+
 - name: "Backend | Render systemd units from templates (#12777, #13828)"
   ansible.builtin.template:
     src: "{{ item }}.j2"
@@ -52,4 +56,67 @@
     daemon_reload: true
   become: true
   when: _backend_units_rendered.changed
+  tags: [backend, systemd, unit]
+
+# #13765: retire the out-of-band memory override, but ONLY once the rendered
+# unit demonstrably carries limits of its own.
+#
+# /etc/systemd/system.control/ is where `systemctl set-property` writes, and a
+# drop-in there OVERRIDES the unit file — so shipping derived limits without
+# this leaves the hand-applied 8G/12G in force and changes nothing on the host
+# that reported the incident. Removing it is therefore part of the fix, not
+# cleanup afterwards.
+#
+# The ordering the owner set on #13765 is load-bearing in the other direction
+# too: "removed only after the template lands", because a host stripped of the
+# override while the template emits nothing (small host, or a missing memory
+# fact) loses a protection someone deliberately added and gains none.
+#
+# So the gate OBSERVES the rendered unit rather than recomputing the template's
+# condition. Predicting it here would put the same decision in two places, free
+# to disagree — and the half that silently answered "no limits" would be the
+# half that deletes the only limits the host has.
+- name: "Backend | Read back the rendered unit to see whether limits landed (#13765)"
+  ansible.builtin.slurp:
+    src: /etc/systemd/system/autobot-backend.service
+  become: true
+  register: _backend_unit_rendered_bytes
+  tags: [backend, systemd, unit]
+
+- name: "Backend | Record whether the unit declares its own memory limits (#13765)"
+  ansible.builtin.set_fact:
+    backend_unit_declares_memory_limits: >-
+      {{ (_backend_unit_rendered_bytes.content | b64decode)
+         is search('(?m)^MemoryHigh=') }}
+  tags: [backend, systemd, unit]
+
+- name: "Backend | Remove the out-of-band set-property memory override (#13765)"
+  ansible.builtin.file:
+    path: "{{ item }}/autobot-backend.service.d"
+    state: absent
+  become: true
+  loop:
+    - /etc/systemd/system.control
+    - /run/systemd/system.control
+  when: backend_unit_declares_memory_limits | bool
+  register: _backend_out_of_band_removed
+  tags: [backend, systemd, unit]
+
+# Say so when the override is being LEFT in place. An operator reading a green
+# run must not have to infer from a skipped task that this host is still running
+# under limits no artifact records — that invisibility is the defect (#13765).
+- name: "Backend | Report an out-of-band override left in place (#13765)"
+  ansible.builtin.debug:
+    msg: >-
+      autobot-backend's rendered unit declares no memory limits, so any
+      out-of-band /etc/systemd/system.control override is being LEFT in place
+      (#13765). This host is running under limits no repo artifact records.
+  when: not (backend_unit_declares_memory_limits | bool)
+  tags: [backend, systemd, unit]
+
+- name: "Backend | Reload systemd after removing the override (#13765)"
+  ansible.builtin.systemd:
+    daemon_reload: true
+  become: true
+  when: _backend_out_of_band_removed is changed
   tags: [backend, systemd, unit]

--- a/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
+++ b/autobot-slm-backend/ansible/roles/backend/templates/autobot-backend.service.j2
@@ -95,6 +95,55 @@ StartLimitBurst=5
 # Matches the convention used by every other AutoBot unit (slm-agent, frontend,
 # ollama, browser, coordinator = 65535/65536).
 LimitNOFILE={{ backend_nofile_limit | default(65536) }}
+# #13765: memory limits DERIVED from detected host memory, never a literal.
+#
+# This host ran for months under MemoryHigh=8G/MemoryMax=12G applied by hand
+# with `systemctl set-property`, which writes into /etc/systemd/system.control/
+# — a tree no template, role or repo artifact mentions. On 2026-08-03 the
+# backend pinned itself at that 8 GiB watermark with `memory.events high` at
+# 21,052, the process in STAT=D and /health timing out, while `systemctl`
+# reported `active` throughout. MemoryHigh does not kill; it applies escalating
+# reclaim pressure, so the unit never crashed, never restarted and never entered
+# `failed`.
+#
+# Owner decision (#13765, 2026-08-09): "8 GB is our dev box, RTX 4070 RAM max.
+# Different users have different hardware — it should be autodetected." A
+# literal here would ship one machine's hardware to every install: the same
+# defect as the drop-in, only versioned and therefore harder to notice.
+#
+# The percentages, and the ratio between them, are the tunables — see
+# defaults/main.yml for why each number is what it is. On a 16 GiB host they
+# reproduce the hand-applied 8 GiB / 12 GiB exactly, which is the check that
+# this derivation replaces the override rather than merely differing from it.
+#
+# MemoryAccounting is emitted UNCONDITIONALLY, limits or not. It is what makes
+# memory.current / memory.events exist for CgroupMemoryCollector, and the
+# reclaim counter is the only signal that separates a throttled service from a
+# healthy one. A host with no limits still needs to be able to say so.
+MemoryAccounting=yes
+{% set _mem_total_mb = ansible_memtotal_mb | default(0) | int %}
+{% set _high_mb = ((_mem_total_mb * (backend_memory_high_pct | default(50) | int)) / 100) | round | int %}
+{% set _max_mb = ((_mem_total_mb * (backend_memory_max_pct | default(75) | int)) / 100) | round | int %}
+{% if _high_mb >= (backend_memory_floor_mb | default(6144) | int) %}
+MemoryHigh={{ _high_mb }}M
+MemoryMax={{ _max_mb }}M
+{% else %}
+# No memory limits on this host: a derived MemoryHigh of {{ _high_mb }}M is below
+# the {{ backend_memory_floor_mb | default(6144) | int }}M floor
+# (detected host memory: {{ _mem_total_mb }}M).
+#
+# Deliberately emitting NOTHING rather than a smaller cap. This backend's
+# observed steady state is ~4.3 GiB, so a watermark under the floor throttles it
+# at idle — which is precisely the incident this block exists to prevent, and
+# handing an undersized host a cap it cannot meet would reproduce it by
+# template on every small install.
+#
+# A rendered comment rather than silence: an operator reading `systemctl cat`
+# must be able to tell "this host was evaluated and deliberately left
+# unlimited" from "the memory fact never resolved". If the detected memory
+# above reads 0, the fact was missing — tasks/memory_limits.yml exists to stop
+# that reaching here and fails loudly when it cannot.
+{% endif %}
 StandardOutput=append:{{ backend_log_dir }}/backend.log
 StandardError=append:{{ backend_log_dir }}/backend-error.log
 

--- a/autobot-slm-backend/services/role_delivery_probe.py
+++ b/autobot-slm-backend/services/role_delivery_probe.py
@@ -42,6 +42,21 @@ MAX_ARTIFACT_BYTES = 256 * 1024
 _UNIT_DIR = Path(os.getenv("SLM_SYSTEMD_UNIT_DIR", "/etc/systemd/system"))
 _CREDENTIALS_DIR = Path(os.getenv("SLM_CREDENTIALS_DIR", "/etc/autobot"))
 
+# #13765: the two trees `systemctl set-property` writes into. NOTHING in this
+# repo renders here — ansible's own drop-ins go to /etc/systemd/system/<unit>.d/
+# — so every file under these roots is out-of-band by construction. That is the
+# whole reason the scan can be unbounded rather than a list of units to keep in
+# sync: the issue explicitly asks for every service, because
+# `paperclip.service.d` was found alongside `autobot-backend.service.d`.
+_CONTROL_ROOTS = tuple(
+    Path(raw)
+    for raw in os.getenv(
+        "SLM_SYSTEMD_CONTROL_ROOTS",
+        "/etc/systemd/system.control:/run/systemd/system.control",
+    ).split(":")
+    if raw
+)
+
 CONTAINS = "contains"
 UNIQUE_KEY = "unique_key"
 
@@ -108,10 +123,19 @@ class RoleDeliveryVerdict:
     skipped: int = 0
     undelivered: list[str] = field(default_factory=list)
     reason: str | None = None
+    #: Units running under memory limits their unit file does not declare
+    #: (#13765). Kept separate from ``undelivered`` because the remedy differs:
+    #: an undelivered role change needs a redeploy, an out-of-band override
+    #: needs the drop-in retiring once the template carries the decision.
+    out_of_band: list[str] = field(default_factory=list)
+    #: False when the set-property trees could not be read, so ``out_of_band``
+    #: being empty means "did not look", not "nothing there". None when the
+    #: scan was not requested at all.
+    out_of_band_observed: bool | None = None
 
     @property
     def degraded(self) -> bool:
-        return bool(self.undelivered)
+        return bool(self.undelivered) or bool(self.out_of_band)
 
 
 def _read(path: Path) -> str | None:
@@ -133,12 +157,87 @@ def _satisfied(inv: RoleInvariant, text: str) -> bool:
     return inv.marker in text
 
 
-def probe_role_delivery(checks: list[RoleInvariant] | None = None) -> RoleDeliveryVerdict:
-    """Report role-owned changes missing from this host (#12959).
+def probe_out_of_band_limits(control_roots: tuple[Path, ...] | None = None) -> tuple[list[str], bool]:
+    """Units running under memory limits no repo artifact declares (#13765).
+
+    Returns ``(unit names, observed)``. ``observed`` is False when the trees
+    could not be read, and the caller must then report *skipped* rather than
+    clean — an unreadable control tree looks exactly like an empty one, and
+    "nothing found" is the reassuring answer this issue exists to distrust.
+
+    A *missing* root is genuinely clean and says so: `systemctl set-property`
+    creates the tree on first use, so its absence means no property override has
+    ever been applied on this host. That is an observation, not an absence of
+    evidence.
+
+    `autobot-backend` ran for months under `MemoryHigh=8G` / `MemoryMax=12G`
+    applied this way. Reading the role, the unit template or the repo gave no
+    indication the limits existed, a fresh install of the same commit got none,
+    and the state they produced — throttled, `STAT=D`, health timing out,
+    systemd `active` — sent whoever investigated toward application code. That
+    is the host-differs-from-repo condition this probe exists to catch.
+
+    The predicate is imported from the metrics collector rather than
+    reimplemented: `autobot_cgroup_memory_limits_out_of_band` answers the same
+    question, and two definitions of "out-of-band" free to drift apart would
+    make one surface contradict the other about the same unit. That collector's
+    scope is also hard-won — it deliberately excludes
+    `/etc/systemd/system/<unit>.d/`, where the redis role legitimately renders
+    `MemoryLimit=`, and matches only properties that actually cap memory rather
+    than any `Memory*=`.
+    """
+    roots = _CONTROL_ROOTS if control_roots is None else control_roots
+    try:
+        from autobot_shared.monitoring.metrics.cgroup_memory import has_out_of_band_limits
+    except Exception as exc:  # noqa: BLE001 — never raise out of a status probe
+        logger.warning("role-delivery: out-of-band check unavailable: %s", exc)
+        return [], False
+
+    units: set[str] = set()
+    observed = False
+    for root in roots:
+        try:
+            if not root.is_dir():
+                # Never created => set-property has never run here. Observed.
+                observed = True
+                continue
+            entries = sorted(root.iterdir())
+        except OSError as exc:
+            logger.warning("role-delivery: cannot read %s: %s", root, exc)
+            continue
+        observed = True
+        for entry in entries:
+            if not entry.name.endswith(".service.d"):
+                continue
+            unit = entry.name[: -len(".d")]
+            if has_out_of_band_limits(unit, (root,)):
+                units.add(unit)
+    return sorted(units), observed
+
+
+def probe_role_delivery(
+    checks: list[RoleInvariant] | None = None,
+    control_roots: tuple[Path, ...] | None = None,
+) -> RoleDeliveryVerdict:
+    """Report role-owned changes missing from this host (#12959, #13765).
 
     Never raises. An artifact that does not exist is *skipped*, not failed:
     absence means the component is not installed here, which is not the same as
     an update that failed to deliver.
+
+    The #13765 out-of-band scan runs when this probes THE HOST — ``checks`` left
+    at its default — or when ``control_roots`` is given explicitly. Passing a
+    ``checks`` list means "evaluate exactly these", and having that quietly also
+    walk the real ``/etc/systemd/system.control`` would make a unit test's
+    verdict depend on the machine running it. That is not hypothetical here: the
+    self-hosted runner is the very host whose out-of-band drop-in this issue was
+    filed about, so the scan would have reddened unrelated assertions on one
+    runner and passed on another.
+
+    ``out_of_band`` is deliberately NOT folded into ``checked``/``skipped``.
+    Those count role-owned invariants; an override is a different question with
+    a different remedy, and merging them would have silently shifted every
+    existing count assertion by one.
     """
     verdict = RoleDeliveryVerdict()
     for inv in checks if checks is not None else invariants():
@@ -150,6 +249,9 @@ def probe_role_delivery(checks: list[RoleInvariant] | None = None) -> RoleDelive
         if not _satisfied(inv, text):
             verdict.undelivered.append(f"{inv.role} ({inv.issue}): {inv.describes}")
 
+    if checks is None or control_roots is not None:
+        verdict.out_of_band, verdict.out_of_band_observed = probe_out_of_band_limits(control_roots)
+
     verdict.reason = _describe(verdict)
     if verdict.degraded:
         logger.error("role-delivery probe: %s", verdict.reason)
@@ -158,11 +260,26 @@ def probe_role_delivery(checks: list[RoleInvariant] | None = None) -> RoleDelive
 
 def _describe(v: RoleDeliveryVerdict) -> str:
     """Name what is undelivered, not just that something is."""
+    parts: list[str] = []
+    if v.undelivered:
+        parts.append(
+            f"{len(v.undelivered)} of {v.checked} role-owned change(s) never reached this host "
+            f"— the updater does not apply these roles (#12959): " + "; ".join(v.undelivered)
+        )
+    if v.out_of_band:
+        parts.append(
+            f"{len(v.out_of_band)} unit(s) run under memory limits their unit file does not "
+            f"declare, applied out-of-band with `systemctl set-property` — a fresh install of "
+            f"this commit would not reproduce them (#13765): " + ", ".join(v.out_of_band)
+        )
+    if v.out_of_band_observed is False:
+        # Not degraded — an unreadable tree is not a finding. But it must not be
+        # reported as a clean scan either: "found nothing" and "could not look"
+        # are the same empty list, and reading one as the other is the defect
+        # this probe exists to catch (#13765).
+        parts.append("out-of-band memory overrides could not be checked on this host (#13765)")
+    if parts:
+        return "; ".join(parts)
     if not v.checked:
         return "no role-owned artifacts present to verify"
-    if not v.undelivered:
-        return f"all {v.checked} role-owned invariant(s) satisfied"
-    return (
-        f"{len(v.undelivered)} of {v.checked} role-owned change(s) never reached this host "
-        f"— the updater does not apply these roles (#12959): " + "; ".join(v.undelivered)
-    )
+    return f"all {v.checked} role-owned invariant(s) satisfied"

--- a/autobot-slm-backend/services/role_delivery_probe.py
+++ b/autobot-slm-backend/services/role_delivery_probe.py
@@ -135,7 +135,26 @@ class RoleDeliveryVerdict:
 
     @property
     def degraded(self) -> bool:
-        return bool(self.undelivered) or bool(self.out_of_band)
+        """Undelivered work, an out-of-band override, OR a scan that could not run.
+
+        The third clause is the one this class of bug keeps costing. Review
+        found `degraded` reading `out_of_band` but never `out_of_band_observed`,
+        so a control tree that exists and raises `OSError` on `iterdir()` --
+        the SLM backend runs unprivileged -- produced an empty list, a False
+        flag, and `degraded is False`. `_describe` still composed the "could not
+        be checked" sentence, and both consumers dropped it unread:
+        `_merge_role_delivery` returns early on `not degraded`, and the
+        fleet-update stage gates its whole pass/fail on this property. An
+        update-all job would have reported the stage successful on a host whose
+        scan silently failed.
+
+        That is exactly the defect this probe exists to catch, one frame up:
+        "found nothing" and "could not look" are the same empty list, and only
+        the flag separates them. `is False` rather than a falsy test on purpose
+        -- `None` means the scan was not requested at all, which is not a
+        failure to observe.
+        """
+        return bool(self.undelivered) or bool(self.out_of_band) or self.out_of_band_observed is False
 
 
 def _read(path: Path) -> str | None:

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
@@ -20,14 +20,19 @@ pass vacuously against MagicMock attributes.
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 _BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_REPO_ROOT = _BACKEND_ROOT.parent
+_METRICS_DIR = _REPO_ROOT / "autobot_shared" / "monitoring" / "metrics"
+_CGROUP_MEMORY = "autobot_shared.monitoring.metrics.cgroup_memory"
 
 
 def _load(module_name: str, alias: str):
@@ -47,6 +52,53 @@ def _load(module_name: str, alias: str):
 
 
 _probe = _load("role_delivery_probe", "_rdp_13765")
+
+
+@pytest.fixture(autouse=True)
+def _resolvable_cgroup_memory():
+    """Guarantee the collector's predicate resolves, whatever else leaked.
+
+    `probe_out_of_band_limits` imports `has_out_of_band_limits` from the metrics
+    collector at call time, and reports "could not look" when that import fails
+    — correct behaviour in production, and exactly what happened here: several
+    suite files replace `sys.modules["autobot_shared.monitoring"]` (and, when an
+    `exec_module` raises before their restore block, `sys.modules["autobot_
+    shared"]` itself) at MODULE scope with no teardown, so a stub survives for
+    the rest of the session. Under xdist the victim is whichever worker drew the
+    leaker, which is why this reddened one shard and not the other eleven.
+
+    Every negative assertion in this file would pass against that stub — an
+    unreadable-tree case and a scan-did-not-run case both expect an empty list —
+    so without this the suite would have gone green for the wrong reason. Same
+    load-past-the-stub technique `_load` above uses for `services/*`, one package
+    level deeper.
+
+    Restores sys.modules exactly, including deleting keys that were absent, so
+    the repo-wide leak guard (#13337) sees a zero delta and this fixture does not
+    become the next file in the paragraph above.
+    """
+    names = (_CGROUP_MEMORY, "autobot_shared.monitoring.metrics")
+    saved = {name: sys.modules.get(name) for name in names}
+    try:
+        importlib.import_module(_CGROUP_MEMORY)
+    except Exception:
+        # Rebuild only what is missing: a real path-carrying package entry, then
+        # the module itself loaded from disk. Deliberately does NOT execute
+        # `metrics/__init__.py`, which would drag in every other collector.
+        pkg = types.ModuleType("autobot_shared.monitoring.metrics")
+        pkg.__path__ = [str(_METRICS_DIR)]
+        sys.modules["autobot_shared.monitoring.metrics"] = pkg
+        spec = importlib.util.spec_from_file_location(_CGROUP_MEMORY, _METRICS_DIR / "cgroup_memory.py")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[_CGROUP_MEMORY] = module
+        spec.loader.exec_module(module)
+    yield
+    for name, previous in saved.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
 
 probe_out_of_band_limits = _probe.probe_out_of_band_limits
 probe_role_delivery = _probe.probe_role_delivery

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
@@ -77,7 +77,7 @@ def _resolvable_cgroup_memory():
     the repo-wide leak guard (#13337) sees a zero delta and this fixture does not
     become the next file in the paragraph above.
     """
-    names = (_CGROUP_MEMORY, "autobot_shared.monitoring.metrics")
+    names = (_CGROUP_MEMORY, "autobot_shared.monitoring.metrics", "autobot_shared.logging_manager")
     saved = {name: sys.modules.get(name) for name in names}
     try:
         importlib.import_module(_CGROUP_MEMORY)
@@ -85,13 +85,40 @@ def _resolvable_cgroup_memory():
         # Rebuild only what is missing: a real path-carrying package entry, then
         # the module itself loaded from disk. Deliberately does NOT execute
         # `metrics/__init__.py`, which would drag in every other collector.
+        #
+        # `logging_manager` is stubbed across the exec for the same reason
+        # `_load` above stubs it, and the first attempt at this fixture proved
+        # why the hard way. `cgroup_memory` calls `get_logger(__name__)` at
+        # module scope; the REAL logging_manager then builds a
+        # RotatingFileHandler from config values that a leaked
+        # `autobot_shared.ssot_config` stub had turned into MagicMocks, and
+        # `maxBytes > 0` raised TypeError inside the fixture. Loading a module
+        # past one leaked stub is no good if the load itself trips over the
+        # next one.
+        sys.modules["autobot_shared.logging_manager"] = MagicMock()
         pkg = types.ModuleType("autobot_shared.monitoring.metrics")
         pkg.__path__ = [str(_METRICS_DIR)]
         sys.modules["autobot_shared.monitoring.metrics"] = pkg
         spec = importlib.util.spec_from_file_location(_CGROUP_MEMORY, _METRICS_DIR / "cgroup_memory.py")
         module = importlib.util.module_from_spec(spec)
         sys.modules[_CGROUP_MEMORY] = module
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            # Un-register the half-built module before re-raising. Without this
+            # the first failure poisons every later test: `module_from_spec`
+            # registers BEFORE `exec_module` runs, the fixture dies before its
+            # `yield` so no teardown happens, and the broken object stays in
+            # sys.modules. The next test's `import_module` then SUCCEEDS,
+            # returning a module with no `has_out_of_band_limits` -- so the
+            # fixture reports itself healthy and the tests fail on bare
+            # `assert False` instead of on the real cause.
+            #
+            # Observed exactly that: one honest ERROR naming the TypeError,
+            # followed by seven failures pointing nowhere near it. A diagnostic
+            # that degrades after its first use is its own bug.
+            sys.modules.pop(_CGROUP_MEMORY, None)
+            raise
     yield
     for name, previous in saved.items():
         if previous is None:

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
@@ -217,6 +217,75 @@ def test_a_finding_degrades_the_verdict_and_names_the_unit(tmp_path: Path) -> No
     assert "#13765" in (verdict.reason or "")
 
 
+def test_an_unreadable_tree_degrades_the_VERDICT_not_just_the_tuple(tmp_path: Path) -> None:
+    """The property, not the helper — review found `degraded` ignoring the flag.
+
+    `probe_out_of_band_limits` distinguished "clean" from "could not look" all
+    along, and `_describe` composed the explanatory sentence, but `degraded`
+    read only `out_of_band`. So an unreadable control tree returned an empty
+    list, a False flag, and `degraded is False` — and both consumers dropped the
+    sentence unread, because `_merge_role_delivery` returns early on
+    `not degraded` and the fleet-update stage gates its pass/fail on the same
+    property. An update-all job reported the stage successful on a host whose
+    scan had silently failed.
+
+    Testing the tuple only, as this file previously did, could never catch that:
+    the tuple was correct. Drive the property.
+    """
+    root = tmp_path / "system.control"
+    root.mkdir()
+    root.chmod(0o000)
+    try:
+        verdict = probe_role_delivery(checks=[], control_roots=(root,))
+    finally:
+        root.chmod(0o755)
+
+    if verdict.out_of_band_observed:
+        pytest.skip("running as a user that can read a 0o000 directory (root); the flag cannot be exercised")
+
+    assert verdict.out_of_band == []
+    assert verdict.out_of_band_observed is False
+    assert verdict.degraded is True, "a scan that could not run must not read as a clean host"
+    assert "could not be checked" in (verdict.reason or "")
+
+
+def test_a_scan_that_was_not_requested_is_not_a_degradation(tmp_path: Path) -> None:
+    """`None` and `False` must not collapse.
+
+    `None` means the caller passed explicit checks and never asked for the
+    scan; `False` means it was asked for and could not run. Only the second is
+    a failure to observe, so `degraded` tests `is False` rather than falsiness —
+    otherwise every unit test passing explicit checks would degrade.
+    """
+    artifact = tmp_path / "unit.service"
+    artifact.write_text("Environment=MARKER=1\n", encoding="utf-8")
+    inv = RoleInvariant(
+        role="backend",
+        issue="#12777",
+        artifact=artifact,
+        kind=CONTAINS,
+        marker="MARKER",
+        describes="artifact is missing the role-owned change",
+    )
+
+    verdict = probe_role_delivery(checks=[inv])
+
+    assert verdict.out_of_band_observed is None
+    assert verdict.degraded is False
+
+
+def test_a_readable_empty_tree_is_still_not_degraded(tmp_path: Path) -> None:
+    """The fix must not turn every ordinary host into a permanent alarm.
+
+    Most hosts have never had `systemctl set-property` run, so the tree does not
+    exist. That is an observation, and observing nothing is clean.
+    """
+    verdict = probe_role_delivery(checks=[], control_roots=(tmp_path / "never-created",))
+
+    assert verdict.out_of_band_observed is True
+    assert verdict.degraded is False
+
+
 def test_out_of_band_does_not_disturb_the_role_invariant_counters(tmp_path: Path) -> None:
     """`checked`/`skipped` count role-owned invariants and must keep doing so.
 

--- a/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
+++ b/autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py
@@ -1,0 +1,214 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Out-of-band memory overrides are a host-differs-from-repo condition (#13765).
+
+`autobot-backend` ran for months under `MemoryHigh=8G` / `MemoryMax=12G` applied
+by hand with `systemctl set-property`, which writes into
+`/etc/systemd/system.control/`. Nothing in the unit template, the role or the
+repo mentioned those values, a fresh install of the same commit got none, and
+the state they produced — throttled, `STAT=D`, `/health` timing out, systemd
+`active` — sent a full diagnostic cycle toward application code.
+
+#13765's acceptance list asks for exactly this: the `system.control/` tree added
+to the role-delivery probe, because a service running under limits its unit does
+not declare is the condition that probe exists to catch.
+
+Loaded past the suite's session-global ``services`` stub the same way as
+``test_role_delivery_probe_12959.py``; without that every assertion here would
+pass vacuously against MagicMock attributes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(module_name: str, alias: str):
+    saved = sys.modules.get("autobot_shared.logging_manager")
+    sys.modules["autobot_shared.logging_manager"] = MagicMock()
+    try:
+        spec = importlib.util.spec_from_file_location(alias, _BACKEND_ROOT / "services" / f"{module_name}.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[alias] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is None:
+            sys.modules.pop("autobot_shared.logging_manager", None)
+        else:
+            sys.modules["autobot_shared.logging_manager"] = saved
+
+
+_probe = _load("role_delivery_probe", "_rdp_13765")
+
+probe_out_of_band_limits = _probe.probe_out_of_band_limits
+probe_role_delivery = _probe.probe_role_delivery
+RoleInvariant = _probe.RoleInvariant
+CONTAINS = _probe.CONTAINS
+
+# The values the incident host actually carried.
+_INCIDENT_DROP_IN = "MemoryHigh=8589934592\nMemoryMax=12884901888\n"
+
+
+def _control_root(tmp_path: Path, unit: str = "autobot-backend.service", body: str = _INCIDENT_DROP_IN) -> Path:
+    root = tmp_path / "system.control"
+    drop_in = root / f"{unit}.d"
+    drop_in.mkdir(parents=True)
+    (drop_in / "50-MemoryHigh.conf").write_text(body, encoding="utf-8")
+    return root
+
+
+def test_the_predicate_under_test_actually_exists() -> None:
+    """Assert the target before asserting about it.
+
+    Every negative case below would pass against a probe that had lost the
+    check entirely — an empty ``out_of_band`` list reads exactly like "nothing
+    found". Pin the mechanism first, and pin that it is the collector's
+    definition rather than a second one that can drift from the metric.
+    """
+    from autobot_shared.monitoring.metrics.cgroup_memory import has_out_of_band_limits
+
+    assert callable(has_out_of_band_limits)
+    source = (_BACKEND_ROOT / "services" / "role_delivery_probe.py").read_text(encoding="utf-8")
+    assert "has_out_of_band_limits" in source, "the probe must reuse the collector's predicate, not reimplement it"
+
+
+def test_the_incident_drop_in_is_reported(tmp_path: Path) -> None:
+    """The literal state that ran undetected for months."""
+    units, observed = probe_out_of_band_limits((_control_root(tmp_path),))
+
+    assert observed
+    assert units == ["autobot-backend.service"]
+
+
+def test_every_service_is_covered_not_just_the_backend(tmp_path: Path) -> None:
+    """#13765: `paperclip.service.d` was found alongside the backend's.
+
+    The scan walks the tree instead of consulting a list of units, so a service
+    nobody thought to enumerate is still covered.
+    """
+    root = _control_root(tmp_path, unit="paperclip.service")
+    (root / "some-other.service.d").mkdir()
+    (root / "some-other.service.d" / "override.conf").write_text("MemoryMax=4G\n", encoding="utf-8")
+
+    units, observed = probe_out_of_band_limits((root,))
+
+    assert observed
+    assert units == ["paperclip.service", "some-other.service"]
+
+
+def test_a_drop_in_that_sets_no_memory_property_is_not_a_finding(tmp_path: Path) -> None:
+    """The directory exists for ANY property — CPUQuota, Restart, Slice.
+
+    Keying on its existence would make the report's own words ("its effective
+    memory limits are not in the unit template") false, and a permanent false
+    warning is the failure this issue is about.
+    """
+    root = tmp_path / "system.control"
+    (root / "autobot-celery.service.d").mkdir(parents=True)
+    (root / "autobot-celery.service.d" / "50-CPUQuota.conf").write_text("CPUQuota=50%\n", encoding="utf-8")
+
+    units, observed = probe_out_of_band_limits((root,))
+
+    assert observed
+    assert units == []
+
+
+def test_an_absent_control_tree_is_clean_and_observed(tmp_path: Path) -> None:
+    """`set-property` creates the tree on first use, so absence is a real answer.
+
+    Distinct from "could not look": this must report observed, or a host that
+    has simply never had an override applied would permanently read as
+    unverifiable and train operators to ignore the field.
+    """
+    units, observed = probe_out_of_band_limits((tmp_path / "never-created",))
+
+    assert units == []
+    assert observed is True
+
+
+def test_an_unreadable_tree_is_not_reported_as_clean(tmp_path: Path) -> None:
+    """An empty result must not read as a clean result.
+
+    A root that exists but cannot be listed yields the same empty list as a host
+    with no overrides. The flag is what separates them, and it is the reason the
+    caller can tell "nothing found" from "did not look".
+    """
+    root = tmp_path / "system.control"
+    root.mkdir()
+    root.chmod(0o000)
+    try:
+        units, observed = probe_out_of_band_limits((root,))
+    finally:
+        root.chmod(0o755)
+
+    if units == [] and observed:
+        pytest.skip("running as a user that can read a 0o000 directory (root); the flag cannot be exercised")
+    assert units == []
+    assert observed is False
+
+
+def test_a_finding_degrades_the_verdict_and_names_the_unit(tmp_path: Path) -> None:
+    """The probe feeds `self_update_incomplete`, so it has to actually degrade."""
+    verdict = probe_role_delivery(checks=[], control_roots=(_control_root(tmp_path),))
+
+    assert verdict.degraded
+    assert verdict.out_of_band == ["autobot-backend.service"]
+    assert "autobot-backend.service" in (verdict.reason or "")
+    assert "#13765" in (verdict.reason or "")
+
+
+def test_out_of_band_does_not_disturb_the_role_invariant_counters(tmp_path: Path) -> None:
+    """`checked`/`skipped` count role-owned invariants and must keep doing so.
+
+    Folding a fourth question into those counters would silently shift every
+    existing count assertion in test_role_delivery_probe_12959.py by one.
+    """
+    artifact = tmp_path / "unit.service"
+    artifact.write_text("Environment=MARKER=1\n", encoding="utf-8")
+    inv = RoleInvariant(
+        role="backend",
+        issue="#12777",
+        artifact=artifact,
+        kind=CONTAINS,
+        marker="MARKER",
+        describes="artifact is missing the role-owned change",
+    )
+
+    verdict = probe_role_delivery(checks=[inv], control_roots=(_control_root(tmp_path),))
+
+    assert verdict.checked == 1
+    assert verdict.skipped == 0
+    assert verdict.out_of_band == ["autobot-backend.service"]
+
+
+def test_explicit_checks_alone_never_touch_the_real_host_tree(tmp_path: Path) -> None:
+    """A unit test's verdict must not depend on the machine running it.
+
+    The self-hosted runner IS the host whose out-of-band drop-in this issue was
+    filed about, so an unconditional scan would have reddened unrelated
+    assertions on one runner and passed on another.
+    """
+    artifact = tmp_path / "unit.service"
+    artifact.write_text("Environment=MARKER=1\n", encoding="utf-8")
+    inv = RoleInvariant(
+        role="backend",
+        issue="#12777",
+        artifact=artifact,
+        kind=CONTAINS,
+        marker="MARKER",
+        describes="artifact is missing the role-owned change",
+    )
+
+    verdict = probe_role_delivery(checks=[inv])
+
+    assert verdict.out_of_band == []
+    assert verdict.out_of_band_observed is None, "the scan must not have run at all"
+    assert not verdict.degraded

--- a/autobot-slm-backend/tests/test_backend_memory_limits_13765.py
+++ b/autobot-slm-backend/tests/test_backend_memory_limits_13765.py
@@ -195,6 +195,13 @@ def test_the_role_guarantees_the_fact_before_rendering():
     guard = (_ROLE_DIR / "tasks" / "memory_limits.yml").read_text(encoding="utf-8")
     assert "ansible.builtin.setup" in guard
     assert "ansible.builtin.assert" in guard
+    # MemoryHigh throttles and MemoryMax kills, so an inverted pair gives a unit
+    # killed before it is ever throttled — the warning band gone and the gentler
+    # limit unreachable. The shipped defaults are safe; the percentages are
+    # overridable per-inventory, and nothing else would notice the swap until a
+    # host started dying under load (#13765 review).
+    assert "backend_memory_max_pct" in guard and "backend_memory_high_pct" in guard
+    assert ">" in guard, "the guard must order the two percentages, not merely mention them"
 
     for task_file in ("unit_only.yml", "main.yml"):
         text = (_ROLE_DIR / "tasks" / task_file).read_text(encoding="utf-8")

--- a/autobot-slm-backend/tests/test_backend_memory_limits_13765.py
+++ b/autobot-slm-backend/tests/test_backend_memory_limits_13765.py
@@ -1,0 +1,220 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Render tests for the backend unit's derived memory limits (#13765).
+
+`autobot-backend` ran for months under `MemoryHigh=8G` / `MemoryMax=12G` applied
+by hand with `systemctl set-property`, which writes into
+`/etc/systemd/system.control/` — a tree no template, role or repo artifact
+mentions. On 2026-08-03 it pinned itself at that watermark with
+`memory.events high` at 21,052, the process in `STAT=D` and `/health` timing
+out, while `systemctl` reported `active` for the whole window.
+
+The owner's decision (#13765, 2026-08-09) was that the limits must be
+*autodetected* rather than templated, because 8 GiB was never a policy — it was
+that box. So the acceptance criterion is not "a number is present": it is that
+**two hosts with different RAM render different, sensible limits**, which is
+what this file asserts.
+
+Follows the render-test precedent in test_backend_service_faulthandler_12777.py.
+"""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+jinja2 = pytest.importorskip("jinja2")
+
+_ROLE_DIR = Path(__file__).resolve().parents[1] / "ansible" / "roles" / "backend"
+_TEMPLATE_DIR = _ROLE_DIR / "templates"
+_TEMPLATE = "autobot-backend.service.j2"
+
+# The host the incident was reported from. Its hand-applied override was
+# MemoryHigh=8589934592 (8 GiB) / MemoryMax=12884901888 (12 GiB).
+_INCIDENT_HOST_MB = 16384
+_INCIDENT_HIGH_MB = 8192
+_INCIDENT_MAX_MB = 12288
+
+_CTX = {
+    "backend_install_dir": "/opt/autobot/autobot-backend",
+    "backend_code_dir": "/opt/autobot/autobot-backend",
+    "backend_log_dir": "/var/log/autobot",
+    "backend_host": "0.0.0.0",
+    "backend_port": 8001,
+    "backend_workers": 1,
+    "backend_user": "autobot",
+    "backend_group": "autobot",
+}
+
+
+def _render(**overrides) -> str:
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(_TEMPLATE_DIR)))
+    # Ansible filters the real template uses; not Jinja2 builtins.
+    env.filters["dirname"] = os.path.dirname
+    env.filters["basename"] = os.path.basename
+    env.filters["bool"] = lambda v: str(v).strip().lower() in ("true", "yes", "1", "on")
+    return env.get_template(_TEMPLATE).render(**{**_CTX, **overrides})
+
+
+def _limits(rendered: str) -> tuple[int | None, int | None]:
+    """Return (MemoryHigh MB, MemoryMax MB) actually emitted by the unit.
+
+    Anchored to line starts so a value quoted inside one of the template's
+    explanatory comments cannot be mistaken for a live directive — the comments
+    discuss these exact numbers, so an unanchored search would pass on a
+    template that emits nothing at all.
+    """
+    high = re.search(r"(?m)^MemoryHigh=(\d+)M$", rendered)
+    hard = re.search(r"(?m)^MemoryMax=(\d+)M$", rendered)
+    return (int(high.group(1)) if high else None, int(hard.group(1)) if hard else None)
+
+
+def test_template_actually_derives_from_the_memory_fact():
+    """Guard the target exists before anything below asserts about it.
+
+    Every other test here would pass vacuously against a template that had lost
+    the block entirely: `_limits` would return (None, None) and the "no limits"
+    assertions would hold. Assert the mechanism is present first.
+    """
+    source = (_TEMPLATE_DIR / _TEMPLATE).read_text(encoding="utf-8")
+    assert "ansible_memtotal_mb" in source, "unit no longer derives limits from the host memory fact"
+    assert "MemoryHigh=" in source
+    assert "backend_memory_floor_mb" in source
+
+
+def test_two_hosts_with_different_ram_render_different_limits():
+    """The acceptance criterion, stated directly (#13765).
+
+    A literal in the template would make these identical — which is the defect
+    the owner rejected, not a smaller version of it.
+    """
+    small_high, small_max = _limits(_render(ansible_memtotal_mb=16384))
+    large_high, large_max = _limits(_render(ansible_memtotal_mb=65536))
+
+    assert small_high is not None and large_high is not None
+    assert small_high != large_high
+    assert small_max != large_max
+    assert large_high > small_high
+    assert large_max > small_max
+
+
+def test_derivation_reproduces_the_hand_applied_override():
+    """On the incident host the derived values must equal the override.
+
+    This is the check that the derivation *replaces* the out-of-band drop-in
+    rather than merely differing from it. `unit_only.yml` deletes that drop-in
+    once the unit declares limits of its own, so a derivation that landed on
+    different numbers would silently change the incident host's behaviour under
+    cover of a fix.
+    """
+    high, hard = _limits(_render(ansible_memtotal_mb=_INCIDENT_HOST_MB))
+    assert high == _INCIDENT_HIGH_MB
+    assert hard == _INCIDENT_MAX_MB
+
+
+@pytest.mark.parametrize(
+    ("total_mb", "expected_high", "expected_max"),
+    [
+        (12288, 6144, 9216),
+        (16384, 8192, 12288),
+        (32768, 16384, 24576),
+        (65536, 32768, 49152),
+        (131072, 65536, 98304),
+    ],
+)
+def test_sensible_limits_across_the_hardware_range(total_mb, expected_high, expected_max):
+    """Sensible, not merely different: MemoryHigh below MemoryMax, both below total.
+
+    MemoryHigh throttles and MemoryMax kills, so a host where they cross — or
+    where either exceeds physical memory — has a limit that can never bind, or
+    one that binds before the other in the wrong order.
+    """
+    high, hard = _limits(_render(ansible_memtotal_mb=total_mb))
+    assert (high, hard) == (expected_high, expected_max)
+    assert high < hard < total_mb
+
+
+@pytest.mark.parametrize("total_mb", [1024, 2048, 4096, 8192])
+def test_small_hosts_get_no_limits_rather_than_a_cap_they_cannot_meet(total_mb):
+    """A watermark under the backend's ~4.3 GiB working set throttles it at idle.
+
+    Emitting a smaller cap for a smaller host would reproduce the incident by
+    template on every small install, so below the floor the unit emits nothing.
+    """
+    rendered = _render(ansible_memtotal_mb=total_mb)
+    assert _limits(rendered) == (None, None)
+    # And says so, so `systemctl cat` distinguishes "evaluated, left unlimited"
+    # from "the fact never resolved".
+    assert "No memory limits on this host" in rendered
+    assert str(total_mb) in rendered
+
+
+def test_accounting_is_emitted_even_when_no_limits_are():
+    """memory.current / memory.events are what CgroupMemoryCollector reads.
+
+    The reclaim counter is the only signal separating a throttled service from a
+    healthy one, and an unlimited host still has to be able to report it. Gating
+    accounting on the limits would leave exactly the small hosts dark.
+    """
+    for total_mb in (2048, 16384):
+        assert re.search(r"(?m)^MemoryAccounting=yes$", _render(ansible_memtotal_mb=total_mb))
+
+
+def test_percentages_are_tunable_and_the_template_holds_no_byte_literal():
+    """The owner rejected a literal; a default that ignores its var is one."""
+    high, hard = _limits(_render(ansible_memtotal_mb=32768, backend_memory_high_pct=25, backend_memory_max_pct=40))
+    assert (high, hard) == (8192, 13107)
+
+
+def test_floor_is_tunable_so_a_deliberate_small_host_can_opt_in():
+    """Raising the floor must remove limits a lower floor would have emitted."""
+    assert _limits(_render(ansible_memtotal_mb=16384)) == (_INCIDENT_HIGH_MB, _INCIDENT_MAX_MB)
+    assert _limits(_render(ansible_memtotal_mb=16384, backend_memory_floor_mb=999999)) == (None, None)
+
+
+def test_missing_memory_fact_does_not_render_a_confident_zero():
+    """The builtin update path runs `gather_facts: false` on every play.
+
+    Without the fact the template must not emit `MemoryHigh=0M` — a cap that
+    would kill the backend on start. It renders no limits, and
+    tasks/memory_limits.yml is what stops this state reaching a host at all.
+    """
+    rendered = _render()
+    assert _limits(rendered) == (None, None)
+    assert not re.search(r"(?m)^Memory(High|Max)=0M$", rendered)
+
+
+def test_the_role_guarantees_the_fact_before_rendering():
+    """A template guard is not enough on its own — assert the wiring, not the helper.
+
+    memory_limits.yml exists precisely because the render above is silent about
+    a missing fact. If the unit-rendering task file stops including it, the
+    builtin updater silently renders every host unlimited.
+    """
+    guard = (_ROLE_DIR / "tasks" / "memory_limits.yml").read_text(encoding="utf-8")
+    assert "ansible.builtin.setup" in guard
+    assert "ansible.builtin.assert" in guard
+
+    for task_file in ("unit_only.yml", "main.yml"):
+        text = (_ROLE_DIR / "tasks" / task_file).read_text(encoding="utf-8")
+        assert "memory_limits.yml" in text, f"{task_file} renders the unit without guaranteeing the memory fact"
+
+
+def test_out_of_band_override_is_removed_only_when_the_unit_carries_limits():
+    """Ordering the owner set on #13765, and the reason it is load-bearing.
+
+    A `system.control` drop-in overrides the unit file, so leaving it defeats
+    the derived limits entirely; removing it on a host whose unit declares none
+    strips a protection someone deliberately added. The gate must therefore read
+    the unit that was actually rendered rather than recompute the template's
+    condition — two copies of that decision are free to disagree, and the half
+    that answers "no limits" is the half that deletes.
+    """
+    text = (_ROLE_DIR / "tasks" / "unit_only.yml").read_text(encoding="utf-8")
+    assert "/etc/systemd/system.control" in text
+    assert "/run/systemd/system.control" in text
+    assert "ansible.builtin.slurp" in text, "the removal gate must observe the rendered unit, not predict it"
+    assert "backend_unit_declares_memory_limits" in text
+    # The removal is conditional, and the condition is the observation.
+    assert re.search(r"when:\s*backend_unit_declares_memory_limits \| bool", text)

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -879,6 +879,22 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_AUDIT_FILING_STATUS_TTL_S",
+        type=int,
+        default=2592000,
+        description=(
+            "Seconds the audit worker's filing-health record survives in Redis. "
+            "Refreshed on every run and at worker startup, so this only has to "
+            "outlive the longest gap between runs (the claims audit is weekly); "
+            "it exists so a record left by a worker that has since stopped does "
+            "not keep answering for one that no longer exists (#13570)."
+        ),
+        component="backend",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_CODE_ANALYSIS_POOL_WORKERS",
         type=int,
         default=2,

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -439,6 +439,7 @@ To add a new variable:
 |---|---|---|---|---|
 | `AUTOBOT_ALLOW_CONFIG_EDITS` | system | bool | false | Permit writes to the repository's tracked config files. Off by default: the codebase is the source of truth and an edit made here is invisible to deployment (#11220). |
 | `AUTOBOT_APPROVAL_PENDING_SESSION_TTL_SECONDS` | execution | int | `604800` | Seconds a session holding a pending approval survives in Redis. Deliberately long — what it waits for is a person, and expiring sooner discards the approval rather than the wait (#13478). |
+| `AUTOBOT_AUDIT_FILING_STATUS_TTL_S` | backend | int | `2592000` | Seconds the audit worker's filing-health record survives in Redis. Refreshed on every run and at worker startup, so this only has to outlive the longest gap between runs (the claims audit is weekly); it exists so a record left by a worker that has since stopped does not keep answering for one that no longer exists (#13570). |
 | `AUTOBOT_AUDIT_MAX_DEFERRED` | backend | int | `10000` | Ceiling on audit records held in the deferred queue when the sink is unavailable. Beyond it the oldest are dropped, bounding memory rather than letting an outage grow it without limit. |
 | `AUTOBOT_BACKEND_HOST` | backend | str | `'10.0.0.1'` | Hostname or IP address of the AutoBot backend service. |
 | `AUTOBOT_BACKEND_PORT` | backend | str | `'8001'` | TCP port of the AutoBot backend service. |
@@ -585,5 +586,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*147 variables registered as of last generation.*
+*148 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->


### PR DESCRIPTION
Refs #13765, Refs #14212
Refs #13570

Two CRITICAL findings from umbrella #13852, both instances of its shared shape: **a failure that reports success.** They do not share code, so they are separate commits in one PR.

**Neither issue is closed by this PR.** Both have acceptance criteria that only host evidence can settle, and the per-issue split is stated in full below.

## Thinking Path

Both issues have had substantial work land already, so the first job was working out what is genuinely left rather than re-solving the solved half.

**#13765.** The reclaim-counter metric, the alert rules and the out-of-band flag all landed in #13909. What never landed is the owner's first acceptance criterion from 2026-08-09: *"8 GB is our dev box, RTX 4070 RAM max. Different users have different hardware — it should be autodetected."* The unit template still declared no memory limits at all, so the only thing capping the backend anywhere was the hand-applied `systemctl set-property` drop-in — the exact artifact the issue exists to retire. Criterion 4 (`system.control/` added to the role-delivery probe) was also still open: the tree was known to the metrics collector but not to the probe that answers "does this host differ from the repo".

Deriving the limits raised the question of what the percentages should be, and the answer turned out to be checkable rather than arbitrary. `MemoryHigh` at 50% and `MemoryMax` at 75% of detected memory reproduce the hand-applied 8 GiB / 12 GiB **exactly** on a 16 GiB host. That is the difference between replacing the override and merely differing from it — which matters, because the same change also deletes the override.

Three traps shaped the implementation:

- **The builtin update path runs `gather_facts: false` on every play.** `ansible_memtotal_mb` is therefore undefined exactly where the unit is rendered for real. The template's `| default(0)` would then compute a limit of 0M, fall under the floor, and emit nothing — a silent no-op indistinguishable from a deliberate "this host is too small". A guard task gathers the one fact subset that carries memory and asserts it resolved, rather than leaving the template to be quietly wrong.
- **A drop-in under `system.control/` overrides the unit file.** Shipping derived limits without removing it changes nothing on the affected host. But removing it on a host whose unit declares no limits strips a protection someone deliberately added. The gate therefore *reads back the rendered unit* instead of recomputing the template's condition — two copies of that decision are free to disagree, and the half that answers "no limits" is the half that deletes.
- **A very small host must not get a cap it cannot meet.** The backend's observed steady state is ~4.3 GiB, so a watermark near that throttles it at idle. Below a 6 GiB floor the template emits *no limits and a rendered comment saying why*, rather than a proportionally smaller cap that would reproduce the incident by template on every small install.

**#13570.** The owner's pickup note on 2026-08-23 reads "Nothing to build" — the retention half is fixed and host-verified (1,644 findings queued and readable), and the remaining blocker is provisioning a credential. That is correct about the *cause*, but two things were still buildable and both are the issue's own words.

Fix 3 in the issue body — *"fail loudly at startup when the worker's filing credential is absent, rather than per-finding at run time"* — never landed. `_gh_available` runs inside a task, so the first signal that filing is broken arrives whenever an audit next happens to produce a finding, which is weekly for `audit_claims`. On the live host the lapse accumulated 1,644 findings before anyone noticed, and there is still no way to say when it broke. A worker that cannot file has been unable to file since it started.

The second is worse, and is the theme of this PR verbatim: **all three audit tasks returned `"status": "success"` unconditionally.** The run that queued 1,644 unfileable findings reported success to Celery — the one machine-readable surface these tasks produce. The log said CRITICAL; the result said success. Worse still, a run whose dead-letter queue could not be written returned `issues_deferred: 0`, byte-identical to a clean run, because both loss paths return 0 and 0 is also the normal drained state. The count that said "nothing was deferred" was emitted by a run that had just destroyed its own findings.

## What Changed

**#13765 — derived memory limits (`1c63fba3b`)**

- `autobot-backend.service.j2` derives `MemoryHigh`/`MemoryMax` from `ansible_memtotal_mb` via tunable percentages. `MemoryAccounting=yes` is emitted unconditionally, limits or not — it is what makes `memory.current`/`memory.events` exist for the collector, and an unlimited host still has to be able to report its reclaim counter.
- `defaults/main.yml`: `backend_memory_high_pct` (50), `backend_memory_max_pct` (75), `backend_memory_floor_mb` (6144), each documented with why the number is that number.
- New `tasks/memory_limits.yml` gathers the hardware fact subset when absent and **asserts** it resolved, included by both the full-role path and `unit_only.yml`.
- `unit_only.yml` reads back the rendered unit and removes the out-of-band `system.control` drop-in **only when the unit demonstrably carries limits of its own**, reporting explicitly when it is being left in place.

**#13765 — out-of-band override probe (`289bfa2f4`)**

- `probe_out_of_band_limits()` walks the two `set-property` trees and reports units running under memory limits no repo artifact declares, folded into the existing `self_update_incomplete` surface so operators do not learn a second place to look.
- Scans the tree rather than a unit list — the issue notes a second service's drop-in alongside the backend's, so an enumeration would go stale by construction.
- Reuses the metrics collector's `has_out_of_band_limits` predicate rather than reimplementing it: two definitions of "out-of-band" free to drift would make one surface contradict the other about the same unit.
- Returns an explicit `observed` flag. An unreadable tree yields the same empty list as a clean host, and reading one as the other is the defect this probe exists to catch.

**#13570 — an audit run that filed nothing is not a success (`27ae77106`)**

- `_dedupe_and_file` returns a `FilingOutcome` carrying a **`lost`** count — the number the old `(filed, deferred)` pair could not express — derived from what was observed to happen, not from a failure flag.
- Task results now carry `status` of `success` / `degraded` / `error`, plus `issues_lost` and `filing_available`. Queued is recoverable and lost is not, so they do not share a status; and a worker that cannot file is degraded whether or not this particular run produced anything.
- `check_filing_credential_at_startup()`, wired to both `worker_ready` and `beat_init` — Beat and the worker are separate processes with separate deployments.
- `audit:filing_status` is written on **every** run and at startup: a key that only appears when something is wrong cannot distinguish "the worker is fine" from "the worker never ran", and the second is how this lapse stayed invisible. A CRITICAL log line is not a surface a check can query, which is umbrella #13852's whole criterion.

## Verification

**Render matrix (#13765 acceptance criterion 2 — "two hosts with different RAM render different, sensible limits, output in the PR").** Produced by rendering the real template through Jinja2 with the role's defaults:

```
detected memory   MemoryHigh   MemoryMax    MemoryAccounting
   (undefined)         —            —             yes
      1024M            —            —             yes
      2048M            —            —             yes
      4096M            —            —             yes
      8192M            —            —             yes
     12288M         6144M        9216M            yes
     16384M         8192M       12288M            yes
     32768M        16384M       24576M            yes
     65536M        32768M       49152M            yes
    131072M        65536M       98304M            yes
```

The 16384M row is the affected host, and `8192M / 12288M` is exactly the hand-applied `MemoryHigh=8589934592` / `MemoryMax=12884901888`. Below the floor the unit emits no limits plus a comment naming the detected memory, so `systemctl cat` distinguishes "evaluated and deliberately left unlimited" from "the fact never resolved".

**New tests.**

- `autobot-slm-backend/tests/test_backend_memory_limits_13765.py` — 11 test functions, 18 collected cases. Every row above is asserted; so are the floor path, the tunability of both percentages and the floor, the absence of a confident `MemoryHigh=0M` when the fact is missing, and that `MemoryAccounting` survives the no-limits branch.
- `autobot-slm-backend/tests/services/test_role_delivery_probe_out_of_band_13765.py` — 9 test functions covering the incident drop-in, multi-service coverage, a `CPUQuota`-only drop-in that must **not** be a finding, an absent tree (clean *and* observed), an unreadable tree (empty *and not* observed), and that the existing role-invariant counters are undisturbed.
- `autobot-backend/workers/audit_tasks_test.py` — 20 new test functions across `_run_status`, loss counting, the queryable status key, and the startup guard.

**Trap guards, deliberately.**

- Both new test files open with a case asserting **the target exists** before anything else asserts about it. Every other case in each file would pass vacuously against a template or probe that had lost the mechanism entirely, because "found nothing" and "the code is gone" produce the same empty result.
- The limit regexes are line-anchored. The template's own comments discuss these exact byte counts, so an unanchored search would pass against a template that emits nothing.
- `test_the_guard_is_actually_wired_to_celery_startup` and `test_the_module_carrying_the_guard_is_imported_at_worker_startup` assert the **wiring**, not the helper: a startup guard nothing imports is registered on nothing, and this file's other tests would stay green because they import it themselves.
- The out-of-band scan is deliberately **not** run when explicit `checks` are passed. The self-hosted runner is the very host carrying the drop-in this issue is about, so an unconditional scan would have reddened unrelated assertions on one runner and passed on another.
- Loss is derived from an observation, not from `deferred_count == 0` — that number is also what a healthy drained run returns, and a false alarm is the same defect class as a false reassurance.

**One CI failure, root-caused rather than retried (`15d9face0`).** `python-suite shard 12/12` went red with `ModuleNotFoundError: ... 'autobot_shared.monitoring.metrics' is not a package`. The production code was correct and behaved as designed — `probe_out_of_band_limits` reported "could not look" and logged a WARNING rather than a false clean. The cause is a session-scoped `sys.modules` leak: several suite files replace `sys.modules["autobot_shared.monitoring"]` (or, when an `exec_module` raises before their restore block, `sys.modules["autobot_shared"]` itself) at **module** scope with no teardown. Under xdist the victim is whichever worker drew the leaker, which is why one shard reddened and eleven did not.

That failure also exposed a false green in my own file: of nine tests, seven failed loudly and **one passed while never reaching the code it names** — `test_an_unreadable_tree_is_not_reported_as_clean` expects an empty list, and the "could not read the directory" path and the "could not import the predicate" path produce the same empty list. The fix loads the real module past whatever leaked (the same technique `_load` already uses for `services/*`, one package level deeper) and restores `sys.modules` exactly, deleting keys that were absent, so the repo-wide leak guard (#13337) sees a zero delta and the fixture cannot become the next entry in that list.

Verified against the reproduction, not the predicate: simulating the leak reproduces `([], False)`, the fixture turns it into `(['autobot-backend.service'], True)`, and the unreadable-directory case still returns `([], False)` — now for the right reason (permission denied, not an import error).

**The underlying leak is filed as #14950** and is deliberately NOT fixed here: pinning one more culprit produces one more in-place mitigation (#13312, #14741, #14750 each did exactly that) while the mechanism stays armed. It needs a guard against module-scope `sys.modules` assignment in test files.

**Not run locally:** no code from the codebase was executed. CI is the verification for the suites above. The render matrix was produced against a copy of the template outside the repo, with the two Ansible-only filters the template uses registered as their stdlib equivalents — the same technique the existing `test_backend_service_faulthandler_12777.py` uses.

### Review fixes (`3f8001599`)

Review found three defects, and two of them are the defect class this PR exists to close, one frame up from where I fixed it. Recorded because that is the point.

**1. `RoleDeliveryVerdict.degraded` never read `out_of_band_observed`.** `probe_out_of_band_limits` distinguished "clean" from "could not look" correctly, and `_describe` even composed the "could not be checked" sentence — but the property that gates everything read only `out_of_band`. A control tree that exists and raises `OSError` on `iterdir()` (the SLM backend runs unprivileged) produced an empty list, a `False` flag, and `degraded is False`.

Not cosmetic: two consumers gate on it. `_merge_role_delivery` returns early on `not degraded`, so the explanatory text was computed and discarded unreached; and the fleet-update stage gates an entire stage's pass/fail on the same property, so an update-all job would report the stage successful on a host whose scan had silently failed. My own docstring names the shape — *"an unreadable control tree looks exactly like an empty one, and 'nothing found' is the reassuring answer this issue exists to distrust."* I wrote the flag, wrote the sentence, and then did not read the flag.

Fixed, and the tests now drive the **property** rather than the tuple — the tuple was always correct, which is precisely why the old tests could not catch it. Three cases: unreadable degrades, `None` (scan not requested) does not, and an absent tree stays clean so the fix cannot turn every ordinary host into a permanent alarm.

**2. Loss accounting was blind at the cap boundary.** `lost` was derived from `deferred_count == 0`, which is only the write-failure boundary. When `_persist_deferred` sheds past `_MAX_DEFERRED` it returns the **post-shed** count, which is nonzero — so findings dropped for good reported `lost: 0`, and `filed + deferred + lost` undercounted by exactly the shed amount. The same "0 where loss occurred" defect, moved one boundary over. Now measured as `unique_deferred - deferred_count`, which is correct at both boundaries and dedupes by title first so a re-discovered finding is not reported as a phantom loss.

**3. Nothing ordered the two percentages.** `MemoryHigh` throttles and `MemoryMax` kills, so an inverted override gives a unit killed before it is ever throttled — warning band gone, gentler limit unreachable. The shipped defaults are safe, but they are overridable per-inventory and nothing would have noticed until a host started dying under load. Added an assert in `memory_limits.yml`.

Verified against reproductions rather than predicates: the unreadable tree reproduces `degraded=False` before and `degraded=True` after, while the absent-tree and scan-not-requested cases stay clean; the loss arithmetic is checked at write-failure, shed, exact-cap, normal and dedupe-collapse boundaries.

**Known and not overclaimed:** `audit:filing_status` is queryable as the issue asked, but nothing reads it yet — it is a surface for a check, not a wired alert. Worth a follow-up rather than a claim.

### CI round 2 — the fixture needed two more fixes (`a0b57e548`)

Shard 12/12 went red again, and the fix was not the one I expected. Recorded because both defects are the PR's own theme.

**The leaks compose.** The fixture loaded `cgroup_memory` from disk past the shadowed `monitoring` package — and then died inside `exec_module`:

```
cgroup_memory.py:67   logger = get_logger(__name__)
logging_manager.py:182  RotatingFileHandler(log_file, maxBytes=max_bytes, ...)
TypeError: '>' not supported between instances of 'MagicMock' and 'int'
```

`logging_manager` there is the **real** module; its config values are MagicMocks from a leaked `ssot_config` stub, so real code ran on fake configuration and died in the stdlib. Loading past one leaked stub is worthless if the load itself trips over the next. The file's own `_load` helper already stubs `logging_manager` for exactly this reason — I had not applied it to my load.

**A failed load poisoned every later test.** `module_from_spec` registers in `sys.modules` *before* `exec_module` runs; the fixture died before its `yield`, so no teardown ran and the half-built object stayed registered. Every later test's `import_module` then **succeeded**, returning a module with no `has_out_of_band_limits` — so the fixture reported itself healthy and seven tests failed on bare `assert False`.

That is why the first log showed **one honest ERROR and seven failures pointing nowhere near it**. A diagnostic that degrades after its first use is its own bug, and this one actively misdirected. Now `sys.modules.pop(...)` before re-raising, so a failure stays one clear error.

Verified against the reproduction, not the predicate: simulating both leaks reproduces the exact `TypeError` with the old fixture body and loads cleanly with the new one; forcing an exec failure confirms the module is no longer left registered and a subsequent test still gets a working predicate.

**#14950 updated** with the second instance — the composition effect and the poisoning behaviour, plus the two additions they imply for the guard.

### CI: green on the rebased head, deduped to the latest entry per check name

```
required gate (10)                          all checks
  SUCCESS  No commit trailers                 all 12 python-suite shards SUCCESS
  SUCCESS  No open blocks-merge issues        0 FAILURE / 0 ERROR across all 12 shard logs
  SUCCESS  code-quality                       absent = 0
  SUCCESS  migration-matrix
  SUCCESS  smoke-test                       satisfied by a SKIP, not a pass:
  SUCCESS  startup-import-smoke               - api-wiring
  SUCCESS  verify-generated-types             - Unit & Integration Tests (Frontend
  SUCCESS  verify-precommit-config              Testing Suite job, gated on changed
  SUCCESS  Unit & Integration Tests             frontend paths; this PR touches none)
  SKIPPED  api-wiring
```

**The point of the rebase, confirmed by execution rather than by reading.** One of `#14929`'s tree-wide guards is named in shard 10's slowest-durations report in the `call` phase, which only happens for a test whose body actually ran:

```
18.23s call  repo_tests/tests_that_return_instead_of_asserting_test.py::test_the_known_offender_budgets_only_ever_shrink
10.43s call  repo_tests/tests_that_return_instead_of_asserting_test.py::test_no_tree_outside_the_known_set_has_a_test_that_returns_a_value
```

Note the second one is a **ratchet** — this PR's two new test files did not increase its offender budget.

**Stated precisely, because absence of a name proves nothing here:** `collected_modules_inert_on_import_test.py` is not individually named in any shard log. Under `-q` a passing test is named only if it reaches the slowest-durations list, so that is expected for a fast guard and is *not* evidence either way. What is established is that `repo_tests/` is inside the collected set on this branch (its sibling ran), both guard files are present in the tree, and no shard reported a failure or error. Per-file proof beyond that is not claimed.

**Suite reconciliation across the rebase** — the split shifted twice as base gained test files, so the collected total was re-checked rather than assumed:

| | SLM session, shard 12/12 |
|---|---|
| pre-rebase (green) | `863 passed, 1 skipped` = **864** |
| post-rebase (green) | `863 passed, 1 skipped` = **864** |

Same total, so this PR's tests are still collected and still passing on the new base.

### Rebased — the earlier "no overlap" argument was the weaker one

An earlier revision of this section argued for *not* rebasing, on the grounds that the incoming commit shared no files with this PR. That reasoning was wrong, and it is replaced rather than quietly deleted because the mistake is instructive.

`10d7be234` (#14929) adds two **repo-wide AST guards** that read every test file in the tree, including the two test files this PR adds. Zero shared paths, real coupling — "no file overlap" is not the right test when the incoming change globs the whole tree. And by my own account those guards *never ran on this branch*, which is the textbook stale-green direction: the green described a merge base where they did not exist.

Checking them by hand is reading, not executing. That is the same distinction this PR spends three sections on, applied to its own branch, and the hand-check does not substitute for CI running them.

`strict=false` is true and beside the point: GitHub permitting a stale merge is precisely why the gate is the project's rather than the platform's (#14500).

Rebased, force-pushed with `--force-with-lease`, and verified by comparing tips rather than trusting the push's exit status. All twelve of this PR's files are **blob-identical** across the rebase, and the two hard-won behaviours were re-verified in place afterwards:

- `degraded` still tests `out_of_band_observed is False`, not falsiness — `None` means the scan was never requested, and collapsing the two would degrade every unit test that passes explicit `checks`.
- The fixture still stubs `logging_manager` across the `exec_module` (the leaks compose) and still `sys.modules.pop`s a half-built module before re-raising (a failed load otherwise reports itself healthy and poisons every later test — the reason shard 12 lied twice).

The env-var registry count and its generated docs table were re-checked for consistency after the rebase (148/148); a mismatch there survived a rebase once already on this branch.

**Rebased twice, ending on `774527f5b`.** The first rebase (mine) landed on `10d7be234`; `#14936` then merged into `Dev_new_gui`, and this repo's `auto-update-pr-branches.yml` — which runs on every push to the base precisely to update behind branches — replayed this PR onto it. Verified rather than assumed: all six commits have **identical patch-ids** across both rebases, and the twelve files this PR owns are untouched by the second replay. `behind = 0`.

The lesson from the first rebase was applied to the new base too. `#14936` is auth/RBAC work and adds **no tree-wide guard** — its new tests (`roles_do_not_collide_test.py`, `roles_are_canonical_test.py`) are scoped to permissions, not sweeps of every test file — so the coupling that made `#14929` matter is absent here. CI runs against it regardless, which is the whole point.

### Acceptance criteria — delivered vs host-gated

**#13765** (owner's list, 2026-08-09)

| # | Criterion | State |
|---|---|---|
| 1 | `MemoryHigh`/`MemoryMax` derived from detected host memory in the unit template | **Delivered** |
| 2 | Two hosts with different RAM render different, sensible limits — output in the PR | **Delivered** (matrix above) |
| 3 | The `system.control/` override removed only after the template lands, **verified on the host** | **Code delivered, verification host-gated.** The removal is implemented and correctly ordered and gated. Confirming it happened needs an update run and a `systemctl cat` I cannot perform. |
| 4 | `system.control/` added to the role-delivery probe (#13125) | **Delivered** |
| 5 | Alert on `memory.events high` increasing, not on memory usage | Already delivered by #13909 |

Also still outstanding for #13765 and untouched here: the monitoring redeploy recorded on 2026-08-16/17, without which the scrape target is not picked up and no `autobot_cgroup_memory` series is collected. And #14212 — the collector runs in-process on two hosts only, so a unit on any other node is structurally absent from these series regardless of this PR.

**#13570**

| Issue fix | State |
|---|---|
| 1. A vault-owned filing credential rather than ambient CLI auth | Code landed in #13859. **Provisioning `github_issue_filing_token` for the service account is host-gated** and is the entire remaining blocker — it releases the 1,644 queued findings automatically. |
| 2. Make the DLQ path verifiable | Landed in #13860, host-verified 2026-08-16 |
| 3. Fail loudly at startup when the filing credential is absent | **Delivered here** — this one had never landed |
| — | **Delivered here (beyond the issue's list):** a run that filed nothing no longer reports `success`, and lost findings are counted rather than reported as `deferred: 0` |

**Neither issue may be closed on this PR.** #13765 needs host verification of criterion 3 plus the monitoring redeploy; #13570 needs the service account to be able to file. Merge evidence does not settle either.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`), extended thinking.







