### PR TITLE
fix(test): three checks that could not report what they were written to report (#14931, #14941, #14927)

### DIFF
--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -164,26 +164,59 @@ def check_delete_host(host_id):
     return True
 
 
+# What the worker writes to its log when it has come up. Both tokens are
+# required: "ready" alone appears in lines other processes write, and the
+# service name alone appears before the worker has finished starting.
+_WORKER_READY_MARKERS = ("autobot-worker", "ready")
+
+
 def test_celery_worker_status():
-    """Test 9: Celery Worker Status"""
-    # Check if Celery worker is running by checking logs
-    try:
-        with open(
-            str(project_root() / "logs" / "celery-worker.log"),
-            "r",
-            encoding="utf-8",
-        ) as f:
-            logs = f.read()
-            if "ready" in logs and "autobot-worker" in logs:
-                print("✅ Test 9: Celery Worker - PASSED")  # noqa: print
-                print("   Worker is running with queues: celery, deployments")  # noqa: print
-                return True
-            else:
-                print("❌ Test 9: Celery Worker - FAILED")  # noqa: print
-                return False
-    except Exception as e:
-        print(f"❌ Test 9: Celery Worker - ERROR: {e}")  # noqa: print
-        return False
+    """Test 9: Celery Worker Status — the worker's own log is the only evidence.
+
+    #14941: this used to wrap its whole body in ``try/except Exception`` and end
+    every path with ``return True`` or ``return False``. pytest discards a test's
+    return value, so no log content, no service state and no raised exception
+    could make it fail — it reported pass unconditionally, in a marker set that
+    until #14930 ran in no gating workflow at all.
+
+    The only thing that legitimately excuses this check is a checkout that is not
+    a deployment, and that is decided by the ``logs/`` directory rather than by
+    the log file: if ``logs/`` is absent nothing on this host ever ran, so there
+    is nothing to report on. If ``logs/`` exists and the worker's log does not,
+    the worker never started, and that is a failure rather than a non-result.
+
+    ``main()`` calls this bare and discards whatever it returns, so unlike the
+    npu_code_search drivers (#14920) there is no truthiness contract to keep and
+    the function returns nothing at all.
+    """
+    log_directory = project_root() / "logs"
+    log_file = log_directory / "celery-worker.log"
+
+    if not log_directory.is_dir():
+        pytest.skip(
+            f"{log_directory} does not exist — this checkout is not a deployment, "
+            "so no service on this host has written a log to read"
+        )
+
+    assert log_file.is_file(), (
+        f"{log_file} is absent while {log_directory} exists — this host runs services "
+        "but the Celery worker has never written a log, so it never started"
+    )
+
+    logs = log_file.read_text(encoding="utf-8", errors="replace")
+    assert logs.strip(), (
+        f"{log_file} is empty — the worker process produced no output at all, "
+        "so it did not come up"
+    )
+
+    missing = [marker for marker in _WORKER_READY_MARKERS if marker not in logs]
+    assert not missing, (
+        f"{log_file} never mentions {missing} — the Celery worker did not report "
+        f"itself ready ({len(logs)} bytes of log read)"
+    )
+
+    print("✅ Test 9: Celery Worker - PASSED")  # noqa: print
+    print("   Worker is running with queues: celery, deployments")  # noqa: print
 
 
 def main():

--- a/autobot-backend/api/infrastructure_integration_test.py
+++ b/autobot-backend/api/infrastructure_integration_test.py
@@ -204,10 +204,7 @@ def test_celery_worker_status():
     )
 
     logs = log_file.read_text(encoding="utf-8", errors="replace")
-    assert logs.strip(), (
-        f"{log_file} is empty — the worker process produced no output at all, "
-        "so it did not come up"
-    )
+    assert logs.strip(), f"{log_file} is empty — the worker process produced no output at all, " "so it did not come up"
 
     missing = [marker for marker in _WORKER_READY_MARKERS if marker not in logs]
     assert not missing, (

--- a/autobot-backend/utils/entity_resolution_test.py
+++ b/autobot-backend/utils/entity_resolution_test.py
@@ -26,7 +26,12 @@ from utils.entity_resolver import EntityResolver
 class TestEntityResolution:
     """Test cases for entity resolution functionality."""
 
-    def __init__(self):
+    # #14927: this was ``__init__``. pytest refuses to collect a class that has a
+    # constructor -- it emits PytestCollectionWarning and moves on -- so every
+    # ``test_*`` method below was silently uncollected despite the class matching
+    # ``python_classes = Test*``. ``setup_method`` is pytest's own per-test hook and
+    # runs before each test, which is what this body always meant.
+    def setup_method(self):
         self.resolver = EntityResolver()
 
         # Test entities with known duplicates

--- a/autobot-backend/utils/semantic_chunking_test.py
+++ b/autobot-backend/utils/semantic_chunking_test.py
@@ -9,6 +9,8 @@ import asyncio
 import os
 import sys
 
+import pytest
+
 # Add project root to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -18,7 +20,12 @@ from utils.semantic_chunker import AutoBotSemanticChunker, SemanticChunk
 class TestSemanticChunking:
     """Test cases for semantic chunking functionality."""
 
-    def __init__(self):
+    # #14927: this was ``__init__``. pytest refuses to collect a class that has a
+    # constructor -- it emits PytestCollectionWarning and moves on -- so every
+    # ``test_*`` method below was silently uncollected despite the class matching
+    # ``python_classes = Test*``. ``setup_method`` is pytest's own per-test hook and
+    # runs before each test, which is what this body always meant.
+    def setup_method(self):
         self.chunker = AutoBotSemanticChunker(
             embedding_model="all-MiniLM-L6-v2",
             percentile_threshold=95.0,
@@ -28,6 +35,11 @@ class TestSemanticChunking:
 
     async def test_basic_chunking(self):
         """Test basic semantic chunking functionality."""
+        # Real semantic splitting needs the embedding model; without it the
+        # chunker falls back to a single chunk and this asserts nothing about
+        # semantics. Declare the dependency rather than assert against a
+        # fallback (#14927).
+        pytest.importorskip("sentence_transformers")
         print("Testing basic semantic chunking...")  # noqa: print
 
         test_text = """

--- a/autobot-backend/utils/terminal_input_handler.py
+++ b/autobot-backend/utils/terminal_input_handler.py
@@ -196,9 +196,7 @@ class TerminalInputHandler:
         # #315 because the test that covers it sat in a class pytest could not
         # collect, so it never ran. A numbered selection is phrased at least as
         # often with "select" or "option" as with "choice".
-        if any(word in prompt_lower for word in _CHOICE_KEYWORDS) and any(
-            char.isdigit() for char in prompt
-        ):
+        if any(word in prompt_lower for word in _CHOICE_KEYWORDS) and any(char.isdigit() for char in prompt):
             numbers = [char for char in prompt if char.isdigit()]
             return numbers[0] if numbers else config.misc.default_choice or _get_config_default("default_choice", "1")
 

--- a/autobot-backend/utils/terminal_input_handler.py
+++ b/autobot-backend/utils/terminal_input_handler.py
@@ -11,6 +11,7 @@ and automated testing environments, preventing test timeouts and CI/CD failures.
 
 import asyncio
 import queue
+import re
 import sys
 import threading
 from contextlib import contextmanager
@@ -30,6 +31,15 @@ _YES_NO_KEYWORDS = frozenset({"yes", "no", "y/n"})
 # Words that introduce a numbered selection. Module-level frozenset for the same
 # reason as _YES_NO_KEYWORDS (#380), and used by _generate_intelligent_default.
 _CHOICE_KEYWORDS = frozenset({"choice", "choose", "option", "select"})
+
+# The second half of that test: an enumerated range in parentheses -- "(1-5)",
+# "(3)". These four keywords are generic enough that pairing them with "any
+# digit anywhere in the prompt" claimed prompts meant for the branches below:
+# "Select a config file (1 of 3):" and "Select the port to use:" would both have
+# answered with a bare digit instead of a path or a port. A parenthesised range
+# is a menu and nothing else, which is why this branch still runs first, and the
+# answer is taken from inside the range rather than from the prompt at large.
+_ENUMERATED_RANGE = re.compile(r"\(\s*(\d+)\s*(?:-\s*\d+\s*)?\)")
 
 # Import configuration for fallback defaults
 try:
@@ -190,15 +200,18 @@ class TerminalInputHandler:
         if any(word in prompt_lower for word in _YES_NO_KEYWORDS):
             return "y"
 
-        # Check choice pattern with digits. #14927: this matched only the literal
-        # word "choice", so "Select option (1-5):" fell through every branch below
-        # and returned "" -- not a selectable value. The gap has been live since
-        # #315 because the test that covers it sat in a class pytest could not
-        # collect, so it never ran. A numbered selection is phrased at least as
-        # often with "select" or "option" as with "choice".
-        if any(word in prompt_lower for word in _CHOICE_KEYWORDS) and any(char.isdigit() for char in prompt):
-            numbers = [char for char in prompt if char.isdigit()]
-            return numbers[0] if numbers else config.misc.default_choice or _get_config_default("default_choice", "1")
+        # Check numbered-menu pattern: a choice keyword AND an enumerated range.
+        # #14927: this matched only the literal word "choice", so
+        # "Select option (1-5):" fell through every branch below and returned ""
+        # -- not a selectable value. The gap has been live since #315 because the
+        # test that covers it sat in a class pytest could not collect, so it never
+        # ran. A numbered selection is phrased at least as often with "select" or
+        # "option" as with "choice". See _ENUMERATED_RANGE for why the range, and
+        # not a loose digit scan, is what admits a prompt to this branch.
+        if any(word in prompt_lower for word in _CHOICE_KEYWORDS):
+            enumerated = _ENUMERATED_RANGE.search(prompt)
+            if enumerated:
+                return enumerated.group(1)
 
         # Check command pattern (requires both keywords)
         if "enter" in prompt_lower and "command" in prompt_lower:

--- a/autobot-backend/utils/terminal_input_handler.py
+++ b/autobot-backend/utils/terminal_input_handler.py
@@ -27,6 +27,10 @@ logger = get_logger(__name__)
 # Issue #380: Module-level frozensets for prompt pattern matching
 _YES_NO_KEYWORDS = frozenset({"yes", "no", "y/n"})
 
+# Words that introduce a numbered selection. Module-level frozenset for the same
+# reason as _YES_NO_KEYWORDS (#380), and used by _generate_intelligent_default.
+_CHOICE_KEYWORDS = frozenset({"choice", "choose", "option", "select"})
+
 # Import configuration for fallback defaults
 try:
     from config import unified_config_manager
@@ -186,8 +190,15 @@ class TerminalInputHandler:
         if any(word in prompt_lower for word in _YES_NO_KEYWORDS):
             return "y"
 
-        # Check choice pattern with digits
-        if "choice" in prompt_lower and any(char.isdigit() for char in prompt):
+        # Check choice pattern with digits. #14927: this matched only the literal
+        # word "choice", so "Select option (1-5):" fell through every branch below
+        # and returned "" -- not a selectable value. The gap has been live since
+        # #315 because the test that covers it sat in a class pytest could not
+        # collect, so it never ran. A numbered selection is phrased at least as
+        # often with "select" or "option" as with "choice".
+        if any(word in prompt_lower for word in _CHOICE_KEYWORDS) and any(
+            char.isdigit() for char in prompt
+        ):
             numbers = [char for char in prompt if char.isdigit()]
             return numbers[0] if numbers else config.misc.default_choice or _get_config_default("default_choice", "1")
 

--- a/autobot-backend/utils/terminal_input_handler_test.py
+++ b/autobot-backend/utils/terminal_input_handler_test.py
@@ -287,6 +287,35 @@ class TestTerminalInputHandler:
         print("✓ Built-in input patching working")  # noqa: print
         return
 
+    def test_choice_keywords_do_not_hijack_file_and_port_prompts(self):
+        """A choice keyword alone must not answer a prompt with a bare digit.
+
+        #14927 widened _CHOICE_KEYWORDS to "select"/"option", and the branch is
+        checked before the file/path and port branches. With "any digit anywhere"
+        as the discriminator, "Select a config file (1 of 3):" answered "1" and
+        "Select the port to use:" answered nothing useful either. Only a real
+        enumerated range -- "(1-5)" -- makes a prompt a numbered menu.
+        """
+        self.handler.is_testing = True
+        self.handler.set_mock_responses([])
+
+        menu = self.handler.get_input("Select option (1-5):")
+        assert menu == "1", f"an enumerated menu still answers with its first entry, got {menu!r}"
+
+        file_prompt = self.handler.get_input("Select a config file (1 of 3):")
+        assert not file_prompt.isdigit(), (
+            f"'(1 of 3)' is not an enumerated range; a file prompt must reach the "
+            f"file/path branch, got {file_prompt!r}"
+        )
+        assert "/" in file_prompt, f"expected a path-shaped default, got {file_prompt!r}"
+
+        port_prompt = self.handler.get_input("Select the port to use:")
+        assert port_prompt == self.handler.get_input("Port number:"), (
+            "a port prompt phrased with 'select' must resolve to the same port "
+            f"default as a plain one, got {port_prompt!r}"
+        )
+        assert port_prompt != "1", "the port default must not be the menu fallback"
+
     def test_intelligent_defaults(self):
         """Test intelligent default response generation."""
         print("\nTesting intelligent default responses...")  # noqa: print

--- a/autobot-backend/utils/terminal_input_handler_test.py
+++ b/autobot-backend/utils/terminal_input_handler_test.py
@@ -29,7 +29,12 @@ from utils.terminal_input_handler import (
 class TestTerminalInputHandler:
     """Test cases for terminal input handler functionality."""
 
-    def __init__(self):
+    # #14927: this was ``__init__``. pytest refuses to collect a class that has a
+    # constructor -- it emits PytestCollectionWarning and moves on -- so every
+    # ``test_*`` method below was silently uncollected despite the class matching
+    # ``python_classes = Test*``. ``setup_method`` is pytest's own per-test hook and
+    # runs before each test, which is what this body always meant.
+    def setup_method(self):
         self.handler = TerminalInputHandler()
 
     def test_environment_detection(self):

--- a/autobot-infrastructure/shared/scripts/analysis/test_npu_code_search.py
+++ b/autobot-infrastructure/shared/scripts/analysis/test_npu_code_search.py
@@ -142,7 +142,11 @@ async def test_development_speedup():
                 logger.info(f"         - {loc[0]}:{loc[1]}")
 
     except Exception as e:
-        logger.error(f"   ❌ Duplicate detection failed: {e}")
+        # #14931: this logged and continued, so a failure of duplicate detection left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"duplicate detection failed: {e}") from e
 
     # Test 2: Pattern analysis
     logger.info("\n2. Testing code pattern analysis...")
@@ -162,7 +166,11 @@ async def test_development_speedup():
             logger.info(f"      💡 Suggestion: {pattern['suggestion']}")
 
     except Exception as e:
-        logger.error(f"   ❌ Pattern analysis failed: {e}")
+        # #14931: this logged and continued, so a failure of pattern analysis left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"pattern analysis failed: {e}") from e
 
     # Test 3: Import analysis
     logger.info("\n3. Testing import analysis...")
@@ -182,7 +190,11 @@ async def test_development_speedup():
                 print(f"      - {unused_import['file']}:{unused_import['line']} - {unused_import['import']}")
 
     except Exception as e:
-        logger.error(f"   ❌ Import analysis failed: {e}")
+        # #14931: this logged and continued, so a failure of import analysis left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"import analysis failed: {e}") from e
 
     # Test 4: Quick comprehensive analysis
     logger.info("\n4. Testing comprehensive analysis...")

--- a/autobot-npu-worker/npu_code_search_test.py
+++ b/autobot-npu-worker/npu_code_search_test.py
@@ -140,7 +140,11 @@ async def test_development_speedup():
                 print(f"         - {loc[0]}:{loc[1]}")
 
     except Exception as e:
-        print(f"   ❌ Duplicate detection failed: {e}")
+        # #14931: this logged and continued, so a failure of duplicate detection left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"duplicate detection failed: {e}") from e
 
     # Test 2: Pattern analysis
     print("\n2. Testing code pattern analysis...")
@@ -160,7 +164,11 @@ async def test_development_speedup():
             print(f"      💡 Suggestion: {pattern['suggestion']}")
 
     except Exception as e:
-        print(f"   ❌ Pattern analysis failed: {e}")
+        # #14931: this logged and continued, so a failure of pattern analysis left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"pattern analysis failed: {e}") from e
 
     # Test 3: Import analysis
     print("\n3. Testing import analysis...")
@@ -180,7 +188,11 @@ async def test_development_speedup():
                 print(f"      - {unused_import['file']}:{unused_import['line']} - {unused_import['import']}")
 
     except Exception as e:
-        print(f"   ❌ Import analysis failed: {e}")
+        # #14931: this logged and continued, so a failure of import analysis left the
+        # function reaching `return True` and the driver counting the whole test as
+        # passed. Only the fourth handler was converted by #14929; three quarters of
+        # what this test exercises could still fail silently.
+        raise AssertionError(f"import analysis failed: {e}") from e
 
     # Test 4: Quick comprehensive analysis
     print("\n4. Testing comprehensive analysis...")

--- a/repo_tests/test_methods_in_uncollected_classes_test.py
+++ b/repo_tests/test_methods_in_uncollected_classes_test.py
@@ -192,6 +192,14 @@ def _dotted(node: ast.AST) -> str:
 
 
 def _has_init(node: ast.ClassDef) -> bool:
+    """Known gap (#14984): the class's OWN body only, not an inherited __init__.
+
+    pytest asks ``cls.__init__ is not object.__init__``, which walks the MRO, so
+    a ``Test*`` class inheriting ``__init__`` from a plain base is skipped by
+    pytest and counted as collected here. A repo-wide sweep found zero instances
+    when this was written, so the budgets below are unaffected; resolving bases
+    across modules is a model change, tracked in #14984.
+    """
     return any(
         isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == "__init__"
         for child in node.body

--- a/repo_tests/test_methods_in_uncollected_classes_test.py
+++ b/repo_tests/test_methods_in_uncollected_classes_test.py
@@ -73,12 +73,19 @@ import sys
 import textwrap
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PYTEST_INI = _REPO_ROOT / "pytest.ini"
 
 _SKIP = {
     ".git",
     ".worktrees",
+    # Harness territory: tooling config plus the agent worktrees checked out
+    # under it, which hold other branches' work in progress and are not always
+    # parseable. pytest's own testpaths never reach it either, so nothing here
+    # is collectable and nothing here is this sweep's subject.
+    ".claude",
     "__pycache__",
     "node_modules",
     ".venv",
@@ -131,6 +138,32 @@ def _pytest_option(name: str) -> list[str]:
     values = parser.get("pytest", name, fallback="").split()
     assert values, f"pytest.ini declares no {name} — the population cannot be derived"
     return values
+
+
+def _parse_module(path: Path) -> ast.Module:
+    """Parse one swept file, failing loudly and by name if it cannot be parsed.
+
+    This sweep is a denylist walk from the repo root, filtered only by ``_SKIP``,
+    so it reaches files pytest's ``testpaths`` allowlist never would: scratch
+    copies, templates, half-written drafts. An unparseable one must never read as
+    "clean" -- skipping it silently is the exact under-reporting failure this
+    guard exists to catch -- so it is raised as a failure that names the file and
+    says how to take it out of the sweep on purpose.
+    """
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        relative = path.relative_to(_REPO_ROOT)
+        raise AssertionError(
+            f"{relative}:{exc.lineno or 0} is not parseable Python ({exc.msg}). "
+            "This guard sweeps every *.py under the repo root as a denylist, so it "
+            "sees files pytest's own testpaths allowlist never reaches. Fix the "
+            "file, or -- if it is scratch, vendored or another branch's work and "
+            "does not belong in the sweep -- add its top-level directory to _SKIP "
+            "in every repo_tests guard that sweeps, the way .claude and .worktrees "
+            "already are. Do not silence this by skipping the file: a file the "
+            "sweep cannot read is not a file the sweep has cleared."
+        ) from exc
 
 
 def _test_modules() -> list[Path]:
@@ -276,8 +309,8 @@ def _scan() -> tuple[dict[str, tuple[str, ...]], dict[str, int], tuple[str, ...]
     for module in _test_modules():
         relative = module.relative_to(_REPO_ROOT)
         tree_name = relative.parts[0]
+        parsed = _parse_module(module)
         source = module.read_text(encoding="utf-8")
-        parsed = ast.parse(source)
 
         population[tree_name] = population.get(tree_name, 0) + _scanned_test_functions(parsed)
         for class_name, method, line in uncollected_test_methods(source):
@@ -546,3 +579,28 @@ def test_the_model_agrees_with_pytest_on_every_shape(tmp_path: Path) -> None:
         "The model is what every count in this file rests on — fix it here, do not "
         "adjust the budgets to match a wrong model (#14927)."
     )
+
+
+def test_an_unparseable_swept_file_fails_loudly_instead_of_reading_as_clean() -> None:
+    """The sweep is a denylist from the repo root, so it meets stray files.
+
+    One must never be skipped: a file the walk could not read is not a file the
+    walk cleared, and dropping it silently is the under-reporting this guard
+    exists to catch. It has to fail, name the file and say what to do about it.
+
+    The probe is written under a ``_SKIP``ped directory so no concurrently
+    running sweep can pick it up while it exists.
+    """
+    scratch = _REPO_ROOT / "__pycache__"
+    scratch.mkdir(exist_ok=True)
+    stray = scratch / "unparseable_probe_test.py"
+    stray.write_text("from a-b.c import (\n", encoding="utf-8")
+    try:
+        with pytest.raises(AssertionError) as raised:
+            _parse_module(stray)
+    finally:
+        stray.unlink()
+
+    message = str(raised.value)
+    assert "unparseable_probe_test.py" in message, "the failure must name the file"
+    assert "_SKIP" in message, "the failure must say how to exclude a file on purpose"

--- a/repo_tests/test_methods_in_uncollected_classes_test.py
+++ b/repo_tests/test_methods_in_uncollected_classes_test.py
@@ -1,0 +1,548 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A ``test_*`` method in a class pytest will not collect never runs (#14927).
+
+This is a strictly worse defect than the one #14920 drains. A test that returns
+instead of asserting is at least *counted*: it appears in the total, it has a
+node id, and a reader who looks for it finds it. A method in an uncollected
+class contributes nothing at all. The file is named ``*_test.py``, it sits in a
+collected tree, it imports cleanly, and every signal a reader has says the
+tests ran. ``security_idor_hotfix_test.py`` was believed for weeks to be in
+this state.
+
+WHY AN AST SWEEP MUST MODEL PYTEST, NOT ``python_classes``
+----------------------------------------------------------
+#14927 measured this population by matching class names against
+``python_classes = Test*`` and reported 120 methods in 23 classes. Checked by
+actually collecting the files, 30 of those 120 were false and 41 real ones were
+missing. ``python_classes`` is only one of three rules pytest applies, and the
+other two run in opposite directions:
+
+* **``unittest.TestCase`` subclasses are collected whatever their name.** pytest
+  hands them to its unittest integration, which does not consult
+  ``python_classes`` at all. 23 of the 120 are ``TestCase`` subclasses -- among
+  them all 13 in ``security_idor_hotfix_test.py``, the case #14927 called its
+  sharpest. They collect, they run, and they pass.
+* **A base class contributes its methods through any collected subclass.**
+  ``ReadOnlyCapabilityChecks`` matches nothing, but ``TestReadOnlyContract`` and
+  ``TestDispatchReadOnlyContract`` both inherit it, so its five methods collect
+  twice each.
+* **A class with ``__init__`` is NOT collected, however it is named.** pytest
+  emits ``PytestCollectionWarning`` and moves on. This is the direction that
+  actually bites, because the class is *called* ``Test*`` and looks correct:
+  five such classes held 41 methods that ran nowhere, and #14927 never counted
+  them because it filtered on the name.
+
+So the model below is checked against pytest itself, in
+``test_the_model_agrees_with_pytest_on_every_shape``, by running a real
+``--collect-only`` over a module carrying one of every shape. A model of a
+collector is worthless if nothing ever compares it to the collector.
+
+WHAT IS DELIBERATELY NOT COUNTED
+--------------------------------
+A private stand-in implementing a production interface that happens to declare
+a ``test_*`` method. ``AbstractConnector.test_connection`` is such an interface:
+``_MinimalConnector`` and ``_DummyConnector`` must implement it under that
+name, and renaming it is not available. They are not tests and pytest is right
+not to collect them. The exemption is pinned at its exact measured size below
+rather than left open, so a third one cannot arrive unnoticed.
+
+THE RATCHET
+-----------
+Keyed on the top-level tree, never on a filename -- an exemption keyed on a path
+is stranded by the first rename, and a stranded exemption exempts nothing while
+looking authoritative. Every tree not named in ``_KNOWN_OFFENDERS`` is pinned at
+zero by derivation. The named trees may only shrink, and an entry reaching zero
+must be deleted rather than left at ``0``.
+
+The population floors are the half that matters most. A sweep that quietly stops
+matching finds no offenders, and "no offenders" is indistinguishable from
+finished work -- so the collapse is checked *first*, and it fails telling the
+reader to fix the sweep rather than to write the zero down.
+"""
+
+from __future__ import annotations
+
+import ast
+import configparser
+import functools
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYTEST_INI = _REPO_ROOT / "pytest.ini"
+
+_SKIP = {
+    ".git",
+    ".worktrees",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".tox",
+}
+
+# Measured on this branch, per top-level tree:
+#   tree: (uncollected test_* methods that must not be exceeded,
+#          collectable test functions that must STILL be found in that tree)
+#
+# The second number is not decoration. Without it, a walk that breaks and finds
+# nothing looks identical to a tree somebody finished draining, and this file
+# would record the collapse as a triumph and lock it in.
+#
+# Every one of the remaining offenders is a live-service validation driver: a
+# class with `__init__`, a `run_all_*` loop and a `main()`, whose methods dial a
+# running backend and return bool. Converting one is a rewrite, not a rename --
+# and a bare rename is actively harmful, because a `Test*` class that keeps its
+# `__init__` collects zero while looking fixed. They are filed with per-file
+# counts rather than swept, and this ceiling is what stops the population
+# growing back while that work is queued.
+_KNOWN_OFFENDERS = {
+    # 77, not 79: the two interface stubs below are exempt and counted separately.
+    "autobot-backend": (77, 18000),
+    # The floor equals the ceiling here, and legitimately so: this tree holds one
+    # test module whose single class is uncollected, so every test-shaped thing in
+    # it is also an offender. Collecting them moves the ceiling to 0 and leaves the
+    # floor at 10, which is exactly the shape a real fix has.
+    "autobot-frontend": (10, 10),
+    "autobot-infrastructure": (19, 250),
+}
+
+# Floors under the whole population, for the same reason as the per-tree ones.
+_MIN_MODULES = 1800
+_MIN_TEST_FUNCTIONS = 25000
+
+# Private stand-ins implementing a production interface that declares a `test_*`
+# method. Pinned at the exact measured count: the exemption is a convention rule
+# ("a leading underscore means a helper"), and a convention rule with no ceiling
+# is a bypass waiting to be used.
+_INTERFACE_STUBS = 2
+
+
+def _pytest_option(name: str) -> list[str]:
+    parser = configparser.ConfigParser(inline_comment_prefixes=("#",))
+    parser.read(_PYTEST_INI, encoding="utf-8")
+    values = parser.get("pytest", name, fallback="").split()
+    assert values, f"pytest.ini declares no {name} — the population cannot be derived"
+    return values
+
+
+def _test_modules() -> list[Path]:
+    """Every file pytest's own ``python_files`` globs would consider."""
+    patterns = _pytest_option("python_files")
+    return sorted(
+        path
+        for path in _REPO_ROOT.rglob("*.py")
+        if not _SKIP.intersection(path.relative_to(_REPO_ROOT).parts)
+        and any(path.match(pattern) for pattern in patterns)
+    )
+
+
+def _prefixes() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    functions = tuple(p.rstrip("*") for p in _pytest_option("python_functions"))
+    classes = tuple(p.rstrip("*") for p in _pytest_option("python_classes"))
+    return functions, classes
+
+
+def _dotted(node: ast.AST) -> str:
+    if isinstance(node, ast.Attribute):
+        return f"{_dotted(node.value)}.{node.attr}"
+    if isinstance(node, ast.Name):
+        return node.id
+    return "?"
+
+
+def _has_init(node: ast.ClassDef) -> bool:
+    return any(
+        isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name == "__init__"
+        for child in node.body
+    )
+
+
+def _collected_classes(classes: dict[str, ast.ClassDef]) -> set[str]:
+    """The class names pytest would collect from this module.
+
+    Three rules, applied in pytest's own order of precedence. See the module
+    docstring for why each is load-bearing.
+    """
+    _, class_prefixes = _prefixes()
+
+    def is_unittest(node: ast.ClassDef, seen: frozenset[str] = frozenset()) -> bool:
+        for base in node.bases:
+            dotted = _dotted(base)
+            if dotted.rsplit(".", 1)[-1].endswith("TestCase"):
+                return True
+            if dotted in classes and dotted not in seen:
+                if is_unittest(classes[dotted], seen | {dotted}):
+                    return True
+        return False
+
+    collected = set()
+    for name, node in classes.items():
+        if is_unittest(node):
+            # unittest.TestCase never consults python_classes, and its own
+            # __init__ is part of the framework rather than a blocker.
+            collected.add(name)
+        elif name.startswith(class_prefixes) and not _has_init(node):
+            collected.add(name)
+
+    # A base of a collected class contributes its methods through the subclass.
+    changed = True
+    while changed:
+        changed = False
+        for name in list(collected):
+            for base in classes[name].bases:
+                dotted = _dotted(base)
+                if dotted in classes and dotted not in collected:
+                    collected.add(dotted)
+                    changed = True
+    return collected
+
+
+def uncollected_test_methods(source: str) -> list[tuple[str, str, int]]:
+    """``(class, method, line)`` for every ``test_*`` method pytest cannot reach.
+
+    A plain function over source text, so it can be driven with a synthetic
+    module. A detector only ever pointed at the real tree cannot be told apart
+    from one that has stopped detecting.
+    """
+    function_prefixes, _ = _prefixes()
+    tree = ast.parse(source)
+    classes = {n.name: n for n in tree.body if isinstance(n, ast.ClassDef)}
+    collected = _collected_classes(classes)
+
+    found: list[tuple[str, str, int]] = []
+    for name, node in classes.items():
+        if name in collected or _is_interface_stub(node):
+            continue
+        found.extend(
+            (name, child.name, child.lineno)
+            for child in node.body
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and child.name.startswith(function_prefixes)
+        )
+    return found
+
+
+def _is_interface_stub(node: ast.ClassDef) -> bool:
+    """A private stand-in implementing a base class that dictates the name."""
+    return node.name.startswith("_") and bool(node.bases)
+
+
+def _scanned_test_functions(tree: ast.Module) -> int:
+    """Everything test-shaped this guard LOOKS AT, collected or not.
+
+    Deliberately not "everything pytest collects". A tree can legitimately hold
+    zero collectable tests while holding plenty for this sweep to examine --
+    ``autobot-frontend`` is exactly that today, one module whose only class is
+    uncollected. A floor on the collected subset would read as a collapsed sweep
+    there, and the first person to see it would "fix" it by deleting the floor.
+    The invariant that actually matters is that the walk still reaches its
+    subject, so the subject is what gets counted.
+    """
+    function_prefixes, _ = _prefixes()
+    total = 0
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            total += node.name.startswith(function_prefixes)
+        elif isinstance(node, ast.ClassDef):
+            total += sum(
+                1
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and child.name.startswith(function_prefixes)
+            )
+    return total
+
+
+@functools.lru_cache(maxsize=1)
+def _scan() -> tuple[dict[str, tuple[str, ...]], dict[str, int], tuple[str, ...]]:
+    """Walk every module once. Offenders, population and stubs, per tree.
+
+    Cached because five assertions in this file need the same walk over ~2,000
+    modules, and repeating it made this the slowest test in the repository.
+    """
+    offenders: dict[str, list[str]] = {}
+    population: dict[str, int] = {}
+    stubs: list[str] = []
+    function_prefixes, _ = _prefixes()
+
+    for module in _test_modules():
+        relative = module.relative_to(_REPO_ROOT)
+        tree_name = relative.parts[0]
+        source = module.read_text(encoding="utf-8")
+        parsed = ast.parse(source)
+
+        population[tree_name] = population.get(tree_name, 0) + _scanned_test_functions(parsed)
+        for class_name, method, line in uncollected_test_methods(source):
+            offenders.setdefault(tree_name, []).append(f"{relative}:{line} {class_name}.{method}")
+        for node in parsed.body:
+            if isinstance(node, ast.ClassDef) and _is_interface_stub(node):
+                stubs.extend(
+                    f"{relative}::{node.name}.{child.name}"
+                    for child in node.body
+                    if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and child.name.startswith(function_prefixes)
+                )
+    return (
+        {tree: tuple(sites) for tree, sites in offenders.items()},
+        population,
+        tuple(stubs),
+    )
+
+
+def _offenders_by_tree() -> dict[str, tuple[str, ...]]:
+    return _scan()[0]
+
+
+def _population_by_tree() -> dict[str, int]:
+    return _scan()[1]
+
+
+def test_the_population_is_present_and_large_enough_to_mean_anything() -> None:
+    """Floors on the subject, not on the findings. Zero of zero is not clean."""
+    modules = _test_modules()
+    assert len(modules) >= _MIN_MODULES, (
+        f"only {len(modules)} modules match pytest's python_files "
+        f"{_pytest_option('python_files')} — expected at least {_MIN_MODULES}. "
+        "The sweep has stopped matching and would call every tree clean."
+    )
+    total = sum(_population_by_tree().values())
+    assert total >= _MIN_TEST_FUNCTIONS, (
+        f"only {total} collectable test functions found across {len(modules)} modules "
+        f"— expected at least {_MIN_TEST_FUNCTIONS}; the collector model has drifted "
+        "from pytest's and this guard is looking at the wrong population"
+    )
+
+
+def test_no_tree_outside_the_known_set_holds_an_uncollected_test_method() -> None:
+    """The hard zero, derived — no list to go stale."""
+    offenders = _offenders_by_tree()
+    surprises = {
+        tree: sites for tree, sites in offenders.items() if tree not in _KNOWN_OFFENDERS
+    }
+    detail = "\n".join(
+        f"  {tree}:\n    " + "\n    ".join(sorted(sites))
+        for tree, sites in sorted(surprises.items())
+    )
+    assert not surprises, (
+        "these test_* methods sit in a class pytest will not collect, in a tree "
+        f"that was clean:\n{detail}\n"
+        "Nothing runs them and they contribute zero to the suite total. Give the "
+        "class a Test* name AND no __init__ (use setup_method), or derive it from "
+        "unittest.TestCase, or move the methods to module level. If the class is a "
+        "helper, rename the methods out of the test_* namespace (#14927)."
+    )
+
+
+def test_the_known_offender_budgets_only_ever_shrink() -> None:
+    """Ratchet, both directions — a recorded shrink must be locked in (#14498).
+
+    There is no sanctioned route to raise a number, and that is deliberate. A
+    ``test_*`` method that nothing collects is never the right thing to write:
+    every reader is told a check exists where none runs. Lowering a number needs
+    no permission at all — fix a class and the assertion below names the new
+    figure.
+    """
+    offenders = _offenders_by_tree()
+    populations = _population_by_tree()
+
+    collapsed = {
+        tree: (populations.get(tree, 0), floor)
+        for tree, (_, floor) in _KNOWN_OFFENDERS.items()
+        if populations.get(tree, 0) < floor
+    }
+    assert not collapsed, (
+        "the sweep no longer finds the tests it is supposed to be scanning "
+        f"(found, floor): {collapsed}. Every count below is therefore untrusted — "
+        "a scan that finds nothing reports a clean tree and a drop to zero reads "
+        "as progress. Fix the sweep; do NOT lower these numbers to match it."
+    )
+
+    over = {
+        tree: (len(offenders.get(tree, [])), budget)
+        for tree, (budget, _) in _KNOWN_OFFENDERS.items()
+        if len(offenders.get(tree, [])) > budget
+    }
+    assert not over, (
+        "these trees gained a test_* method in a class pytest cannot collect "
+        f"(actual, budget): {over}. The budgets are ceilings and there is no "
+        "route to raise one (#14927)."
+    )
+    drained = sorted(tree for tree in _KNOWN_OFFENDERS if not offenders.get(tree))
+    assert not drained, (
+        f"{drained} no longer hold any uncollected test method — delete the entry "
+        "from _KNOWN_OFFENDERS so the tree is pinned at zero by derivation. A "
+        "budget left behind after the work is done is spendable, and it will be spent."
+    )
+    spent = {
+        tree: (len(offenders.get(tree, [])), budget)
+        for tree, (budget, _) in _KNOWN_OFFENDERS.items()
+        if len(offenders.get(tree, [])) < budget
+    }
+    assert not spent, (
+        "these trees are now BELOW their recorded budget (actual, budget): "
+        f"{spent}. Lower the number here in the same commit, or the methods a fix "
+        "collected can be spent back inside a stale tolerance."
+    )
+
+
+def test_the_interface_stub_exemption_has_not_grown() -> None:
+    """The one exemption, pinned at its exact size.
+
+    ``_MinimalConnector`` and ``_DummyConnector`` implement
+    ``AbstractConnector.test_connection``; the production interface dictates the
+    name, so neither renaming the method nor collecting the class is available.
+    Exempting them is right. Leaving the exemption open-ended is not — "starts
+    with an underscore" is a convention, and a convention with no ceiling is a
+    bypass. A third stand-in must be looked at rather than absorbed.
+    """
+    stubs = _scan()[2]
+    assert len(stubs) == _INTERFACE_STUBS, (
+        f"the interface-stub exemption now covers {len(stubs)} methods, not "
+        f"{_INTERFACE_STUBS}: {sorted(stubs)}. Each one is a test_* method nothing "
+        "collects, exempted only because a production interface dictates its name. "
+        "Confirm that is still true of every entry before changing this number."
+    )
+
+
+def test_the_detector_finds_a_planted_method_and_spares_the_legitimate_ones() -> None:
+    """Self-test. Every branch is exercised, not merely written down."""
+    assert uncollected_test_methods("class Helper:\n    def test_a(self):\n        pass\n") == [
+        ("Helper", "test_a", 2)
+    ]
+
+    # Collected, each for a different reason.
+    assert not uncollected_test_methods("class TestX:\n    def test_a(self):\n        pass\n")
+    assert not uncollected_test_methods(
+        "import unittest\n\n\nclass Anything(unittest.TestCase):\n"
+        "    def test_a(self):\n        pass\n"
+    ), "unittest.TestCase is collected whatever python_classes says"
+    assert not uncollected_test_methods(
+        "import unittest\n\n\nclass Base(unittest.TestCase):\n    pass\n\n\n"
+        "class Deeper(Base):\n    def test_a(self):\n        pass\n"
+    ), "a TestCase subclass reached through another class in the module"
+    assert not uncollected_test_methods(
+        "class Mixin:\n    def test_a(self):\n        pass\n\n\n"
+        "class TestReal(Mixin):\n    pass\n"
+    ), "a base contributes its methods through any collected subclass"
+    assert not uncollected_test_methods(
+        "class _Stub(AbstractConnector):\n    async def test_connection(self):\n        pass\n"
+    ), "a private stand-in implementing an interface that dictates the name"
+
+    # The direction #14927 missed entirely.
+    assert uncollected_test_methods(
+        "class TestX:\n    def __init__(self):\n        pass\n\n"
+        "    def test_a(self):\n        pass\n"
+    ) == [("TestX", "test_a", 5)], "a Test* class with __init__ is NOT collected by pytest"
+
+    # A module-level function is pytest's business, not this guard's.
+    assert not uncollected_test_methods("def test_a():\n    pass\n")
+    # A private stand-in with no base class is just a class named with an underscore.
+    assert uncollected_test_methods("class _Loose:\n    def test_a(self):\n        pass\n")
+
+
+_EVERY_SHAPE = '''
+import unittest
+
+
+class TestPlain:
+    def test_collected_plain(self):
+        assert True
+
+
+class TestWithInit:
+    def __init__(self):
+        self.x = 1
+
+    def test_blocked_by_init(self):
+        assert True
+
+
+class NotNamedTest:
+    def test_blocked_by_name(self):
+        assert True
+
+
+class LowerCaseCase(unittest.TestCase):
+    def test_collected_unittest(self):
+        assert True
+
+
+class Mixin:
+    def test_collected_through_subclass(self):
+        assert True
+
+
+class TestFromMixin(Mixin):
+    pass
+'''
+
+
+def test_the_model_agrees_with_pytest_on_every_shape(tmp_path: Path) -> None:
+    """Run the real collector and compare. A model nothing checks is a guess.
+
+    #14927 reported 120 methods from an AST model of ``python_classes`` alone.
+    Collecting the files put the real figure at 90, with 30 false positives and
+    41 real offenders the model could not see. That error is only catchable by
+    asking pytest, so this asks pytest — on a module carrying one of every shape,
+    in its own directory with its own config, so neither the repo's conftest nor
+    its testpaths can influence the answer.
+    """
+    module = tmp_path / "shapes_test.py"
+    module.write_text(textwrap.dedent(_EVERY_SHAPE), encoding="utf-8")
+    config = tmp_path / "pytest.ini"
+    config.write_text(
+        "[pytest]\npython_files = test_*.py *_test.py\n"
+        "python_classes = Test*\npython_functions = test_*\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(  # nosec B603
+        [
+            sys.executable, "-m", "pytest", str(module),
+            "--collect-only", "-q", "--no-header",
+            "-c", str(config), "-p", "no:cacheprovider",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=False,
+    )
+    # Presence, not absence of failure: an empty stdout would otherwise agree
+    # with a model that found nothing either.
+    node_ids = {
+        line.split("::")[-1].strip()
+        for line in result.stdout.splitlines()
+        if "::" in line and line.startswith("shapes_test.py")
+    }
+    assert node_ids, (
+        "pytest collected nothing from the shape module, so this comparison proves "
+        f"nothing.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    source = module.read_text(encoding="utf-8")
+    every_method = {
+        child.name
+        for node in ast.parse(source).body
+        if isinstance(node, ast.ClassDef)
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and child.name.startswith("test_")
+    }
+    predicted_uncollected = {method for _, method, _ in uncollected_test_methods(source)}
+    predicted_collected = every_method - predicted_uncollected
+
+    assert predicted_collected == node_ids, (
+        "this file's model of pytest's collection disagrees with pytest.\n"
+        f"  pytest collected : {sorted(node_ids)}\n"
+        f"  model predicted  : {sorted(predicted_collected)}\n"
+        "The model is what every count in this file rests on — fix it here, do not "
+        "adjust the budgets to match a wrong model (#14927)."
+    )

--- a/repo_tests/tests_that_return_instead_of_asserting_test.py
+++ b/repo_tests/tests_that_return_instead_of_asserting_test.py
@@ -99,12 +99,19 @@ import ast
 import configparser
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PYTEST_INI = _REPO_ROOT / "pytest.ini"
 
 _SKIP = {
     ".git",
     ".worktrees",
+    # Harness territory: tooling config plus the agent worktrees checked out
+    # under it, which hold other branches' work in progress and are not always
+    # parseable. pytest's own testpaths never reach it either, so nothing here
+    # is collectable and nothing here is this sweep's subject.
+    ".claude",
     "__pycache__",
     "node_modules",
     ".venv",
@@ -162,6 +169,32 @@ def _pytest_option(name: str) -> list[str]:
     values = parser.get("pytest", name, fallback="").split()
     assert values, f"pytest.ini declares no {name} — the population cannot be derived"
     return values
+
+
+def _parse_module(path: Path) -> ast.Module:
+    """Parse one swept file, failing loudly and by name if it cannot be parsed.
+
+    This sweep is a denylist walk from the repo root, filtered only by ``_SKIP``,
+    so it reaches files pytest's ``testpaths`` allowlist never would: scratch
+    copies, templates, half-written drafts. An unparseable one must never read as
+    "clean" -- skipping it silently is the exact under-reporting failure this
+    guard exists to catch -- so it is raised as a failure that names the file and
+    says how to take it out of the sweep on purpose.
+    """
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        relative = path.relative_to(_REPO_ROOT)
+        raise AssertionError(
+            f"{relative}:{exc.lineno or 0} is not parseable Python ({exc.msg}). "
+            "This guard sweeps every *.py under the repo root as a denylist, so it "
+            "sees files pytest's own testpaths allowlist never reaches. Fix the "
+            "file, or -- if it is scratch, vendored or another branch's work and "
+            "does not belong in the sweep -- add its top-level directory to _SKIP "
+            "in every repo_tests guard that sweeps, the way .claude and .worktrees "
+            "already are. Do not silence this by skipping the file: a file the "
+            "sweep cannot read is not a file the sweep has cleared."
+        ) from exc
 
 
 def _test_modules() -> list[Path]:
@@ -233,7 +266,11 @@ def offending_returns(source: str) -> list[tuple[str, int]]:
     module. A detector only ever pointed at the real tree cannot be told apart
     from one that has stopped detecting.
     """
-    tree = ast.parse(source)
+    return _offending_returns(ast.parse(source))
+
+
+def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
+    """The tree-driven half, so the repo sweep parses each module once."""
     found: list[tuple[str, int]] = []
     for function in _collectable_tests(tree):
         if _is_fixture(function) or _own_nodes(function, (ast.Yield, ast.YieldFrom)):
@@ -257,7 +294,7 @@ def _offenders_by_tree() -> dict[str, list[str]]:
     counts: dict[str, list[str]] = {}
     for module in _test_modules():
         relative = module.relative_to(_REPO_ROOT)
-        for name, line in offending_returns(module.read_text(encoding="utf-8")):
+        for name, line in _offending_returns(_parse_module(module)):
             counts.setdefault(relative.parts[0], []).append(f"{relative}:{line} {name}")
     return counts
 
@@ -272,7 +309,7 @@ def _test_functions_by_tree() -> dict[str, int]:
     counts: dict[str, int] = {}
     for module in _test_modules():
         tree = module.relative_to(_REPO_ROOT).parts[0]
-        found = _collectable_tests(ast.parse(module.read_text(encoding="utf-8")))
+        found = _collectable_tests(_parse_module(module))
         counts[tree] = counts.get(tree, 0) + len(found)
     return counts
 
@@ -286,7 +323,7 @@ def test_the_population_is_present_and_large_enough_to_mean_anything() -> None:
         "The sweep has stopped matching and would call every tree clean."
     )
     total = sum(
-        len(_collectable_tests(ast.parse(module.read_text(encoding="utf-8"))))
+        len(_collectable_tests(_parse_module(module)))
         for module in modules
     )
     assert total >= _MIN_TEST_FUNCTIONS, (
@@ -412,3 +449,28 @@ def test_the_detector_finds_a_planted_return_and_spares_the_legitimate_ones() ->
     assert offending_returns(
         "def test_c():\n    return True\n"
     ), "a test whose return is its ONLY verdict is still an offence"
+
+
+def test_an_unparseable_swept_file_fails_loudly_instead_of_reading_as_clean() -> None:
+    """The sweep is a denylist from the repo root, so it meets stray files.
+
+    One must never be skipped: a file the walk could not read is not a file the
+    walk cleared, and dropping it silently is the under-reporting this guard
+    exists to catch. It has to fail, name the file and say what to do about it.
+
+    The probe is written under a ``_SKIP``ped directory so no concurrently
+    running sweep can pick it up while it exists.
+    """
+    scratch = _REPO_ROOT / "__pycache__"
+    scratch.mkdir(exist_ok=True)
+    stray = scratch / "unparseable_probe_test.py"
+    stray.write_text("from a-b.c import (\n", encoding="utf-8")
+    try:
+        with pytest.raises(AssertionError) as raised:
+            _parse_module(stray)
+    finally:
+        stray.unlink()
+
+    message = str(raised.value)
+    assert "unparseable_probe_test.py" in message, "the failure must name the file"
+    assert "_SKIP" in message, "the failure must say how to exclude a file on purpose"

--- a/repo_tests/tests_that_return_instead_of_asserting_test.py
+++ b/repo_tests/tests_that_return_instead_of_asserting_test.py
@@ -41,13 +41,23 @@ WHAT IS DELIBERATELY NOT COUNTED, AND WHY
 -----------------------------------------
 Measured on this branch, each derived from the code rather than from a list:
 
-* **152** returns in ``test_*`` methods of classes that do not match
-  ``python_classes`` — pytest never collects them, so they are ordinary
-  methods that happen to be named like tests. Counting them would demand edits
-  to code nothing executes, and the conversion has to wait until the methods
-  are actually collected. That is its own defect, filed as **#14927** (120
-  methods in 23 classes across 19 files, including 13 in an IDOR hotfix suite),
-  and it must be fixed first.
+* returns in ``test_*`` methods of classes pytest does not collect — they are
+  ordinary methods that happen to be named like tests, so converting their
+  ``return`` to ``assert`` would change nothing until something runs them. That
+  is its own defect, tracked by **#14927** and guarded by
+  ``repo_tests/test_methods_in_uncollected_classes_test.py``.
+
+  This exclusion used to be described here as "152 returns in classes that do
+  not match ``python_classes``", citing #14927's figure of 120 methods in 23
+  classes including 13 in an IDOR hotfix suite. That description was wrong, and
+  wrong in a way worth recording: ``python_classes`` is only one of pytest's
+  three collection rules. ``unittest.TestCase`` subclasses are collected
+  whatever they are called — which is why all 13 of the IDOR tests were
+  collecting, running and passing the entire time — and a base class is
+  collected through any ``Test*`` subclass that inherits it. Pulling the other
+  way, a class WITH ``__init__`` is not collected however it is named, which hid
+  41 further methods that neither #14927 nor this file could see. The corrected
+  figure was settled by running ``--collect-only``, not by matching names.
 * **11** returns in ``test_*`` functions decorated with ``@pytest.fixture`` —
   a fixture is *supposed* to return; its name is the only thing test-shaped
   about it.
@@ -132,7 +142,10 @@ _KNOWN_OFFENDERS = {
     #
     # The drop is not a sweep collapse — the population floors below are
     # untouched and still pass, which is what tells the two apart.
-    "autobot-backend": (78, 18000),
+    # 78 -> 75 with #14941 (test_celery_worker_status stopped returning a verdict
+    # pytest discards) and #14927 (three classes converted to collect, which moves
+    # their methods into this file's population as well).
+    "autobot-backend": (75, 18000),
     "autobot-infrastructure": (126, 250),
     "autobot-npu-worker": (7, 150),
 }


### PR DESCRIPTION
Closes #14931, #14941
Refs #14927, #14984

Three issues, one defect: a check that cannot report what it was written to report.

## Thinking Path

#14927 says 120 `test_*` methods sit in non-`Test*` classes and that 13 of them are an IDOR hotfix suite that has never run. Collection is exactly where that failure would manifest, so I settled the population by running `--collect-only` on all 19 files rather than by matching class names.

**The 13 IDOR tests were already collecting, and all 13 pass.** Every class in that file derives from `unittest.TestCase` or `IsolatedAsyncioTestCase`, and pytest hands those to its unittest integration, which never consults `python_classes`. No security finding.

That made the whole 120 suspect, and it was wrong in both directions. `python_classes` is one of three rules pytest applies:

1. `unittest.TestCase` subclasses collect whatever their name — 23 of the 120 (13 IDOR + 10 file-upload), all passing.
2. A base class collects through any `Test*` subclass that inherits it — `ReadOnlyCapabilityChecks` collects twice over, once per subclass.
3. **A class with `__init__` does NOT collect, however it is named.** pytest emits `PytestCollectionWarning` and moves on.

Rule 3 is the one that hurt. It cuts the opposite way to the issue's model, so the model could not see it: **five `Test*`-named classes held 41 methods that ran nowhere**, and a reader looking at `class TestEntityResolution:` has no reason to suspect anything. Corrected total: 90 of the reported 120 are real, plus 41 the name-based model missed.

Rule 3 also makes the obvious fix a trap. Renaming a class to `Test*` while it keeps its `__init__` collects **zero** while looking fixed — the defect reproduced under a better name. So "rename the 23 classes" would have produced a green-looking sweep with no new coverage.

On scope: I converted the tranche that comes out green and held back the rest rather than shipping a large tranche of new red. The two held-back suites fail for real product reasons, not conversion damage, and are filed with per-failure detail (#14978). The 90 live-service drivers are each a rewrite — `__init__` plus a `run_all_*` loop plus methods that dial a running backend and return bool — so they are filed with per-file counts (#14979) and pinned by the ratchet meanwhile. I did not mark anything skip or xfail to clear the board.

## What Changed

**#14941 — `test_celery_worker_status` could not fail.** It wrapped its body in `try/except Exception` and ended every path with `return True`/`return False`, which pytest discards. It now asserts on what it read. The driver contract was checked rather than assumed: `main()` calls it bare and discards the result, so unlike the npu_code_search drivers there is no truthiness contract and the function returns nothing — which also takes it out of #14920's offender population. A checkout with no `logs/` directory skips with a named reason; a `logs/` that exists without the worker's log fails, because that means the worker never started.

**#14931 — three of four sub-tests swallowed their failures.** #14929 converted only the fourth handler; the other three logged and continued, so the function still reached `return True` and the driver counted it passed. All four now raise. `return True` is kept deliberately here: this driver does `result = await test_func()` and sums truthiness, so the test needs both a real assertion and a truthy return. Landed identically in both near-identical copies.

**#14927 — the guard, plus the tranche that could go green.**

- `repo_tests/test_methods_in_uncollected_classes_test.py` models all three collection rules, ratchets per top-level tree (ceilings only, 77 / 10 / 19), and asserts its own agreement with a real `--collect-only` over a module carrying one of every shape. A model of a collector that nothing ever compares to the collector is a guess, and that guess is what produced the 120.
- Population floors count what the sweep **looks at**, not what pytest keeps. `autobot-frontend` legitimately has zero collectable tests, so a floor on the collected subset would read there as a collapsed sweep and the first person to see it would delete the floor.
- Three of the five `__init__`-blocked classes converted to `setup_method`.
- The one exemption — two private stand-ins implementing `AbstractConnector.test_connection`, where the interface dictates the name — is pinned at its exact size, because "starts with an underscore" is a convention and a convention with no ceiling is a bypass.
- `tests_that_return_instead_of_asserting_test.py`: its docstring asserted the IDOR suite was uncollected and cited the 120/152 figures. Corrected, and its `autobot-backend` budget moves 78 → 75.

**One production defect the conversion immediately exposed.** `test_intelligent_defaults` failed the moment it could run, and it was right: `_generate_intelligent_default` matched only the literal word `"choice"`, so `"Select option (1-5):"` fell through every branch and returned `""` instead of a selectable value. Live since #315, guarded the whole time by a test that could not run. Fixed with a `_CHOICE_KEYWORDS` frozenset alongside the existing `_YES_NO_KEYWORDS`.

**Review follow-ups, fixed in this PR.**

*One stray file could blank both repo-wide sweeps.* Both guards walk every `*.py` under the repo root as a **denylist** filtered only by `_SKIP`, and called `ast.parse` on each with nothing catching `SyntaxError`. One unparseable file anywhere outside `_SKIP` therefore took down every assertion in the module at once — and because the new guard's walk is `lru_cache`d and shared, all of its tests died on the first bad file. Real pytest never hits this: `testpaths` is an allowlist. The breadth that exposed the gap is the deliberate design choice, so the breadth stays and the parse gets a guard.

Two changes, because either alone leaves the trap armed. The harness directory is now in `_SKIP` in both guards: agent worktrees are checked out under it, work in progress on another branch is not this repo's tree, and pytest's own `testpaths` never reaches it. And both guards now parse through one `_parse_module` helper that, on `SyntaxError`, raises a failure naming the unparseable path and saying how to exclude a directory deliberately. Deliberately **not** a skip or a `continue`: a file the sweep could not read is not a file the sweep cleared, and quietly under-reporting is the exact defect this pair of guards exists to catch. The returns guard also grew a tree-driven `_offending_returns` so the sweep parses each module once rather than twice.

*The choice-keyword heuristic was too loose.* Widening `_CHOICE_KEYWORDS` to `select`/`option` paired those four generic words with a discriminator of "any digit anywhere in the prompt", in a branch checked **before** the file/path and port branches. `"Select a config file (1 of 3):"` answered `"1"` instead of a path, and `"Select the port to use:"` could not reach the port default at all. The discriminator is now an enumerated range anchored in parentheses, and the answer is taken from inside that range rather than from the first digit found anywhere. `"(1 of 3)"` is not a range, so a file prompt reaches the file branch. Live exposure was nil — every caller passes an explicit `default=`, and `_generate_intelligent_default` is only consulted when that default is falsy — so the tightening is behaviour-preserving for every current call site.

*One dormant modelling gap, filed rather than fixed.* `_has_init()` reads a class's own body; pytest asks `cls.__init__ is not object.__init__`, which walks the MRO. A `Test*` class inheriting `__init__` from a plain base is skipped by pytest and modelled here as collected. A repo-wide sweep found **zero** instances, so no budget moves. Resolving bases across module boundaries is a design change to the model, not a one-line edit, so it is #14984 and the limitation is recorded in a comment at the function it affects.

## Verification

**Collected count, same invocation on both trees** (the CI shard's path list). Note `addopts` forces `--verbose`, so a single `-q` nets to verbosity 0 and prints a *tree*; `-q -q` is required to get node IDs, and the shape was confirmed before the diff was trusted.

| | collected | errors |
|---|---|---|
| base `342eeb05e6` | 28,168 | 6 |
| branch | **28,191** | 6 |
| delta | **+23** | 0 |

The 6 collection errors are pre-existing and identical on both sides. Diffing the node-ID sets: **0 removed**, 23 added — 11 `terminal_input_handler`, 6 `semantic_chunking`, 6 the new guard. `entity_resolution`'s 8 contribute 0 because that module already skips at import on a missing dependency.

**Newly collected, pass/fail/error.** 41 methods were unblocked across five classes; 25 are in the three converted here.

| file | collected | pass | fail | error |
|---|---|---|---|---|
| `terminal_input_handler_test.py` | 11 | 11 | 0 | 0 |
| `semantic_chunking_test.py` | 6 | 5 | 0 | 0 |
| `entity_resolution_test.py` | 0 | — | — | 0 |
| **held back** `atomic_facts_extraction_test.py` | 8 | 1 | 7 | 0 |
| **held back** `temporal_invalidation_test.py` | 8 | 1 | 7 | 0 |

The `semantic_chunking` sixth declares `pytest.importorskip("sentence_transformers")` — real semantic splitting needs the embedding model, and without it the chunker falls back to a single chunk and the test asserts nothing about semantics. That is declaring a dependency, not clearing a board.

**The IDOR suite, stated plainly: 13 collected, 13 passed, 0 failed, 0 errors.** They were collecting on base too. Also verified: `file_upload_comprehensive_test.py` 10 collected (4 pass, 6 skip on absent deps, 0 fail) and `remediation_loop_test.py` 40 passed.

**Mutation, in pairs, against a scratch tree of real files — never in-tree, never committed.**

| mutation | result |
|---|---|
| rename a `Test*` class out of the prefix | offenders 1 → 2, caught |
| add `__init__`, name unchanged | offenders 1 → 2, caught |
| move the offending file to another tree | re-attributed, guard follows |
| fix the offender | offenders → 0, population held |
| break the sweep entirely | offenders → 0 **and population → 0**; the collapse assertion fires rather than reporting a clean tree |

The last row is the one that matters: a broken sweep finds zero offenders, which is indistinguishable from finished work. The floors are checked first and fail telling the reader to fix the sweep, not to write the zero down.

**#14931**, breaking each of the four sub-calls in turn:

| | base | fixed |
|---|---|---|
| break `find_duplicate_code` | returned `True` — green | `AssertionError` — red |
| break `identify_code_patterns` | returned `True` — green | `AssertionError` — red |
| break `analyze_imports_and_dependencies` | returned `True` — green | `AssertionError` — red |
| break `analyze_codebase` | red | red |
| nothing broken | `True` | `True` (driver contract kept) |

**#14941**, across five states of the log tree: no `logs/` dir → skipped with a named reason; no log file → failed; empty log → failed; wrong content → failed; ready marker present → passed. On base, every one of those five passed.

**The production fix**, mutated in-process: with `_CHOICE_KEYWORDS` intact `"Select option (1-5):"` returns `'1'` and the test passes; narrowed back to `{"choice"}` it returns `''` and the test goes red.

**The review follow-ups, by running them.**

*The unparseable-file guard.* An unparseable probe (`from a-b.c import (`) was dropped into a swept tree and into the harness directory at once. The harness copy was skipped; the swept one failed both guards by name, e.g.

```
AssertionError: autobot-backend/stray_probe_test.py:1 is not parseable Python (invalid syntax).
This guard sweeps every *.py under the repo root as a denylist, so it sees files pytest's own
testpaths allowlist never reaches. Fix the file, or -- if it is scratch, vendored or another
branch's work and does not belong in the sweep -- add its top-level directory to _SKIP ...
Do not silence this by skipping the file: a file the sweep cannot read is not a file the sweep
has cleared.
```

Before the fix that same probe produced a raw `SyntaxError` out of `ast.parse` and took all five tests in the new guard down with it. Removing the swept copy and leaving the harness one in place, both guards go green — which is the `_SKIP` half proved separately from the `try/except` half. Each guard now carries a regression test that writes its probe under a `_SKIP`ped directory, so no concurrent sweep can see it.

*The tightened heuristic*, mutated back to the loose form in-process:

| prompt | loose discriminator | enumerated range |
|---|---|---|
| `Select option (1-5):` | `'1'` | `'1'` — unchanged, the case the tightening had to preserve |
| `Select a config file (1 of 3):` | `'1'` | a path — reaches the file branch |
| `Select the port to use:` | port default only by luck of having no digit | the port default, same as `Port number:` |

Reverting to the loose form fails the new test with `'(1 of 3)' is not an enumerated range; a file prompt must reach the file/path branch, got '1'`. `terminal_input_handler_test.py`: **12 passed**.

**Ratchet numbers re-measured after every change, all unchanged.**

| | measured | budget |
|---|---|---|
| uncollected — `autobot-backend` | 77 | 77 |
| uncollected — `autobot-frontend` | 10 | 10 |
| uncollected — `autobot-infrastructure` | 19 | 19 |
| interface stubs | 2 | 2 |
| returns — `autobot-backend` | 75 | 75 |
| returns — `autobot-infrastructure` | 126 | 126 |
| returns — `autobot-npu-worker` | 7 | 7 |

Modules swept 1,978; population 27,672 (was 27,669 — the three tests added here), both far above their floors.

Both ratchets green together: 12 passed. All three touched suites together: 24 passed.

## Model Used

Claude Opus 5 (1M context)

