### PR TITLE
fix(enums): collapse four divergent enum forks to the union of their members (#13845, #13846, #13597, #13578)

### DIFF
--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -8273,23 +8273,44 @@ class TestBatch54TerminalMigrations(unittest.TestCase):
         self.assertEqual(try_count, 0, "Should have NO try-catch blocks (Simple Pattern)")
 
     def test_execute_single_command_business_logic_preserved(self):
-        """Test execute_single_command business logic preserved"""
-        import inspect
+        """Assessment behaviour of execute_single_command, not its source text.
+
+        #13845: this used to grep the function body for the literal
+        ``risk_level = CommandRiskLevel.SAFE``. That assertion could not
+        distinguish "the classification still works" from "the identifier was
+        renamed", so it went red on an enum union that changed no behaviour at
+        all. Drive the endpoint and assert on what it returns.
+        """
+        import asyncio
 
         from api.terminal import execute_single_command
+        from api.schemas_terminal import CommandRequest
+        from autobot_shared.status_enums import CommandRisk
+        from constants.terminal_constants import (
+            MODERATE_RISK_PATTERNS,
+            RISKY_COMMAND_PATTERNS,
+        )
 
-        source = inspect.getsource(execute_single_command)
+        def _assess(command):
+            return asyncio.run(
+                execute_single_command(
+                    CommandRequest(command=command),
+                    current_user={"user_id": "test", "username": "test"},
+                )
+            )
 
-        # Core business logic should be preserved
-        self.assertIn("risk_level = CommandRiskLevel.SAFE", source)
-        self.assertIn("command_lower = request.command.lower().strip()", source)
-        self.assertIn("for pattern in RISKY_COMMAND_PATTERNS:", source)
-        self.assertIn("risk_level = CommandRiskLevel.DANGEROUS", source)
-        self.assertIn("for pattern in MODERATE_RISK_PATTERNS:", source)
-        self.assertIn("risk_level = CommandRiskLevel.MODERATE", source)
-        self.assertIn('"command": request.command', source)
-        self.assertIn('"risk_level": risk_level.value', source)
-        self.assertIn('"requires_confirmation"', source)
+        safe = _assess("echo hello")
+        self.assertEqual(safe["command"], "echo hello")
+        self.assertEqual(safe["risk_level"], CommandRisk.SAFE.value)
+        self.assertFalse(safe["requires_confirmation"])
+
+        risky = _assess(f"{RISKY_COMMAND_PATTERNS[0]} /tmp/x")
+        self.assertEqual(risky["risk_level"], CommandRisk.DANGEROUS.value)
+        self.assertTrue(risky["requires_confirmation"])
+
+        moderate = _assess(f"{MODERATE_RISK_PATTERNS[0]} whoami")
+        self.assertEqual(moderate["risk_level"], CommandRisk.MODERATE.value)
+        self.assertTrue(moderate["requires_confirmation"])
 
     def test_execute_single_command_error_handling(self):
         """Test error handling configuration in execute_single_command"""

--- a/autobot-backend/api/api_endpoint_migrations_test.py
+++ b/autobot-backend/api/api_endpoint_migrations_test.py
@@ -8283,8 +8283,8 @@ class TestBatch54TerminalMigrations(unittest.TestCase):
         """
         import asyncio
 
-        from api.terminal import execute_single_command
         from api.schemas_terminal import CommandRequest
+        from api.terminal import execute_single_command
         from autobot_shared.status_enums import CommandRisk
         from constants.terminal_constants import (
             MODERATE_RISK_PATTERNS,

--- a/autobot-backend/api/collaboration_test.py
+++ b/autobot-backend/api/collaboration_test.py
@@ -29,7 +29,8 @@ from api.collaboration import (
     remove_collaborator,
     share_secret_with_session,
 )
-from models.secret import Secret, SecretScope, SecretType
+from autobot_shared.status_enums import SecretType
+from models.secret import Secret, SecretScope
 from models.session_collaboration import PermissionLevel, SessionCollaboration
 
 

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3558,7 +3558,6 @@ class SecretCreateRequest(BaseModel):
             )
         return value
 
-
     @field_validator("name")
     @classmethod
     def validate_name(cls, v: str) -> str:

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3546,6 +3546,7 @@ class SecretCreateRequest(BaseModel):
                 "not a storable kind; pick a concrete type"
             )
         return value
+
     scope: ChatSecretScope
     value: str = Field(..., min_length=1, max_length=65536)
     chat_id: str | None = Field(None, max_length=128)

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import MAX_THOUGHT_COUNT, SuccessDataResponse, SuccessMessageResponse
 from api.system_health import HealthStatus
+from autobot_shared.status_enums import SecretType
 from constants.threshold_constants import RetryConfig
 from services.audit_logger import AuditResult
 from services.feature_flags import EnforcementMode
@@ -3507,19 +3508,6 @@ class ChatSecretScope(str, Enum):
     ORGANIZATION = "organization"
 
 
-class SecretType(str, Enum):
-    """Secret type enumeration."""
-
-    SSH_KEY = "ssh_key"
-    PASSWORD = "password"  # nosec B105  # enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
-    API_KEY = "api_key"  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
-    TOKEN = "token"  # nosec B105  # enum value  # nosemgrep: autobot-hardcoded-secret-key  # nosemgrep
-    CERTIFICATE = "certificate"
-    DATABASE_URL = "database_url"
-    INFRASTRUCTURE_HOST = "infrastructure_host"
-    OTHER = "other"
-
-
 class SecretModel(BaseModel):
     """Secret data model."""
 
@@ -3541,6 +3529,23 @@ class SecretCreateRequest(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=256)
     type: SecretType
+
+    @field_validator("type")
+    @classmethod
+    def _reject_the_wildcard(cls, value: SecretType) -> SecretType:
+        """``ANY`` is a requirement quantifier, never a stored classification.
+
+        #13846: the canonical ``SecretType`` carries the wildcard so an agent
+        mapping can say "any available secret". Persisting it would put the
+        string "any" in the ``secrets.type`` column, where it matches no kind
+        and every by-type query would step over it.
+        """
+        if value is SecretType.ANY:
+            raise ValueError(
+                f"secret type '{SecretType.ANY.value}' is a requirement wildcard, "
+                "not a storable kind; pick a concrete type"
+            )
+        return value
     scope: ChatSecretScope
     value: str = Field(..., min_length=1, max_length=65536)
     chat_id: str | None = Field(None, max_length=128)

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -3529,6 +3529,17 @@ class SecretCreateRequest(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=256)
     type: SecretType
+    scope: ChatSecretScope
+    value: str = Field(..., min_length=1, max_length=65536)
+    chat_id: str | None = Field(None, max_length=128)
+    description: str | None = Field("", max_length=1024)
+    tags: List[str] = Field(default_factory=list)
+    expires_at: datetime | None = None
+    metadata: Metadata = Field(default_factory=dict)
+    owner_id: str | None = Field(None, max_length=128, description="Owner user ID")
+    org_id: str | None = Field(None, max_length=128, description="Organization ID for org-level secrets")
+    team_ids: List[str] = Field(default_factory=list, description="Team IDs for group-level secrets")
+    shared_with: List[str] = Field(default_factory=list, description="User IDs to share with")
 
     @field_validator("type")
     @classmethod
@@ -3547,17 +3558,6 @@ class SecretCreateRequest(BaseModel):
             )
         return value
 
-    scope: ChatSecretScope
-    value: str = Field(..., min_length=1, max_length=65536)
-    chat_id: str | None = Field(None, max_length=128)
-    description: str | None = Field("", max_length=1024)
-    tags: List[str] = Field(default_factory=list)
-    expires_at: datetime | None = None
-    metadata: Metadata = Field(default_factory=dict)
-    owner_id: str | None = Field(None, max_length=128, description="Owner user ID")
-    org_id: str | None = Field(None, max_length=128, description="Organization ID for org-level secrets")
-    team_ids: List[str] = Field(default_factory=list, description="Team IDs for group-level secrets")
-    shared_with: List[str] = Field(default_factory=list, description="User IDs to share with")
 
     @field_validator("name")
     @classmethod

--- a/autobot-backend/api/schemas_terminal.py
+++ b/autobot-backend/api/schemas_terminal.py
@@ -470,15 +470,6 @@ class SecurityLevel(Enum):
     RESTRICTED = "restricted"
 
 
-class CommandRiskLevel(Enum):
-    """Risk assessment levels for commands"""
-
-    SAFE = "safe"
-    MODERATE = "moderate"
-    HIGH = "high"
-    DANGEROUS = "dangerous"
-
-
 # Request/Response Models
 class CommandRequest(BaseModel):
     command: str

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -50,8 +50,8 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.rate_limiter import RateLimiter
-from autobot_shared.status_enums import SecretType
 from autobot_shared.ssot_config import config as ssot_config
+from autobot_shared.status_enums import SecretType
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
 from services.audit.audit import AuditAction, audit_record  # GH#8290 Phase 2

--- a/autobot-backend/api/secrets.py
+++ b/autobot-backend/api/secrets.py
@@ -42,7 +42,6 @@ from api.schemas_system import (
     SecretsStatusResponse,
     SecretTransferData,
     SecretTransferRequest,
-    SecretType,
     SecretTypesData,
     SecretUpdateRequest,
 )
@@ -51,6 +50,7 @@ from autobot_memory_graph import AutoBotMemoryGraph
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.rate_limiter import RateLimiter
+from autobot_shared.status_enums import SecretType
 from autobot_shared.ssot_config import config as ssot_config
 from autobot_shared.time_utils import parse_utc_iso
 from middleware.proxy_utils import get_client_ip
@@ -692,7 +692,9 @@ async def get_secret_types(
     return JSONResponse(
         status_code=200,
         content={
-            "types": [{"value": t.value, "label": t.value.replace("_", " ").title()} for t in SecretType],
+            # #13846: ``concrete()``, not the whole enum — ANY is a requirement
+            # wildcard and must never be offered as a storable type.
+            "types": [{"value": t.value, "label": t.value.replace("_", " ").title()} for t in SecretType.concrete()],
             "scopes": [{"value": s.value, "label": s.value.title()} for s in ChatSecretScope],
         },
     )

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -33,16 +33,30 @@ EXPECTED_SCOPES = [
     {"value": "organization", "label": "Organization"},
 ]
 
+# What GET /api/secrets/types serves: the CONCRETE taxonomy, in declaration
+# order. #13846 unioned three forked secret-kind enums, so this gained
+# `oauth_refresh_token` (which the DB row could always store but the API
+# vocabulary could not express) and `connector_oauth_token` (which was a bare
+# string in credential_store.py, belonging to no enum at all).
+#
+# `any` is deliberately absent: it is a requirement wildcard, never a storable
+# kind, and the endpoint serves SecretType.concrete() rather than the whole
+# enum. test_secret_type_values_pinned below pins that difference explicitly.
 EXPECTED_TYPES = [
     {"value": "ssh_key", "label": "Ssh Key"},
     {"value": "password", "label": "Password"},
     {"value": "api_key", "label": "Api Key"},
     {"value": "token", "label": "Token"},
+    {"value": "oauth_refresh_token", "label": "Oauth Refresh Token"},
+    {"value": "connector_oauth_token", "label": "Connector Oauth Token"},
     {"value": "certificate", "label": "Certificate"},
     {"value": "database_url", "label": "Database Url"},
     {"value": "infrastructure_host", "label": "Infrastructure Host"},
     {"value": "other", "label": "Other"},
 ]
+
+# The wildcard, kept out of everything the API serves or accepts (#13846).
+EXPECTED_WILDCARD = "any"
 
 
 class TestChatSecretScopeEnum:
@@ -66,7 +80,30 @@ class TestChatSecretScopeEnum:
         assert "workflow" not in {scope.value for scope in ChatSecretScope}
 
     def test_secret_type_values_pinned(self):
-        assert [t.value for t in SecretType] == [t["value"] for t in EXPECTED_TYPES]
+        """The enum carries the wildcard; the endpoint does not.
+
+        #13846: these are two different populations on purpose. Asserting the
+        enum equals the served list would have hidden exactly the thing worth
+        pinning -- that `any` exists as a requirement vocabulary member and is
+        excluded from every storable/presentable surface.
+        """
+        assert [t.value for t in SecretType] == [
+            t["value"] for t in EXPECTED_TYPES
+        ] + [EXPECTED_WILDCARD]
+        assert [t.value for t in SecretType.concrete()] == [t["value"] for t in EXPECTED_TYPES]
+        assert EXPECTED_WILDCARD not in {t.value for t in SecretType.concrete()}
+
+    def test_the_oauth_kinds_are_expressible(self):
+        """#13846's functional gap: neither kind could be named before.
+
+        `OAUTH_REFRESH_TOKEN` existed only on the persisted enum, so the API
+        vocabulary could not express it; `connector_oauth_token` was a bare
+        string that belonged to no enum at all.
+        """
+        assert SecretType.OAUTH_REFRESH_TOKEN.value == "oauth_refresh_token"
+        assert SecretType.CONNECTOR_OAUTH_TOKEN.value == "connector_oauth_token"
+        served = {t["value"] for t in EXPECTED_TYPES}
+        assert {"oauth_refresh_token", "connector_oauth_token"} <= served
 
 
 @pytest.mark.asyncio

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -87,9 +87,7 @@ class TestChatSecretScopeEnum:
         pinning -- that `any` exists as a requirement vocabulary member and is
         excluded from every storable/presentable surface.
         """
-        assert [t.value for t in SecretType] == [
-            t["value"] for t in EXPECTED_TYPES
-        ] + [EXPECTED_WILDCARD]
+        assert [t.value for t in SecretType] == [t["value"] for t in EXPECTED_TYPES] + [EXPECTED_WILDCARD]
         assert [t.value for t in SecretType.concrete()] == [t["value"] for t in EXPECTED_TYPES]
         assert EXPECTED_WILDCARD not in {t.value for t in SecretType.concrete()}
 

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -18,8 +18,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from api.schemas_system import ChatSecretScope
-from autobot_shared.status_enums import SecretType
 from autobot_shared.scoping.scope_level import ScopeLevel
+from autobot_shared.status_enums import SecretType
 
 # Exact response content served by GET /api/secrets/types — order and
 # strings pinned; the #11759 rename must not change any of this.

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -17,7 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.schemas_system import ChatSecretScope, SecretType
+from api.schemas_system import ChatSecretScope
+from autobot_shared.status_enums import SecretType
 from autobot_shared.scoping.scope_level import ScopeLevel
 
 # Exact response content served by GET /api/secrets/types — order and

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -125,7 +125,6 @@ from api.schemas_terminal import (
     AdminExecuteResponse,
     CommandAssessResponse,
     CommandRequest,
-    CommandRiskLevel,
     SecurityLevel,
     SSHKeyAgentRequest,
     SSHKeyAgentResponse,
@@ -158,6 +157,7 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.error_utils import safe_http_detail
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import CommandRisk
 from constants.error_constants import ERR_SESSION_NOT_FOUND
 from constants.terminal_constants import MODERATE_RISK_PATTERNS, RISKY_COMMAND_PATTERNS
 from services.simple_pty import simple_pty_manager
@@ -654,17 +654,17 @@ async def execute_single_command(
     # Assess command for security risk
 
     # Assess command risk
-    risk_level = CommandRiskLevel.SAFE
+    risk_level = CommandRisk.SAFE
     command_lower = request.command.lower().strip()
 
     for pattern in RISKY_COMMAND_PATTERNS:
         if pattern in command_lower:
-            risk_level = CommandRiskLevel.DANGEROUS
+            risk_level = CommandRisk.DANGEROUS
             break
     else:
         for pattern in MODERATE_RISK_PATTERNS:
             if pattern in command_lower:
-                risk_level = CommandRiskLevel.MODERATE
+                risk_level = CommandRisk.MODERATE
                 break
 
     # Log command execution attempt
@@ -676,7 +676,7 @@ async def execute_single_command(
         "risk_level": risk_level.value,
         "status": "assessed",
         "message": f"Command assessed as {risk_level.value} risk",
-        "requires_confirmation": risk_level != CommandRiskLevel.SAFE,
+        "requires_confirmation": risk_level != CommandRisk.SAFE,
     }
 
 

--- a/autobot-backend/api/terminal_handlers.py
+++ b/autobot-backend/api/terminal_handlers.py
@@ -32,10 +32,10 @@ from fastapi import WebSocket
 
 # Import models from dedicated module (Issue #185)
 from api.schemas_terminal import (
-    CommandRiskLevel,
     SecurityLevel,
 )
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import CommandRisk
 from chat_history import ChatHistoryManager
 from constants.path_constants import PATH
 from constants.terminal_constants import (
@@ -1064,32 +1064,35 @@ class TerminalWebSocket:
             logger.error("Error sending signal: %s", e)
             await self._send_signal_error("Error sending signal")
 
-    def _assess_command_risk(self, command: str) -> CommandRiskLevel:
+    def _assess_command_risk(self, command: str) -> CommandRisk:
         """Assess the security risk level of a command"""
         command_lower = command.lower().strip()
 
         # Check for dangerous patterns
         for pattern in RISKY_COMMAND_PATTERNS:
             if pattern in command_lower:
-                return CommandRiskLevel.DANGEROUS
+                return CommandRisk.DANGEROUS
 
         # Check for moderate risk patterns
         for pattern in MODERATE_RISK_PATTERNS:
             if pattern in command_lower:
-                return CommandRiskLevel.MODERATE
+                return CommandRisk.MODERATE
 
         # Special checks for high-risk operations (Issue #326: O(1) lookups)
         if any(x in command_lower for x in SHELL_OPERATORS):
-            return CommandRiskLevel.HIGH
+            return CommandRisk.HIGH
 
-        return CommandRiskLevel.SAFE
+        return CommandRisk.SAFE
 
-    async def _should_block_command(self, command: str, risk_level: CommandRiskLevel) -> bool:
+    async def _should_block_command(self, command: str, risk_level: CommandRisk) -> bool:
         """Determine if command should be blocked based on security level"""
         if self.security_level == SecurityLevel.RESTRICTED:
             return risk_level in HIGH_RISK_COMMAND_LEVELS
         elif self.security_level == SecurityLevel.ELEVATED:
-            return risk_level == CommandRiskLevel.DANGEROUS
+            # #13845: ``.blocks`` covers FORBIDDEN as well as DANGEROUS. The
+            # equality check this replaces let the executor's own blocking
+            # verdict through once both enums became one.
+            return risk_level.blocks
 
         return False  # STANDARD level allows most commands
 

--- a/autobot-backend/api/user_provider_credentials.py
+++ b/autobot-backend/api/user_provider_credentials.py
@@ -21,7 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.user_management.dependencies import get_current_user_id, get_db_session
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
-from models.secret import Secret, SecretScope, SecretType
+from autobot_shared.status_enums import SecretType
+from models.secret import Secret, SecretScope
 from services.secrets_service import SecretsService
 
 logger = get_logger(__name__)

--- a/autobot-backend/knowledge/connectors/credential_store.py
+++ b/autobot-backend/knowledge/connectors/credential_store.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 from autobot_shared.leader_lease import LeaderLease
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import SecretType
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from services.credential_read import load_imported_credential
 from services.credential_write import delete_credential_from_vault, mirror_credential_to_vault
@@ -343,7 +344,7 @@ class ConnectorCredentialStore:
             None,
             lambda: self._svc.create_secret(
                 name=name,
-                secret_type="connector_oauth_token",  # nosec B106  # SecretType label, not a credential
+                secret_type=SecretType.CONNECTOR_OAUTH_TOKEN.value,
                 value=value,
                 scope="user",
                 created_by=owner_id,
@@ -356,7 +357,7 @@ class ConnectorCredentialStore:
                 owner_id,
                 value,
                 name=name,
-                secret_type="connector_oauth_token",  # nosec B106  # SecretType label, not a credential
+                secret_type=SecretType.CONNECTOR_OAUTH_TOKEN.value,
             )
         return result["id"]
 

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -18,7 +18,6 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Uuid
 
 from autobot_shared.scoping import Principal, ResourceDescriptor, ScopeLevel, is_visible
-from autobot_shared.status_enums import SecretType
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
 

--- a/autobot-backend/models/secret.py
+++ b/autobot-backend/models/secret.py
@@ -11,7 +11,6 @@ Part of Issue #870 - User-Centric Session Tracking (#608 Phase 1-2).
 
 import uuid
 from datetime import datetime
-from enum import Enum
 
 from sqlalchemy import Boolean, DateTime, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB
@@ -19,6 +18,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import Uuid
 
 from autobot_shared.scoping import Principal, ResourceDescriptor, ScopeLevel, is_visible
+from autobot_shared.status_enums import SecretType
 from autobot_shared.time_utils import now_utc
 from user_management.models.base import Base
 
@@ -28,23 +28,6 @@ from user_management.models.base import Base
 # (user/session/shared/group/organization/workflow) are unchanged — the
 # canonical enum carries the same .value strings.
 SecretScope = ScopeLevel
-
-
-class SecretType(str, Enum):
-    """Secret type classification."""
-
-    SSH_KEY = "ssh_key"
-    # nosemgrep: autobot-hardcoded-secret-key
-    PASSWORD = "password"  # nosec B105  # enum value, not actual password
-    # nosemgrep: autobot-hardcoded-secret-key
-    API_KEY = "api_key"
-    # nosemgrep: autobot-hardcoded-secret-key
-    TOKEN = "token"  # nosec B105  # enum value, not actual token
-    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"  # nosec B105  # enum value
-    CERTIFICATE = "certificate"
-    DATABASE_URL = "database_url"
-    INFRASTRUCTURE_HOST = "infrastructure_host"
-    OTHER = "other"
 
 
 class Secret(Base):

--- a/autobot-backend/models/secret_test.py
+++ b/autobot-backend/models/secret_test.py
@@ -17,7 +17,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.datetime_utils import datetime_now
-from models.secret import Secret, SecretScope, SecretType
+from autobot_shared.status_enums import SecretType
+from models.secret import Secret, SecretScope
 
 
 class TestSecretModel:

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -841,7 +841,7 @@ class SecureCommandExecutor:
             "return_code": 1,
             "status": "error",
             "security": {
-                "risk": "forbidden",
+                "risk": CommandRisk.FORBIDDEN.value,
                 "reasons": [rule_info.get("description", "Denied by rule")],
                 "blocked": True,
                 "permission_rule": rule_info,

--- a/autobot-backend/secure_command_executor.py
+++ b/autobot-backend/secure_command_executor.py
@@ -14,12 +14,12 @@ import logging
 import os
 import re
 import shlex
-from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import CommandRisk
 from constants.network_constants import NetworkConstants
 from security.command_patterns import (
     FORBIDDEN_COMMANDS,
@@ -122,16 +122,11 @@ _FIND_SUID_RECON_PATTERNS = (
 # MODERATE so they're audit-logged.
 _DNS_RECON_COMMANDS = frozenset({"dig", "nslookup", "host", "whois", "drill"})
 
-# #7406: ordering for CommandRisk so chained-command detection can pick the
-# strictest risk across sub-commands. Strings are used here because the enum
-# class is defined later in this module; the caller compares via this lookup.
-_RISK_ORDER: Dict[str, int] = {
-    "safe": 0,
-    "moderate": 1,
-    "high": 2,
-    "critical": 3,
-    "forbidden": 4,
-}
+# #7406: chained-command detection picks the strictest risk across sub-commands.
+# #13845: the ordering now comes from ``CommandRisk.rank``, derived from the
+# enum's own declaration order. The string table this replaces listed five
+# members by hand and so silently rated ``DANGEROUS`` as unknown once the two
+# risk enums were unioned.
 
 
 def _check_argument_aware_risk(command: str) -> Tuple["CommandRisk", List[str]] | None:
@@ -221,7 +216,7 @@ def _check_argument_aware_risk(command: str) -> Tuple["CommandRisk", List[str]] 
                     continue
                 sub_risk, sub_reasons = sub_result
                 # Take the strictest risk (FORBIDDEN > HIGH > MODERATE > SAFE).
-                if highest_risk is None or _RISK_ORDER[sub_risk.value] > _RISK_ORDER[highest_risk.value]:
+                if highest_risk is None or sub_risk.rank > highest_risk.rank:
                     highest_risk = sub_risk
                 all_reasons.extend(sub_reasons)
             if highest_risk is not None:
@@ -266,16 +261,6 @@ def _check_dangerous_env_var_prefix(command: str) -> List[str] | None:
 
 
 # Issue #765: Path constants now imported from security.command_patterns
-
-
-class CommandRisk(Enum):
-    """Risk levels for commands"""
-
-    SAFE = "safe"
-    MODERATE = "moderate"
-    HIGH = "high"
-    CRITICAL = "critical"
-    FORBIDDEN = "forbidden"
 
 
 class SecurityPolicy:
@@ -1149,7 +1134,10 @@ class SecureCommandExecutor:
         risk, reasons = self.assess_command_risk(command)
         log_entry = self._build_standard_log_entry(command, risk, reasons)
 
-        if risk == CommandRisk.FORBIDDEN:
+        # #13845: ask ``.blocks`` rather than comparing against FORBIDDEN alone.
+        # DANGEROUS is the terminal layer's blocking verdict for the same enum;
+        # an equality check here would run a command that layer refuses.
+        if risk.blocks:
             return await self._handle_forbidden_command(command, risk, reasons, log_entry)
 
         denial_result = await self._handle_approval_flow(

--- a/autobot-backend/secure_command_executor_argument_aware_test.py
+++ b/autobot-backend/secure_command_executor_argument_aware_test.py
@@ -26,7 +26,8 @@ arguments BEFORE base-command lookup so the more-specific reason wins.
 
 import pytest
 
-from secure_command_executor import CommandRisk, SecureCommandExecutor
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor
 
 
 @pytest.fixture

--- a/autobot-backend/secure_command_executor_env_prefix_test.py
+++ b/autobot-backend/secure_command_executor_env_prefix_test.py
@@ -15,7 +15,8 @@ linker hijack of any dynamic symbol) and must classify as FORBIDDEN.
 
 import pytest
 
-from secure_command_executor import CommandRisk, SecureCommandExecutor
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor
 
 
 @pytest.fixture

--- a/autobot-backend/secure_command_executor_export_chain_test.py
+++ b/autobot-backend/secure_command_executor_export_chain_test.py
@@ -23,7 +23,8 @@ shapes that the prefix-form / first-token-only rules missed:
 
 import pytest
 
-from secure_command_executor import CommandRisk, SecureCommandExecutor
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor
 
 
 @pytest.fixture

--- a/autobot-backend/secure_command_executor_test.py
+++ b/autobot-backend/secure_command_executor_test.py
@@ -12,7 +12,8 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 # Import the modules to test
-from secure_command_executor import CommandRisk, SecureCommandExecutor, SecurityPolicy
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor, SecurityPolicy
 
 
 class TestSecurityPolicy:

--- a/autobot-backend/security/prompt_injection_detector.py
+++ b/autobot-backend/security/prompt_injection_detector.py
@@ -189,7 +189,18 @@ INVISIBLE_UNICODE_RANGES = {
 
 
 class InjectionRisk(Enum):
-    """Risk levels for detected injection patterns"""
+    """Risk levels for detected injection patterns.
+
+    #13845: deliberately NOT the canonical ``autobot_shared.status_enums``
+    ``CommandRisk``, and not ``Severity`` either, despite the overlapping
+    member names. This grades a piece of *text* for injection patterns; those
+    grade a *command* for execution policy and an *outcome* for how bad it is.
+    The scales differ at both ends — ``LOW`` exists only here, ``DANGEROUS``
+    and ``FORBIDDEN`` only there — and a value from this enum must never reach
+    a ``.blocks`` check, which answers a question about running a command.
+    ``repo_tests/enum_union_guard_test.py`` records this as a known-distinct
+    enum so the fork scan does not flag it.
+    """
 
     SAFE = "safe"
     LOW = "low"

--- a/autobot-backend/security/security_edge_cases_test.py
+++ b/autobot-backend/security/security_edge_cases_test.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from secure_command_executor import CommandRisk
+from autobot_shared.status_enums import CommandRisk
 from security_layer import SecurityLayer
 
 

--- a/autobot-backend/security/security_integration_test.py
+++ b/autobot-backend/security/security_integration_test.py
@@ -15,7 +15,8 @@ from fastapi.testclient import TestClient
 
 # Import system components
 from app_factory import create_app
-from secure_command_executor import CommandRisk, SecureCommandExecutor
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor
 from security_layer import SecurityLayer
 
 

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -26,8 +26,8 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
 from autobot_shared.paths import project_root
 from autobot_shared.ssot_config import config
-from config import get_config_manager
 from autobot_shared.status_enums import CommandRisk
+from config import get_config_manager
 from secure_command_executor import SecureCommandExecutor, SecurityPolicy
 
 logger = get_logger(__name__)

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -27,7 +27,8 @@ from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_s
 from autobot_shared.paths import project_root
 from autobot_shared.ssot_config import config
 from config import get_config_manager
-from secure_command_executor import CommandRisk, SecureCommandExecutor, SecurityPolicy
+from autobot_shared.status_enums import CommandRisk
+from secure_command_executor import SecureCommandExecutor, SecurityPolicy
 
 logger = get_logger(__name__)
 

--- a/autobot-backend/security_layer_test.py
+++ b/autobot-backend/security_layer_test.py
@@ -18,7 +18,7 @@ import pytest
 # Import the modules to test
 import security_layer
 from autobot_shared.paths import project_root
-from secure_command_executor import CommandRisk
+from autobot_shared.status_enums import CommandRisk
 from security_layer import SecurityLayer
 
 

--- a/autobot-backend/services/agent_secrets_integration.py
+++ b/autobot-backend/services/agent_secrets_integration.py
@@ -15,35 +15,40 @@ Related Issues:
 
 import threading
 from dataclasses import dataclass, field
-from enum import Enum
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List, Set
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
+from autobot_shared.status_enums import SecretType
 from services.secrets_service import SecretsService, get_secrets_service
 
 logger = get_logger(__name__)
 
 
-class SecretRequirement(Enum):
-    """Types of secrets that agents may require."""
-
-    SSH_KEY = "ssh_key"
-    API_KEY = "api_key"  # nosemgrep
-    PASSWORD = "password"  # nosemgrep  # nosec B105
-    TOKEN = "token"  # nosemgrep  # nosec B105
-    CERTIFICATE = "certificate"
-    DATABASE_URL = "database_url"
-    ANY = "any"  # Agent can use any available secrets
+# #13846: ``SecretRequirement`` used to be declared here — six members copied
+# verbatim from ``SecretType``, down to the identical ``# nosec B105`` and
+# ``# nosemgrep`` comments, plus ``ANY``. It had no ``OAUTH_REFRESH_TOKEN``, so
+# an agent that authenticates by OAuth could only be described as ``ANY``: the
+# blanket "every available secret" grant standing in for the most specific
+# requirement there is. The requirement vocabulary is now the canonical
+# ``SecretType`` itself, wildcard included, so a mapping can name the exact
+# kind it needs.
 
 
 @dataclass
 class AgentSecretMapping:
-    """Defines which secret types an agent needs."""
+    """Defines which secret types an agent needs.
+
+    ``required_types`` / ``optional_types`` hold :class:`SecretType` members —
+    not bare strings. A typo used to produce a set that matched no secret and
+    reported success; an unknown member is now impossible to construct.
+    ``SecretType.ANY`` is legal here and means "any available secret"; it is
+    resolved by :meth:`SecretType.expand` before any lookup.
+    """
 
     agent_type: str
-    required_types: Set[str] = field(default_factory=set)
-    optional_types: Set[str] = field(default_factory=set)
+    required_types: Set[SecretType] = field(default_factory=set)
+    optional_types: Set[SecretType] = field(default_factory=set)
     auto_inject: bool = True  # Whether to automatically inject secrets
     description: str = ""
 
@@ -55,14 +60,14 @@ AGENT_SECRET_MAPPINGS: Dict[str, AgentSecretMapping] = {
     "interactive_terminal": AgentSecretMapping(
         agent_type="interactive_terminal",
         required_types=set(),
-        optional_types={"ssh_key", "password"},
+        optional_types={SecretType.SSH_KEY, SecretType.PASSWORD},
         auto_inject=True,
         description="Terminal agent may use SSH keys for remote connections",
     ),
     "system_command": AgentSecretMapping(
         agent_type="system_command",
         required_types=set(),
-        optional_types={"ssh_key", "password", "api_key"},
+        optional_types={SecretType.SSH_KEY, SecretType.PASSWORD, SecretType.API_KEY},
         auto_inject=True,
         description="System command agent for remote command execution",
     ),
@@ -70,21 +75,21 @@ AGENT_SECRET_MAPPINGS: Dict[str, AgentSecretMapping] = {
     "research": AgentSecretMapping(
         agent_type="research",
         required_types=set(),
-        optional_types={"api_key", "token"},
+        optional_types={SecretType.API_KEY, SecretType.TOKEN},
         auto_inject=True,
         description="Research agent may need API keys for external services",
     ),
     "web_research": AgentSecretMapping(
         agent_type="web_research",
         required_types=set(),
-        optional_types={"api_key", "token"},
+        optional_types={SecretType.API_KEY, SecretType.TOKEN},
         auto_inject=True,
         description="Web research agent for API-based searches",
     ),
     "advanced_web_research": AgentSecretMapping(
         agent_type="advanced_web_research",
         required_types=set(),
-        optional_types={"api_key", "token"},
+        optional_types={SecretType.API_KEY, SecretType.TOKEN},
         auto_inject=True,
         description="Advanced research with external API support",
     ),
@@ -92,14 +97,14 @@ AGENT_SECRET_MAPPINGS: Dict[str, AgentSecretMapping] = {
     "security_scanner": AgentSecretMapping(
         agent_type="security_scanner",
         required_types=set(),
-        optional_types={"ssh_key", "password", "api_key", "token"},
+        optional_types={SecretType.SSH_KEY, SecretType.PASSWORD, SecretType.API_KEY, SecretType.TOKEN},
         auto_inject=True,
         description="Security scanner may need credentials for authenticated scans",
     ),
     "network_discovery": AgentSecretMapping(
         agent_type="network_discovery",
         required_types=set(),
-        optional_types={"ssh_key", "password"},
+        optional_types={SecretType.SSH_KEY, SecretType.PASSWORD},
         auto_inject=True,
         description="Network discovery agent for authenticated scanning",
     ),
@@ -107,14 +112,14 @@ AGENT_SECRET_MAPPINGS: Dict[str, AgentSecretMapping] = {
     "rag": AgentSecretMapping(
         agent_type="rag",
         required_types=set(),
-        optional_types={"database_url", "api_key"},
+        optional_types={SecretType.DATABASE_URL, SecretType.API_KEY},
         auto_inject=True,
         description="RAG agent for knowledge retrieval",
     ),
     "knowledge_retrieval": AgentSecretMapping(
         agent_type="knowledge_retrieval",
         required_types=set(),
-        optional_types={"database_url", "api_key"},
+        optional_types={SecretType.DATABASE_URL, SecretType.API_KEY},
         auto_inject=True,
         description="Knowledge retrieval agent",
     ),
@@ -186,19 +191,39 @@ class AgentSecretsIntegration:
         self._custom_mappings[mapping.agent_type] = mapping
         logger.info("Registered secret mapping for agent: %s", mapping.agent_type)
 
+    @staticmethod
+    def _coerce_types(values: "Iterable[SecretType | str]") -> Set[SecretType]:
+        """Accept members or their wire strings; reject anything else loudly.
+
+        #13846: callers outside this module pass raw strings. A string that
+        names no kind used to become a filter that matched nothing and
+        returned an empty result — a silent miss dressed as "no secrets".
+        """
+        coerced: Set[SecretType] = set()
+        for value in values:
+            coerced.add(value if isinstance(value, SecretType) else SecretType(value))
+        return coerced
+
     def _determine_types_to_fetch(
         self,
         mapping: AgentSecretMapping,
-        secret_types: List[str] | None,
-    ) -> Set[str]:
-        """Determine which secret types to fetch based on mapping and overrides (Issue #665: extracted helper)."""
+        secret_types: "List[SecretType | str] | None",
+    ) -> Set[SecretType]:
+        """Determine which secret types to fetch based on mapping and overrides (Issue #665: extracted helper).
+
+        #13846: ``SecretType.ANY`` is expanded here into the concrete taxonomy.
+        Left unexpanded it would be looked up as the literal type "any", which
+        no stored secret carries — so the broadest possible requirement used to
+        fetch the narrowest possible result: nothing.
+        """
         if secret_types:
-            return set(secret_types)
-        return mapping.required_types | mapping.optional_types
+            return set(SecretType.expand(self._coerce_types(secret_types)))
+        requested = mapping.required_types | mapping.optional_types
+        return set(SecretType.expand(requested))
 
     async def _fetch_and_merge_secrets(
         self,
-        types_to_fetch: Set[str],
+        types_to_fetch: Set[SecretType],
         agent_type: str,
         chat_id: str | None,
         include_general: bool,
@@ -232,7 +257,7 @@ class AgentSecretsIntegration:
         agent_type: str,
         chat_id: str | None = None,
         include_general: bool = True,
-        secret_types: List[str] | None = None,
+        secret_types: "List[SecretType | str] | None" = None,
         accessed_by: str | None = None,
     ) -> Dict[str, str]:
         """Get relevant secrets for a specific agent type.
@@ -278,7 +303,7 @@ class AgentSecretsIntegration:
 
     async def _fetch_secrets_by_types(
         self,
-        secret_types: Set[str],
+        secret_types: Set[SecretType],
         scope: str,
         chat_id: str | None,
         accessed_by: str | None,
@@ -300,7 +325,10 @@ class AgentSecretsIntegration:
             secrets = self.secrets_service.list_secrets(
                 scope=scope,
                 chat_id=chat_id,
-                secret_type=secret_type,
+                # #14944: ``.value``, never the member. ``SecretType`` is a str
+                # subclass, but str() of a member is "SecretType.API_KEY" and
+                # this value reaches a SQL parameter.
+                secret_type=secret_type.value,
                 include_expired=False,
             )
 
@@ -334,7 +362,7 @@ class AgentSecretsIntegration:
         keys = self.secrets_service.list_secrets(  # nosec B106  # secret type filter
             scope=scope,
             chat_id=chat_id,
-            secret_type="ssh_key",
+            secret_type=SecretType.SSH_KEY.value,
         )
         for key in keys:
             full_key = self.secrets_service.get_secret(
@@ -407,7 +435,7 @@ class AgentSecretsIntegration:
             secrets = self.secrets_service.list_secrets(  # nosec B106
                 scope="chat",
                 chat_id=chat_id,
-                secret_type="api_key",
+                secret_type=SecretType.API_KEY.value,
             )
             for secret in secrets:
                 if service_name.lower() in secret["name"].lower():
@@ -422,7 +450,7 @@ class AgentSecretsIntegration:
         # Try general scope
         secrets = self.secrets_service.list_secrets(  # nosec B106  # secret type filter
             scope="general",
-            secret_type="api_key",
+            secret_type=SecretType.API_KEY.value,
         )
         for secret in secrets:
             if service_name.lower() in secret["name"].lower():
@@ -436,19 +464,24 @@ class AgentSecretsIntegration:
 
         return None
 
-    def get_available_secret_types(self, agent_type: str) -> Set[str]:
-        """Get the set of secret types available for an agent.
+    def get_available_secret_types(self, agent_type: str) -> Set[SecretType]:
+        """Get the concrete secret kinds available to an agent.
+
+        #13846: returns :class:`SecretType` members, and expands
+        ``SecretType.ANY`` to the whole concrete taxonomy so a wildcard
+        requirement reports the kinds it actually grants rather than the
+        wildcard itself.
 
         Args:
             agent_type: Type of agent to query
 
         Returns:
-            Set of secret type strings the agent can use
+            Set of SecretType members the agent can use
         """
         mapping = self.get_agent_mapping(agent_type)
         if mapping is None:
             return set()
-        return mapping.required_types | mapping.optional_types
+        return set(SecretType.expand(mapping.required_types | mapping.optional_types))
 
     def is_auto_inject_enabled(self, agent_type: str) -> bool:
         """Check if auto-injection is enabled for an agent type.

--- a/autobot-backend/services/agent_terminal/approval_handler.py
+++ b/autobot-backend/services/agent_terminal/approval_handler.py
@@ -13,7 +13,7 @@ import time
 from typing import Dict
 
 from autobot_shared.logging_manager import get_logger
-from secure_command_executor import CommandRisk
+from autobot_shared.status_enums import CommandRisk
 from services.command_approval_manager import CommandApprovalManager
 
 from .models import AgentTerminalSession

--- a/autobot-backend/services/agent_terminal/utils.py
+++ b/autobot-backend/services/agent_terminal/utils.py
@@ -11,11 +11,23 @@ Helper functions for agent terminal operations.
 import re
 from typing import TYPE_CHECKING
 
+from autobot_shared.status_enums import CommandRisk
 from models.command_execution import CommandExecution, CommandState, RiskLevel
-from secure_command_executor import CommandRisk
 
 if TYPE_CHECKING:
     from .models import AgentTerminalSession
+
+
+# Boundary table: canonical CommandRisk -> the deliberate #7258 RiskLevel fork.
+# Every CommandRisk member must appear; see map_risk_to_level for why.
+_COMMAND_RISK_TO_RISK_LEVEL: dict[CommandRisk, RiskLevel] = {
+    CommandRisk.SAFE: RiskLevel.LOW,  # Safe commands -> Low risk
+    CommandRisk.MODERATE: RiskLevel.MEDIUM,  # Moderate commands -> Medium risk
+    CommandRisk.HIGH: RiskLevel.HIGH,  # High risk commands -> High risk
+    CommandRisk.CRITICAL: RiskLevel.CRITICAL,  # Critical commands -> Critical risk
+    CommandRisk.DANGEROUS: RiskLevel.CRITICAL,  # Destructive pattern -> blocked
+    CommandRisk.FORBIDDEN: RiskLevel.CRITICAL,  # Deny-listed command -> blocked
+}
 
 
 def map_risk_to_level(risk: CommandRisk) -> RiskLevel:
@@ -24,8 +36,13 @@ def map_risk_to_level(risk: CommandRisk) -> RiskLevel:
 
     REUSABLE PRINCIPLE: Single function, clear responsibility, reusable across codebase.
 
-    CommandRisk enum values: SAFE, MODERATE, HIGH, CRITICAL, FORBIDDEN
-    RiskLevel enum values: LOW, MEDIUM, HIGH, CRITICAL
+    ``RiskLevel`` here is ``models.command_execution.RiskLevel`` — the
+    deliberate fork documented in #7258 (uppercase wire format, already
+    serialized by legacy Redis/SQLite records). It is NOT converged, and this
+    function is the boundary that converts into it.
+
+    CommandRisk members: SAFE, MODERATE, HIGH, CRITICAL, DANGEROUS, FORBIDDEN
+    RiskLevel members: LOW, MEDIUM, HIGH, CRITICAL
 
     Args:
         risk: CommandRisk from security assessment
@@ -33,14 +50,12 @@ def map_risk_to_level(risk: CommandRisk) -> RiskLevel:
     Returns:
         Corresponding RiskLevel enum
     """
-    risk_mapping = {
-        CommandRisk.SAFE: RiskLevel.LOW,  # Safe commands → Low risk
-        CommandRisk.MODERATE: RiskLevel.MEDIUM,  # Moderate commands → Medium risk
-        CommandRisk.HIGH: RiskLevel.HIGH,  # High risk commands → High risk
-        CommandRisk.CRITICAL: RiskLevel.CRITICAL,  # Critical commands → Critical risk
-        CommandRisk.FORBIDDEN: (RiskLevel.CRITICAL),  # Forbidden commands → Critical risk (blocked)
-    }
-    return risk_mapping.get(risk, RiskLevel.MEDIUM)
+    # #13845: the fallback is CRITICAL, not MEDIUM. The table used to omit
+    # DANGEROUS (it lived in the other fork), and an unmapped member fell
+    # through to MEDIUM — a blocking verdict silently downgraded to the middle
+    # of the scale. An unrecognised risk now fails closed. Totality of this
+    # table is asserted by ``repo_tests/enum_union_guard_test.py``.
+    return _COMMAND_RISK_TO_RISK_LEVEL.get(risk, RiskLevel.CRITICAL)
 
 
 def extract_terminal_and_chat_ids(session: "AgentTerminalSession") -> tuple[str, str]:

--- a/autobot-backend/services/approval_memory.py
+++ b/autobot-backend/services/approval_memory.py
@@ -51,6 +51,7 @@ from typing import Any, Dict, List
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
 from autobot_shared.ssot_config import config
+from autobot_shared.status_enums import CommandRisk
 
 logger = get_logger(__name__)
 
@@ -105,14 +106,16 @@ class ApprovalMemoryManager:
         enabled: Whether approval memory is enabled
     """
 
-    # Risk level ordering for comparison
-    RISK_LEVELS = {
-        "safe": 0,
-        "moderate": 1,
-        "high": 2,
-        "critical": 3,
-        "forbidden": 4,
-    }
+    # Risk-level ordering for comparison, keyed by the wire value that is
+    # actually stored in the Redis approval records.
+    #
+    # #13845: derived from ``CommandRisk.rank`` rather than hand-written. The
+    # literal table this replaces named five members and so had no entry for
+    # ``DANGEROUS`` — the sixth, which arrived when the executor's risk enum
+    # was unioned with the terminal schema's. Only the relative order matters
+    # here (both sides of the comparison come from this same table) and the
+    # order is unchanged; the absolute integers are never persisted.
+    RISK_LEVELS = {risk.value: risk.rank for risk in CommandRisk}
 
     def __init__(
         self,

--- a/autobot-backend/services/command_approval_manager.py
+++ b/autobot-backend/services/command_approval_manager.py
@@ -29,7 +29,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
-from secure_command_executor import CommandRisk
+from autobot_shared.status_enums import CommandRisk
 from type_defs.common import Metadata
 
 # Permission system v2 imports (lazy to avoid circular imports)
@@ -41,14 +41,10 @@ logger = get_logger(__name__)
 # Performance optimization: O(1) lookup for subcommand patterns (Issue #326)
 SUBCOMMAND_TOOLS = {"git", "docker", "kubectl", "npm", "yarn"}
 
-# Numeric risk levels for comparison
-_RISK_LEVELS = {
-    CommandRisk.SAFE: 0,
-    CommandRisk.MODERATE: 1,
-    CommandRisk.HIGH: 2,
-    CommandRisk.CRITICAL: 3,
-    CommandRisk.FORBIDDEN: 4,
-}
+# #13845: risk ordering comes from ``CommandRisk.rank``, derived from the enum's
+# own declaration order. The hand-written table this replaces named five members
+# and would have rated the sixth (DANGEROUS) as 999 — treating a blocking
+# verdict as "off the scale" rather than as the blocking verdict it is.
 
 
 class AgentRole(Enum):
@@ -185,7 +181,7 @@ class CommandApprovalManager:
         supervised_mode = perms.supervised_mode
         effective_max_risk = CommandRisk.FORBIDDEN if supervised_mode else perms.max_risk
 
-        if _RISK_LEVELS.get(command_risk, 999) > _RISK_LEVELS.get(effective_max_risk, 0):
+        if command_risk.rank > effective_max_risk.rank:
             if supervised_mode:
                 reason = f"Command risk {command_risk.value} exceeds supervised mode limit"
             else:
@@ -286,12 +282,11 @@ class CommandApprovalManager:
 
         supervised_mode = perms.supervised_mode
 
-        # In supervised mode, HIGH/CRITICAL/FORBIDDEN always need approval
-        if supervised_mode and command_risk in {
-            CommandRisk.HIGH,
-            CommandRisk.CRITICAL,
-            CommandRisk.FORBIDDEN,
-        }:
+        # In supervised mode anything at or above HIGH always needs approval.
+        # #13845: expressed as a rank comparison so DANGEROUS — added by the
+        # union with the terminal schema's enum — is covered without the set
+        # having to be edited.
+        if supervised_mode and command_risk.rank >= CommandRisk.HIGH.rank:
             return True
 
         # SAFE commands can be auto-approved if permitted

--- a/autobot-backend/services/llc_secrets_importer.py
+++ b/autobot-backend/services/llc_secrets_importer.py
@@ -50,7 +50,8 @@ from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
 from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
 from autobot_shared.secrets_vault import VaultKind, VaultRef
 from llc.models.secret import LLCSecret
-from models.secret import Secret, SecretType
+from autobot_shared.status_enums import SecretType
+from models.secret import Secret
 from models.secret_grant import SecretGrant
 
 _MARKER = "imported_from_llc_secrets"

--- a/autobot-backend/services/llc_secrets_importer.py
+++ b/autobot-backend/services/llc_secrets_importer.py
@@ -49,8 +49,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from autobot_shared.legacy_secret_keys import derive_llc_company_fernet
 from autobot_shared.secrets_envelope import derive_vault_key, seal, wrap_dek
 from autobot_shared.secrets_vault import VaultKind, VaultRef
-from llc.models.secret import LLCSecret
 from autobot_shared.status_enums import SecretType
+from llc.models.secret import LLCSecret
 from models.secret import Secret
 from models.secret_grant import SecretGrant
 

--- a/autobot-backend/services/terminal_websocket/security.py
+++ b/autobot-backend/services/terminal_websocket/security.py
@@ -29,9 +29,7 @@ LOGGING_SECURITY_LEVELS: Set[SecurityLevel] = {
 # Performance optimization: O(1) lookup for high-risk command levels (Issue #326).
 # #13845: derived from ``CommandRisk.blocks`` plus HIGH rather than listed by
 # hand, so a blocking member added later cannot be missed here.
-HIGH_RISK_COMMAND_LEVELS: Set[CommandRisk] = {
-    risk for risk in CommandRisk if risk.blocks
-} | {CommandRisk.HIGH}
+HIGH_RISK_COMMAND_LEVELS: Set[CommandRisk] = {risk for risk in CommandRisk if risk.blocks} | {CommandRisk.HIGH}
 
 
 class CommandSecurityAssessor:

--- a/autobot-backend/services/terminal_websocket/security.py
+++ b/autobot-backend/services/terminal_websocket/security.py
@@ -10,10 +10,8 @@ Command risk assessment and security enforcement for terminal operations.
 
 from typing import Set
 
-from api.schemas_terminal import (
-    CommandRiskLevel,
-    SecurityLevel,
-)
+from api.schemas_terminal import SecurityLevel
+from autobot_shared.status_enums import CommandRisk
 from autobot_shared.logging_manager import get_logger
 from constants.terminal_constants import MODERATE_RISK_PATTERNS, RISKY_COMMAND_PATTERNS
 
@@ -28,47 +26,50 @@ LOGGING_SECURITY_LEVELS: Set[SecurityLevel] = {
     SecurityLevel.RESTRICTED,
 }
 
-# Performance optimization: O(1) lookup for high-risk command levels (Issue #326)
-HIGH_RISK_COMMAND_LEVELS: Set[CommandRiskLevel] = {
-    CommandRiskLevel.DANGEROUS,
-    CommandRiskLevel.HIGH,
-}
+# Performance optimization: O(1) lookup for high-risk command levels (Issue #326).
+# #13845: derived from ``CommandRisk.blocks`` plus HIGH rather than listed by
+# hand, so a blocking member added later cannot be missed here.
+HIGH_RISK_COMMAND_LEVELS: Set[CommandRisk] = {
+    risk for risk in CommandRisk if risk.blocks
+} | {CommandRisk.HIGH}
 
 
 class CommandSecurityAssessor:
     """Assesses command security risks and enforces security policies"""
 
-    def assess_command_risk(self, command: str) -> CommandRiskLevel:
+    def assess_command_risk(self, command: str) -> CommandRisk:
         """Assess the security risk level of a command"""
         command_lower = command.lower().strip()
 
         # Check for dangerous patterns
         for pattern in RISKY_COMMAND_PATTERNS:
             if pattern in command_lower:
-                return CommandRiskLevel.DANGEROUS
+                return CommandRisk.DANGEROUS
 
         # Check for moderate risk patterns
         for pattern in MODERATE_RISK_PATTERNS:
             if pattern in command_lower:
-                return CommandRiskLevel.MODERATE
+                return CommandRisk.MODERATE
 
         # Special checks for high-risk operations (Issue #326: O(1) lookups)
         if any(x in command_lower for x in SHELL_OPERATORS):
-            return CommandRiskLevel.HIGH
+            return CommandRisk.HIGH
 
-        return CommandRiskLevel.SAFE
+        return CommandRisk.SAFE
 
     def should_block_command(
         self,
         command: str,
-        risk_level: CommandRiskLevel,
+        risk_level: CommandRisk,
         security_level: SecurityLevel,
     ) -> bool:
         """Determine if command should be blocked based on security level"""
         if security_level == SecurityLevel.RESTRICTED:
             return risk_level in HIGH_RISK_COMMAND_LEVELS
         elif security_level == SecurityLevel.ELEVATED:
-            return risk_level == CommandRiskLevel.DANGEROUS
+            # #13845: ``.blocks`` also covers FORBIDDEN, which the unioned enum
+            # can now carry into this path.
+            return risk_level.blocks
 
         return False  # STANDARD level allows most commands
 

--- a/autobot-backend/services/terminal_websocket/security.py
+++ b/autobot-backend/services/terminal_websocket/security.py
@@ -11,8 +11,8 @@ Command risk assessment and security enforcement for terminal operations.
 from typing import Set
 
 from api.schemas_terminal import SecurityLevel
-from autobot_shared.status_enums import CommandRisk
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import CommandRisk
 from constants.terminal_constants import MODERATE_RISK_PATTERNS, RISKY_COMMAND_PATTERNS
 
 logger = get_logger(__name__)

--- a/autobot-backend/slash_command_handler.py
+++ b/autobot-backend/slash_command_handler.py
@@ -1184,7 +1184,8 @@ Your secret has been securely encrypted and stored.
             return validation_error
 
         try:
-            from api.secrets import ChatSecretScope, SecretCreateRequest, SecretType
+            from api.secrets import ChatSecretScope, SecretCreateRequest
+            from autobot_shared.status_enums import SecretType
 
             scope = ChatSecretScope.CHAT if self.chat_id else ChatSecretScope.GENERAL
             request = SecretCreateRequest(

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -92213,10 +92213,35 @@ export interface components {
         };
         /**
          * SecretType
-         * @description Secret type enumeration.
+         * @description What kind of credential a secret is (#13846).
+         *
+         *     Canonical union of three definitions that classified the same thing under
+         *     two names, in three layers:
+         *
+         *     * ``models.secret.SecretType`` — the persisted classification on the
+         *       ``secrets`` row. Had all nine concrete kinds.
+         *     * ``api.schemas_system.SecretType`` — the request/response vocabulary.
+         *       Had eight: no ``OAUTH_REFRESH_TOKEN``, so ``POST /secrets`` could not
+         *       accept the one kind the row could already store.
+         *     * ``services.agent_secrets_integration.SecretRequirement`` — what an agent
+         *       type may request. Had six of the nine, duplicated verbatim down to the
+         *       identical ``# nosec B105`` / ``# nosemgrep`` comments, plus ``ANY``.
+         *       With no ``OAUTH_REFRESH_TOKEN`` member, an ``AgentSecretMapping`` could
+         *       only describe an OAuth-authenticating agent as ``ANY`` — the blanket
+         *       "every available secret" grant standing in for the most specific one.
+         *
+         *     Every member of every side is here. ``str`` subclass so the persisted
+         *     ``secrets.type`` column, which stores these values, keeps comparing and
+         *     serializing exactly as before.
+         *
+         *     ``ANY`` is the odd one out: a wildcard *quantifier* over the taxonomy, not
+         *     a kind of credential. It is legal in a requirement (an agent that may use
+         *     any secret) and illegal at rest — nothing may be stored with type "any".
+         *     Use :meth:`concrete` for every persistence or presentation surface, and
+         *     :meth:`expand` to resolve a requirement set into concrete kinds.
          * @enum {string}
          */
-        SecretType: "ssh_key" | "password" | "api_key" | "token" | "certificate" | "database_url" | "infrastructure_host" | "other";
+        SecretType: "ssh_key" | "password" | "api_key" | "token" | "oauth_refresh_token" | "connector_oauth_token" | "certificate" | "database_url" | "infrastructure_host" | "other" | "any";
         /**
          * SecretTypesData
          * @description Response data for get_secret_types.

--- a/autobot-infrastructure/shared/scripts/secrets_manager.py
+++ b/autobot-infrastructure/shared/scripts/secrets_manager.py
@@ -49,6 +49,13 @@ logger = logging.getLogger(__name__)
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
+# Standalone copy of the secret-kind vocabulary (#13846).
+# Canonical enum: autobot_shared/status_enums.py::SecretType.
+# Deliberately NOT converged and NOT imported: this script is run standalone on
+# infrastructure hosts and never imports application packages — the same reason
+# ChatSecretScope below is duplicated (#11759). WEBHOOK_URL and CUSTOM are
+# infra-only kinds with no backend producer; CUSTOM is this layer's spelling of
+# the canonical OTHER. Keep in step by hand when the canonical enum changes.
 class SecretType:
     """Supported secret types."""
 

--- a/autobot-slm-backend/api/stateful.py
+++ b/autobot-slm-backend/api/stateful.py
@@ -18,7 +18,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
-from models.database import Backup, BackupStatus, Node, Replication, ReplicationStatus
+from models.database import Backup, BackupServiceType, BackupStatus, Node, Replication, ReplicationStatus
 from models.schemas import (
     ActionResponse,
     BackupCreate,
@@ -49,7 +49,7 @@ async def list_backups(
     db: Annotated[AsyncSession, Depends(get_db)],
     _: Annotated[dict, Depends(get_current_user)],
     node_id: str | None = Query(None),
-    service_type: str | None = Query(None),
+    service_type: BackupServiceType | None = Query(None),
     status_filter: str | None = Query(None, alias="status"),
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
@@ -60,7 +60,9 @@ async def list_backups(
     if node_id:
         query = query.where(Backup.node_id == node_id)
     if service_type:
-        query = query.where(Backup.service_type == service_type)
+        # #14944: compare the stored string against ``.value``, never the
+        # member — str() of a (str, Enum) member is "BackupServiceType.REDIS".
+        query = query.where(Backup.service_type == service_type.value)
     if status_filter:
         query = query.where(Backup.status == status_filter)
 
@@ -121,7 +123,7 @@ async def create_backup(
     backup = Backup(
         backup_id=backup_id,
         node_id=request.node_id,
-        service_type=request.service_type,
+        service_type=request.service_type.value,
         status=BackupStatus.PENDING.value,
     )
     db.add(backup)
@@ -315,7 +317,7 @@ async def start_replication(
         replication_id=replication_id,
         source_node_id=request.source_node_id,
         target_node_id=request.target_node_id,
-        service_type=request.service_type,
+        service_type=request.service_type.value,
         status=ReplicationStatus.PENDING.value,
     )
     db.add(replication)
@@ -489,7 +491,7 @@ async def verify_data(
     details = {}
     is_healthy = True
 
-    if request.service_type == "redis":
+    if request.service_type is BackupServiceType.REDIS:
         verify_result = await _verify_redis(node.ip_address)
         checks = verify_result["checks"]
         details = verify_result["details"]
@@ -499,13 +501,13 @@ async def verify_data(
             {
                 "name": "service_check",
                 "status": "skipped",
-                "message": f"Verification not implemented for {request.service_type}",
+                "message": f"Verification not implemented for {request.service_type.value}",
             }
         )
 
     return DataVerifyResponse(
         is_healthy=is_healthy,
-        service_type=request.service_type,
+        service_type=request.service_type.value,
         details=details,
         checks=checks,
     )
@@ -516,12 +518,12 @@ async def verify_data(
 # =============================================================================
 
 
-async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
+async def _run_backup(backup_id: str, host: str, service_type: BackupServiceType) -> None:
     """Execute backup operation asynchronously using the backup service."""
     from services.backup import backup_service
     from services.database import db_service
 
-    logger.info("Running backup %s for host %s (service: %s)", backup_id, host, service_type)
+    logger.info("Running backup %s for host %s (service: %s)", backup_id, host, service_type.value)
 
     async with db_service.session() as db:
         # Get the backup record
@@ -546,10 +548,13 @@ async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
         # #13307: PostgreSQL holds users, LLC work items and chat/session data.
         # It was simply absent from a feature called "Backups", so a restore
         # silently omitted all of it — discovered only during recovery.
+        # #13578: keyed on enum members. The table used to carry two spellings
+        # of postgres because nothing constrained what a caller could send;
+        # ``BackupServiceType._missing_`` now folds "postgresql" into POSTGRES
+        # at the boundary, so this dispatch has one key per engine again.
         runners = {
-            "redis": backup_service.execute_redis_backup,
-            "postgres": backup_service.execute_postgres_backup,
-            "postgresql": backup_service.execute_postgres_backup,
+            BackupServiceType.REDIS: backup_service.execute_redis_backup,
+            BackupServiceType.POSTGRES: backup_service.execute_postgres_backup,
         }
         runner = runners.get(service_type)
         if runner is not None:
@@ -560,11 +565,11 @@ async def _run_backup(backup_id: str, host: str, service_type: str) -> None:
                 # #13307: prune here rather than on a timer — a new good backup
                 # is the only moment it is safe to drop an old one, and it keeps
                 # retention working without a scheduler this service does not have.
-                await backup_service.apply_retention(db, backup.node_id, service_type)
+                await backup_service.apply_retention(db, backup.node_id, service_type.value)
         else:
             # For unsupported service types, mark as failed
             backup.status = BackupStatus.FAILED.value
-            backup.error = f"Unsupported service type: {service_type}"
+            backup.error = f"Unsupported service type: {service_type.value}"
             backup.completed_at = datetime.now(timezone.utc)
             await db.commit()
             logger.warning("Backup %s failed: unsupported service type", backup_id)

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -118,10 +118,17 @@ class BackupServiceType(str, enum.Enum):
         without a second class to keep in step — and collapses it to one
         canonical member at the boundary, so nothing downstream branches twice.
         """
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in _BACKUP_SERVICE_TYPE_ALIASES:
-                return _BACKUP_SERVICE_TYPE_ALIASES[normalized]
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        if normalized in _BACKUP_SERVICE_TYPE_ALIASES:
+            return _BACKUP_SERVICE_TYPE_ALIASES[normalized]
+        # Case only. Without this the resolution is inconsistent in a way that
+        # reads as a bug from outside: "POSTGRESQL" would resolve through the
+        # alias table while "POSTGRES" — the canonical spelling — would 422.
+        for member in cls:
+            if member.value == normalized:
+                return member
         return None
 
 

--- a/autobot-slm-backend/models/database.py
+++ b/autobot-slm-backend/models/database.py
@@ -89,6 +89,49 @@ class SyncType(str, enum.Enum):
     PACKAGE = "package"
 
 
+class BackupServiceType(str, enum.Enum):
+    """Data service a backup, replication or verification targets (#13578).
+
+    ``service_type`` was the outlier among the eight sibling enums in this
+    module: a bare ``String(32)`` with no constraint anywhere. The cost landed
+    the moment a second engine arrived — the dispatch table in
+    ``api/stateful.py`` had to accept two spellings of the same engine, and an
+    unknown value was not rejected at the API boundary at all. It reached
+    ``_run_backup``, wrote a ``Backup`` row, and only then failed, leaving a
+    ``BackupStatus.FAILED`` row for a typo that is indistinguishable from one
+    for a real failure.
+
+    The column stays a string at rest (#13578: existing rows keep working);
+    this enum is the boundary that decides what may enter.
+    """
+
+    REDIS = "redis"
+    POSTGRES = "postgres"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "BackupServiceType | None":
+        """Accept ``postgresql`` as a spelling of ``postgres``.
+
+        Both spellings were live keys in the backup dispatch table, so both are
+        already in stored ``backups.service_type`` values and in whatever
+        callers send. Resolving the alias here keeps every old spelling parsing
+        without a second class to keep in step — and collapses it to one
+        canonical member at the boundary, so nothing downstream branches twice.
+        """
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in _BACKUP_SERVICE_TYPE_ALIASES:
+                return _BACKUP_SERVICE_TYPE_ALIASES[normalized]
+        return None
+
+
+# Wire spellings that are not member values. Kept next to the enum so the set of
+# accepted inputs is one greppable place rather than a dispatch-table key.
+_BACKUP_SERVICE_TYPE_ALIASES: dict[str, BackupServiceType] = {
+    "postgresql": BackupServiceType.POSTGRES,
+}
+
+
 class Node(Base):
     """Node model representing a managed machine."""
 
@@ -183,7 +226,7 @@ class Backup(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     backup_id = Column(String(64), unique=True, nullable=False, index=True)
     node_id = Column(String(64), nullable=False, index=True)
-    service_type = Column(String(32), default="redis")
+    service_type = Column(String(32), default=BackupServiceType.REDIS.value)
     backup_path = Column(String(512), nullable=True)
     status = Column(String(20), default=BackupStatus.PENDING.value)
 
@@ -317,7 +360,7 @@ class Replication(Base):
     replication_id = Column(String(64), unique=True, nullable=False, index=True)
     source_node_id = Column(String(64), nullable=False)
     target_node_id = Column(String(64), nullable=False)
-    service_type = Column(String(32), default="redis")
+    service_type = Column(String(32), default=BackupServiceType.REDIS.value)
     status = Column(String(20), default=ReplicationStatus.PENDING.value)
     sync_position = Column(String(128), nullable=True)
     lag_bytes = Column(Integer, default=0)

--- a/autobot-slm-backend/models/schemas.py
+++ b/autobot-slm-backend/models/schemas.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from .database import NodeStatus
+from .database import BackupServiceType, NodeStatus
 
 # =============================================================================
 # Authentication Schemas
@@ -320,10 +320,15 @@ class DeploymentListResponse(BaseModel):
 
 
 class BackupCreate(BaseModel):
-    """Backup request."""
+    """Backup request.
+
+    #13578: ``service_type`` is the enum, not a bare string, so FastAPI rejects
+    an unknown engine with 422 *before* ``_run_backup`` writes a ``Backup`` row
+    that would otherwise sit there as a FAILED record for a typo.
+    """
 
     node_id: str
-    service_type: str = "redis"
+    service_type: BackupServiceType = BackupServiceType.REDIS
 
 
 class BackupResponse(BaseModel):
@@ -725,11 +730,11 @@ class UpdateApplyAllRequest(BaseModel):
 
 
 class ReplicationCreate(BaseModel):
-    """Replication request."""
+    """Replication request (#13578: enum-constrained service_type)."""
 
     source_node_id: str
     target_node_id: str
-    service_type: str = "redis"
+    service_type: BackupServiceType = BackupServiceType.REDIS
 
 
 class ReplicationResponse(BaseModel):
@@ -785,10 +790,10 @@ class BackupRestoreResponse(BaseModel):
 
 
 class DataVerifyRequest(BaseModel):
-    """Data verification request."""
+    """Data verification request (#13578: enum-constrained service_type)."""
 
     node_id: str
-    service_type: str = "redis"
+    service_type: BackupServiceType = BackupServiceType.REDIS
 
 
 class DataVerifyResponse(BaseModel):

--- a/autobot-slm-backend/services/replication.py
+++ b/autobot-slm-backend/services/replication.py
@@ -78,7 +78,7 @@ class ReplicationService:
         # it would have silently passed a plain "redis" from any caller and
         # silently failed on any other spelling.
         if service_type is not BackupServiceType.REDIS:
-            return False, f"Unsupported service type: {BackupServiceType(service_type).value}"
+            return False, f"Unsupported service type: {service_type.value}"
 
         replication = await self._log_and_load_replication(db, replication_id, source_node, target_node)
         if not replication:

--- a/autobot-slm-backend/services/replication.py
+++ b/autobot-slm-backend/services/replication.py
@@ -22,7 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
-from models.database import Node, Replication, ReplicationStatus
+from models.database import BackupServiceType, Node, Replication, ReplicationStatus
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class ReplicationService:
         replication_id: str,
         source_node: Node,
         target_node: Node,
-        service_type: str = "redis",
+        service_type: BackupServiceType = BackupServiceType.REDIS,
     ) -> Tuple[bool, str]:
         """Set up replication from source to target using Ansible.
 
@@ -68,13 +68,17 @@ class ReplicationService:
             replication_id: Replication ID to track
             source_node: Primary/master node
             target_node: Replica node
-            service_type: Service type (currently only 'redis' supported)
+            service_type: Service to replicate (currently only REDIS supported)
 
         Returns:
             Tuple of (success, message)
         """
-        if service_type != "redis":
-            return False, f"Unsupported service type: {service_type}"
+        # #13578: identity against the member. The string comparison this
+        # replaces only worked because ``BackupServiceType`` subclasses ``str``;
+        # it would have silently passed a plain "redis" from any caller and
+        # silently failed on any other spelling.
+        if service_type is not BackupServiceType.REDIS:
+            return False, f"Unsupported service type: {BackupServiceType(service_type).value}"
 
         replication = await self._log_and_load_replication(db, replication_id, source_node, target_node)
         if not replication:

--- a/autobot-slm-backend/tests/api/test_apply_secrets.py
+++ b/autobot-slm-backend/tests/api/test_apply_secrets.py
@@ -77,6 +77,21 @@ class _NodeStatus(str, Enum):
     DECOMMISSIONED = "decommissioned"
 
 
+class _BackupServiceType(str, Enum):
+    """Real-enough stand-in so models/schemas.py enum fields build (#13578).
+
+    Same reason as ``_NodeStatus`` above: ``models/schemas.py`` now also imports
+    ``BackupServiceType`` from ``models.database``, and pydantic needs a genuine
+    enum type to build a schema for ``BackupCreate.service_type``. Left as a
+    ``MagicMock`` attribute it raises ``PydanticSchemaGenerationError`` at
+    import, which is a *collection* error — every test in this file stops
+    running rather than one failing.
+    """
+
+    REDIS = "redis"
+    POSTGRES = "postgres"
+
+
 class _Permission:
     SECURITY_MANAGE = "security:manage"
 
@@ -105,6 +120,7 @@ def _load_secrets_module():
         sys.modules["models.database"].Node = MagicMock()
         sys.modules["models.database"].SystemSecret = MagicMock()
         sys.modules["models.database"].NodeStatus = _NodeStatus
+        sys.modules["models.database"].BackupServiceType = _BackupServiceType
         sys.modules["services.ansible_secrets"]._SECRET_TO_DEPENDENT_ROLES = {"hf_token": ["tts-worker"]}
 
         # Real-load models/schemas.py so response_model=ApplySecretsResponse

--- a/autobot-slm-frontend/openapi.json
+++ b/autobot-slm-frontend/openapi.json
@@ -1542,16 +1542,15 @@
         "type": "object"
       },
       "BackupCreate": {
-        "description": "Backup request.",
+        "description": "Backup request.\n\n#13578: ``service_type`` is the enum, not a bare string, so FastAPI rejects\nan unknown engine with 422 *before* ``_run_backup`` writes a ``Backup`` row\nthat would otherwise sit there as a FAILED record for a typo.",
         "properties": {
           "node_id": {
             "title": "Node Id",
             "type": "string"
           },
           "service_type": {
-            "default": "redis",
-            "title": "Service Type",
-            "type": "string"
+            "$ref": "#/components/schemas/BackupServiceType",
+            "default": "redis"
           }
         },
         "required": [
@@ -1713,6 +1712,15 @@
         ],
         "title": "BackupRestoreResponse",
         "type": "object"
+      },
+      "BackupServiceType": {
+        "description": "Data service a backup, replication or verification targets (#13578).\n\n``service_type`` was the outlier among the eight sibling enums in this\nmodule: a bare ``String(32)`` with no constraint anywhere. The cost landed\nthe moment a second engine arrived — the dispatch table in\n``api/stateful.py`` had to accept two spellings of the same engine, and an\nunknown value was not rejected at the API boundary at all. It reached\n``_run_backup``, wrote a ``Backup`` row, and only then failed, leaving a\n``BackupStatus.FAILED`` row for a typo that is indistinguishable from one\nfor a real failure.\n\nThe column stays a string at rest (#13578: existing rows keep working);\nthis enum is the boundary that decides what may enter.",
+        "enum": [
+          "redis",
+          "postgres"
+        ],
+        "title": "BackupServiceType",
+        "type": "string"
       },
       "BlueGreenActionResponse": {
         "description": "Blue-green action response.",
@@ -3249,16 +3257,15 @@
         "type": "object"
       },
       "DataVerifyRequest": {
-        "description": "Data verification request.",
+        "description": "Data verification request (#13578: enum-constrained service_type).",
         "properties": {
           "node_id": {
             "title": "Node Id",
             "type": "string"
           },
           "service_type": {
-            "default": "redis",
-            "title": "Service Type",
-            "type": "string"
+            "$ref": "#/components/schemas/BackupServiceType",
+            "default": "redis"
           }
         },
         "required": [
@@ -8306,12 +8313,11 @@
         "type": "object"
       },
       "ReplicationCreate": {
-        "description": "Replication request.",
+        "description": "Replication request (#13578: enum-constrained service_type).",
         "properties": {
           "service_type": {
-            "default": "redis",
-            "title": "Service Type",
-            "type": "string"
+            "$ref": "#/components/schemas/BackupServiceType",
+            "default": "redis"
           },
           "source_node_id": {
             "title": "Source Node Id",
@@ -32913,7 +32919,7 @@
             "schema": {
               "anyOf": [
                 {
-                  "type": "string"
+                  "$ref": "#/components/schemas/BackupServiceType"
                 },
                 {
                   "type": "null"

--- a/autobot-slm-frontend/src/types/generated/api.ts
+++ b/autobot-slm-frontend/src/types/generated/api.ts
@@ -7547,15 +7547,16 @@ export interface components {
         /**
          * BackupCreate
          * @description Backup request.
+         *
+         *     #13578: ``service_type`` is the enum, not a bare string, so FastAPI rejects
+         *     an unknown engine with 422 *before* ``_run_backup`` writes a ``Backup`` row
+         *     that would otherwise sit there as a FAILED record for a typo.
          */
         BackupCreate: {
             /** Node Id */
             node_id: string;
-            /**
-             * Service Type
-             * @default redis
-             */
-            service_type: string;
+            /** @default redis */
+            service_type: components["schemas"]["BackupServiceType"];
         } & {
             [key: string]: unknown;
         };
@@ -7620,6 +7621,24 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /**
+         * BackupServiceType
+         * @description Data service a backup, replication or verification targets (#13578).
+         *
+         *     ``service_type`` was the outlier among the eight sibling enums in this
+         *     module: a bare ``String(32)`` with no constraint anywhere. The cost landed
+         *     the moment a second engine arrived — the dispatch table in
+         *     ``api/stateful.py`` had to accept two spellings of the same engine, and an
+         *     unknown value was not rejected at the API boundary at all. It reached
+         *     ``_run_backup``, wrote a ``Backup`` row, and only then failed, leaving a
+         *     ``BackupStatus.FAILED`` row for a typo that is indistinguishable from one
+         *     for a real failure.
+         *
+         *     The column stays a string at rest (#13578: existing rows keep working);
+         *     this enum is the boundary that decides what may enter.
+         * @enum {string}
+         */
+        BackupServiceType: "redis" | "postgres";
         /**
          * BlueGreenActionResponse
          * @description Blue-green action response.
@@ -8331,16 +8350,13 @@ export interface components {
         };
         /**
          * DataVerifyRequest
-         * @description Data verification request.
+         * @description Data verification request (#13578: enum-constrained service_type).
          */
         DataVerifyRequest: {
             /** Node Id */
             node_id: string;
-            /**
-             * Service Type
-             * @default redis
-             */
-            service_type: string;
+            /** @default redis */
+            service_type: components["schemas"]["BackupServiceType"];
         } & {
             [key: string]: unknown;
         };
@@ -10963,14 +10979,11 @@ export interface components {
         };
         /**
          * ReplicationCreate
-         * @description Replication request.
+         * @description Replication request (#13578: enum-constrained service_type).
          */
         ReplicationCreate: {
-            /**
-             * Service Type
-             * @default redis
-             */
-            service_type: string;
+            /** @default redis */
+            service_type: components["schemas"]["BackupServiceType"];
             /** Source Node Id */
             source_node_id: string;
             /** Target Node Id */
@@ -24536,7 +24549,7 @@ export interface operations {
         parameters: {
             query?: {
                 node_id?: string | null;
-                service_type?: string | null;
+                service_type?: components["schemas"]["BackupServiceType"] | null;
                 status?: string | null;
                 page?: number;
                 per_page?: number;

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -210,6 +210,78 @@ _COMMAND_RISK_BLOCKING: "frozenset[CommandRisk]" = frozenset(
 )
 
 
+class SecretType(str, Enum):
+    """What kind of credential a secret is (#13846).
+
+    Canonical union of three definitions that classified the same thing under
+    two names, in three layers:
+
+    * ``models.secret.SecretType`` — the persisted classification on the
+      ``secrets`` row. Had all nine concrete kinds.
+    * ``api.schemas_system.SecretType`` — the request/response vocabulary.
+      Had eight: no ``OAUTH_REFRESH_TOKEN``, so ``POST /secrets`` could not
+      accept the one kind the row could already store.
+    * ``services.agent_secrets_integration.SecretRequirement`` — what an agent
+      type may request. Had six of the nine, duplicated verbatim down to the
+      identical ``# nosec B105`` / ``# nosemgrep`` comments, plus ``ANY``.
+      With no ``OAUTH_REFRESH_TOKEN`` member, an ``AgentSecretMapping`` could
+      only describe an OAuth-authenticating agent as ``ANY`` — the blanket
+      "every available secret" grant standing in for the most specific one.
+
+    Every member of every side is here. ``str`` subclass so the persisted
+    ``secrets.type`` column, which stores these values, keeps comparing and
+    serializing exactly as before.
+
+    ``ANY`` is the odd one out: a wildcard *quantifier* over the taxonomy, not
+    a kind of credential. It is legal in a requirement (an agent that may use
+    any secret) and illegal at rest — nothing may be stored with type "any".
+    Use :meth:`concrete` for every persistence or presentation surface, and
+    :meth:`expand` to resolve a requirement set into concrete kinds.
+    """
+
+    SSH_KEY = "ssh_key"
+    # nosemgrep: autobot-hardcoded-secret-key
+    PASSWORD = "password"  # nosec B105  # enum value, not actual password
+    # nosemgrep: autobot-hardcoded-secret-key
+    API_KEY = "api_key"
+    # nosemgrep: autobot-hardcoded-secret-key
+    TOKEN = "token"  # nosec B105  # enum value, not actual token
+    OAUTH_REFRESH_TOKEN = "oauth_refresh_token"  # nosec B105  # enum value
+    # nosemgrep: autobot-hardcoded-secret-key
+    # #13846: the OAuth bundle the knowledge connectors persist. It was a bare
+    # string in credential_store.py, commented "SecretType label" while being
+    # absent from every SecretType there was. The value is unchanged so rows
+    # already written keep resolving.
+    CONNECTOR_OAUTH_TOKEN = "connector_oauth_token"  # nosec B105  # enum value
+    CERTIFICATE = "certificate"
+    DATABASE_URL = "database_url"
+    INFRASTRUCTURE_HOST = "infrastructure_host"
+    OTHER = "other"
+    ANY = "any"  # Wildcard: "any available secret". Never persisted.
+
+    @classmethod
+    def concrete(cls) -> "tuple[SecretType, ...]":
+        """Every real credential kind — the taxonomy without the wildcard.
+
+        Derived by excluding ``ANY`` rather than by listing the members, so a
+        kind added later is included here without a second edit.
+        """
+        return tuple(member for member in cls if member is not cls.ANY)
+
+    @classmethod
+    def expand(cls, requirements: "Iterable[SecretType]") -> "frozenset[SecretType]":
+        """Resolve a requirement set into the concrete kinds it asks for.
+
+        ``ANY`` expands to the whole taxonomy; everything else maps to itself.
+        Without this, a requirement of ``{ANY}`` would be looked up as the
+        literal type ``"any"`` and match nothing at all.
+        """
+        wanted = set(requirements)
+        if cls.ANY in wanted:
+            return frozenset(cls.concrete())
+        return frozenset(wanted)
+
+
 class Priority(Enum):
     """
     Priority level enumeration.
@@ -409,6 +481,7 @@ __all__ = [
     "Severity",
     "RiskLevel",
     "CommandRisk",
+    "SecretType",
     "Priority",
     "TaskPriority",
     "LLMProvider",

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -197,17 +197,13 @@ class CommandRisk(Enum):
 
 # Rank table derived from declaration order — never hand-written, so it cannot
 # narrow silently when a member is added (#13845).
-_COMMAND_RISK_RANK: "dict[CommandRisk, int]" = {
-    member: index for index, member in enumerate(CommandRisk)
-}
+_COMMAND_RISK_RANK: "dict[CommandRisk, int]" = {member: index for index, member in enumerate(CommandRisk)}
 
 # The verdicts that mean "refuse". DANGEROUS blocks because the command matched
 # a destructive pattern; FORBIDDEN because the base command is denied outright.
 # CRITICAL is deliberately not here: the approval layer grants it under
 # ``allow_dangerous`` rather than refusing it.
-_COMMAND_RISK_BLOCKING: "frozenset[CommandRisk]" = frozenset(
-    {CommandRisk.DANGEROUS, CommandRisk.FORBIDDEN}
-)
+_COMMAND_RISK_BLOCKING: "frozenset[CommandRisk]" = frozenset({CommandRisk.DANGEROUS, CommandRisk.FORBIDDEN})
 
 
 class SecretType(str, Enum):

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -22,6 +22,7 @@ Usage:
 """
 
 from enum import Enum
+from typing import Iterable
 
 
 class TaskStatus(Enum):
@@ -134,6 +135,79 @@ class Severity(Enum):
 # rather than "severity"; canonically the same enum (#6689). Use whichever
 # name reads clearer at the call site.
 RiskLevel = Severity
+
+
+class CommandRisk(Enum):
+    """Risk classification for a shell command, for policy decisions (#13845).
+
+    Canonical union of two forks that modelled the same concept under
+    different names, so neither side's tail is lost:
+
+    * ``secure_command_executor.CommandRisk`` — SAFE / MODERATE / HIGH /
+      CRITICAL / FORBIDDEN, used for executor policy decisions.
+    * ``api.schemas_terminal.CommandRiskLevel`` — SAFE / MODERATE / HIGH /
+      DANGEROUS, the wire schema for the *same* subsystem.
+
+    Three members matched; the tails did not. A command the executor rated
+    ``FORBIDDEN`` had no faithful representation in its own wire schema, and
+    ``DANGEROUS`` — already serialized by ``POST /terminal/command`` and by
+    the terminal WebSocket — existed nowhere in the executor's vocabulary.
+    Both tails are kept here rather than one being picked as the survivor.
+
+    ``DANGEROUS`` and ``FORBIDDEN`` are distinct *reasons* that reach the same
+    verdict: DANGEROUS means the command matched a destructive pattern
+    (``RISKY_COMMAND_PATTERNS``), FORBIDDEN means the base command is on the
+    executor's deny list (``FORBIDDEN_COMMANDS``). They keep separate values
+    because ``"dangerous"`` is already on the wire; ask ``.blocks`` rather
+    than comparing against one of them, or a blocking verdict raised by the
+    other producer reads as permitted.
+
+    Not to be confused with ``Severity``/``RiskLevel`` above, which grades how
+    bad an *outcome* is. This grades what a *command* is allowed to do.
+    """
+
+    SAFE = "safe"
+    MODERATE = "moderate"
+    HIGH = "high"
+    CRITICAL = "critical"
+    DANGEROUS = "dangerous"
+    FORBIDDEN = "forbidden"
+
+    @property
+    def rank(self) -> int:
+        """Strictness rank, ascending. Declaration order is the ordering.
+
+        Derived from the enum itself so a member added later cannot be missed
+        by a hand-written rank table — which is exactly how ``DANGEROUS`` was
+        absent from both of the ones this replaces.
+        """
+        return _COMMAND_RISK_RANK[self]
+
+    @property
+    def blocks(self) -> bool:
+        """True when the verdict is "do not run this", whatever the reason."""
+        return self in _COMMAND_RISK_BLOCKING
+
+    @classmethod
+    def strictest(cls, risks: "Iterable[CommandRisk]") -> "CommandRisk | None":
+        """Highest-ranked risk in ``risks``, or None when empty."""
+        ranked = sorted(risks, key=lambda risk: risk.rank)
+        return ranked[-1] if ranked else None
+
+
+# Rank table derived from declaration order — never hand-written, so it cannot
+# narrow silently when a member is added (#13845).
+_COMMAND_RISK_RANK: "dict[CommandRisk, int]" = {
+    member: index for index, member in enumerate(CommandRisk)
+}
+
+# The verdicts that mean "refuse". DANGEROUS blocks because the command matched
+# a destructive pattern; FORBIDDEN because the base command is denied outright.
+# CRITICAL is deliberately not here: the approval layer grants it under
+# ``allow_dangerous`` rather than refusing it.
+_COMMAND_RISK_BLOCKING: "frozenset[CommandRisk]" = frozenset(
+    {CommandRisk.DANGEROUS, CommandRisk.FORBIDDEN}
+)
 
 
 class Priority(Enum):
@@ -334,6 +408,7 @@ __all__ = [
     "WorkflowStatus",
     "Severity",
     "RiskLevel",
+    "CommandRisk",
     "Priority",
     "TaskPriority",
     "LLMProvider",

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -1,0 +1,424 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#13845/#13846/#13597/#13578 — the unioned enums may not lose a member again.
+
+Four enum families had been forked, and in every case the *divergent tail* was
+the functionality:
+
+* ``CommandRisk`` / ``CommandRiskLevel`` — pick a survivor and ``FORBIDDEN``
+  (or ``DANGEROUS``) stops existing.
+* ``SecretType`` / ``SecretRequirement`` / a third copy in the API schemas —
+  pick a survivor and an agent can never again state that it needs OAuth
+  credentials, only ``ANY``, the blanket grant.
+* ``AlertSeverity`` / ``ErrorSeverity`` vs the canonical ``Severity``.
+* ``service_type`` — no enum at all, and two spellings of postgres.
+
+So these tests pin **member sets**, not names. A rename is a member-set change
+and fails here by name; a member quietly dropped fails here by name. Both
+directions were mutation-checked before this file was committed.
+
+Three traps this file is deliberately built against:
+
+* *An empty result reads as clean.* Every scan asserts it reached something
+  before it asserts anything about what it found.
+* *A guard fed a hand-written list guards that list only.* The severity-literal
+  ratchet derives its population from the tree with the same matcher the count
+  came from, and floors the file enumeration.
+* *A guard whose target is missing reports a false PASS.* Each mapping test
+  asserts the target table exists and is non-empty first.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import re
+import subprocess  # nosec B404  # fixed argv, no shell, no caller input
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.status_enums import CommandRisk, SecretType, Severity
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND = REPO_ROOT / "autobot-backend"
+SLM = REPO_ROOT / "autobot-slm-backend"
+
+
+def _members(enum_cls) -> set[tuple[str, str]]:
+    """(name, value) pairs — the identity a rename cannot survive."""
+    return {(member.name, member.value) for member in enum_cls}
+
+
+# --------------------------------------------------------------------------
+# #13845 — CommandRisk carries both tails
+# --------------------------------------------------------------------------
+
+# Every member of every side of the fork. FORBIDDEN and CRITICAL came from
+# the executor's enum; DANGEROUS from the terminal wire schema; SAFE/MODERATE/
+# HIGH were the three that already matched.
+COMMAND_RISK_UNION = {
+    ("SAFE", "safe"),
+    ("MODERATE", "moderate"),
+    ("HIGH", "high"),
+    ("CRITICAL", "critical"),
+    ("DANGEROUS", "dangerous"),
+    ("FORBIDDEN", "forbidden"),
+}
+
+
+def test_command_risk_is_exactly_the_union_of_both_forks():
+    assert _members(CommandRisk) == COMMAND_RISK_UNION
+
+
+@pytest.mark.parametrize("name", sorted(name for name, _ in COMMAND_RISK_UNION))
+def test_every_command_risk_member_is_present_by_name(name):
+    """Presence, asserted one member at a time, so a loss names itself."""
+    assert hasattr(CommandRisk, name), f"#13845: CommandRisk lost {name}"
+
+
+def test_the_wire_spellings_of_both_forks_still_parse():
+    """Values already emitted by the API and stored in logs must resolve."""
+    assert CommandRisk("dangerous") is CommandRisk.DANGEROUS
+    assert CommandRisk("forbidden") is CommandRisk.FORBIDDEN
+
+
+def test_rank_covers_every_member_and_is_strictly_ascending():
+    ranks = [risk.rank for risk in CommandRisk]
+    assert len(ranks) == len(CommandRisk)
+    assert ranks == sorted(ranks) == list(range(len(CommandRisk)))
+
+
+def test_both_blocking_verdicts_block_and_nothing_else_does():
+    """The whole point of ``.blocks``: neither producer's verdict is missed."""
+    blocking = {risk for risk in CommandRisk if risk.blocks}
+    assert blocking == {CommandRisk.DANGEROUS, CommandRisk.FORBIDDEN}
+
+
+# Deliberately distinct, verified by reading its docstring — not a fork.
+# ``InjectionRisk`` grades a piece of *text* for injection patterns; CommandRisk
+# grades a *command* for execution policy. Different subject, and the scales
+# differ at both ends (LOW only there, DANGEROUS/FORBIDDEN only here).
+KNOWN_DISTINCT_RISK_ENUMS = {
+    "autobot-backend/security/prompt_injection_detector.py::InjectionRisk",
+}
+
+
+def test_no_second_command_risk_enum_has_regrown():
+    """A same-concept fork is what this issue was; catch the next copy."""
+    found = set(_enums_matching(lambda members: {"SAFE", "MODERATE", "HIGH"} <= members))
+    assert found, "scan reached no enum at all — the matcher is broken, not the tree"
+    assert found - KNOWN_DISTINCT_RISK_ENUMS == {
+        "autobot_shared/status_enums.py::CommandRisk"
+    }, f"#13845: a second command-risk enum exists: {sorted(found - KNOWN_DISTINCT_RISK_ENUMS)}"
+
+
+def test_every_known_distinct_entry_still_names_a_real_enum():
+    """An allowlist entry stranded by a rename exempts nothing, silently."""
+    declared = {f"{rel}::{name}" for rel, name, _ in _declared_enums()}
+    stale = KNOWN_DISTINCT_RISK_ENUMS - declared
+    assert not stale, f"#13845: allowlist entries name no enum any more: {sorted(stale)}"
+
+
+# --------------------------------------------------------------------------
+# #13846 — SecretType carries every kind plus the wildcard
+# --------------------------------------------------------------------------
+
+SECRET_TYPE_UNION = {
+    ("SSH_KEY", "ssh_key"),
+    ("PASSWORD", "password"),
+    ("API_KEY", "api_key"),
+    ("TOKEN", "token"),
+    ("OAUTH_REFRESH_TOKEN", "oauth_refresh_token"),
+    ("CONNECTOR_OAUTH_TOKEN", "connector_oauth_token"),
+    ("CERTIFICATE", "certificate"),
+    ("DATABASE_URL", "database_url"),
+    ("INFRASTRUCTURE_HOST", "infrastructure_host"),
+    ("OTHER", "other"),
+    ("ANY", "any"),
+}
+
+
+def test_secret_type_is_exactly_the_union_of_all_three_forks():
+    assert _members(SecretType) == SECRET_TYPE_UNION
+
+
+@pytest.mark.parametrize("name", sorted(name for name, _ in SECRET_TYPE_UNION))
+def test_every_secret_kind_is_present_by_name(name):
+    assert hasattr(SecretType, name), f"#13846: SecretType lost {name}"
+
+
+def test_an_agent_requirement_can_name_oauth_without_falling_back_to_any():
+    """The functional gap #13846 was filed for, asserted as behaviour.
+
+    ``SecretRequirement`` had no OAuth member, so an OAuth-authenticating agent
+    could only be described as ANY — the broadest possible grant standing in
+    for the most specific request.
+    """
+    requirement = {SecretType.OAUTH_REFRESH_TOKEN}
+    resolved = SecretType.expand(requirement)
+    assert resolved == {SecretType.OAUTH_REFRESH_TOKEN}
+    assert SecretType.ANY not in resolved
+    assert resolved != SecretType.expand({SecretType.ANY})
+
+
+def test_the_wildcard_is_preserved_and_expands_to_the_whole_taxonomy():
+    assert SecretType.ANY in SecretType
+    expanded = SecretType.expand({SecretType.ANY})
+    assert expanded == set(SecretType.concrete())
+    assert SecretType.ANY not in expanded
+
+
+def test_the_wildcard_is_never_a_storable_kind():
+    assert SecretType.ANY not in SecretType.concrete()
+    assert len(SecretType.concrete()) == len(SecretType) - 1
+
+
+def test_no_second_secret_kind_enum_has_regrown():
+    found = _enums_matching(lambda members: {"SSH_KEY", "API_KEY", "TOKEN"} <= members)
+    assert found, "scan reached no enum at all — the matcher is broken, not the tree"
+    assert sorted(found) == ["autobot_shared/status_enums.py::SecretType"], (
+        f"#13846: a second secret-kind enum exists: {sorted(found)}"
+    )
+
+
+# --------------------------------------------------------------------------
+# #13845 — the boundary table into the DELIBERATE #7258 fork stays total
+# --------------------------------------------------------------------------
+
+
+def test_the_risk_level_boundary_table_covers_every_command_risk():
+    """``map_risk_to_level`` used to default to MEDIUM for an unmapped member.
+
+    Read by AST rather than imported: ``services.agent_terminal.utils`` pulls in
+    the SQLAlchemy models, and this guard must not depend on a database.
+    """
+    source = (BACKEND / "services" / "agent_terminal" / "utils.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    mapped: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            for key in node.keys:
+                if (
+                    isinstance(key, ast.Attribute)
+                    and isinstance(key.value, ast.Name)
+                    and key.value.id == "CommandRisk"
+                ):
+                    mapped.add(key.attr)
+    assert mapped, "target table not found — the guard would pass on an empty scan"
+    assert mapped == {member.name for member in CommandRisk}, (
+        f"#13845: _COMMAND_RISK_TO_RISK_LEVEL is missing {sorted({m.name for m in CommandRisk} - mapped)}"
+    )
+
+
+# --------------------------------------------------------------------------
+# #13578 — the backup service vocabulary
+# --------------------------------------------------------------------------
+
+BACKUP_SERVICE_TYPE_UNION = {("REDIS", "redis"), ("POSTGRES", "postgres")}
+
+
+def _enum_members_from_source(path: Path, class_name: str) -> set[tuple[str, str]] | None:
+    """Member (name, value) pairs read by AST — no import, no DB, no app config."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                (target.id, stmt.value.value)
+                for stmt in node.body
+                if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant)
+                for target in stmt.targets
+                if isinstance(target, ast.Name) and not target.id.startswith("_")
+            }
+    return None
+
+
+def test_backup_service_type_exists_and_names_both_engines():
+    members = _enum_members_from_source(SLM / "models" / "database.py", "BackupServiceType")
+    assert members is not None, "#13578: BackupServiceType is gone from models/database.py"
+    assert members == BACKUP_SERVICE_TYPE_UNION
+
+
+def test_the_postgres_alias_is_declared_next_to_the_enum():
+    """"postgresql" was a live dispatch key, so it is already in stored rows."""
+    source = (SLM / "models" / "database.py").read_text(encoding="utf-8")
+    assert "_BACKUP_SERVICE_TYPE_ALIASES" in source
+    assert '"postgresql"' in source
+
+
+def test_the_backup_dispatch_no_longer_carries_two_spellings():
+    source = (SLM / "api" / "stateful.py").read_text(encoding="utf-8")
+    assert "BackupServiceType.POSTGRES: backup_service.execute_postgres_backup" in source
+    assert '"postgresql": backup_service' not in source
+
+
+# --------------------------------------------------------------------------
+# #13597 — the severity literals may not grow back
+# --------------------------------------------------------------------------
+
+# Bare `"severity": "<literal>"` dict entries. Not converted in this change —
+# see the issue trail — but ratcheted so the population cannot grow while the
+# conversion is outstanding.
+_SEVERITY_LITERAL = re.compile(r"""["']severity["']\s*:\s*["'][A-Za-z_]+["']""")
+
+# Measured on this tree at the time of writing. #13597 filed it as 119; it had
+# grown to this before anything stopped it. Lower it as literals are converted;
+# never raise it.
+SEVERITY_LITERAL_CEILING = 169
+
+# Floor for the enumeration itself. An empty walk must not read as "clean".
+_TRACKED_PY_FLOOR = 3000
+
+# Floor for the enum scan (measured at 300+ on this tree). A parse pass that
+# silently stopped matching would otherwise report every fork as collapsed.
+_DECLARED_ENUM_FLOOR = 150
+
+
+@functools.lru_cache(maxsize=1)
+def _tracked_python_files() -> tuple[str, ...]:
+    out = subprocess.run(  # nosec B603  # fixed argv, no shell
+        ["git", "ls-files", "*.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return tuple(line for line in out.stdout.splitlines() if line)
+
+
+def _severity_literal_hits() -> list[str]:
+    hits = []
+    for rel in _tracked_python_files():
+        if not (rel.startswith("autobot-backend/") or rel.startswith("autobot_shared/")):
+            continue
+        try:
+            text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in _SEVERITY_LITERAL.finditer(text):
+            hits.append(f"{rel}:{match.group(0)}")
+    return hits
+
+
+def test_the_enumeration_reaches_the_repo():
+    """Guards every scan below: an empty file list agrees with anything."""
+    assert len(_tracked_python_files()) >= _TRACKED_PY_FLOOR
+
+
+def test_the_severity_literal_matcher_still_matches():
+    """A regex that stopped matching would report a clean tree (#13597)."""
+    assert _SEVERITY_LITERAL.search('{"severity": "high"}')
+    assert _SEVERITY_LITERAL.search("{'severity': 'critical'}")
+    assert not _SEVERITY_LITERAL.search('{"severity": severity_value}')
+
+
+def test_bare_severity_literals_do_not_grow():
+    hits = _severity_literal_hits()
+    assert hits, "matcher reached nothing — broken matcher, not a clean tree"
+    assert len(hits) <= SEVERITY_LITERAL_CEILING, (
+        f"#13597: bare severity literals grew to {len(hits)} (ceiling "
+        f"{SEVERITY_LITERAL_CEILING}). Use autobot_shared.status_enums.Severity."
+    )
+
+
+@pytest.mark.parametrize(
+    ("rel", "alias"),
+    [
+        ("autobot-backend/utils/monitoring_alerts.py", "AlertSeverity"),
+        ("autobot-backend/utils/error_boundaries/types.py", "ErrorSeverity"),
+    ],
+)
+def test_the_severity_aliases_still_point_at_the_canonical_enum(rel, alias):
+    """#13597's first half, already landed — assert it stayed landed.
+
+    Read by AST: importing these pulls the whole backend app in. The assertion
+    is on the binding, so re-declaring a local ``class AlertSeverity(Enum)``
+    fails here even though the name would still exist.
+    """
+    path = REPO_ROOT / rel
+    assert path.exists(), f"#13597: {rel} is gone — the guard has no target"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bindings = [
+        node.value.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        and isinstance(node.value, ast.Name)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id == alias
+    ]
+    redeclared = [
+        node.name for node in tree.body if isinstance(node, ast.ClassDef) and node.name == alias
+    ]
+    assert not redeclared, f"#13597: {alias} was re-declared as its own enum in {rel}"
+    assert bindings == ["Severity"], (
+        f"#13597: {alias} in {rel} is bound to {bindings or 'nothing'}, not Severity"
+    )
+
+
+def test_the_canonical_severity_still_carries_every_aliased_member():
+    """The aliases are only safe while Severity is a superset of both forks."""
+    for name in ("LOW", "MEDIUM", "HIGH", "CRITICAL"):
+        assert hasattr(Severity, name), f"#13597: Severity lost {name}"
+
+
+# --------------------------------------------------------------------------
+# Shared scan helper
+# --------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=1)
+def _declared_enums() -> tuple[tuple[str, str, frozenset[str]], ...]:
+    """Every ``class X(...Enum)`` under the Python roots, with its member names.
+
+    Parsed once for the whole module — the two fork scans below would otherwise
+    re-read several thousand files each.
+    """
+    declared: list[tuple[str, str, frozenset[str]]] = []
+    for rel in _tracked_python_files():
+        if not (rel.startswith("autobot-backend/") or rel.startswith("autobot_shared/")):
+            continue
+        try:
+            tree = ast.parse((REPO_ROOT / rel).read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            bases = {
+                base.id if isinstance(base, ast.Name) else getattr(base, "attr", "")
+                for base in node.bases
+            }
+            if "Enum" not in bases:
+                continue
+            names = frozenset(
+                target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant)
+                for target in stmt.targets
+                if isinstance(target, ast.Name)
+            )
+            if names:
+                declared.append((rel, node.name, names))
+    return tuple(declared)
+
+
+def _enums_matching(predicate) -> list[str]:
+    """Enums whose MEMBER SET matches — never their class name.
+
+    A same-name sweep is exactly what missed these forks: each pair used
+    different names for one concept.
+    """
+    return [
+        f"{rel}::{name}" for rel, name, members in _declared_enums() if predicate(members)
+    ]
+
+
+def test_the_enum_scan_reaches_the_repo():
+    """A scan that parsed nothing would agree with every assertion above."""
+    declared = _declared_enums()
+    assert len(declared) >= _DECLARED_ENUM_FLOOR, (
+        f"enum scan found only {len(declared)} enums — the matcher is broken, "
+        f"not the tree"
+    )

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -368,9 +368,59 @@ def test_the_canonical_severity_still_carries_every_aliased_member():
 # --------------------------------------------------------------------------
 
 
+_ENUM_BASES = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag"}
+
+
+def _local_enum_names(tree: ast.Module) -> set[str]:
+    """Local names in this module that are bound to an ``enum`` base class.
+
+    Resolving the *import* rather than matching the literal word "Enum" is what
+    makes the scan survive ``from enum import Enum as _E``. Matching the word
+    alone reported a re-declared ``CommandRiskLevel`` as absent — a fail-open
+    found by mutating this guard, not by reading it.
+    """
+    local = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "enum":
+            for alias in node.names:
+                if alias.name in _ENUM_BASES:
+                    local.add(alias.asname or alias.name)
+    return local
+
+
+def _base_names(node: ast.ClassDef) -> set[str]:
+    """Base names as written: bare ``Enum`` and dotted ``enum.Enum`` alike."""
+    names = set()
+    for base in node.bases:
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
+def _enums_in_tree(tree: ast.Module) -> list[tuple[str, frozenset[str]]]:
+    """(class name, member names) for every enum declared in one module."""
+    local = _local_enum_names(tree) | _ENUM_BASES
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or not (_base_names(node) & local):
+            continue
+        names = frozenset(
+            target.id
+            for stmt in node.body
+            if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant)
+            for target in stmt.targets
+            if isinstance(target, ast.Name)
+        )
+        if names:
+            found.append((node.name, names))
+    return found
+
+
 @functools.lru_cache(maxsize=1)
 def _declared_enums() -> tuple[tuple[str, str, frozenset[str]], ...]:
-    """Every ``class X(...Enum)`` under the Python roots, with its member names.
+    """Every enum under the Python roots, with its member names.
 
     Parsed once for the whole module — the two fork scans below would otherwise
     re-read several thousand files each.
@@ -383,25 +433,30 @@ def _declared_enums() -> tuple[tuple[str, str, frozenset[str]], ...]:
             tree = ast.parse((REPO_ROOT / rel).read_text(encoding="utf-8"))
         except (OSError, SyntaxError):
             continue
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.ClassDef):
-                continue
-            bases = {
-                base.id if isinstance(base, ast.Name) else getattr(base, "attr", "")
-                for base in node.bases
-            }
-            if "Enum" not in bases:
-                continue
-            names = frozenset(
-                target.id
-                for stmt in node.body
-                if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Constant)
-                for target in stmt.targets
-                if isinstance(target, ast.Name)
-            )
-            if names:
-                declared.append((rel, node.name, names))
+        declared.extend((rel, name, members) for name, members in _enums_in_tree(tree))
     return tuple(declared)
+
+
+def test_the_scan_sees_an_enum_whose_base_was_imported_under_an_alias():
+    """The fail-open this guard shipped with, pinned against synthetic source.
+
+    Mutation M9 re-declared ``CommandRiskLevel`` with ``from enum import Enum
+    as _E`` and the fork scan stayed green: it matched the literal word "Enum"
+    in the base list, which an alias removes. Run against a string here, so the
+    check does not depend on the tree containing an example.
+    """
+    aliased = ast.parse(
+        "from enum import Enum as _E\n\n\nclass Regrown(_E):\n    SAFE = 'safe'\n"
+    )
+    assert _enums_in_tree(aliased) == [("Regrown", frozenset({"SAFE"}))]
+
+    dotted = ast.parse("import enum\n\n\nclass Dotted(enum.Enum):\n    SAFE = 'safe'\n")
+    assert _enums_in_tree(dotted) == [("Dotted", frozenset({"SAFE"}))]
+
+    plain = ast.parse("from enum import Enum\n\n\nclass Plain(Enum):\n    SAFE = 'safe'\n")
+    assert _enums_in_tree(plain) == [("Plain", frozenset({"SAFE"}))]
+
+    assert _enums_in_tree(ast.parse("class NotAnEnum:\n    SAFE = 'safe'\n")) == []
 
 
 def _enums_matching(predicate) -> list[str]:

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -378,6 +378,16 @@ def _local_enum_names(tree: ast.Module) -> set[str]:
     makes the scan survive ``from enum import Enum as _E``. Matching the word
     alone reported a re-declared ``CommandRiskLevel`` as absent — a fail-open
     found by mutating this guard, not by reading it.
+
+    Boundary of what this resolves, stated so the next reader does not assume
+    more: it follows a DIRECT ``from enum import ...`` in the module being
+    scanned. A two-hop re-export — module A doing ``from enum import Enum as
+    _E; Base = _E``, module B doing ``from A import Base`` — is not resolved
+    and would be invisible. That is evasion-only rather than a shape anyone
+    writes by accident, and closing it means resolving imports across modules;
+    ``test_a_two_hop_re_export_is_a_known_blind_spot`` pins the limit so it is
+    a documented boundary rather than a silent one. A star-import and
+    subclassing an already-populated Enum are both covered.
     """
     local = set()
     for node in ast.walk(tree):
@@ -457,6 +467,23 @@ def test_the_scan_sees_an_enum_whose_base_was_imported_under_an_alias():
     assert _enums_in_tree(plain) == [("Plain", frozenset({"SAFE"}))]
 
     assert _enums_in_tree(ast.parse("class NotAnEnum:\n    SAFE = 'safe'\n")) == []
+
+
+def test_a_two_hop_re_export_is_a_known_blind_spot():
+    """Pin the scan's limit so it is documented rather than discovered.
+
+    ``_local_enum_names`` resolves a direct ``from enum import ...``. It does
+    not chase a base re-exported through another module. This test asserts the
+    CURRENT behaviour: if someone teaches the scan to follow re-exports, this
+    test goes red and should be updated to assert the enum IS found — which is
+    the point. A limit nobody wrote down is the one that gets mistaken for
+    coverage.
+    """
+    two_hop = ast.parse("from shims import Base\n\n\nclass Hidden(Base):\n    SAFE = 'safe'\n")
+    assert _enums_in_tree(two_hop) == [], (
+        "the scan now follows two-hop re-exports — good; update this test to "
+        "assert the enum is found rather than deleting it"
+    )
 
 
 def _enums_matching(predicate) -> list[str]:


### PR DESCRIPTION
Closes #13845, #13846, #13597, #13578

## Thinking Path

Four issues, one shape: an enum forked into two or more definitions, and in **every** case
the divergent tail was the functionality. So the method was member **sets**, not names — a
same-name sweep is precisely what missed these, since each pair used different names for
one concept.

**1. Member sets first.** Enumerated every side of every fork as a set before touching
anything. That immediately turned up two forks the issues did not name:

* a **third** `SecretType` in `api/schemas_system.py` — the request/response vocabulary,
  also missing `OAUTH_REFRESH_TOKEN`. So `POST /secrets` could not even accept the one kind
  the database row could already store. #13846 described the gap at the agent layer; it was
  live at the API layer too.
* `"connector_oauth_token"` — a bare string persisted by `knowledge/connectors/credential_store.py`,
  commented *"SecretType label"* while being absent from every `SecretType` that existed.
  The real OAuth producer was already bypassing the taxonomy.

**2. Deliberate forks checked before collapsing.** Read the docstrings first. Three found,
none collapsed:

| enum | why it stays | evidence |
| --- | --- | --- |
| `models/command_execution.py::RiskLevel` | uppercase wire format already serialized by legacy Redis/SQLite records, 8+ producers | its own docstring, #7258 — named as out of scope by #13845 |
| `security/prompt_injection_detector.py::InjectionRisk` | grades *text* for injection patterns, not a *command* for execution policy; scales differ at both ends (`LOW` only there, `DANGEROUS`/`FORBIDDEN` only here) | found by the new fork scan; docstring added recording the distinction, and it is allowlisted in the guard with a test that the allowlist entry still names a real enum |
| `autobot-infrastructure/shared/scripts/secrets_manager.py::SecretType` | runs standalone on infrastructure hosts and never imports application packages — the same reason `ChatSecretScope` is duplicated there (#11759) | canonical-pointer comment added; `WEBHOOK_URL` / `CUSTOM` are infra-only |

**3. Wire and persistence surface checked per fork.** `"dangerous"` is emitted by
`POST /terminal/command` and by the terminal WebSocket; `"postgresql"` was a live dispatch
key and so is already in stored rows; `secrets.type` stores `SecretType` values; the SLM
`service_type` column is a plain string at rest. Every one of those spellings still parses
and, where it was emitted, is still emitted.

**4. Then union.** One canonical name per concept, plain concept names, no compat aliases
left behind — every call site migrated.

## What Changed

### #13845 — `CommandRisk` ∪ `CommandRiskLevel`

Canonical `CommandRisk` now lives in `autobot_shared/status_enums.py`, the documented enum
home. Both fork sites were deleted and all 14 importers migrated.

| member | `CommandRisk` (executor) | `CommandRiskLevel` (wire schema) | canonical member | value |
| --- | :-: | :-: | --- | --- |
| `SAFE` | yes | yes | `CommandRisk.SAFE` | `safe` |
| `MODERATE` | yes | yes | `CommandRisk.MODERATE` | `moderate` |
| `HIGH` | yes | yes | `CommandRisk.HIGH` | `high` |
| `CRITICAL` | yes | — | `CommandRisk.CRITICAL` | `critical` |
| **`FORBIDDEN`** | **yes** | **—** | **`CommandRisk.FORBIDDEN`** | `forbidden` |
| **`DANGEROUS`** | **—** | **yes** | **`CommandRisk.DANGEROUS`** | `dangerous` |

Nothing dropped. `FORBIDDEN` and `DANGEROUS` are kept as **separate members with separate
values** rather than one folded into the other, because `"dangerous"` is already on the wire
and they are genuinely different *reasons*: DANGEROUS = matched a destructive pattern,
FORBIDDEN = base command is deny-listed. They reach the same verdict, so the enum grew a
`.blocks` property and every blocking decision now asks it. Comparing against one member
alone would have let the *other* producer's blocking verdict through — a fail-open the union
created and `.blocks` closes.

Two hand-written rank tables (`_RISK_ORDER` in the executor, `_RISK_LEVELS` in the approval
manager) listed five members each and would both have rated `DANGEROUS` as off-scale. Both
are gone; ordering is now `CommandRisk.rank`, derived from declaration order.

`services/agent_terminal/utils.py::map_risk_to_level` defaulted an unmapped member to
`RiskLevel.MEDIUM` — a blocking verdict silently downgraded to mid-scale. It now has an
explicit entry per member, a fail-closed `CRITICAL` default, and a guard asserting totality.

### #13846 — `SecretType` ∪ `SecretRequirement` ∪ the schema fork

| member | `models.secret` | `schemas_system` | `SecretRequirement` | canonical member |
| --- | :-: | :-: | :-: | --- |
| `SSH_KEY` | yes | yes | yes | `SecretType.SSH_KEY` |
| `PASSWORD` | yes | yes | yes | `SecretType.PASSWORD` |
| `API_KEY` | yes | yes | yes | `SecretType.API_KEY` |
| `TOKEN` | yes | yes | yes | `SecretType.TOKEN` |
| `CERTIFICATE` | yes | yes | yes | `SecretType.CERTIFICATE` |
| `DATABASE_URL` | yes | yes | yes | `SecretType.DATABASE_URL` |
| **`OAUTH_REFRESH_TOKEN`** | **yes** | **—** | **—** | **`SecretType.OAUTH_REFRESH_TOKEN`** |
| `INFRASTRUCTURE_HOST` | yes | yes | — | `SecretType.INFRASTRUCTURE_HOST` |
| `OTHER` | yes | yes | — | `SecretType.OTHER` |
| **`ANY`** | — | — | **yes** | **`SecretType.ANY`** |
| **`connector_oauth_token`** | *(bare string, no enum)* | — | — | **`SecretType.CONNECTOR_OAUTH_TOKEN`** |

Nothing dropped, and one kind recovered from a bare string. The `# nosec B105` /
`# nosemgrep` suppressions survive on the canonical definition.

`ANY` is preserved as a real member but is **not a storable kind**: `SecretType.concrete()`
excludes it (derived by exclusion, so a kind added later is included without a second edit),
`GET /secrets/types` serves `concrete()`, and `SecretCreateRequest` rejects it with a named
validator. `SecretType.expand()` resolves `ANY` to the whole taxonomy — without which a
requirement of `{ANY}` would be looked up as the literal type `"any"`, which no stored secret
carries, so the broadest possible requirement fetched nothing at all.

`AgentSecretMapping.required_types` / `optional_types` were `Set[str]` of bare strings while
`SecretRequirement` sat unused beside them. They are now `Set[SecretType]`, so an agent
mapping can name `OAUTH_REFRESH_TOKEN` directly instead of falling back to the blanket grant.

### #13597 — severity

The enum half (`AlertSeverity` / `ErrorSeverity` → canonical `Severity`) had already landed
on base; this PR asserts it **stayed** landed, by AST, so re-declaring either as its own enum
fails even though the name would still exist.

The second half is the literal sweep, and the honest number is **169**, not 119 — measured
on this tree with the matcher the ratchet uses, across 43 files. It grew by 50 between filing
and being worked. **43 of the 169 are already outside the canonical vocabulary**
(`warning` ×25, `HIGH` ×9, `CRITICAL` ×3, `MEDIUM` ×3, `error`, `degraded`, `Extreme`).

Converting 169 call sites alongside three enum collapses is not a safely reviewable change,
so this PR ships the **ratchet** — pinned at exactly 169, to be lowered as literals convert,
never raised — and files the remainder with the full distribution as **#14956**. A guard that
stops regrowth is worth more than a partial sweep: the count moved 119 → 169 precisely
because nothing stopped it. `Closes #13597` is claimed because the enum consolidation the
issue is titled for is complete and the literal half is now tracked, bounded and guarded.

### #13578 — `service_type`

`BackupServiceType(str, enum.Enum)` added to `models/database.py` beside the eight siblings.
`BackupCreate`, `ReplicationCreate` and `DataVerifyRequest` are typed with it, so an unknown
engine is a 422 *before* a `Backup` row is written — no more `FAILED` row for a typo that is
indistinguishable from a real failure. Dispatch is keyed on members.

| spelling | before | canonical member |
| --- | --- | --- |
| `redis` | dispatch key | `BackupServiceType.REDIS` |
| `postgres` | dispatch key | `BackupServiceType.POSTGRES` |
| `postgresql` | **second** dispatch key for the same engine | `BackupServiceType.POSTGRES` via `_missing_` |

`postgresql` still parses — it was a live key and is therefore already in stored rows — but
it collapses to one member at the boundary, so nothing downstream branches twice. The column
stays a string at rest, so existing rows are untouched. Response schemas keep `service_type:
str`, so the response wire shape is unchanged.

Every persistence and comparison site uses `.value` explicitly (#14944): `str()` of a
`(str, Enum)` member is `"BackupServiceType.REDIS"`, and these values reach SQL parameters.

## Verification

Guard: `repo_tests/enum_union_guard_test.py`, **40 tests, all passing**. Run against a
scratch copy of the tree outside the repo; no mutation was ever committed or pushed.

Mutation pairs — each removal **and** each rename must go red, because green after a rename
is what going blind looks like:

| # | mutation | result |
| --- | --- | --- |
| M1 | drop `CommandRisk.FORBIDDEN` | RED (import fails closed) |
| M2 | rename `DANGEROUS` → `DESTRUCTIVE`, value kept | RED (import fails closed) |
| M3 | drop `CommandRisk.CRITICAL` | RED — 3 tests, incl. `...is_present_by_name[CRITICAL]` |
| M4 | rename `SAFE` → `NONE`, value kept | RED — 4 tests, incl. `...is_present_by_name[SAFE]` |
| M5 | drop `SecretType.OAUTH_REFRESH_TOKEN` | RED — 3 tests, incl. the OAuth-expressibility test |
| M6 | rename `SecretType.ANY` → `WILDCARD` | RED — 5 tests |
| M7 | add one bare `{"severity": "high"}` | RED — ratchet ceiling |
| M8 | drop `BackupServiceType.POSTGRES` | RED |
| M9 | re-declare `CommandRiskLevel` with `from enum import Enum as _E` | **GREEN — fail-open, see below** |
| M10 | re-declare `SecretRequirement` with a plain `Enum` base | RED |

**M9 caught a fail-open in my own guard.** The fork scan matched the literal word `Enum` in
the base list, so a base imported under an alias made a re-declared `CommandRiskLevel`
invisible and the scan reported the fork collapsed. Fixed by resolving the `enum` import to
its local names, and pinned by
`test_the_scan_sees_an_enum_whose_base_was_imported_under_an_alias`, which drives synthetic
source rather than depending on the tree containing an example. After the fix, M9 is RED and
the clean tree is 40/40.

Anti-false-pass measures, since an empty result reads as a clean one:

* `test_the_enumeration_reaches_the_repo` floors the tracked-Python walk at 3000.
* `test_the_enum_scan_reaches_the_repo` floors the enum scan at 150.
* `test_the_severity_literal_matcher_still_matches` proves the regex still matches, and still
  does not match a non-literal.
* `test_every_known_distinct_entry_still_names_a_real_enum` fails if an allowlist entry is
  stranded by a rename — an entry naming nothing exempts nothing, silently.
* Every mutation asserted its own target existed before mutating.

Enum semantics verified in a scratch copy outside the repo: rank/blocks/strictest, both wire
spellings parsing, `concrete()`/`expand()`, `_missing_` resolving `postgresql`/`POSTGRES`/
`" Redis "` and rejecting `mysql`/`""`/`"any"`, and pydantic honouring `_missing_` while
still rejecting an unknown engine. The `str()` trap was confirmed live:
`str(SecretType.API_KEY)` is `'SecretType.API_KEY'`, not `'api_key'` — hence `.value` at
every boundary.

`api_endpoint_migrations_test.py` asserted on **source text** (`self.assertIn("risk_level =
CommandRiskLevel.SAFE", source)`), so it could not tell "the classification still works" from
"the identifier was renamed" and went red on a no-behaviour-change union. Rewritten to drive
the endpoint and assert on what it returns.

Not verified locally, left to CI: the full Python suite, and any runtime import of backend
modules — this repo's rule is that CI verifies correctness and the host verifies runtime.

## Model Used

Claude Opus 5 (1M context)

---

### Discovered and filed, not fixed here

* **#14956** — the 169 severity literals, with the full value distribution and the 43 already
  out of vocabulary.
* **#14955** — `useCommandApproval.ts::getRiskClass` keys `MODERATE` and `DANGEROUS`, which
  no producer emits; the actual producer emits `MEDIUM` and `CRITICAL`, so a **CRITICAL**
  command renders in the same neutral grey as an unclassified one. Pre-dates this change and
  survives it unchanged; fixing it needs the producer set confirmed and a duplicate map in
  `ApprovalRequestCard.vue` reconciled, which is a different blast radius.
* `AgentSecretsIntegration.get_secrets_for_agent` has **no caller** outside its own module —
  the agent secret-injection path is built but unwired. Noted here rather than filed blind;
  it is the seam #13711 is due to wire.


---

### Generated types, and one consequence worth a reviewer's eye

The OpenAPI schema changes here, so both `api.ts` files drift. They were **not** hand-edited:
the repo's own `autofix-types` job regenerated and committed them
(`e19554fa chore(types): regenerate generated API types from OpenAPI schema(s)`), which is the
builtin path rather than a side-channel. `CommandRiskLevel` was never in `api.ts` — it was
never a pydantic field type — so nothing drifts there.

That regeneration surfaced a real consequence of preserving `ANY` as an enum member:
`SecretType` types both `SecretCreateRequest.type` and `SecretModel.type`, so the public type
now advertises `"any"` on a request and a response that always reject it. It is not a
functional bug — the `_reject_the_wildcard` validator returns 422, `GET /secrets/types` serves
`concrete()`, and nothing can therefore be stored or returned with that value — but the
**declared** type is wider than the **accepted** type.

Filed as **#14974** with three options and a recommendation, rather than resolved unilaterally:
narrowing it correctly requires verifying a real schema dump rather than predicting one, and
the alternative (moving the wildcard out of the enum) contradicts #13846's explicit acceptance
criterion that `ANY` be preserved. Flagging it here so the reviewer sees it in the diff rather
than discovering it in `api.ts`.


---

### Review fix — a confirmed regression, and the sweep that followed it

Review found one blocking regression, and it was mine. `autobot-slm-backend/models/schemas.py`
now imports `BackupServiceType` from `models.database`, but
`autobot-slm-backend/tests/api/test_apply_secrets.py` replaces `models.database` with a bare
`MagicMock()` and hand-installs one real stand-in (`NodeStatus`) precisely because pydantic
needs a genuine enum type to build a schema. There was no equivalent for `BackupServiceType`,
so it resolved to a `MagicMock` attribute and pydantic raised
`PydanticSchemaGenerationError` — a **collection** error, so all 9 tests in the file stopped
running rather than one failing.

Fixed by adding a real `_BackupServiceType` stand-in beside `_NodeStatus`, with a comment
saying why it must be a real enum.

I did not stop at the file the log named. Grep could not answer "is anything else stubbed the
same way", so I settled it by collecting instead:

| tree | result |
| --- | --- |
| this branch, `autobot-slm-backend/tests/` | **1697 collected, 0 collection errors** |
| `origin/Dev_new_gui`, same invocation | **1697 collected** |

Identical counts, so parity is restored and nothing else has the same shape. The 9 tests in
`test_apply_secrets.py` were then run directly: **9 passed**.

The local run also reports a `multipart` sys.modules leak from
`autobot-slm-backend/tests/api/conftest.py`. That is **not** mine: the base tree produces a
byte-identical leak report, including the same 7 known leakers. It is an artifact of running
the whole SLM tests directory in one invocation locally, which `pytest.ini` documents. I
checked rather than assumed, after a truncated `grep | head` first made the base look clean —
the same empty-result-reads-as-clean trap this PR's guard is built against, this time in my
own tooling.

Two smaller review items, in the same commit (`579eeca9`, whose message names only the
blocking fix):

* `repo_tests/enum_union_guard_test.py` — the fork scan resolves a **direct**
  `from enum import ...`, so a two-hop re-export is invisible. Narrower than M9 and
  evasion-only, but real. Now stated in `_local_enum_names`'s docstring and pinned by
  `test_a_two_hop_re_export_is_a_known_blind_spot`, which asserts the current limit and tells
  the next person to update it rather than delete it if the scan learns to follow re-exports.
  A limit nobody wrote down is the one mistaken for coverage.
* `autobot-slm-backend/services/replication.py` — dropped a redundant
  `BackupServiceType(service_type).value` re-wrap on an already-typed member.

Guard after these edits: **41 passed** (40 + the new boundary test).


---

### CI went red on `python-suite shard 10/12` — root-caused and fixed

Two failures, both mine, both in `autobot-backend/api/secrets_test.py`:

```
FAILED TestChatSecretScopeEnum::test_secret_type_values_pinned
FAILED test_get_secret_types_response_pinned
```

These are pin tests over the secret-kind vocabulary, and they went red for exactly the right
reason: the vocabulary changed. `test_secret_type_values_pinned` imported `SecretType` from
`api.schemas_system` — the 8-member fork — and now sees the 11-member union;
`test_get_secret_types_response_pinned` pins the `/secrets/types` payload, which now serves
`concrete()` (10) instead of 8.

Updated rather than deleted, and made sharper in the process. The enum and the endpoint are
now **deliberately different populations**, so the test says so instead of asserting they are
equal — asserting equality would have hidden the one thing most worth pinning:

* `EXPECTED_TYPES` — the 10 concrete kinds the endpoint serves, gaining `oauth_refresh_token`
  and `connector_oauth_token`.
* `test_secret_type_values_pinned` — pins all 11 enum values *and* that `concrete()` is the
  10, *and* that `any` is in neither served nor concrete.
* `test_the_oauth_kinds_are_expressible` — new, asserting #13846's actual functional gap is
  closed rather than inferring it from a list length.

Verified against the reproduction: `secrets_test.py` **10 passed**. Shard 10 reported
`2 failed, 2467 passed`; the other 9 finished shards were green, so these two were the whole
of the red.

### A third hand-written risk-rank table, found by sweeping rather than by CI

Grepping the risk vocabulary while fixing the above turned up
`services/approval_memory.py::RISK_LEVELS` — a **third** literal rank table (after the two in
`secure_command_executor.py` and `command_approval_manager.py`), listing the same five members
and therefore blind to `DANGEROUS`. Now derived: `{risk.value: risk.rank for risk in CommandRisk}`.
Only relative order matters there (both sides of the comparison read the same table) and the
order is unchanged; the integers are never persisted. Also replaced a hardcoded
`"risk": "forbidden"` in `secure_command_executor.py` with `CommandRisk.FORBIDDEN.value`.

### Branch was BEHIND, and the comparison that revealed it was wrong first

While checking whether the change dropped any tests, a backend collection showed base at
23783 and this branch at 23714 — 69 fewer. The removals were all in RBAC and auth-parity
files this PR never touches, which is what made it worth chasing rather than rounding off.

Cause: base had moved two commits since this branch was cut, one of them
**#14936 "establish the canonical role vocabulary"** — which reparametrizes exactly those
role/permission tests. I had been diffing my branch against a *newer* base than it was built
on, so the delta was someone else's work, not a regression here.

Branch updated by merging `origin/Dev_new_gui` in (clean, no conflicts; merged rather than
rebased because CI has pushed commits to this branch and a force-push would discard them).
Two files were touched by both sides — `autobot-backend/security_layer.py` and
`autobot-frontend/src/types/generated/api.ts` — and both retain both sides' changes. Branch is
now 0 commits behind base.
