### PR TITLE
fix(auth): resolve a Role member to its value in every role lookup (#14944)

### DIFF
--- a/autobot-backend/api/auth.py
+++ b/autobot-backend/api/auth.py
@@ -36,7 +36,7 @@ from api.schemas_common import DataResponse
 from api.schemas_system import AuthLogoutData, AuthRefreshData
 from auth_middleware import check_admin_permission, get_auth_middleware, get_current_user
 from autobot_shared.auth.jwt_core import JWTDecodeError, _peek_alg, decode_jwt_no_verify_exp
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, is_admin_role, role_value
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.security.password_weakness import check_password_weakness
@@ -770,7 +770,7 @@ async def get_role_permissions(
     Gated by ``get_current_user`` (any authenticated caller).
     """
     try:
-        role_enum = Role(role.lower())
+        role_enum = Role(role_value(role).lower())
     except ValueError:
         raise HTTPException(status_code=404, detail=f"Unknown role: {role!r}")
     perms = ROLE_PERMISSIONS.get(role_enum, [])

--- a/autobot-backend/auth_rbac.py
+++ b/autobot-backend/auth_rbac.py
@@ -44,6 +44,7 @@ from autobot_shared.auth.permissions import (  # noqa: F401 — re-exported for 
     Permission,
     Role,
     is_admin_role,
+    role_value,
 )
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.singleton_factory import lazy_singleton
@@ -78,7 +79,7 @@ def _get_user_permissions(user_role: str) -> List[str]:
 
     # Get RBAC permissions from our mapping
     try:
-        role_enum = Role(user_role.lower())
+        role_enum = Role(role_value(user_role).lower())
         role_perms = ROLE_PERMISSIONS.get(role_enum, [])
         permissions.extend([p.value if isinstance(p, Permission) else p for p in role_perms])
     except ValueError:
@@ -267,8 +268,13 @@ def require_role(*roles: Role | str) -> Callable:
         if not user_data:
             raise_auth_error("AUTH_0002", "Authentication required")
 
-        user_role = user_data.get("role", "").lower()
-        allowed_roles = [r.value if isinstance(r, Role) else r.lower() for r in roles]
+        # role_value(), not a hand-rolled isinstance ladder: it is the same
+        # decision, in one place, and it rejects a member of a *different* role
+        # vocabulary instead of lowercasing it into this one (#14944, #14024).
+        # A str-mixin enum answers `.lower()` with its value, so the old ladder
+        # would have admitted MembershipRole.ADMIN as a platform admin.
+        user_role = role_value(user_data.get("role")).lower()
+        allowed_roles = [role_value(r).lower() for r in roles]
 
         if user_role not in allowed_roles:
             _deny_role_access(user_data, allowed_roles, user_role, request)

--- a/autobot-backend/conftest.py
+++ b/autobot-backend/conftest.py
@@ -868,6 +868,43 @@ if "auth_middleware" not in sys.modules:
         return _device_jwt_dep
 
     _auth_stub.require_device_jwt = _require_device_jwt_stub  # type: ignore[attr-defined]
+
+    # get_auth_middleware must yield a middleware whose get_user_from_request()
+    # returns a REAL dict -- #13253's rule applied to this module's sibling
+    # accessor, which it missed (#14944).
+    #
+    # Without this, the catch-all below hands out a bare MagicMock, so
+    # ``get_auth_middleware().get_user_from_request(request)`` auto-vivifies a
+    # mock "user", and ``user.get("role")`` auto-vivifies another. Nothing
+    # errored, because everything downstream stringified it: the old
+    # ``is_admin_role`` computed ``str(<MagicMock ...>).lower()``, matched
+    # nothing, and returned False. Twelve tests across three shards asserted
+    # non-admin behaviour and passed for that reason rather than on the auth
+    # logic they name. Typing ``role_value`` strictly (#14944) turned that
+    # silent wrong answer into a TypeError, which is how the gap surfaced.
+    #
+    # Only get_user_from_request is pinned. The middleware carries a dozen other
+    # attributes (create_jwt_token, security_layer, enable_auth, ...) that tests
+    # legitimately auto-mock, so the object stays a MagicMock and only the value
+    # whose *shape* is load-bearing is made real -- a fresh dict per call, so a
+    # test mutating it cannot leak into the next.
+    _auth_middleware_stub_instance = MagicMock()
+    _auth_middleware_stub_instance.get_user_from_request.side_effect = (
+        lambda *_args, **_kwargs: _get_current_user_stub()
+    )
+
+    def _get_auth_middleware_stub():  # noqa: E301
+        return _auth_middleware_stub_instance
+
+    _auth_stub.get_auth_middleware = _get_auth_middleware_stub  # type: ignore[attr-defined]
+
+    # NOTE: this catch-all is why the gap above was silent -- a name nobody
+    # stubbed becomes a MagicMock that answers every call rather than an
+    # AttributeError that names the missing stub. It is deliberately left in
+    # place here: `authenticate_websocket`, `verify_internal_api_key` and
+    # `AuthenticationMiddleware` still reach it, and several tests configure
+    # them as mocks, so removing it belongs in its own change with its own CI
+    # run rather than riding along inside an auth fix (#14982).
     _auth_stub.__getattr__ = lambda attr: MagicMock()  # type: ignore[attr-defined]
     sys.modules["auth_middleware"] = _auth_stub
 

--- a/autobot-backend/security/canonical_permissions_test.py
+++ b/autobot-backend/security/canonical_permissions_test.py
@@ -21,7 +21,7 @@ invisible gap for another.
 import pytest
 
 from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
-from security_layer import SecurityLayer, canonical_role_permissions
+from security_layer import SecurityLayer, _normalise_role, canonical_role_permissions
 
 
 @pytest.fixture
@@ -280,3 +280,67 @@ def test_any_extra_the_gate_grants_comes_from_a_wildcard(gate):
                     unexplained.append((role.value, permission.value))
 
     assert unexplained == [], f"granted by neither the mapping nor a wildcard: {unexplained[:5]}"
+
+
+# ------------------------------- a Role member resolves like its value (#14944)
+
+
+def test_the_role_population_this_section_runs_over_is_the_real_one():
+    """Floor asserted at the real number, so a shrunken enum cannot pass by holding nothing."""
+    assert len(list(Role)) == 7, f"expected 7 Role members, got {len(list(Role))}"
+
+
+@pytest.mark.parametrize("member", list(Role), ids=lambda r: r.value)
+def test_canonical_role_permissions_resolves_a_member_like_its_value(member):
+    """``Role`` is a ``(str, Enum)`` mixin, so ``str(member)`` is ``"Role.ADMIN"``.
+
+    This resolver built ``str(user_role or "").strip().lower()`` and then
+    ``Role(...)`` on the result — ``Role("role.admin")``, a ``ValueError``,
+    caught, and answered ``[]``. So passing the canonical enum member returned
+    *no permissions for admin*, while the string spelling returned all of them.
+
+    Passes the member itself, never ``member.value``: an assertion with
+    ``.value`` on both sides cannot fail here.
+
+    Note this function is ``lru_cache``d, and a member does **not** share a cache
+    entry with its value — ``lru_cache`` fast-paths only exact ``str`` — so the
+    wrong answer was deterministic rather than call-order dependent.
+    """
+    assert canonical_role_permissions(member) == canonical_role_permissions(member.value)
+
+
+def test_admin_resolves_its_whole_grant_list_when_passed_as_a_member():
+    """Presence, not parity alone — parity is also satisfied by two empty lists."""
+    resolved = canonical_role_permissions(Role.ADMIN)
+    assert len(resolved) == len(ROLE_PERMISSIONS[Role.ADMIN])
+    assert Permission.ADMIN_SYSTEM.value in resolved
+
+
+@pytest.mark.parametrize("member", list(Role), ids=lambda r: r.value)
+def test_normalise_role_resolves_a_member_like_its_value(member):
+    """The shared normalisation both gates use (#13820) had the same defect.
+
+    ``_normalise_role(Role.ADMIN)`` returned ``"role.admin"`` — an identity no
+    permission source knows, so it cleared neither gate and, in
+    ``_should_force_approval``, found an empty permission list where no approval
+    branch can fire.
+    """
+    assert _normalise_role(member) == _normalise_role(member.value) == member.value
+
+
+def test_the_live_gate_admits_a_member_exactly_as_it_admits_the_string(gate):
+    """End to end at the real entry point, not only at the helper.
+
+    ``check_permission`` is what actually runs; asserting only on the resolvers
+    would leave the seam between them untested.
+    """
+    for permission in (Permission.MCP_BROWSER_CONTROL.value, "allow_voice_speak"):
+        assert gate.check_permission(Role.ADMIN, permission) is gate.check_permission("admin", permission)
+    assert gate.check_permission(Role.ADMIN, Permission.MCP_BROWSER_CONTROL.value) is True
+
+
+@pytest.mark.parametrize("bad", [42, ["admin"], {"role": "admin"}])
+def test_a_non_role_argument_is_rejected_rather_than_stringified(bad):
+    """Consistent with ``is_admin_role`` — see ``role_value`` (#14944)."""
+    with pytest.raises(TypeError):
+        _normalise_role(bad)

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -127,7 +127,7 @@ def canonical_role_permissions(user_role: str) -> List[str]:
     so.
 
     An unrecognised role yields ``[]`` — no grant, and no exception either.
-   
+
     A ``Role`` member resolves the same as its value (#14944); it previously
     stringified to ``"role.admin"`` and yielded ``[]``. Note this function is
     ``lru_cache``d and a member does NOT share a cache entry with its value

--- a/autobot-backend/security_layer.py
+++ b/autobot-backend/security_layer.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 from typing import Any, Dict, List
 
 from autobot_shared.async_compat import run_or_schedule
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Permission, Role, role_value
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.monitoring.metrics.audit import record_audit_write_failure_safely
 from autobot_shared.paths import project_root
@@ -98,8 +98,11 @@ def _normalise_role(user_role: str) -> str:
     resolver, and leaving one of them out is what created the gap in the first
     place. The audit entry stays with ``_handle_deprecated_role`` so a downgrade is
     still logged exactly once.
+
+    Takes the role string via ``role_value`` so a ``Role`` **member** normalises
+    to its value rather than to ``"role.admin"`` (#14944).
     """
-    normalised = str(user_role or "").strip().lower()
+    normalised = role_value(user_role).strip().lower()
     return Role.ADMIN.value if normalised in DEPRECATED_PRIVILEGED_ROLES else normalised
 
 
@@ -124,8 +127,14 @@ def canonical_role_permissions(user_role: str) -> List[str]:
     so.
 
     An unrecognised role yields ``[]`` — no grant, and no exception either.
+   
+    A ``Role`` member resolves the same as its value (#14944); it previously
+    stringified to ``"role.admin"`` and yielded ``[]``. Note this function is
+    ``lru_cache``d and a member does NOT share a cache entry with its value
+    (``lru_cache`` fast-paths exact ``str`` only), so the two were cached
+    separately and the wrong answer was deterministic, not call-order dependent.
     """
-    normalised = str(user_role or "").strip().lower()
+    normalised = role_value(user_role).strip().lower()
     if not normalised:
         return []
     try:

--- a/autobot-backend/services/mcp_dispatch.py
+++ b/autobot-backend/services/mcp_dispatch.py
@@ -28,7 +28,7 @@ import uuid
 
 import aiohttp
 
-from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role
+from autobot_shared.auth.permissions import ROLE_PERMISSIONS, Role, role_value
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from constants.network_constants import NetworkConstants
@@ -185,10 +185,15 @@ class MCPDispatcher:
         # short-circuit was the last place where being in ``ADMIN_ROLES``
         # granted access that ``ROLE_PERMISSIONS`` never wrote down.
         try:
-            held = _ROLE_PERMISSION_VALUES[Role(str(role or "").lower())]
-        except (ValueError, KeyError):
+            # role_value(), not str(): a ``Role`` member stringifies to
+            # "Role.ADMIN" and would be reported as unknown-role (#14944).
+            held = _ROLE_PERMISSION_VALUES[Role(role_value(role).lower())]
+        except (ValueError, KeyError, TypeError):
             # An unrecognised role string is itself worth surfacing rather than
-            # silently treating as permitted.
+            # silently treating as permitted. TypeError covers a role that is not
+            # a str/Role at all (#14944): this gate denies and reports it rather
+            # than raising out of a dispatch, which is the same fail-closed
+            # answer an unknown role already gets.
             return f"unknown-role:{role}"
         return None if declared in held else f"missing:{declared}"
 

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -193,7 +193,61 @@ _ADMINISTRATIVE_ROLES: frozenset = frozenset({Role.ADMIN, Role.SUPERADMIN})
 ADMIN_ROLES: frozenset = frozenset(role.value for role in _ADMINISTRATIVE_ROLES)
 
 
-def is_admin_role(role) -> bool:
+def role_value(role: "Role | str | None") -> str:
+    """The role string *role* denotes -- the one safe way to stringify a role (#14944).
+
+    Every role lookup in this codebase keys on a string, and every one of them
+    used to reach that string with ``str(role)``. For a ``(str, Enum)`` mixin
+    that is **wrong**::
+
+        str(Role.ADMIN)   == "Role.ADMIN"     # Enum.__str__ wins
+        f"{Role.ADMIN}"   == "admin"          # mixin __format__ uses the value
+        Role.ADMIN        == "admin"          # str.__eq__ -- True
+        Role.ADMIN in ADMIN_ROLES             # True
+
+    So a member behaves like its value under ``==``, under ``in``, and in an
+    f-string, and *only* ``str()`` disagrees -- which is why every role resolver
+    picked the one spelling that fails, and why nothing noticed. Note this is
+    **not** fixed by a newer Python: ``enum.StrEnum`` (3.11+) would return the
+    value, but ``Role`` is the ``(str, Enum)`` mixin shape, which keeps
+    ``Enum.__str__``.
+
+    Deliberately does **not** change case or strip whitespace. Callers differ --
+    ``is_admin_role`` lowercases, ``canonical_role_permissions`` strips *and*
+    lowercases -- and #13820 showed that applying a normalisation to one role
+    source and not another creates a second identity for the same role that
+    holds some grants and not others. This helper fixes the type coercion only;
+    each caller keeps the normalisation it already had.
+
+    A member of a **different** enum is rejected rather than coerced, and that is
+    the point of doing this by ``isinstance`` rather than by ``.lower()``.
+    ``MembershipRole`` and the chat-role constants share literals with this
+    vocabulary (#14024, #13934), and every one of them is also a ``str``
+    subclass -- so the obvious "fix", ``role.lower()``, quietly returns
+    ``"admin"`` for ``MembershipRole.ADMIN`` and would admit a *company*
+    membership role as a *platform* administrator. ``str()`` happened to reject
+    that by accident; this rejects it on purpose, and loudly.
+
+    A non-role type is likewise a programming error, not data: every caller
+    passes a ``str`` or ``None`` off an authenticated session. Returning False
+    for an object nobody meant to pass would answer an authorization question
+    that was never asked.
+    """
+    if role is None:
+        return ""
+    if isinstance(role, Role):
+        return role.value
+    if isinstance(role, Enum):
+        raise TypeError(
+            f"{type(role).__name__}.{role.name} is not a platform role -- "
+            f"autobot_shared.auth.permissions.Role is the platform RBAC vocabulary (#14024)"
+        )
+    if isinstance(role, str):
+        return role
+    raise TypeError(f"role must be a Role, str or None, not {type(role).__name__}")
+
+
+def is_admin_role(role: "Role | str | None") -> bool:
     """Return True when *role* is administrative (admin or superadmin).
 
     Use this instead of ``role == "admin"`` for imperative checks that cannot
@@ -201,8 +255,17 @@ def is_admin_role(role) -> bool:
     self-access, or that pass an ``is_admin`` flag further down.
 
     Case-insensitive, matching require_role(), which lowercases both sides.
+
+    Accepts a ``Role`` member as well as a raw string (#14944). It previously
+    called ``str(role)``, which yields ``"Role.ADMIN"`` for a member and so
+    reported an administrator as non-administrative -- a failure in the unsafe
+    direction, because ``api/user_management/users.py`` and ``llc/api/companies.py``
+    feed the result into an ``is_platform_admin`` flag passed further down.
+    ``require_role`` already guarded this case; this closes the asymmetry.
+
+    Raises ``TypeError`` for anything that is neither -- see :func:`role_value`.
     """
-    return str(role or "").lower() in ADMIN_ROLES
+    return role_value(role).lower() in ADMIN_ROLES
 
 
 # Canonical role-to-permission mappings.
@@ -414,7 +477,7 @@ _ROLE_PERMISSION_VALUES: Dict[Role, frozenset] = {
 }
 
 
-def role_has_permission(role: str | None, permission: str) -> bool:
+def role_has_permission(role: "Role | str | None", permission: str) -> bool:
     """Return True when *role* holds *permission* (a dot-style Permission value).
 
     This is the canonical role/permission check other lookups (e.g.
@@ -440,11 +503,16 @@ def role_has_permission(role: str | None, permission: str) -> bool:
     rather than defaulting to permissive for a role this module cannot resolve.
     A ``Role`` member with no ROLE_PERMISSIONS entry likewise denies instead of
     raising ``KeyError`` at request time, which a bare subscript here did.
+
+    A ``Role`` **member** resolves the same as its value (#14944). This used to
+    build ``Role(str(role).lower())``, which for a member is ``Role("role.admin")``
+    -- a ``ValueError``, caught, and denied. A wrongly-typed argument still
+    raises ``TypeError`` rather than being denied: see :func:`role_value`.
     """
     if not role:
         return False
     try:
-        role_enum = Role(str(role).lower())
+        role_enum = Role(role_value(role).lower())
     except ValueError:
         return False
     return permission in _ROLE_PERMISSION_VALUES.get(role_enum, frozenset())

--- a/autobot_shared/auth/permissions.py
+++ b/autobot_shared/auth/permissions.py
@@ -509,10 +509,16 @@ def role_has_permission(role: "Role | str | None", permission: str) -> bool:
     -- a ``ValueError``, caught, and denied. A wrongly-typed argument still
     raises ``TypeError`` rather than being denied: see :func:`role_value`.
     """
-    if not role:
+    # Resolve the type FIRST, then test the resolved string for emptiness --
+    # the same order as ``_normalise_role`` and ``canonical_role_permissions``.
+    # A leading ``if not role`` would swallow a falsy non-role (0, [], {}, False)
+    # into a quiet False while its siblings raise, which is the inconsistency
+    # #14944 set out to remove rather than reproduce.
+    resolved = role_value(role)
+    if not resolved:
         return False
     try:
-        role_enum = Role(role_value(role).lower())
+        role_enum = Role(resolved.lower())
     except ValueError:
         return False
     return permission in _ROLE_PERMISSION_VALUES.get(role_enum, frozenset())

--- a/autobot_shared/auth/roles_are_canonical_test.py
+++ b/autobot_shared/auth/roles_are_canonical_test.py
@@ -278,3 +278,45 @@ def test_the_absent_role_is_still_answered_quietly(empty):
     assert role_value(empty) == ""
     assert is_admin_role(empty) is False
     assert role_has_permission(empty, Permission.API_READ.value) is False
+
+
+@pytest.mark.parametrize("falsy", [0, False, [], {}, set()])
+def test_a_FALSY_non_role_is_rejected_like_any_other_non_role(falsy):
+    """The case the existing parametrisation missed — it only covered strings and None.
+
+    ``role_has_permission`` tested ``if not role`` *before* coercing, so a falsy
+    non-role returned a quiet ``False`` while ``_normalise_role`` and
+    ``canonical_role_permissions`` raised on the very same input. Truthiness is
+    not the question being asked; the resolved role string's emptiness is, so
+    the type is resolved first and the emptiness test moved after it.
+
+    ``0`` and ``False`` matter most: both are plausible JSON values, and both are
+    the kind of input for which an authorization helper answering ``False``
+    confidently is worse than refusing to answer.
+    """
+    with pytest.raises(TypeError):
+        role_value(falsy)
+    with pytest.raises(TypeError):
+        is_admin_role(falsy)
+    with pytest.raises(TypeError):
+        role_has_permission(falsy, Permission.API_READ.value)
+
+
+def test_every_role_taking_function_agrees_on_how_it_refuses():
+    """The uniformity this PR claims, asserted rather than described.
+
+    All three take a role and must dispose of a non-role the same way. Asserted
+    as a property across the set, so a function added later that quietly returns
+    False instead of raising is caught by the same test.
+    """
+    refusers = (
+        role_value,
+        is_admin_role,
+        lambda r: role_has_permission(r, Permission.API_READ.value),
+    )
+    assert len(refusers) == 3, "the set of role-taking entry points changed"
+    for refuse in refusers:
+        with pytest.raises(TypeError):
+            refuse(0)
+        with pytest.raises(TypeError):
+            refuse(_ForeignRole.ADMIN)

--- a/autobot_shared/auth/roles_are_canonical_test.py
+++ b/autobot_shared/auth/roles_are_canonical_test.py
@@ -23,6 +23,8 @@ failure — an empty vocabulary would otherwise satisfy every "nothing is wrong"
 assertion here.
 """
 
+from enum import Enum
+
 import pytest
 
 from autobot_shared.auth.permissions import (
@@ -33,7 +35,21 @@ from autobot_shared.auth.permissions import (
     Role,
     is_admin_role,
     role_has_permission,
+    role_value,
 )
+
+
+class _ForeignRole(str, Enum):
+    """Stands in for ``MembershipRole`` — a *different* vocabulary, same literal.
+
+    Declared here rather than imported so this file keeps no dependency on the
+    LLC package, and so the test states the shape it is guarding against
+    (``(str, Enum)`` with the value ``"admin"``) rather than pointing at
+    something that could be changed out from under it.
+    """
+
+    ADMIN = "admin"
+
 
 # The vocabulary as of #13854, written out. A rename or a removal fails here
 # first, with a message naming the member — rather than silently shrinking the
@@ -161,3 +177,104 @@ def test_every_role_has_role_metadata():
 def test_an_unresolvable_role_is_denied_rather_than_raising(unknown):
     """Fail closed, and fail quietly — never a 500 from the permission gate."""
     assert role_has_permission(unknown, Permission.API_READ.value) is False
+
+
+# ------------------------------------- a Role MEMBER resolves like its value
+
+
+# The population these guards run over, derived rather than hand-listed, with a
+# floor asserted AT the real number so a shrunken enum cannot make them vacuous.
+_ADMIN_MEMBERS = sorted((r for r in Role if r.value in ADMIN_ROLES), key=lambda r: r.value)
+
+
+def test_the_member_population_these_guards_run_over_is_the_real_one():
+    """A guard over an empty or shrunken set passes by holding nothing."""
+    assert len(_ADMIN_MEMBERS) == 2, f"expected 2 administrative Role members, got {_ADMIN_MEMBERS}"
+    assert len(list(Role)) == 7, f"expected 7 Role members, got {len(list(Role))}"
+    assert {r.value for r in _ADMIN_MEMBERS} == EXPECTED_ADMIN_ROLE_VALUES
+
+
+@pytest.mark.parametrize("member", _ADMIN_MEMBERS, ids=lambda r: r.value)
+def test_is_admin_role_accepts_the_enum_member_itself(member):
+    """#14944: the case no test covered, because every test passed ``.value``.
+
+    ``Role`` is the ``(str, Enum)`` mixin shape, so ``str(Role.ADMIN)`` is
+    ``"Role.ADMIN"`` — while ``f"{Role.ADMIN}"``, ``Role.ADMIN == "admin"`` and
+    ``Role.ADMIN in ADMIN_ROLES`` all say ``"admin"``. The member therefore
+    behaved correctly everywhere except under ``str()``, which is the one
+    construct ``is_admin_role`` used. It returned **False for an administrator**.
+
+    Deliberately passes the member, never ``member.value`` — an assertion with
+    ``.value`` on both sides cannot fail here.
+    """
+    assert is_admin_role(member) is True, f"{member!r} is administrative but is_admin_role said False"
+
+
+@pytest.mark.parametrize("member", list(Role), ids=lambda r: r.value)
+def test_every_role_resolves_identically_as_member_and_as_value(member):
+    """The invariant, not one instance of it (#14944).
+
+    Whatever a role string resolves to, the enum member spelling of that same
+    role must resolve to exactly the same thing — through every function that
+    takes a role. That is the property the ``str()`` bug broke, and asserting it
+    over the whole vocabulary means a newly added role is covered on arrival.
+    """
+    assert role_value(member) == member.value
+    assert is_admin_role(member) is is_admin_role(member.value)
+    for permission in Permission:
+        assert role_has_permission(member, permission.value) is role_has_permission(
+            member.value, permission.value
+        ), f"{member!r} disagrees with {member.value!r} on {permission.value}"
+
+
+def test_admin_holds_its_whole_grant_list_when_passed_as_a_member():
+    """Presence, not parity alone — parity is also satisfied by two Falses."""
+    granted = [p.value for p in Permission if role_has_permission(Role.ADMIN, p.value)]
+    assert len(granted) == len(list(Permission)), f"Role.ADMIN resolved {len(granted)} of {len(list(Permission))}"
+
+
+# --------------------------- a role from a DIFFERENT vocabulary is not coerced
+
+
+def test_a_foreign_role_enum_is_rejected_rather_than_lowercased():
+    """The trap in the obvious fix (#14944, #14024, #13934).
+
+    ``MembershipRole`` (company membership) and the chat-role constants share
+    literals with this vocabulary, and a ``(str, Enum)`` member *is* a ``str`` —
+    so ``role.lower()`` answers with the **value**. Fixing ``is_admin_role`` with
+    a bare ``.lower()`` would therefore have admitted a company-membership admin
+    as a platform administrator: a silent authorization widening introduced by
+    the fix for an authorization narrowing.
+
+    The two assertions matter together. The first proves the hazard is real —
+    without it, the second passes for any implementation that happens to reject
+    everything. ``str()`` rejected this case by accident; this rejects it on
+    purpose.
+    """
+    assert _ForeignRole.ADMIN.lower() in ADMIN_ROLES, "the hazard this guards is not present — test is vacuous"
+
+    with pytest.raises(TypeError):
+        role_value(_ForeignRole.ADMIN)
+    with pytest.raises(TypeError):
+        is_admin_role(_ForeignRole.ADMIN)
+
+
+@pytest.mark.parametrize("bad", [42, 3.5, ["admin"], {"role": "admin"}, object(), Permission.API_READ])
+def test_a_non_role_argument_is_rejected_rather_than_stringified(bad):
+    """An authorization predicate should not answer a question nobody asked.
+
+    Every call site passes a ``str`` or ``None`` off an authenticated session, so
+    any other type is a programming error. Stringifying it produced a confident
+    ``False`` — a claim about the caller, which two call sites forward as an
+    ``is_platform_admin`` flag.
+    """
+    with pytest.raises(TypeError):
+        is_admin_role(bad)
+
+
+@pytest.mark.parametrize("empty", [None, ""])
+def test_the_absent_role_is_still_answered_quietly(empty):
+    """``current_user.get("role")`` returns None routinely — that is data, not a bug."""
+    assert role_value(empty) == ""
+    assert is_admin_role(empty) is False
+    assert role_has_permission(empty, Permission.API_READ.value) is False


### PR DESCRIPTION
Closes #14944

## Thinking Path

#14944 reports that `is_admin_role(Role.ADMIN)` is `False`, because `Role` is the
`(str, Enum)` mixin shape and `str(member)` yields `"Role.ADMIN"`. I reproduced that
standalone on 3.10.12 and confirmed the surrounding facts, which are what make it
invisible: `f"{Role.ADMIN}"` is `'admin'`, `Role.ADMIN == "admin"` is `True`, and
`Role.ADMIN in ADMIN_ROLES` is `True`. The member behaves like its value everywhere
**except** under `str()` — the one construct every role resolver happened to use.

**The obvious fix is a security regression.** Replacing `str(role)` with `role.lower()`
looks right and is wrong. A `(str, Enum)` member *is* a `str`, so `.lower()` answers with
the **value** — including for members of the *other* role vocabularies this codebase
deliberately keeps apart (#14024, #13934). Verified: `MembershipRole.ADMIN.lower()` is a
plain `str` `'admin'`, so a bare-`.lower()` fix would admit a *company-membership* admin
as a *platform* administrator. `str()` was rejecting that by accident.

The load-bearing detail is **dispatch order**: `role_value` tests `isinstance(role, Enum)`
*before* `isinstance(role, str)`. A str-mixin member satisfies both, so checking `str`
first would let it fall through the `str` branch unchanged and reintroduce the widening.

**Sweep result — five sites, not the three on the issue, plus one left deliberately.**
Sweeping on the behaviour (`str(...)` applied to a role, and `.lower()`-based role
normalisation) rather than on the `Role` symbol found `services/mcp_dispatch.py:188` in
addition to the three named. Review then found a sixth, `api/auth.py:773`, now also fixed.

**One suspicion I cleared rather than assumed.** I expected `canonical_role_permissions`'
`lru_cache` to let a member and its value share a slot, making the wrong answer call-order
dependent. It does not: `functools._make_key`'s fast path checks *exact* type, so a `Role`
gets wrapped in `_HashedSeq`, which is never `==` to a bare `str` key even when the hashes
coincide. Separate slots; the wrong answer was deterministic.

## What Changed

**Hardened (6 functions), all routed through one new helper:**

| function | file | was | now |
|---|---|---|---|
| `role_value` *(new)* | `autobot_shared/auth/permissions.py` | — | the single safe role→string coercion |
| `is_admin_role` | `autobot_shared/auth/permissions.py` | `str(role or "")` → `False` for a member | member resolves to its value |
| `role_has_permission` | `autobot_shared/auth/permissions.py` | `Role(str(role).lower())` → `ValueError` → deny | resolves |
| `canonical_role_permissions` | `autobot-backend/security_layer.py` | `str(user_role or "")` → `[]` for a member | resolves |
| `_normalise_role` | `autobot-backend/security_layer.py` | returned `"role.admin"` | returns `"admin"` |
| `_would_deny` | `autobot-backend/services/mcp_dispatch.py` | `unknown-role:Role.ADMIN` | resolves |
| `require_role` / `_get_user_permissions` | `autobot-backend/auth_rbac.py` | hand-rolled `isinstance` ladder / bare `.lower()` | reuse `role_value` |
| `get_role_permissions` | `autobot-backend/api/auth.py` | bare `.lower()` | reuse `role_value` |

`role_value` deliberately does **not** change case or strip whitespace — #13820 showed that
normalising one role source and not another creates a second identity for the same role. It
fixes the type coercion only; every caller keeps the normalisation it had.

It **raises `TypeError`** for a member of a different role enum and for a non-`str`/non-`Role`
argument. `None` and `""` still answer quietly, because `current_user.get("role")` returning
`None` is data, not a bug. `mcp_dispatch` routes that `TypeError` into its existing fail-closed
`unknown-role:` branch rather than raising out of a dispatch.

`role_has_permission` now resolves the type **before** testing emptiness, matching
`_normalise_role` and `canonical_role_permissions`. Its old leading `if not role` swallowed a
falsy non-role (`0`, `False`, `[]`, `{}`) into a quiet `False` while its siblings raised on the
same input — an inconsistency this PR would otherwise have introduced while claiming uniformity.

**Test-harness fix — the root cause of 12 CI failures, not a loosening of the typing.**
`autobot-backend/conftest.py` stubs `auth_middleware` and defines `get_current_user`,
`check_admin_permission` and `require_device_jwt` as real callables (#13253) — but never
`get_auth_middleware`, so the block's catch-all `__getattr__` handed out a bare `MagicMock`.
`get_user_from_request()` auto-vivified a mock "user" and `.get("role")` auto-vivified another.
The old `is_admin_role` computed `str(<MagicMock>).lower()`, matched nothing and returned
`False`, so **12 tests across 3 shards were passing for the wrong reason**. Strict typing turned
that silent wrong answer into a `TypeError`, which is how it surfaced. Fixed at the root:
`get_auth_middleware` is now a real callable returning a middleware whose
`get_user_from_request()` yields the same real dict `_get_current_user_stub` returns — a fresh
dict per call, with every other middleware attribute left as a `MagicMock` because a dozen of
them are legitimately auto-mocked.

The catch-all itself is **left in place and filed as #14982**: `authenticate_websocket`,
`verify_internal_api_key` and `AuthenticationMiddleware` still reach it and several tests
configure them as mocks, so removing it means stubbing all three — a harness change whose
failure mode is "redden many shards", which should not ride along inside an auth fix.

**Call sites whose behaviour changed:** none of the **20 production** callers — all pass a
`str` or `None` off an authenticated session, which is why this was latent rather than live.
**Twelve test call sites did change**, and that is the interesting part: they were asserting
non-admin behaviour that came from a mock rather than from the auth logic they name. They now
exercise a real admin dict.

## Verification

Guard tests in `autobot_shared/auth/roles_are_canonical_test.py` and
`autobot-backend/security/canonical_permissions_test.py`. Every one passes a `Role` **member**,
never `member.value` — an assertion with `.value` on both sides cannot fail here, which is why
no existing test caught this. Populations are derived and floored at the real number (2
administrative members, 7 roles, 54 permissions) so a shrunken enum cannot make them vacuous.

Paired mutation, on an isolated copy outside the repo (nothing mutated was committed; each
mutation asserts its target exists first, so a missing target cannot report a false PASS):

| mutation | result |
|---|---|
| `is_admin_role` reverted to `str(role or "")` | **11 failed**, 24 passed |
| `isinstance(role, Enum)` rejection disabled (the naive `.lower()` fix) | **2 failed**, 33 passed |
| `role_value` renamed to `role_val` | **collection error** — the guard follows the symbol |
| `role_has_permission` reverted to `Role(str(role).lower())` | **7 failed**, 28 passed |
| emptiness test moved back *before* coercion | **6 failed**, 35 passed |
| baseline restored | **58 passed** |

Local suite runs (CPython **3.10.12** — these counts characterise that interpreter; CI runs 3.14
and is authoritative):

| suite | result |
|---|---|
| the 3 previously-failing files (`test_labels`, `test_budget_token_mode`, `test_routine`) | **30 passed, 3 failed** |
| `security/auth_rbac_test` + `canonical_permissions_test` + `test_backlog_reorder` + 4 IDOR suites | **169 passed** |
| `mcp_dispatch` ×2 + `permission_enforcement` ×3 + `roles_do_not_collide` + `security_layer_test` + `security_edge_cases` | **145 passed, 2 xfailed** |
| `autobot_shared/auth` permissions + roles_are_canonical + mcp_tool_permissions | **206 passed** |
| `test_auth_validate_rbac` + `auth_refresh` + `mcp_token_admin` + `voice_bundle_admin` + `ws_security_admin` + `approvals_idor` | **62 passed** |

The 3 remaining failures are `RuntimeError: llc.scheduler.base requires asyncio.Task.cancelling()
(Python 3.11+)` — a module-import interpreter guard that is **already present in
`origin/Dev_new_gui`** (verified with `git show`), unrelated to roles, and cannot occur on CI's
3.14. All 12 originally-failing tests now pass.

`black --check` clean on all changed files (line-length 120).

## Model Used

Claude Opus 5 (1M context)

---

### #14940 is NOT closed by this PR

Investigated; it is **analysis-only** — posted on #14940 and labelled `needs-decision`. The
issue's own recommendation (Option 1, "zero authorization change") does not hold:
`SecurityLayer.check_permission` unions its three sources, so adding a canonical entry can only
widen, and the truly-empty entry that would grant nothing is blocked by an existing guard
(`test_the_permissionless_roles_are_exactly_the_administrative_ones` asserts the permissionless
roles are exactly `{"superadmin"}`). The cheapest Option 1 variant still adds **+5 canonical
grants** at three gates. Whether `developer` is provisioned at all is a **host** question — no
producer for `allowed_users` or `roles` exists in this repo. No code touched.
