### PR TITLE
fix(enums): converge severity literals on the canonical enum and add the three rungs it was missing (#14956, #13597)

### DIFF
--- a/autobot-backend/agents/security_scanner_agent.py
+++ b/autobot-backend/agents/security_scanner_agent.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List
 
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
 from utils.agent_command_helpers import run_agent_command
@@ -469,7 +470,7 @@ class SecurityScannerAgent(StandardizedAgent):
                     vulnerabilities.append(
                         {
                             "vulnerability": lines[0].strip(),
-                            "severity": "unknown",
+                            "severity": Severity.UNKNOWN.value,
                             "description": ("\n".join(lines[1:3]) if len(lines) > 1 else ""),
                         }
                     )

--- a/autobot-backend/api/analytics.py
+++ b/autobot-backend/api/analytics.py
@@ -58,6 +58,7 @@ from auth_middleware import get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import parse_utc_iso
 from constants.network_constants import NetworkConstants
 from constants.threshold_constants import TimingConstants
@@ -205,7 +206,7 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
             {
                 "type": "cpu_high",
                 "message": f"CPU usage at {cpu_usage:.1f}%",
-                "severity": "warning",
+                "severity": Severity.WARNING.value,
             }
         )
 
@@ -216,7 +217,7 @@ def _check_resource_alerts(system_resources: Dict) -> List[Dict[str, Any]]:
             {
                 "type": "memory_high",
                 "message": f"Memory usage at {memory_usage:.1f}%",
-                "severity": "warning",
+                "severity": Severity.WARNING.value,
             }
         )
 

--- a/autobot-backend/api/analytics_agents.py
+++ b/autobot-backend/api/analytics_agents.py
@@ -33,6 +33,7 @@ from api.schemas_analytics import (
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from services.agent_analytics import AgentType, TaskStatus, get_agent_analytics
 
 logger = get_logger(__name__)
@@ -224,7 +225,7 @@ def _check_agent_metrics(metrics) -> list:
         recommendations.append(
             {
                 "type": "high_error_rate",
-                "severity": "high" if metrics.error_rate > 25 else "medium",
+                "severity": Severity.HIGH.value if metrics.error_rate > 25 else "medium",
                 "message": f"Error rate of {metrics.error_rate:.1f}% exceeds threshold",
                 "suggestion": "Review error logs and improve error handling",
             }
@@ -234,7 +235,7 @@ def _check_agent_metrics(metrics) -> list:
         recommendations.append(
             {
                 "type": "slow_performance",
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
                 "message": f"Average duration of {metrics.avg_duration_ms/1000:.1f}s is high",
                 "suggestion": "Consider optimizing task processing or increasing resources",
             }
@@ -246,7 +247,7 @@ def _check_agent_metrics(metrics) -> list:
             recommendations.append(
                 {
                     "type": "timeout_issues",
-                    "severity": "high" if timeout_rate > 15 else "medium",
+                    "severity": Severity.HIGH.value if timeout_rate > 15 else "medium",
                     "message": f"Timeout rate of {timeout_rate:.1f}% indicates issues",
                     "suggestion": "Increase timeout limits or optimize long-running operations",
                 }
@@ -263,7 +264,7 @@ def _check_agent_metrics(metrics) -> list:
                 recommendations.append(
                     {
                         "type": "low_activity",
-                        "severity": "low",
+                        "severity": Severity.LOW.value,
                         "message": "No activity in the last 7 days",
                         "suggestion": "Check if agent is properly configured and active",
                     }

--- a/autobot-backend/api/analytics_bug_prediction.py
+++ b/autobot-backend/api/analytics_bug_prediction.py
@@ -798,7 +798,7 @@ async def _run_bug_analysis(path: str, include_pattern: str, limit: int) -> dict
     analyzed_files.sort(key=lambda x: x["risk_score"], reverse=True)
     high_risk = sum(1 for f in analyzed_files if f["risk_score"] >= 60)
 
-    risk_dist = {level.value: 0 for level in RiskLevel}
+    risk_dist = {level.value: 0 for level in RiskLevel.score_ladder()}
     for f in analyzed_files:
         level = get_risk_level(f["risk_score"])
         risk_dist[level.value] += 1
@@ -868,7 +868,7 @@ def _build_analysis_result(
     """Build the final result dict for a completed analysis (#1418)."""
     analyzed_files.sort(key=lambda x: x["risk_score"], reverse=True)
     high_risk = sum(1 for f in analyzed_files if f["risk_score"] >= 60)
-    risk_dist = {level.value: 0 for level in RiskLevel}
+    risk_dist = {level.value: 0 for level in RiskLevel.score_ladder()}
     for f in analyzed_files:
         level = get_risk_level(f["risk_score"])
         risk_dist[level.value] += 1
@@ -1230,7 +1230,7 @@ def _calculate_risk_distribution(analyzed_files: list) -> dict[str, int]:
     Returns:
         Dict mapping risk level names to counts
     """
-    risk_dist = {level.value: 0 for level in RiskLevel}
+    risk_dist = {level.value: 0 for level in RiskLevel.score_ladder()}
     for f in analyzed_files:
         level = get_risk_level(f["risk_score"])
         risk_dist[level.value] += 1

--- a/autobot-backend/api/analytics_llm_patterns.py
+++ b/autobot-backend/api/analytics_llm_patterns.py
@@ -47,6 +47,7 @@ from api.schemas_analytics import (
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import RedisDatabase
 from autobot_shared.redis_mixin import AsyncRedisClientMixin
+from autobot_shared.status_enums import Severity
 from constants.model_constants import (
     EXPENSIVE_MODEL_MARKER_GPT4,
     EXPENSIVE_MODEL_MARKER_OPUS,
@@ -268,7 +269,7 @@ class LLMPatternAnalyzer(AsyncRedisClientMixin):
                 {
                     "type": "long_prompt",
                     "message": "Prompt is very long, consider reducing context",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                 }
             )
             recommendations.append("Consider extracting only relevant code sections")
@@ -291,7 +292,7 @@ class LLMPatternAnalyzer(AsyncRedisClientMixin):
                 {
                     "type": "redundancy",
                     "message": f"Possible redundancy detected: {', '.join(repeated_words[:5])}",
-                    "severity": "info",
+                    "severity": Severity.INFO.value,
                 }
             )
 

--- a/autobot-backend/api/analytics_quality.py
+++ b/autobot-backend/api/analytics_quality.py
@@ -41,6 +41,7 @@ from api.ws_security import enforce_ws_origin
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 
 logger = get_logger(__name__)
@@ -500,13 +501,13 @@ def _categorize_problems_for_patterns(
     """
     # Count by type category
     categories = {
-        "anti_pattern": {"count": 0, "severity": "high"},
-        "code_smell": {"count": 0, "severity": "medium"},
-        "best_practice": {"count": 0, "severity": "info"},
-        "security_vulnerability": {"count": 0, "severity": "critical"},
-        "performance_issue": {"count": 0, "severity": "high"},
-        "technical_debt": {"count": 0, "severity": "medium"},
-        "bug_risk": {"count": 0, "severity": "high"},
+        "anti_pattern": {"count": 0, "severity": Severity.HIGH.value},
+        "code_smell": {"count": 0, "severity": Severity.MEDIUM.value},
+        "best_practice": {"count": 0, "severity": Severity.INFO.value},
+        "security_vulnerability": {"count": 0, "severity": Severity.CRITICAL.value},
+        "performance_issue": {"count": 0, "severity": Severity.HIGH.value},
+        "technical_debt": {"count": 0, "severity": Severity.MEDIUM.value},
+        "bug_risk": {"count": 0, "severity": Severity.HIGH.value},
     }
 
     for problem in problems:

--- a/autobot-backend/api/code_intelligence.py
+++ b/autobot-backend/api/code_intelligence.py
@@ -66,6 +66,7 @@ from api.schemas_common import DataResponse
 from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import parse_utc_iso
 from code_intelligence.anti_pattern_detector import (
     AntiPatternDetector,
@@ -756,7 +757,7 @@ def _analyze_inline_code(request: CodeIntelAnalysisRequest) -> JSONResponse:
         quality_score -= 10
         issues.append(
             {
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
                 "category": "quality",
                 "message": "File exceeds 300 lines",
             }
@@ -767,7 +768,7 @@ def _analyze_inline_code(request: CodeIntelAnalysisRequest) -> JSONResponse:
             quality_score -= 5
             issues.append(
                 {
-                    "severity": "low",
+                    "severity": Severity.LOW.value,
                     "category": "quality",
                     "message": "Average function length exceeds 50 lines",
                 }

--- a/autobot-backend/api/codebase_analytics/analyzers.py
+++ b/autobot-backend/api/codebase_analytics/analyzers.py
@@ -18,6 +18,7 @@ import aiofiles
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.missing_dep import optional_import
+from autobot_shared.status_enums import Severity
 from constants.network_constants import NetworkConstants
 from llm_shared.types import LLMType
 from services.llm_service import get_llm_service
@@ -753,7 +754,7 @@ def _check_long_function(node: ast.FunctionDef) -> Dict | None:
 
     return {
         "type": "long_function",
-        "severity": "medium",
+        "severity": Severity.MEDIUM.value,
         "line": node.lineno,
         "description": f"Function '{node.name}' is {func_length} lines long",
         "suggestion": "Consider breaking into smaller functions",
@@ -1528,7 +1529,7 @@ def _check_js_console_log(line: str, line_num: int) -> Dict | None:
     if "console.log" in line and not line.strip().startswith("//"):
         return {
             "type": "debug_code",
-            "severity": "low",
+            "severity": Severity.LOW.value,
             "line": line_num,
             "description": "console.log statement found",
             "suggestion": "Remove debug statements before production",
@@ -1562,7 +1563,7 @@ def _create_parse_error_result(error_msg: str) -> Metadata:
     result["problems"] = [
         {
             "type": "parse_error",
-            "severity": "high",
+            "severity": Severity.HIGH.value,
             "line": 1,
             "description": f"Failed to parse file: {error_msg}",
             "suggestion": "Check syntax errors",

--- a/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/codebase_stats_endpoint_test.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import now_utc
 
 
@@ -399,7 +400,7 @@ class TestNormalizeHardcodeRecord:
             "value": "127.0.0.1",
             "line": 1,
             "file": "x.py",
-            "severity": "low",  # override default
+            "severity": Severity.LOW.value,  # override default
         }
         normalized = _normalize_hardcode_record(record)
 
@@ -423,7 +424,7 @@ class TestNormalizeHardcodeRecord:
             "value": "8001",
             "line": 10,
             "file": "app.py",
-            "severity": "medium",
+            "severity": Severity.MEDIUM.value,
             "context": "PORT = 8001",
         }
         normalized = _normalize_hardcode_record(record)

--- a/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis_cached_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/pattern_analysis_cached_test.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.codebase_analytics.endpoints.pattern_analysis import router
+from autobot_shared.status_enums import Severity
 
 _STORAGE_MODULE_NAME = "code_intelligence.pattern_analysis.storage"
 
@@ -92,7 +93,7 @@ class TestGetCachedPatternSummary:
         mock_collection = AsyncMock()
         mock_collection.get.return_value = {
             "metadatas": [
-                {"pattern_type": "duplicate", "severity": "medium", "file_path": "a.py"},
+                {"pattern_type": "duplicate", "severity": Severity.MEDIUM.value, "file_path": "a.py"},
             ]
         }
         stub_storage.get_pattern_collection_async = AsyncMock(return_value=mock_collection)

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -41,6 +41,7 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_utils import decode_redis_value
+from autobot_shared.status_enums import Severity
 from constants.threshold_constants import QueryDefaults
 from services.grounded_agent import (
     Claim,
@@ -264,7 +265,7 @@ async def list_conflicts(
             {
                 "conflict_id": "...",
                 "description": "...",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "resolution": "pending_review",
                 "timestamp": 1234567890
             }

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -41,7 +41,6 @@ from auth_middleware import check_admin_permission, get_current_user
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_utils import decode_redis_value
-from autobot_shared.status_enums import Severity
 from constants.threshold_constants import QueryDefaults
 from services.grounded_agent import (
     Claim,

--- a/autobot-backend/api/knowledge_grounding.py
+++ b/autobot-backend/api/knowledge_grounding.py
@@ -264,7 +264,7 @@ async def list_conflicts(
             {
                 "conflict_id": "...",
                 "description": "...",
-                "severity": Severity.HIGH.value,
+                "severity": "high",
                 "resolution": "pending_review",
                 "timestamp": 1234567890
             }

--- a/autobot-backend/api/knowledge_grounding_conflicts_decode_test.py
+++ b/autobot-backend/api/knowledge_grounding_conflicts_decode_test.py
@@ -24,12 +24,13 @@ import pytest
 from fastapi import HTTPException
 
 from api import knowledge_grounding
+from autobot_shared.status_enums import Severity
 
 # The live wire shape: decode_responses=True means every field is already str.
 DECODED_CONFLICTS = {
     "conflict:abc123": {
         "status": "pending",
-        "severity": "high",
+        "severity": Severity.HIGH.value,
         "description": "KB says X, source says Y",
         "timestamp": "1700000000.0",
     },
@@ -39,7 +40,7 @@ DECODED_CONFLICTS = {
 BYTES_KEY_CONFLICTS = {
     b"conflict:def456": {
         "status": "pending",
-        "severity": "low",
+        "severity": Severity.LOW.value,
         "description": "legacy bytes key",
         "timestamp": "1700000001.0",
     },

--- a/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py
@@ -25,7 +25,20 @@ from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from utils.line_index import LineIndex  # #12884
+
+# Issue #12660: auto-tools/ has no __init__.py (hyphenated dir name isn't a
+# valid package identifier) — add this directory to sys.path so the shared
+# tool skeleton can be imported by every standalone script here.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tool_base import (  # noqa: E402
+    SEVERITY_REPORT_ICONS,
+    SEVERITY_REPORT_ORDER,
+    severity_icon,
+    severity_label,
+)
 
 # Configure logging for security fixer
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -156,27 +169,27 @@ class PlaywrightSecurityFixer:
         patterns = {
             "innerHTML_usage": {
                 "regex": r"\.innerHTML\s*=\s*[^;]+",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "description": "Direct innerHTML assignment detected",
             },
             "dangerouslySetInnerHTML": {
                 "regex": r"dangerouslySetInnerHTML\s*[=:]\s*\{[^}]*__html",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "description": "React dangerouslySetInnerHTML usage detected",
             },
             "eval_usage": {
                 "regex": r"\beval\s*\(",
-                "severity": "CRITICAL",
+                "severity": Severity.CRITICAL.value,
                 "description": "eval() function usage detected",
             },
             "document_write": {
                 "regex": r"document\.write\s*\(",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "description": "document.write() usage detected",
             },
             "javascript_protocol": {
                 "regex": r"javascript\s*:",
-                "severity": "MEDIUM",
+                "severity": Severity.MEDIUM.value,
                 "description": "javascript: protocol detected",
             },
         }
@@ -280,10 +293,8 @@ class PlaywrightSecurityFixer:
         severity_counts: Dict[str, int] = {}
         for vuln in vulnerabilities:
             severity_counts[vuln["severity"]] = severity_counts.get(vuln["severity"], 0) + 1
-        severity_icons = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🟢"}
         for severity, count in severity_counts.items():
-            icon = severity_icons.get(severity, "⚪")
-            logger.info("   %s %s: %d patterns", icon, severity, count)
+            logger.info("   %s %s: %d patterns", severity_icon(severity), severity_label(severity), count)
 
     def _apply_and_write_html(
         self, original_content: str, original_size: int, file_path: str
@@ -403,7 +414,6 @@ class PlaywrightSecurityFixer:
         if not self.report["vulnerabilities"]:
             return "✅ No vulnerability patterns detected in scanned files.\n\n"
 
-        severity_icons = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🟢"}
         severity_groups = {}
         for vuln in self.report["vulnerabilities"]:
             severity = vuln["severity"]
@@ -412,11 +422,11 @@ class PlaywrightSecurityFixer:
             severity_groups[severity].append(vuln)
 
         content = "### Vulnerability Patterns by Severity:\n\n"
-        for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
-            if severity in severity_groups:
-                vulns = severity_groups[severity]
-                icon = severity_icons[severity]
-                content += f"#### {icon} {severity} ({len(vulns)} patterns)\n\n"
+        for level in SEVERITY_REPORT_ORDER:
+            if level.value in severity_groups:
+                vulns = severity_groups[level.value]
+                icon = SEVERITY_REPORT_ICONS[level]
+                content += f"#### {icon} {level.name} ({len(vulns)} patterns)\n\n"
 
                 for vuln in vulns:
                     content += f"- **{vuln['description']}**\n"

--- a/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py
@@ -28,6 +28,7 @@ import sys
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from utils.line_index import LineIndex  # #12884
 
 # Configure logging
@@ -108,7 +109,13 @@ import re  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
 from typing import Any, Dict, List, Tuple  # noqa: E402
 
-from tool_base import SecurityFixToolBase  # noqa: E402
+from tool_base import (  # noqa: E402
+    SEVERITY_REPORT_ICONS,
+    SEVERITY_REPORT_ORDER,
+    SecurityFixToolBase,
+    severity_icon,
+    severity_label,
+)
 
 
 class SecurityFixAgent(SecurityFixToolBase):
@@ -132,7 +139,7 @@ class SecurityFixAgent(SecurityFixToolBase):
         return {
             "direct_innerHTML": {
                 "pattern": r"(?<![\w\.])([\w\.]+)\.innerHTML\s*=\s*([^;]+);",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [
                     'element.innerHTML=""',
                     "innerHTML=null",
@@ -141,47 +148,47 @@ class SecurityFixAgent(SecurityFixToolBase):
             },
             "innerHTML_concat": {
                 "pattern": r"(?<![\w\.])([\w\.]+)\.innerHTML\s*\+=\s*([^;]+);",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [],
             },
             "outerHTML_write": {
                 "pattern": r"(?<![\w\.])([\w\.]+)\.outerHTML\s*=\s*([^;]+);",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [],
             },
             "insertAdjacentHTML_usage": {
                 "pattern": r'\.insertAdjacentHTML\s*\(\s*[\'"](\w+)[\'"]\s*,\s*([^)]+)\)',
-                "severity": "MEDIUM",
+                "severity": Severity.MEDIUM.value,
                 "context_safe": [],
             },
             "document_write_usage": {
                 "pattern": r"document\.write(?:ln)?\s*\(([^)]+)\)",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [],
             },
             "eval_execution": {
                 "pattern": r"\beval\s*\(([^)]+)\)",
-                "severity": "CRITICAL",
+                "severity": Severity.CRITICAL.value,
                 "context_safe": [],
             },
             "function_constructor": {
                 "pattern": r"new\s+Function\s*\(([^)]+)\)",
-                "severity": "CRITICAL",
+                "severity": Severity.CRITICAL.value,
                 "context_safe": [],
             },
             "javascript_protocol": {
                 "pattern": r'(?:href|src)\s*=\s*[\'"]javascript:([^\'\"]+)[\'"]',
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [],
             },
             "data_uri_html": {
                 "pattern": r'(?:href|src)\s*=\s*[\'"]data:text/html[^\'\"]*[\'"]',
-                "severity": "MEDIUM",
+                "severity": Severity.MEDIUM.value,
                 "context_safe": [],
             },
             "react_dangerously_set": {
                 "pattern": r"dangerouslySetInnerHTML\s*=\s*\{\s*__html:\s*([^}]+)\s*\}",
-                "severity": "HIGH",
+                "severity": Severity.HIGH.value,
                 "context_safe": [],
             },
         }
@@ -651,16 +658,10 @@ class SecurityFixAgent(SecurityFixToolBase):
         content = ""
         if severity_counts:
             content += "### Vulnerabilities by Severity:\n\n"
-            severity_icons = {
-                "CRITICAL": "🔴",
-                "HIGH": "🟠",
-                "MEDIUM": "🟡",
-                "LOW": "🟢",
-            }
-            for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
-                if severity in severity_counts:
-                    icon = severity_icons[severity]
-                    content += f"- {icon} **{severity}:** {severity_counts[severity]} vulnerabilities\n"
+            for level in SEVERITY_REPORT_ORDER:
+                if level.value in severity_counts:
+                    icon = SEVERITY_REPORT_ICONS[level]
+                    content += f"- {icon} **{level.name}:** {severity_counts[level.value]} vulnerabilities\n"
             content += f"- 📚 **Library/Framework Code:** {library_vulns} vulnerabilities (mitigated with CSP)\n\n"
 
         return content
@@ -682,18 +683,12 @@ class SecurityFixAgent(SecurityFixToolBase):
         direct_vulns = [v for v in self.report["vulnerabilities"] if not v.get("is_library_code", False)]
         if direct_vulns:
             content += "### Critical Vulnerabilities Fixed:\n\n"
-            severity_icon = {
-                "CRITICAL": "🔴",
-                "HIGH": "🟠",
-                "MEDIUM": "🟡",
-                "LOW": "🟢",
-            }
             for i, vuln in enumerate(direct_vulns, 1):
-                icon = severity_icon.get(vuln["severity"], "⚪")
+                icon = severity_icon(vuln["severity"])
                 content += f"**{i}. {vuln['type'].replace('_', ' ').title()}** {icon}\n"
                 content += f"- **File:** `{vuln['file']}`\n"
                 content += f"- **Line:** {vuln['line']}\n"
-                content += f"- **Severity:** {vuln['severity']}\n"
+                content += f"- **Severity:** {severity_label(vuln['severity'])}\n"
                 match_preview = vuln["match"][:100] + ("..." if len(vuln["match"]) > 100 else "")
                 content += f"- **Pattern:** `{match_preview}`\n\n"
 
@@ -702,7 +697,7 @@ class SecurityFixAgent(SecurityFixToolBase):
             for i, fix in enumerate(self.report["fixes_applied"], 1):
                 content += f"**Fix {i}:** {fix['type'].replace('_', ' ').title()}\n"
                 content += f"- **Line:** {fix['line']}\n"
-                content += f"- **Severity:** {fix['severity']}\n"
+                content += f"- **Severity:** {severity_label(fix['severity'])}\n"
                 orig_preview = fix["original"][:80] + ("..." if len(fix["original"]) > 80 else "")
                 fixed_preview = fix["fixed"][:80] + ("..." if len(fix["fixed"]) > 80 else "")
                 content += f"- **Original:** `{orig_preview}`\n"

--- a/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
+++ b/autobot-backend/code_analysis/auto-tools/security_sanitizer.py
@@ -24,6 +24,7 @@ import sys
 from pathlib import Path
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from utils.line_index import LineIndex  # #12884
 
 # Configure logging
@@ -44,7 +45,13 @@ import re  # noqa: E402
 from datetime import datetime, timezone  # noqa: E402
 from typing import Any, Dict, List, Tuple  # noqa: E402
 
-from tool_base import SecurityFixToolBase  # noqa: E402
+from tool_base import (  # noqa: E402
+    SEVERITY_REPORT_ICONS,
+    SEVERITY_REPORT_ORDER,
+    SecurityFixToolBase,
+    severity_icon,
+    severity_label,
+)
 
 
 class SecurityFixAgent(SecurityFixToolBase):
@@ -153,13 +160,13 @@ class SecurityFixAgent(SecurityFixToolBase):
         medium_vulns = ["outerHTML_assignment", "insertAdjacentHTML"]
 
         if vuln_type in critical_vulns:
-            return "CRITICAL"
+            return Severity.CRITICAL.value
         elif vuln_type in high_vulns:
-            return "HIGH"
+            return Severity.HIGH.value
         elif vuln_type in medium_vulns:
-            return "MEDIUM"
+            return Severity.MEDIUM.value
         else:
-            return "LOW"
+            return Severity.LOW.value
 
     def apply_security_fixes(
         self, content: str, vulnerabilities: List[Dict[str, Any]]
@@ -347,10 +354,9 @@ class SecurityFixAgent(SecurityFixToolBase):
 
         Issue #1183: Extracted from fix_file() to reduce function length.
         """
-        severity_icon = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🟢"}
         for vuln in vulnerabilities:
-            icon = severity_icon.get(vuln["severity"], "⚪")
-            logger.info(f"  {icon} Line {vuln['line']}: {vuln['type']} ({vuln['severity']})")
+            icon = severity_icon(vuln["severity"])
+            logger.info(f"  {icon} Line {vuln['line']}: {vuln['type']} ({severity_label(vuln['severity'])})")
             logger.info("     Match: %s", vuln["match"][:100])
 
     def _apply_fixes_and_write(
@@ -500,7 +506,6 @@ class SecurityFixAgent(SecurityFixToolBase):
         Issue #281: Extracted from generate_report to reduce function length.
         """
         content = ""
-        severity_icons = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡", "LOW": "🟢"}
 
         # Vulnerability breakdown by severity
         severity_counts = {}
@@ -510,21 +515,21 @@ class SecurityFixAgent(SecurityFixToolBase):
 
         if severity_counts:
             content += "### Vulnerabilities by Severity:\n\n"
-            for severity in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
-                if severity in severity_counts:
-                    icon = severity_icons[severity]
-                    content += f"- {icon} **{severity}:** {severity_counts[severity]} vulnerabilities\n"
+            for level in SEVERITY_REPORT_ORDER:
+                if level.value in severity_counts:
+                    icon = SEVERITY_REPORT_ICONS[level]
+                    content += f"- {icon} **{level.name}:** {severity_counts[level.value]} vulnerabilities\n"
             content += "\n"
 
         # Detailed vulnerability list
         if self.report["vulnerabilities"]:
             content += "### Detailed Vulnerabilities:\n\n"
             for i, vuln in enumerate(self.report["vulnerabilities"], 1):
-                icon = severity_icons.get(vuln["severity"], "⚪")
+                icon = severity_icon(vuln["severity"])
                 content += f"**{i}. {vuln['type'].replace('_', ' ').title()}** {icon}\n"
                 content += f"- **File:** `{vuln['file']}`\n"
                 content += f"- **Line:** {vuln['line']}\n"
-                content += f"- **Severity:** {vuln['severity']}\n"
+                content += f"- **Severity:** {severity_label(vuln['severity'])}\n"
                 match_preview = vuln["match"][:100] + ("..." if len(vuln["match"]) > 100 else "")
                 content += f"- **Pattern:** `{match_preview}`\n\n"
 

--- a/autobot-backend/code_analysis/auto-tools/tool_base.py
+++ b/autobot-backend/code_analysis/auto-tools/tool_base.py
@@ -28,8 +28,48 @@ from pathlib import Path
 from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 
 logger = get_logger(__name__)
+
+# Severity rungs these tools grade findings at, worst first, with the icon each
+# renders as. Hosted here once because all three sanitizers had their own copy
+# of the same table and the same ordering list (#14956).
+#
+# The rungs are canonical ``Severity`` members. The tools previously stored the
+# member NAME ("HIGH") where the VALUE ("high") belongs, so anything comparing a
+# finding against ``Severity.HIGH.value`` silently missed every one of them. The
+# stored value is now canonical; the report text still shows the upper-case name,
+# so the human-facing output is unchanged.
+SEVERITY_REPORT_ICONS: Dict[Severity, str] = {
+    Severity.CRITICAL: "🔴",
+    Severity.HIGH: "🟠",
+    Severity.MEDIUM: "🟡",
+    Severity.LOW: "🟢",
+}
+SEVERITY_REPORT_ORDER: tuple = tuple(SEVERITY_REPORT_ICONS)
+UNRANKED_SEVERITY_ICON = "⚪"
+
+
+def severity_icon(value: str) -> str:
+    """Icon for a stored severity value; unranked and unknown both fall back."""
+    try:
+        return SEVERITY_REPORT_ICONS.get(Severity(value), UNRANKED_SEVERITY_ICON)
+    except ValueError:
+        return UNRANKED_SEVERITY_ICON
+
+
+def severity_label(value: str) -> str:
+    """Report text for a stored severity value — the member name, upper-case.
+
+    Keeps the human-facing report identical to what it printed when the tools
+    stored the name instead of the value, so #14956 changed the stored data
+    without changing a single line of the rendered report.
+    """
+    try:
+        return Severity(value).name
+    except ValueError:
+        return str(value)
 
 
 class SecurityFixToolBase:

--- a/autobot-backend/code_analysis/src/patch_generator.py
+++ b/autobot-backend/code_analysis/src/patch_generator.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_1_HOUR
+from autobot_shared.status_enums import Severity
 
 logger = get_logger(__name__)
 
@@ -686,7 +687,7 @@ async def main():
                     "file": "src/example.py",
                     "line": 42,
                     "type": "sql_injection",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "description": "SQL injection vulnerability",
                 }
             ]
@@ -697,7 +698,7 @@ async def main():
                     "file": "src/example.py",
                     "line": 15,
                     "type": "memory_leaks",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "description": "File handle not closed",
                 }
             ]

--- a/autobot-backend/code_analysis/src/remediation_loop_test.py
+++ b/autobot-backend/code_analysis/src/remediation_loop_test.py
@@ -30,6 +30,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import utc_timestamp
 
 # ---------------------------------------------------------------------------
@@ -590,7 +591,7 @@ class TestDispatchProposalDisabled:
                 "file": f"f{i}.py",
                 "line": i,
                 "pattern_type": f"pat_{i}",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "runtime_risk": 0.1,
                 "suggestion": f"Fix {i}",
             }
@@ -663,7 +664,7 @@ class TestDispatchProposalEnabled:
                 "file": f"{file_prefix}{i}.py",
                 "line": i,
                 "pattern_type": f"pat_{i}",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "runtime_risk": 0.2,
                 "suggestion": f"Fix {i}",
             }
@@ -710,7 +711,7 @@ class TestDispatchProposalEnabled:
                     "file": "dup.py",
                     "line": 1,
                     "pattern_type": "god_class",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "runtime_risk": 0.3,
                     "suggestion": "Extract A",
                 },
@@ -718,7 +719,7 @@ class TestDispatchProposalEnabled:
                     "file": "dup.py",
                     "line": 2,
                     "pattern_type": "god_class",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "runtime_risk": 0.4,
                     "suggestion": "Extract B",
                 },
@@ -726,7 +727,7 @@ class TestDispatchProposalEnabled:
                     "file": "unique.py",
                     "line": 5,
                     "pattern_type": "long_method",
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "runtime_risk": 0.1,
                     "suggestion": "Split it",
                 },
@@ -780,7 +781,7 @@ class TestDispatchReadOnlyContract(ReadOnlyCapabilityChecks):
                 "file": f"x{i}.py",
                 "line": i,
                 "pattern_type": "god_class",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "runtime_risk": 0.5,
                 "suggestion": "Refactor",
             }

--- a/autobot-backend/code_intelligence/bug_predictor.py
+++ b/autobot-backend/code_intelligence/bug_predictor.py
@@ -414,7 +414,7 @@ class BugPredictor(_BaseClass):
         high_risk_count = sum(1 for a in assessments if a.risk_level in (RiskLevel.CRITICAL, RiskLevel.HIGH))
 
         # Risk distribution
-        risk_dist = {level.value: 0 for level in RiskLevel}
+        risk_dist = {level.value: 0 for level in RiskLevel.score_ladder()}
         for a in assessments:
             risk_dist[a.risk_level.value] += 1
 

--- a/autobot-backend/code_intelligence/pattern_analysis/source_scoping_test.py
+++ b/autobot-backend/code_intelligence/pattern_analysis/source_scoping_test.py
@@ -32,6 +32,7 @@ from typing import Any, Dict
 import pytest
 
 from api.codebase_analytics.endpoints.pattern_analysis import _build_chromadb_where_filter
+from autobot_shared.status_enums import Severity
 
 
 # ---------------------------------------------------------------------------
@@ -136,7 +137,7 @@ class TestBuildChromaDBWhereFilter:
 
     def test_folds_extra_conditions_with_and(self):
         where = _build_chromadb_where_filter("duplicate", "high", source_id="A")
-        assert where == {"$and": [{"source_id": "A"}, {"pattern_type": "duplicate"}, {"severity": "high"}]}
+        assert where == {"$and": [{"source_id": "A"}, {"pattern_type": "duplicate"}, {"severity": Severity.HIGH.value}]}
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-backend/context_aware_decision/collectors/main.py
+++ b/autobot-backend/context_aware_decision/collectors/main.py
@@ -15,6 +15,7 @@ import asyncio
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from memory import TaskPriority  # canonical enum (#10626)
 from task_execution_tracker import get_task_tracker
 
@@ -199,7 +200,7 @@ class ContextCollector:
                 {
                     "type": "high_cpu_usage",
                     "description": f"CPU usage at {cpu_percent}%",
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "affects": ["resource_intensive_tasks"],
                 }
             )
@@ -210,7 +211,7 @@ class ContextCollector:
                 {
                     "type": "high_memory_usage",
                     "description": f"Memory usage at {memory_percent}%",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "affects": ["memory_intensive_operations"],
                 }
             )
@@ -238,7 +239,7 @@ class ContextCollector:
                 {
                     "type": "human_takeover_active",
                     "description": "Human operator has taken control",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "affects": ["automation_action", "navigation_choice"],
                 }
             )
@@ -255,7 +256,7 @@ class ContextCollector:
                     {
                         "type": "outside_business_hours",
                         "description": "Current time is outside business hours",
-                        "severity": "low",
+                        "severity": Severity.LOW.value,
                         "affects": ["external_communications", "user_interactions"],
                     }
                 )
@@ -353,7 +354,7 @@ class ContextCollector:
         if len(low_confidence_elements) > len(context_elements) * 0.3:
             return {
                 "risk_type": "low_context_confidence",
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
                 "probability": 0.7,
                 "description": (f"{len(low_confidence_elements)} context elements have low confidence"),
                 "mitigation": ("Gather additional context or request human verification"),
@@ -370,7 +371,7 @@ class ContextCollector:
                 risks.append(
                     {
                         "risk_type": "system_overload",
-                        "severity": "high",
+                        "severity": Severity.HIGH.value,
                         "probability": 0.9,
                         "description": "System CPU usage critically high",
                         "mitigation": "Defer non-critical operations",
@@ -383,7 +384,7 @@ class ContextCollector:
         if len(context_elements) > 50:
             return {
                 "risk_type": "information_overload",
-                "severity": "low",
+                "severity": Severity.LOW.value,
                 "probability": 0.4,
                 "description": "Large amount of context data may contain conflicts",
                 "mitigation": "Prioritize most relevant context elements",

--- a/autobot-backend/context_aware_decision/counterfactual_reasoner.py
+++ b/autobot-backend/context_aware_decision/counterfactual_reasoner.py
@@ -20,6 +20,7 @@ from typing import Any, Dict
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_async_redis_client
+from autobot_shared.status_enums import Severity
 
 from .models import DecisionContext, InterventionOutcome
 
@@ -246,7 +247,7 @@ class CounterfactualReasoner:
                 {
                     "type": "latency_increase",
                     "frequency": 0.8,
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "description": "Retries add 2-5s per attempt",
                 }
             ]
@@ -258,13 +259,13 @@ class CounterfactualReasoner:
                 {
                     "type": "user_notification",
                     "frequency": 1.0,
-                    "severity": "low",
+                    "severity": Severity.LOW.value,
                     "description": "User will be notified of escalation",
                 },
                 {
                     "type": "wait_time",
                     "frequency": 0.9,
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "description": "Wait for human response (5-60 minutes)",
                 },
             ]
@@ -276,7 +277,7 @@ class CounterfactualReasoner:
                 {
                     "type": "state_mutation",
                     "frequency": 1.0,
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "description": "Automation modifies system state",
                 }
             ]
@@ -288,7 +289,7 @@ class CounterfactualReasoner:
                 {
                     "type": "deadline_risk",
                     "frequency": 0.6,
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "description": "Waiting might miss deadline",
                 }
             ]

--- a/autobot-backend/context_aware_decision/examples_counterfactual.py
+++ b/autobot-backend/context_aware_decision/examples_counterfactual.py
@@ -14,6 +14,7 @@ Not included in package; for development and documentation only.
 import time
 
 from autobot_shared.async_compat import run_or_schedule
+from autobot_shared.status_enums import Severity
 
 from .counterfactual_reasoner import CounterfactualReasoner
 from .decision_engine import DecisionEngine
@@ -54,7 +55,7 @@ async def example_network_timeout():
                 relevance_score=0.9,
                 timestamp=time.time(),
                 source="network_monitor",
-                metadata={"type": "network", "severity": "high"},
+                metadata={"type": "network", "severity": Severity.HIGH.value},
             ),
         ],
         constraints=[],
@@ -81,7 +82,7 @@ async def example_network_timeout():
         risk_factors=[
             {
                 "risk_type": "network_timeout",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "description": "Network connectivity issue",
             }
         ],
@@ -213,7 +214,7 @@ async def example_database_exhaustion():
         risk_factors=[
             {
                 "risk_type": "resource_exhaustion",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "description": "All connections in use",
             }
         ],

--- a/autobot-backend/context_aware_decision/tests/test_counterfactual_reasoner.py
+++ b/autobot-backend/context_aware_decision/tests/test_counterfactual_reasoner.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from context_aware_decision.counterfactual_reasoner import CounterfactualReasoner
 from context_aware_decision.models import (
     ContextElement,
@@ -127,7 +128,7 @@ def sample_causal_patterns():
                 {
                     "type": "latency_increase",
                     "frequency": 0.9,
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                 }
             ],
         },
@@ -140,7 +141,7 @@ def sample_causal_patterns():
                 {
                     "type": "user_notification",
                     "frequency": 1.0,
-                    "severity": "low",
+                    "severity": Severity.LOW.value,
                 }
             ],
         },
@@ -358,13 +359,13 @@ class TestCausalPrediction:
                 "name": "pattern1",
                 "conditions": {"decision_type": "automation_action"},
                 "predicted_success_rate": 0.6,
-                "side_effects": [{"type": "effect1", "severity": "low"}],
+                "side_effects": [{"type": "effect1", "severity": Severity.LOW.value}],
             },
             {
                 "name": "pattern2",
                 "conditions": {"decision_type": "automation_action"},
                 "predicted_success_rate": 0.8,
-                "side_effects": [{"type": "effect2", "severity": "medium"}],
+                "side_effects": [{"type": "effect2", "severity": Severity.MEDIUM.value}],
             },
         ]
 
@@ -445,7 +446,7 @@ class TestHeuristicPrediction:
         reasoner = CounterfactualReasoner()
 
         # Add high-risk factors
-        sample_context.risk_factors = [{"risk_type": "critical_error", "severity": "high"}]
+        sample_context.risk_factors = [{"risk_type": "critical_error", "severity": Severity.HIGH.value}]
 
         outcome = reasoner._predict_heuristic("retry", sample_context, {"confidence": 0.8})
 
@@ -644,7 +645,7 @@ class TestInterventionOutcomeSerialization:
                 {
                     "type": "latency_increase",
                     "frequency": 0.8,
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                 }
             ],
             confidence=0.8,

--- a/autobot-backend/diagnostics.py
+++ b/autobot-backend/diagnostics.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List
 import psutil
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 
 try:
     from autobot_shared.redis_client import get_redis_client
@@ -300,7 +301,7 @@ class PerformanceOptimizedDiagnostics:
             analysis["bottlenecks"].append(
                 {
                     "type": "cpu",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "message": f"CPU usage at {cpu_usage}% - potential bottleneck",
                 }
             )
@@ -323,7 +324,7 @@ class PerformanceOptimizedDiagnostics:
                 analysis["warnings"].append(
                     {
                         "type": "gpu",
-                        "severity": "medium",
+                        "severity": Severity.MEDIUM.value,
                         "message": (
                             f"GPU utilization low at {gpu_util}% - " f"AI workloads may not be GPU-accelerated"
                         ),
@@ -333,7 +334,7 @@ class PerformanceOptimizedDiagnostics:
                 analysis["bottlenecks"].append(
                     {
                         "type": "gpu",
-                        "severity": "medium",
+                        "severity": Severity.MEDIUM.value,
                         "message": (f"GPU utilization at {gpu_util}% - may be saturated"),
                     }
                 )
@@ -359,7 +360,7 @@ class PerformanceOptimizedDiagnostics:
                 analysis["bottlenecks"].append(
                     {
                         "type": "memory",
-                        "severity": "high",
+                        "severity": Severity.HIGH.value,
                         "message": (f"Memory usage at {memory_info.get('used_percent', 0)}% " f"- approaching limit"),
                     }
                 )

--- a/autobot-backend/knowledge/stats.py
+++ b/autobot-backend/knowledge/stats.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import parse_utc_iso
 
 if TYPE_CHECKING:
@@ -606,7 +607,7 @@ class StatsMixin:
                     {
                         "fact_id": fact_id,
                         "type": "missing_category",
-                        "severity": "warning",
+                        "severity": Severity.WARNING.value,
                         "message": "Fact missing category",
                     }
                 )
@@ -615,7 +616,7 @@ class StatsMixin:
                     {
                         "fact_id": fact_id,
                         "type": "missing_tags",
-                        "severity": "info",
+                        "severity": Severity.INFO.value,
                         "message": "Fact has no tags",
                     }
                 )
@@ -625,7 +626,7 @@ class StatsMixin:
                 {
                     "fact_id": fact.get("fact_id"),
                     "type": "incomplete_data",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": "Fact missing required fields",
                 }
             )
@@ -676,7 +677,7 @@ class StatsMixin:
             issues.append(
                 {
                     "type": "category_fragmentation",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": "Too many categories (%d), consider consolidating" % len(categories),
                 }
             )
@@ -686,7 +687,7 @@ class StatsMixin:
             issues.append(
                 {
                     "type": "sparse_categories",
-                    "severity": "info",
+                    "severity": Severity.INFO.value,
                     "message": "%d categories have fewer than 3 facts" % len(small_categories),
                 }
             )
@@ -707,7 +708,7 @@ class StatsMixin:
             issues.append(
                 {
                     "type": "tag_format_inconsistency",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": "%d tags have inconsistent format" % inconsistent_tags,
                 }
             )
@@ -807,7 +808,7 @@ class StatsMixin:
             issues.append(
                 {
                     "type": "stale_data",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": "%d facts are over 1 year old" % age_buckets["older"],
                 }
             )
@@ -815,7 +816,7 @@ class StatsMixin:
             issues.append(
                 {
                     "type": "missing_timestamps",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": "%d facts have no timestamp" % age_buckets["unknown"],
                 }
             )
@@ -857,7 +858,7 @@ class StatsMixin:
                             "fact_id": fact.get("fact_id"),
                             "duplicate_of": content_hashes[content_hash],
                             "type": "exact_duplicate",
-                            "severity": "warning",
+                            "severity": Severity.WARNING.value,
                             "message": "Exact duplicate content found",
                         }
                     )
@@ -899,7 +900,7 @@ class StatsMixin:
                 {
                     "fact_id": fact_id,
                     "type": "short_content",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": "Content is too short (< 10 chars)",
                 }
             )
@@ -909,7 +910,7 @@ class StatsMixin:
                 {
                     "fact_id": fact_id,
                     "type": "long_content",
-                    "severity": "info",
+                    "severity": Severity.INFO.value,
                     "message": "Content is very long (> 100k chars)",
                 }
             )
@@ -921,7 +922,7 @@ class StatsMixin:
                 {
                     "fact_id": fact_id,
                     "type": "invalid_metadata",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": "Metadata is not a valid dictionary",
                 }
             )
@@ -933,7 +934,7 @@ class StatsMixin:
                 {
                     "fact_id": fact_id,
                     "type": "invalid_fact_id",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": "Invalid or missing fact_id",
                 }
             )

--- a/autobot-backend/llc/tests/test_finding_proposal_service.py
+++ b/autobot-backend/llc/tests/test_finding_proposal_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from llc.models.enums import FindingProposalStatus
 from llc.services.finding_proposal_service import (
     FindingsDisabledError,
@@ -104,7 +105,7 @@ async def test_scan_queues_only_real_and_skips_promoted():
     # Three distinct findings (different file_path → distinct finding_keys)
     finding_real = {
         "type": "bug",
-        "severity": "high",
+        "severity": Severity.HIGH.value,
         "file_path": "a.py",
         "line_number": 1,
         "description": "D1",
@@ -112,7 +113,7 @@ async def test_scan_queues_only_real_and_skips_promoted():
     }
     finding_fake = {
         "type": "style",
-        "severity": "high",
+        "severity": Severity.HIGH.value,
         "file_path": "b.py",
         "line_number": 2,
         "description": "D2",
@@ -120,7 +121,7 @@ async def test_scan_queues_only_real_and_skips_promoted():
     }
     finding_promoted = {
         "type": "bug",
-        "severity": "high",
+        "severity": Severity.HIGH.value,
         "file_path": "c.py",
         "line_number": 3,
         "description": "D3",

--- a/autobot-backend/llc/tests/test_findings_gather.py
+++ b/autobot-backend/llc/tests/test_findings_gather.py
@@ -24,13 +24,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
+
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
 _HIGH = {
     "type": "bug",
-    "severity": "high",
+    "severity": Severity.HIGH.value,
     "file_path": "a.py",
     "line_number": 1,
     "description": "d1",
@@ -38,7 +40,7 @@ _HIGH = {
 }
 _MEDIUM = {
     "type": "style",
-    "severity": "medium",
+    "severity": Severity.MEDIUM.value,
     "file_path": "b.py",
     "line_number": 2,
     "description": "d2",
@@ -46,7 +48,7 @@ _MEDIUM = {
 }
 _LOW = {
     "type": "smell",
-    "severity": "low",
+    "severity": Severity.LOW.value,
     "file_path": "c.py",
     "line_number": 3,
     "description": "d3",

--- a/autobot-backend/llc/tests/test_findings_verify.py
+++ b/autobot-backend/llc/tests/test_findings_verify.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from llc.services.findings_verify import Verdict, combine_verdicts, select_verifier_provider, verify_finding
 
 # ---------------------------------------------------------------------------
@@ -27,7 +28,7 @@ from llc.services.findings_verify import Verdict, combine_verdicts, select_verif
 
 _FINDING = {
     "type": "bug",
-    "severity": "high",
+    "severity": Severity.HIGH.value,
     "file_path": "src/app.py",
     "line_number": 5,
     "description": "Null dereference",

--- a/autobot-backend/monitoring/monitoring_and_alerts_test.py
+++ b/autobot-backend/monitoring/monitoring_and_alerts_test.py
@@ -38,6 +38,7 @@ from typing import Dict, List
 import aiohttp
 
 from autobot_shared.ssot_config import config
+from autobot_shared.status_enums import Severity
 
 # Add AutoBot paths
 sys.path.append(config.project_root)
@@ -872,7 +873,7 @@ class MonitoringAndAlertingTester:
                             f"{backend_url}{endpoint}",
                             json={
                                 "type": scenario["trigger"],
-                                "severity": "warning",
+                                "severity": Severity.WARNING.value,
                                 "test": True,
                             },
                         ) as response:

--- a/autobot-backend/project_state_tracking/tracker.py
+++ b/autobot-backend/project_state_tracking/tracker.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Tuple
 
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.redis_client import get_redis_client
+from autobot_shared.status_enums import Severity
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 from phase_progression_manager import get_progression_manager
@@ -419,7 +420,7 @@ class ProjectStateTracker:
                     "timestamp": datetime.now(tz=timezone.utc).isoformat(),
                 },
                 metadata={
-                    "severity": "error",
+                    "severity": Severity.ERROR.value,
                     "tracking_source": "enhanced_state_tracker",
                 },
             )

--- a/autobot-backend/security/enterprise/compliance_manager.py
+++ b/autobot-backend/security/enterprise/compliance_manager.py
@@ -24,6 +24,7 @@ import yaml
 from cryptography.fernet import Fernet
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
 
@@ -720,7 +721,7 @@ class ComplianceManager:
                 {
                     "framework": "SOC2",
                     "violation_type": "unauthorized_admin_action",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "control": "CC6.1",
                     "description": ("Administrative action performed without proper authorization"),
                 }
@@ -743,7 +744,7 @@ class ComplianceManager:
                 {
                     "framework": "GDPR",
                     "violation_type": "pii_access_without_consent",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "article": "Article 6",
                     "description": "PII accessed without valid legal basis or consent",
                 }

--- a/autobot-backend/security/enterprise/security_policy_manager.py
+++ b/autobot-backend/security/enterprise/security_policy_manager.py
@@ -22,6 +22,7 @@ import yaml
 
 from autobot_shared.auth.permissions import is_admin_role
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
 
@@ -684,7 +685,7 @@ class SecurityPolicyManager:
             "policy_name": policy.name,
             "compliant": True,
             "violation_type": None,
-            "severity": "low",
+            "severity": Severity.LOW.value,
             "details": {},
         }
 

--- a/autobot-backend/security/enterprise/threat_detection/engine.py
+++ b/autobot-backend/security/enterprise/threat_detection/engine.py
@@ -26,6 +26,7 @@ from sklearn.ensemble import IsolationForest
 from sklearn.preprocessing import StandardScaler
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from autobot_shared.time_utils import now_utc, parse_utc_iso, utc_timestamp
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
@@ -219,43 +220,43 @@ class ThreatDetectionEngine:
             {
                 "pattern": r"[;&|`$(){}[\]\\]",
                 "description": "Shell metacharacters",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "category": "shell_injection",
             },
             {
                 "pattern": r"(rm\s+-rf|del\s+/[sf]|format\s+c:)",
                 "description": "Destructive file operations",
-                "severity": "critical",
+                "severity": Severity.CRITICAL.value,
                 "category": "destructive_commands",
             },
             {
                 "pattern": r"(wget|curl|nc|netcat)\s+",
                 "description": "Network tools for data exfiltration",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "category": "network_tools",
             },
             {
                 "pattern": r"(base64|xxd|hexdump)\s+",
                 "description": "Encoding tools for obfuscation",
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
                 "category": "encoding_tools",
             },
             {
                 "pattern": r"(sudo|su|chmod\s+777|chown)",
                 "description": "Privilege escalation attempts",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "category": "privilege_escalation",
             },
             {
                 "pattern": r"(/etc/passwd|/etc/shadow|/etc/hosts)",
                 "description": "System file access",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
                 "category": "system_file_access",
             },
             {
                 "pattern": r"(python\s+-c|perl\s+-e|ruby\s+-e)",
                 "description": "Inline script execution",
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
                 "category": "script_injection",
             },
         ]
@@ -292,24 +293,24 @@ class ThreatDetectionEngine:
                 "pattern": "rapid_sequential_requests",
                 "description": "Rapid API requests indicating automation",
                 "threshold": 50,  # requests per minute
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
             },
             {
                 "pattern": "unusual_endpoint_access",
                 "description": "Access to rarely used endpoints",
                 "threshold": 0.05,  # 5% of normal usage
-                "severity": "medium",
+                "severity": Severity.MEDIUM.value,
             },
             {
                 "pattern": "bulk_data_download",
                 "description": "Large data download operations",
                 "threshold": 1000,  # MB downloaded
-                "severity": "high",
+                "severity": Severity.HIGH.value,
             },
             {
                 "pattern": "privilege_boundary_crossing",
                 "description": "Accessing resources beyond normal permissions",
-                "severity": "high",
+                "severity": Severity.HIGH.value,
             },
         ]
 

--- a/autobot-backend/services/causal_inference_engine_examples.py
+++ b/autobot-backend/services/causal_inference_engine_examples.py
@@ -140,7 +140,7 @@ EXAMPLE_1_POOL_EXHAUSTION = {
             "evidence": ["Queries now hold connections 45-60 seconds"],
         },
     ],
-    "severity": "critical",
+    "severity": CausalSeverity.CRITICAL.value,
     "confidence": 0.88,
     "recommendations": [
         "[URGENT] SHORT-TERM: Increase connection pool size from 30 to 100 connections (85% success likelihood). Reason: More connections available reduces queueing and timeout rate",
@@ -238,7 +238,7 @@ EXAMPLE_2_MEMORY_LEAK = {
             "evidence": ["OOM killer is heavy-handed, graceful restart is cleaner"],
         },
     ],
-    "severity": "degraded",
+    "severity": CausalSeverity.DEGRADED.value,
     "confidence": 0.92,
     "recommendations": [
         "SHORT-TERM: Increase memory allocation to system from 12 GB to 28 GB (95% success likelihood). Reason: Process can grow larger before hitting OOM limit",
@@ -351,7 +351,7 @@ EXAMPLE_3_MULTI_FACTOR = {
             "evidence": ["Confounder: network flakiness normally tolerated via retries"],
         },
     ],
-    "severity": "critical",
+    "severity": CausalSeverity.CRITICAL.value,
     "confidence": 0.90,
     "recommendations": [
         "[URGENT] IMMEDIATE: Revert problematic deployment (commit 7f3a2c) to restore max_retries=3 (98% success likelihood). Reason: Retry logic restored, transient failures now succeed on retry",
@@ -422,7 +422,7 @@ EXAMPLE_4_SINGLE_CLEAR_CAUSE = {
             "evidence": ["Scheduled maintenance confirmed in calendar"],
         },
     ],
-    "severity": "warning",
+    "severity": CausalSeverity.WARNING.value,
     "confidence": 0.99,
     "recommendations": [
         "WAIT: Scheduled maintenance in progress (ends 2026-04-10T02:30:00Z). Service will return to normal. No action needed.",
@@ -488,7 +488,7 @@ EXAMPLE_5_SPARSE_DATA = {
             "evidence": ["Without root cause data, defensive approach is best guess"],
         },
     ],
-    "severity": "warning",
+    "severity": CausalSeverity.WARNING.value,
     "confidence": 0.35,  # Low confidence
     "recommendations": [
         "ENABLE PROFILING: Collect detailed logs and stack traces on next occurrence (80% likelihood improves diagnosis). Reason: Current data insufficient to identify root cause",

--- a/autobot-backend/services/security_workflow_manager_test.py
+++ b/autobot-backend/services/security_workflow_manager_test.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from autobot_shared.status_enums import Severity
 from services.security_workflow_manager import (
     PHASE_DESCRIPTIONS,
     VALID_TRANSITIONS,
@@ -378,7 +379,7 @@ class TestSecurityWorkflowManager:
                 status="up",
                 ports=[{"port": 22, "protocol": "tcp"}],
                 services=[{"name": "ssh", "port": 22}],
-                vulnerabilities=[{"severity": "high", "cve_id": "CVE-2024-1234"}],
+                vulnerabilities=[{"severity": Severity.HIGH.value, "cve_id": "CVE-2024-1234"}],
             )
         ]
         # Add finding for the vulnerability (this is how they're counted)

--- a/autobot-backend/tests/integration/test_causal_framework_integration.py
+++ b/autobot-backend/tests/integration/test_causal_framework_integration.py
@@ -45,6 +45,7 @@ from typing import Any, Dict, List
 import pytest
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 
 logger = get_logger(__name__)
 
@@ -190,7 +191,7 @@ class TestScenarioTimeoutFailure:
                 },
             ],
             "confounder_candidates": ["query_complexity", "table_scan_required"],
-            "severity": "critical",
+            "severity": Severity.CRITICAL.value,
         }
 
     async def _analyze_timeout_chain(self, event: Dict[str, Any]) -> Dict[str, Any]:
@@ -449,7 +450,7 @@ class TestScenarioDatabasePoolExhaustion:
                 },
             ],
             "confounders": ["request_volume_increase", "concurrent_batch_job"],
-            "severity": "critical",
+            "severity": Severity.CRITICAL.value,
         }
 
     async def _analyze_pool_chain(self, event: Dict[str, Any]) -> Dict[str, Any]:

--- a/autobot-backend/tests/memory_graph/test_property_graph.py
+++ b/autobot-backend/tests/memory_graph/test_property_graph.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from autobot_shared.status_enums import Severity
+
 # ---------------------------------------------------------------------------
 # Stub out autobot_shared so PropertyGraph imports without real Redis
 # ---------------------------------------------------------------------------
@@ -193,9 +195,9 @@ class TestQueryNodes:
     @pytest.mark.asyncio
     async def test_query_nodes_single_filter(self):
         g = make_graph()
-        await g.add_node("bug1", {"type": "bug", "severity": "high"})
-        await g.add_node("bug2", {"type": "bug", "severity": "low"})
-        await g.add_node("feat1", {"type": "feature", "severity": "high"})
+        await g.add_node("bug1", {"type": "bug", "severity": Severity.HIGH.value})
+        await g.add_node("bug2", {"type": "bug", "severity": Severity.LOW.value})
+        await g.add_node("feat1", {"type": "feature", "severity": Severity.HIGH.value})
 
         results = await g.query_nodes({"type": "bug"})
         ids = {n["id"] for n in results}
@@ -206,10 +208,10 @@ class TestQueryNodes:
     @pytest.mark.asyncio
     async def test_query_nodes_multi_filter(self):
         g = make_graph()
-        await g.add_node("bug1", {"type": "bug", "severity": "high"})
-        await g.add_node("bug2", {"type": "bug", "severity": "low"})
+        await g.add_node("bug1", {"type": "bug", "severity": Severity.HIGH.value})
+        await g.add_node("bug2", {"type": "bug", "severity": Severity.LOW.value})
 
-        results = await g.query_nodes({"type": "bug", "severity": "high"})
+        results = await g.query_nodes({"type": "bug", "severity": Severity.HIGH.value})
         assert len(results) == 1
         assert results[0]["id"] == "bug1"
 

--- a/autobot-backend/utils/hardware_metrics.py
+++ b/autobot-backend/utils/hardware_metrics.py
@@ -26,6 +26,7 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.http_client import get_http_client
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_1_HOUR
+from autobot_shared.status_enums import Severity
 
 # Import existing monitoring infrastructure
 from constants.api_constants import PATH_API_HEALTH
@@ -1032,7 +1033,7 @@ class HardwarePerformanceMonitor:
             alerts.append(
                 {
                     "category": "gpu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"GPU utilization below target: {gpu['utilization_percent']:.1f}% "
                         f"< {self.performance_baselines['gpu_utilization_target']}%"
@@ -1045,7 +1046,7 @@ class HardwarePerformanceMonitor:
             alerts.append(
                 {
                     "category": "gpu",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": f"GPU thermal throttling active at {gpu['temperature_celsius']}°C",
                     "recommendation": "Check cooling and reduce workload",
                     "timestamp": time.time(),
@@ -1060,7 +1061,7 @@ class HardwarePerformanceMonitor:
             alerts.append(
                 {
                     "category": "npu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"NPU acceleration ratio below target: {npu['acceleration_ratio']:.1f}x "
                         f"< {self.performance_baselines['npu_acceleration_target']}x"
@@ -1078,7 +1079,7 @@ class HardwarePerformanceMonitor:
             alerts.append(
                 {
                     "category": "memory",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": f"High memory usage: {system['memory_usage_percent']:.1f}%",
                     "recommendation": "Enable aggressive cleanup or check for memory leaks",
                     "timestamp": time.time(),
@@ -1088,7 +1089,7 @@ class HardwarePerformanceMonitor:
             alerts.append(
                 {
                     "category": "cpu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"High CPU load: {system['cpu_load_1m']:.1f} " f"on {system['cpu_cores_logical']}-core system"
                     ),
@@ -1106,7 +1107,7 @@ class HardwarePerformanceMonitor:
                 alerts.append(
                     {
                         "category": "service",
-                        "severity": "critical",
+                        "severity": Severity.CRITICAL.value,
                         "message": f"Service {service['service_name']} is {service['status']}",
                         "recommendation": "Check service health and restart if necessary",
                         "timestamp": time.time(),
@@ -1116,7 +1117,7 @@ class HardwarePerformanceMonitor:
                 alerts.append(
                     {
                         "category": "performance",
-                        "severity": "warning",
+                        "severity": Severity.WARNING.value,
                         "message": f"{service['service_name']} slow response: {service['response_time_ms']:.0f}ms",
                         "recommendation": "Investigate service performance bottlenecks",
                         "timestamp": time.time(),

--- a/autobot-backend/utils/performance_monitoring/analyzers.py
+++ b/autobot-backend/utils/performance_monitoring/analyzers.py
@@ -16,6 +16,7 @@ import time
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from utils.performance_monitoring.types import (
     CRITICAL_SERVICE_STATUSES,
     DEFAULT_PERFORMANCE_BASELINES,
@@ -40,7 +41,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "gpu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"GPU utilization below target: {gpu['utilization_percent']:.1f}% < "
                         f"{self.baselines['gpu_utilization_target']}%"
@@ -54,7 +55,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "gpu",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": f"GPU thermal throttling active at {gpu['temperature_celsius']}°C",
                     "recommendation": "Check cooling and reduce workload",
                     "timestamp": time.time(),
@@ -70,7 +71,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "npu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"NPU acceleration ratio below target: {npu['acceleration_ratio']:.1f}x < "
                         f"{self.baselines['npu_acceleration_target']}x"
@@ -89,7 +90,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "memory",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": f"High memory usage: {system['memory_usage_percent']:.1f}%",
                     "recommendation": "Enable aggressive cleanup or check for memory leaks",
                     "timestamp": time.time(),
@@ -100,7 +101,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "cpu",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": (
                         f"High CPU load: {system['cpu_load_1m']:.1f} " f"on {system['cpu_cores_logical']}-core system"
                     ),
@@ -118,7 +119,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "service",
-                    "severity": "critical",
+                    "severity": Severity.CRITICAL.value,
                     "message": f"Service {service['service_name']} is {service['status']}",
                     "recommendation": "Check service health and restart if necessary",
                     "timestamp": time.time(),
@@ -129,7 +130,7 @@ class AlertAnalyzer:
             alerts.append(
                 {
                     "category": "performance",
-                    "severity": "warning",
+                    "severity": Severity.WARNING.value,
                     "message": f"{service['service_name']} slow response: {service['response_time_ms']:.0f}ms",
                     "recommendation": "Investigate service performance bottlenecks",
                     "timestamp": time.time(),

--- a/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
+++ b/autobot-backend/utils/performance_monitoring/monitor_category_default_test.py
@@ -7,6 +7,7 @@
 
 from unittest.mock import MagicMock
 
+from autobot_shared.status_enums import Severity
 from constants.threshold_constants import CategoryDefaults
 from utils.performance_monitoring.monitor import PerformanceMonitor
 
@@ -21,7 +22,7 @@ def _bare_monitor():
 def test_missing_category_defaults_to_unknown():
     monitor = _bare_monitor()
 
-    monitor._push_alerts_to_prometheus([{"severity": "warning"}])
+    monitor._push_alerts_to_prometheus([{"severity": Severity.WARNING.value}])
 
     monitor._prometheus.record_performance_alert.assert_called_once_with(CategoryDefaults.UNKNOWN, "warning")
 
@@ -29,6 +30,6 @@ def test_missing_category_defaults_to_unknown():
 def test_explicit_category_overrides_default():
     monitor = _bare_monitor()
 
-    monitor._push_alerts_to_prometheus([{"category": "cpu", "severity": "critical"}])
+    monitor._push_alerts_to_prometheus([{"category": "cpu", "severity": Severity.CRITICAL.value}])
 
     monitor._prometheus.record_performance_alert.assert_called_once_with("cpu", "critical")

--- a/autobot-backend/utils/timeout_migration_examples.py
+++ b/autobot-backend/utils/timeout_migration_examples.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.status_enums import Severity
 from constants.path_constants import PATH
 from constants.threshold_constants import TimingConstants
 
@@ -800,7 +801,7 @@ class ExistingOperationMigrator:
             vulnerabilities.append(
                 {
                     "type": "hardcoded_credential",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "description": "Potential hardcoded password detected",
                 }
             )
@@ -809,7 +810,7 @@ class ExistingOperationMigrator:
             vulnerabilities.append(
                 {
                     "type": "hardcoded_api_key",
-                    "severity": "high",
+                    "severity": Severity.HIGH.value,
                     "description": "Potential hardcoded API key detected",
                 }
             )
@@ -822,7 +823,7 @@ class ExistingOperationMigrator:
             vulnerabilities.append(
                 {
                     "type": "potential_secret",
-                    "severity": "medium",
+                    "severity": Severity.MEDIUM.value,
                     "description": "Long string detected, might be a secret",
                 }
             )

--- a/autobot-frontend/src/types/_generated/workflow.ts
+++ b/autobot-frontend/src/types/_generated/workflow.ts
@@ -101,8 +101,11 @@ export type Severity =
   | 'info'
   | 'minimal'
   | 'low'
+  | 'warning'
   | 'medium'
+  | 'degraded'
   | 'high'
+  | 'error'
   | 'critical';
 
 /** Generated alias — same union as `Severity` (#6689 / #7226) */

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -9934,7 +9934,7 @@ export interface paths {
          *             {
          *                 "conflict_id": "...",
          *                 "description": "...",
-         *                 "severity": "high",
+         *                 "severity": Severity.HIGH.value,
          *                 "resolution": "pending_review",
          *                 "timestamp": 1234567890
          *             }
@@ -93595,9 +93595,26 @@ export interface components {
          *     "unknown", "info", "minimal") and consolidates 10+ duplicate enums
          *     (#6689): Severity, IssueSeverity, DFASeverity, ImpactLevel, CostLevel,
          *     DebtSeverity, RiskLevel — all collapse to this enum.
+         *
+         *     #14956 added WARNING, DEGRADED and ERROR. They are not synonyms of an
+         *     existing rung and were NOT folded into one, because each is a value the
+         *     platform already emits across a boundary that would change if it moved:
+         *
+         *     * ``warning`` is a Prometheus label value — ``PerformanceMonitor``
+         *       publishes ``update_active_alerts("warning", ...)`` and the shipped
+         *       alert rules carry ``severity: warning``. Mapping it to ``medium``
+         *       would rename a scraped label.
+         *     * ``degraded`` is serialised into the causal-analysis API response and
+         *       grades partial impact between ``warning`` and ``critical``.
+         *     * ``error`` is the rung the capability audit grades findings at, kept
+         *       distinct from ``warning`` because the two are counted separately.
+         *
+         *     So this enum is the severity *vocabulary*. Numeric risk grading uses the
+         *     narrower ``score_ladder()`` — see that method for why the distinction is
+         *     load-bearing rather than cosmetic.
          * @enum {string}
          */
-        Severity: "unknown" | "info" | "minimal" | "low" | "medium" | "high" | "critical";
+        Severity: "unknown" | "info" | "minimal" | "low" | "warning" | "medium" | "degraded" | "high" | "error" | "critical";
         /**
          * SeveritySummary
          * @description Summary of issues by severity.

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -9934,7 +9934,7 @@ export interface paths {
          *             {
          *                 "conflict_id": "...",
          *                 "description": "...",
-         *                 "severity": Severity.HIGH.value,
+         *                 "severity": "high",
          *                 "resolution": "pending_review",
          *                 "timestamp": 1234567890
          *             }

--- a/autobot_shared/status_enums.py
+++ b/autobot_shared/status_enums.py
@@ -83,15 +83,55 @@ class Severity(Enum):
     "unknown", "info", "minimal") and consolidates 10+ duplicate enums
     (#6689): Severity, IssueSeverity, DFASeverity, ImpactLevel, CostLevel,
     DebtSeverity, RiskLevel — all collapse to this enum.
+
+    #14956 added WARNING, DEGRADED and ERROR. They are not synonyms of an
+    existing rung and were NOT folded into one, because each is a value the
+    platform already emits across a boundary that would change if it moved:
+
+    * ``warning`` is a Prometheus label value — ``PerformanceMonitor``
+      publishes ``update_active_alerts("warning", ...)`` and the shipped
+      alert rules carry ``severity: warning``. Mapping it to ``medium``
+      would rename a scraped label.
+    * ``degraded`` is serialised into the causal-analysis API response and
+      grades partial impact between ``warning`` and ``critical``.
+    * ``error`` is the rung the capability audit grades findings at, kept
+      distinct from ``warning`` because the two are counted separately.
+
+    So this enum is the severity *vocabulary*. Numeric risk grading uses the
+    narrower ``score_ladder()`` — see that method for why the distinction is
+    load-bearing rather than cosmetic.
     """
 
     UNKNOWN = "unknown"
     INFO = "info"
     MINIMAL = "minimal"
     LOW = "low"
+    WARNING = "warning"  # #14956: monitoring/log-level rung, a Prometheus label
     MEDIUM = "medium"
+    DEGRADED = "degraded"  # #14956: partial impact, emitted by causal analysis
     HIGH = "high"
+    ERROR = "error"  # #14956: audit-finding rung, graded above "warning"
     CRITICAL = "critical"
+
+    @classmethod
+    def score_ladder(cls) -> tuple["Severity", ...]:
+        """The rungs ``from_score`` can produce, in ascending order.
+
+        The enum is the whole severity *vocabulary*; this is the subset that
+        numeric risk grading maps onto. Distributions keyed by severity
+        (``{level.value: 0 for level in RiskLevel}``) iterate this rather
+        than the enum, so #14956 adding vocabulary members did not silently
+        add three always-zero keys to a shipped API response.
+        """
+        return (
+            cls.UNKNOWN,
+            cls.INFO,
+            cls.MINIMAL,
+            cls.LOW,
+            cls.MEDIUM,
+            cls.HIGH,
+            cls.CRITICAL,
+        )
 
     @classmethod
     def from_score(cls, score: float) -> "Severity":
@@ -124,8 +164,11 @@ class Severity(Enum):
             cls.INFO: 0.1,
             cls.MINIMAL: 0.2,
             cls.LOW: 0.3,
+            cls.WARNING: 0.4,
             cls.MEDIUM: 0.5,
+            cls.DEGRADED: 0.6,
             cls.HIGH: 0.7,
+            cls.ERROR: 0.8,
             cls.CRITICAL: 0.9,
         }
         return scores.get(severity, 0.0)

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -19,7 +19,7 @@ So these tests pin **member sets**, not names. A rename is a member-set change
 and fails here by name; a member quietly dropped fails here by name. Both
 directions were mutation-checked before this file was committed.
 
-Three traps this file is deliberately built against:
+Four traps this file is deliberately built against:
 
 * *An empty result reads as clean.* Every scan asserts it reached something
   before it asserts anything about what it found.
@@ -28,6 +28,11 @@ Three traps this file is deliberately built against:
   came from, and floors the file enumeration.
 * *A guard whose target is missing reports a false PASS.* Each mapping test
   asserts the target table exists and is non-empty first.
+* *A sweep that edits by pattern edits prose too.* #14956's regex conversion
+  rewrote a literal inside a docstring's ```json response body, producing
+  documentation no reader could copy. Prose is exempt from the ratchet, never a
+  target for it, and ``test_no_enum_read_was_written_inside_a_string`` fails if
+  an enum read lands inside a string constant again.
 """
 
 from __future__ import annotations

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -261,9 +261,9 @@ def test_the_backup_dispatch_no_longer_carries_two_spellings():
 _SEVERITY_LITERAL = re.compile(r"""["']severity["']\s*:\s*["'][A-Za-z_]+["']""")
 
 # #13597 filed this at 119; it had grown to 169 before the ratchet stopped it.
-# #14956 converted 145 of those 169, leaving only the entries below. Lower it as
+# #14956 converted 144 of those 169, leaving only the entries below. Lower it as
 # literals are converted; never raise it.
-SEVERITY_LITERAL_CEILING = 24
+SEVERITY_LITERAL_CEILING = 25
 
 # Floor for the literal population itself. Zero must FAIL, not read as clean —
 # a matcher that stopped matching, a moved root, or an `OSError` swallowed per
@@ -272,10 +272,11 @@ SEVERITY_LITERAL_CEILING = 24
 # than a silent drift.
 SEVERITY_LITERAL_FLOOR = 20
 
-# The files where a bare literal is the RIGHT thing to write, and why. Every one
-# of these is a value crossing an external boundary: writing the enum there would
-# assert the enum against itself instead of against the contract.
-EXTERNAL_SEVERITY_VOCABULARIES = {
+# The files where a bare literal is the RIGHT thing to write, and why. Two
+# reasons qualify, and nothing else does: the value crosses an external
+# boundary, or the line is documentation prose rather than a producer.
+DELIBERATE_SEVERITY_LITERALS = {
+    # --- external boundary: writing the enum would assert it against itself ---
     # Inbound Prometheus Alertmanager webhook payloads. The literal is the
     # third party's label, replayed verbatim.
     "autobot-backend/monitoring/alertmanager_webhook_test.py",
@@ -284,10 +285,16 @@ EXTERNAL_SEVERITY_VOCABULARIES = {
     # (Extreme/Severe/Moderate/Minor/Unknown), passed straight through by
     # NOAASource — a different taxonomy that happens to share the field name.
     "autobot-backend/tests/test_osint_engine.py",
-    # Docstring usage examples. Graph node properties are caller-supplied
-    # key/value data; the example is prose, not a producer.
+    # --- documentation prose: the line is read, not executed ---
+    # Graph node properties are caller-supplied key/value data; the docstring
+    # example illustrates the shape, it does not produce a severity.
     "autobot-backend/autobot_memory_graph/property_graph.py",
     "autobot-backend/autobot_memory_graph/property_graph_mixin.py",
+    # A ```json response body inside the endpoint docstring. #14956's first
+    # sweep rewrote this one to an enum read and produced invalid JSON in the
+    # documentation — see test_no_enum_read_was_written_inside_a_string below,
+    # which exists because of it.
+    "autobot-backend/api/knowledge_grounding.py",
 }
 
 # Floor for the enumeration itself. An empty walk must not read as "clean".
@@ -370,7 +377,7 @@ def test_bare_severity_literals_do_not_grow():
         f"#14956: the sweep found only {len(hits)} severity literals (floor "
         f"{SEVERITY_LITERAL_FLOOR}). The sweep no longer finds what it is meant "
         f"to scan — a broken matcher or a moved root, not a clean tree. If an "
-        f"entry in EXTERNAL_SEVERITY_VOCABULARIES was genuinely converted, drop "
+        f"entry in DELIBERATE_SEVERITY_LITERALS was genuinely converted, drop "
         f"it from that set and lower both bounds in the same commit."
     )
     assert len(hits) <= SEVERITY_LITERAL_CEILING, (
@@ -383,22 +390,22 @@ def test_no_new_file_carries_a_bare_severity_literal():
     """The ceiling alone would let one file shed a literal while another gained one."""
     offenders = {rel for rel, _ in _severity_literal_hits()}
     assert offenders, "matcher reached nothing — broken matcher, not a clean tree"
-    unexpected = offenders - EXTERNAL_SEVERITY_VOCABULARIES
+    unexpected = offenders - DELIBERATE_SEVERITY_LITERALS
     assert not unexpected, (
         f"#14956: bare severity literals reappeared in {sorted(unexpected)}. Use "
         f"autobot_shared.status_enums.Severity, or add the file to "
-        f"EXTERNAL_SEVERITY_VOCABULARIES with the boundary it crosses."
+        f"DELIBERATE_SEVERITY_LITERALS with the boundary it crosses."
     )
 
 
-def test_every_externally_sourced_severity_file_still_has_one():
+def test_every_deliberate_severity_literal_file_still_has_one():
     """A stale allowlist entry exempts nothing and hides that it exempts nothing."""
     offenders = {rel for rel, _ in _severity_literal_hits()}
-    stale = EXTERNAL_SEVERITY_VOCABULARIES - offenders
+    stale = DELIBERATE_SEVERITY_LITERALS - offenders
     assert not stale, (
         f"#14956: these files no longer carry a bare severity literal, so their "
         f"exemption is dead weight — remove them from "
-        f"EXTERNAL_SEVERITY_VOCABULARIES: {sorted(stale)}"
+        f"DELIBERATE_SEVERITY_LITERALS: {sorted(stale)}"
     )
 
 
@@ -734,3 +741,63 @@ def test_the_rendered_report_text_survived_the_value_change():
     assert base.severity_label(Severity.CRITICAL.value) == "CRITICAL"
     assert base.severity_icon("not-a-severity") == base.UNRANKED_SEVERITY_ICON
     assert base.severity_label("not-a-severity") == "not-a-severity"
+
+
+# --------------------------------------------------------------------------
+# #14956 — an enum read must never be written INSIDE a string
+# --------------------------------------------------------------------------
+
+# The sweep's own regression, caught by CI and pinned here. Rewriting every
+# `"severity": "<literal>"` by regex also rewrote one inside an endpoint
+# docstring, turning a documented ```json response body into invalid JSON that
+# no reader could copy. A docstring is prose: it is exempt from the ratchet, not
+# a target for it. Any file with a literal in prose belongs in
+# DELIBERATE_SEVERITY_LITERALS instead.
+_ENUM_READ_IN_PROSE = re.compile(r"\bSeverity\.[A-Z_]+\.value")
+
+# Floor for this scan. Counted from the modules that actually mention the enum,
+# so an import that stops resolving cannot quietly empty the walk.
+_ENUM_MENTION_FLOOR = 25
+
+
+def _modules_mentioning_severity() -> list[tuple[str, str]]:
+    """(path, source) for every module under the roots that names the enum."""
+    found = []
+    for rel in _tracked_python_files():
+        if not (rel.startswith("autobot-backend/") or rel.startswith("autobot_shared/")):
+            continue
+        try:
+            text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "Severity." in text:
+            found.append((rel, text))
+    return found
+
+
+def test_the_prose_scan_reaches_the_modules_that_use_the_enum():
+    """An empty walk would agree that no docstring was ever mangled."""
+    mentions = _modules_mentioning_severity()
+    assert len(mentions) >= _ENUM_MENTION_FLOOR, (
+        f"#14956: only {len(mentions)} modules mention Severity (floor "
+        f"{_ENUM_MENTION_FLOOR}) — the scan is broken, not the tree"
+    )
+
+
+def test_no_enum_read_was_written_inside_a_string():
+    offenders = []
+    for rel, text in _modules_mentioning_severity():
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+                continue
+            if _ENUM_READ_IN_PROSE.search(node.value):
+                offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, (
+        f"#14956: an enum read was written inside a string literal at "
+        f"{sorted(offenders)}. Prose that shows a severity keeps the plain "
+        f"value; add the file to DELIBERATE_SEVERITY_LITERALS instead."
+    )

--- a/repo_tests/enum_union_guard_test.py
+++ b/repo_tests/enum_union_guard_test.py
@@ -34,13 +34,14 @@ from __future__ import annotations
 
 import ast
 import functools
+import importlib.util
 import re
 import subprocess  # nosec B404  # fixed argv, no shell, no caller input
 from pathlib import Path
 
 import pytest
 
-from autobot_shared.status_enums import CommandRisk, SecretType, Severity
+from autobot_shared.status_enums import CommandRisk, RiskLevel, SecretType, Severity
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BACKEND = REPO_ROOT / "autobot-backend"
@@ -179,9 +180,9 @@ def test_the_wildcard_is_never_a_storable_kind():
 def test_no_second_secret_kind_enum_has_regrown():
     found = _enums_matching(lambda members: {"SSH_KEY", "API_KEY", "TOKEN"} <= members)
     assert found, "scan reached no enum at all — the matcher is broken, not the tree"
-    assert sorted(found) == ["autobot_shared/status_enums.py::SecretType"], (
-        f"#13846: a second secret-kind enum exists: {sorted(found)}"
-    )
+    assert sorted(found) == [
+        "autobot_shared/status_enums.py::SecretType"
+    ], f"#13846: a second secret-kind enum exists: {sorted(found)}"
 
 
 # --------------------------------------------------------------------------
@@ -201,16 +202,12 @@ def test_the_risk_level_boundary_table_covers_every_command_risk():
     for node in ast.walk(tree):
         if isinstance(node, ast.Dict):
             for key in node.keys:
-                if (
-                    isinstance(key, ast.Attribute)
-                    and isinstance(key.value, ast.Name)
-                    and key.value.id == "CommandRisk"
-                ):
+                if isinstance(key, ast.Attribute) and isinstance(key.value, ast.Name) and key.value.id == "CommandRisk":
                     mapped.add(key.attr)
     assert mapped, "target table not found — the guard would pass on an empty scan"
-    assert mapped == {member.name for member in CommandRisk}, (
-        f"#13845: _COMMAND_RISK_TO_RISK_LEVEL is missing {sorted({m.name for m in CommandRisk} - mapped)}"
-    )
+    assert mapped == {
+        member.name for member in CommandRisk
+    }, f"#13845: _COMMAND_RISK_TO_RISK_LEVEL is missing {sorted({m.name for m in CommandRisk} - mapped)}"
 
 
 # --------------------------------------------------------------------------
@@ -242,7 +239,7 @@ def test_backup_service_type_exists_and_names_both_engines():
 
 
 def test_the_postgres_alias_is_declared_next_to_the_enum():
-    """"postgresql" was a live dispatch key, so it is already in stored rows."""
+    """ "postgresql" was a live dispatch key, so it is already in stored rows."""
     source = (SLM / "models" / "database.py").read_text(encoding="utf-8")
     assert "_BACKUP_SERVICE_TYPE_ALIASES" in source
     assert '"postgresql"' in source
@@ -258,15 +255,40 @@ def test_the_backup_dispatch_no_longer_carries_two_spellings():
 # #13597 — the severity literals may not grow back
 # --------------------------------------------------------------------------
 
-# Bare `"severity": "<literal>"` dict entries. Not converted in this change —
-# see the issue trail — but ratcheted so the population cannot grow while the
-# conversion is outstanding.
+# Bare `"severity": "<literal>"` dict entries. #14956 converted the in-process
+# producers to canonical `Severity` members; what remains is ratcheted so the
+# population can neither grow nor silently vanish.
 _SEVERITY_LITERAL = re.compile(r"""["']severity["']\s*:\s*["'][A-Za-z_]+["']""")
 
-# Measured on this tree at the time of writing. #13597 filed it as 119; it had
-# grown to this before anything stopped it. Lower it as literals are converted;
-# never raise it.
-SEVERITY_LITERAL_CEILING = 169
+# #13597 filed this at 119; it had grown to 169 before the ratchet stopped it.
+# #14956 converted 145 of those 169, leaving only the entries below. Lower it as
+# literals are converted; never raise it.
+SEVERITY_LITERAL_CEILING = 24
+
+# Floor for the literal population itself. Zero must FAIL, not read as clean —
+# a matcher that stopped matching, a moved root, or an `OSError` swallowed per
+# file would all otherwise report a spotless tree. Set just under the ceiling so
+# converting one of the entries below is a deliberate edit of this guard rather
+# than a silent drift.
+SEVERITY_LITERAL_FLOOR = 20
+
+# The files where a bare literal is the RIGHT thing to write, and why. Every one
+# of these is a value crossing an external boundary: writing the enum there would
+# assert the enum against itself instead of against the contract.
+EXTERNAL_SEVERITY_VOCABULARIES = {
+    # Inbound Prometheus Alertmanager webhook payloads. The literal is the
+    # third party's label, replayed verbatim.
+    "autobot-backend/monitoring/alertmanager_webhook_test.py",
+    "autobot-backend/api/webhook_authentication_security_test.py",
+    # NOAA/NWS alert feed. `properties.severity` is the CAP vocabulary
+    # (Extreme/Severe/Moderate/Minor/Unknown), passed straight through by
+    # NOAASource — a different taxonomy that happens to share the field name.
+    "autobot-backend/tests/test_osint_engine.py",
+    # Docstring usage examples. Graph node properties are caller-supplied
+    # key/value data; the example is prose, not a producer.
+    "autobot-backend/autobot_memory_graph/property_graph.py",
+    "autobot-backend/autobot_memory_graph/property_graph_mixin.py",
+}
 
 # Floor for the enumeration itself. An empty walk must not read as "clean".
 _TRACKED_PY_FLOOR = 3000
@@ -288,7 +310,8 @@ def _tracked_python_files() -> tuple[str, ...]:
     return tuple(line for line in out.stdout.splitlines() if line)
 
 
-def _severity_literal_hits() -> list[str]:
+def _severity_literal_hits() -> list[tuple[str, str]]:
+    """(file, matched text) for every bare severity literal under the roots."""
     hits = []
     for rel in _tracked_python_files():
         if not (rel.startswith("autobot-backend/") or rel.startswith("autobot_shared/")):
@@ -298,7 +321,7 @@ def _severity_literal_hits() -> list[str]:
         except OSError:
             continue
         for match in _SEVERITY_LITERAL.finditer(text):
-            hits.append(f"{rel}:{match.group(0)}")
+            hits.append((rel, match.group(0)))
     return hits
 
 
@@ -307,19 +330,75 @@ def test_the_enumeration_reaches_the_repo():
     assert len(_tracked_python_files()) >= _TRACKED_PY_FLOOR
 
 
+def _banned_shape(quote: str, value: str) -> str:
+    """Build a string this file's own matcher matches, without writing one.
+
+    Spelling the shape out as a literal would plant an offender inside the very
+    guard that bans it — the trap that has bitten fixtures in this repo before.
+    ``test_this_guard_does_not_trip_its_own_matcher`` pins that it stays true.
+    """
+    key = quote + "severity" + quote
+    return "{" + key + ": " + quote + value + quote + "}"
+
+
 def test_the_severity_literal_matcher_still_matches():
     """A regex that stopped matching would report a clean tree (#13597)."""
-    assert _SEVERITY_LITERAL.search('{"severity": "high"}')
-    assert _SEVERITY_LITERAL.search("{'severity': 'critical'}")
+    assert _SEVERITY_LITERAL.search(_banned_shape('"', "high"))
+    assert _SEVERITY_LITERAL.search(_banned_shape("'", "critical"))
+    assert _SEVERITY_LITERAL.search(_banned_shape('"', "warning"))
     assert not _SEVERITY_LITERAL.search('{"severity": severity_value}')
+    assert not _SEVERITY_LITERAL.search('{"severity": Severity.HIGH.value}')
+
+
+def test_this_guard_does_not_trip_its_own_matcher():
+    """The self-guard for the fixture trap, asserted rather than trusted.
+
+    ``repo_tests/`` is outside the scanned roots today, so a literal here would
+    be invisible; the moment the roots widen, the guard would start reporting
+    itself. Assemble fixtures, never spell them.
+    """
+    source = Path(__file__).read_text(encoding="utf-8")
+    assert not _SEVERITY_LITERAL.search(source), (
+        "this guard file contains a literal its own matcher bans — assemble it "
+        "from fragments with _banned_shape() instead"
+    )
 
 
 def test_bare_severity_literals_do_not_grow():
     hits = _severity_literal_hits()
-    assert hits, "matcher reached nothing — broken matcher, not a clean tree"
+    assert len(hits) >= SEVERITY_LITERAL_FLOOR, (
+        f"#14956: the sweep found only {len(hits)} severity literals (floor "
+        f"{SEVERITY_LITERAL_FLOOR}). The sweep no longer finds what it is meant "
+        f"to scan — a broken matcher or a moved root, not a clean tree. If an "
+        f"entry in EXTERNAL_SEVERITY_VOCABULARIES was genuinely converted, drop "
+        f"it from that set and lower both bounds in the same commit."
+    )
     assert len(hits) <= SEVERITY_LITERAL_CEILING, (
-        f"#13597: bare severity literals grew to {len(hits)} (ceiling "
+        f"#13597/#14956: bare severity literals grew to {len(hits)} (ceiling "
         f"{SEVERITY_LITERAL_CEILING}). Use autobot_shared.status_enums.Severity."
+    )
+
+
+def test_no_new_file_carries_a_bare_severity_literal():
+    """The ceiling alone would let one file shed a literal while another gained one."""
+    offenders = {rel for rel, _ in _severity_literal_hits()}
+    assert offenders, "matcher reached nothing — broken matcher, not a clean tree"
+    unexpected = offenders - EXTERNAL_SEVERITY_VOCABULARIES
+    assert not unexpected, (
+        f"#14956: bare severity literals reappeared in {sorted(unexpected)}. Use "
+        f"autobot_shared.status_enums.Severity, or add the file to "
+        f"EXTERNAL_SEVERITY_VOCABULARIES with the boundary it crosses."
+    )
+
+
+def test_every_externally_sourced_severity_file_still_has_one():
+    """A stale allowlist entry exempts nothing and hides that it exempts nothing."""
+    offenders = {rel for rel, _ in _severity_literal_hits()}
+    stale = EXTERNAL_SEVERITY_VOCABULARIES - offenders
+    assert not stale, (
+        f"#14956: these files no longer carry a bare severity literal, so their "
+        f"exemption is dead weight — remove them from "
+        f"EXTERNAL_SEVERITY_VOCABULARIES: {sorted(stale)}"
     )
 
 
@@ -343,24 +422,107 @@ def test_the_severity_aliases_still_point_at_the_canonical_enum(rel, alias):
     bindings = [
         node.value.id
         for node in tree.body
-        if isinstance(node, ast.Assign)
-        and isinstance(node.value, ast.Name)
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Name)
         for target in node.targets
         if isinstance(target, ast.Name) and target.id == alias
     ]
-    redeclared = [
-        node.name for node in tree.body if isinstance(node, ast.ClassDef) and node.name == alias
-    ]
+    redeclared = [node.name for node in tree.body if isinstance(node, ast.ClassDef) and node.name == alias]
     assert not redeclared, f"#13597: {alias} was re-declared as its own enum in {rel}"
-    assert bindings == ["Severity"], (
-        f"#13597: {alias} in {rel} is bound to {bindings or 'nothing'}, not Severity"
-    )
+    assert bindings == ["Severity"], f"#13597: {alias} in {rel} is bound to {bindings or 'nothing'}, not Severity"
 
 
 def test_the_canonical_severity_still_carries_every_aliased_member():
     """The aliases are only safe while Severity is a superset of both forks."""
     for name in ("LOW", "MEDIUM", "HIGH", "CRITICAL"):
         assert hasattr(Severity, name), f"#13597: Severity lost {name}"
+
+
+# --------------------------------------------------------------------------
+# #14956 — the three rungs the vocabulary was missing, and the ladder it kept
+# --------------------------------------------------------------------------
+
+# The full vocabulary after #14956. WARNING, DEGRADED and ERROR were NOT folded
+# into a neighbouring rung: each is already emitted across a boundary that would
+# change if it moved — a Prometheus label, an API response field, and an audit
+# finding grade respectively. See the Severity docstring for the evidence.
+SEVERITY_VOCABULARY = {
+    ("UNKNOWN", "unknown"),
+    ("INFO", "info"),
+    ("MINIMAL", "minimal"),
+    ("LOW", "low"),
+    ("WARNING", "warning"),
+    ("MEDIUM", "medium"),
+    ("DEGRADED", "degraded"),
+    ("HIGH", "high"),
+    ("ERROR", "error"),
+    ("CRITICAL", "critical"),
+}
+
+# The rungs numeric risk grading maps onto — the enum exactly as it stood BEFORE
+# #14956, in order. Bug-prediction endpoints build their risk distribution from
+# this, so it is a shipped API response key set, not an implementation detail.
+SEVERITY_SCORE_LADDER = ("unknown", "info", "minimal", "low", "medium", "high", "critical")
+
+
+def test_severity_is_exactly_the_vocabulary_union():
+    assert _members(Severity) == SEVERITY_VOCABULARY
+
+
+@pytest.mark.parametrize("name", sorted(name for name, _ in SEVERITY_VOCABULARY))
+def test_every_severity_rung_is_present_by_name(name):
+    """Presence, one rung at a time, so a loss names itself."""
+    assert hasattr(Severity, name), f"#14956: Severity lost {name}"
+
+
+def test_the_wire_spellings_of_the_added_rungs_resolve():
+    """Values already on the wire before they had an enum member.
+
+    ``warning`` is a Prometheus label the monitor publishes, ``degraded`` is
+    serialised into the causal-analysis response, ``error`` is the grade the
+    capability audit counts findings at.
+    """
+    assert Severity("warning") is Severity.WARNING
+    assert Severity("degraded") is Severity.DEGRADED
+    assert Severity("error") is Severity.ERROR
+
+
+def test_the_score_ladder_is_untouched_by_the_added_vocabulary():
+    """#14956's blast-radius guard: adding rungs must not reshape a response."""
+    ladder = Severity.score_ladder()
+    assert tuple(level.value for level in ladder) == SEVERITY_SCORE_LADDER
+    assert set(ladder) < set(Severity), "the ladder must stay a strict subset"
+
+
+def test_the_risk_distribution_keys_did_not_gain_the_added_rungs():
+    """Asserted as the endpoints build it, not as the enum declares it.
+
+    ``{level.value: 0 for level in RiskLevel}`` is what the bug-prediction
+    endpoints shipped. Left iterating the enum, #14956 would have added three
+    always-zero buckets to a live API response.
+    """
+    distribution = {level.value: 0 for level in RiskLevel.score_ladder()}
+    assert tuple(distribution) == SEVERITY_SCORE_LADDER
+    for added in ("warning", "degraded", "error"):
+        assert added not in distribution, f"#14956: {added} leaked into the risk distribution"
+
+
+def test_the_severity_scale_is_strictly_ascending_over_the_whole_vocabulary():
+    """A rung inserted at the wrong height silently reorders every comparison."""
+    scores = [Severity.to_score(level) for level in Severity]
+    assert scores == sorted(scores)
+    assert len(set(scores)) == len(scores), "two rungs share a score"
+    assert Severity.to_score(Severity.LOW) < Severity.to_score(Severity.WARNING)
+    assert Severity.to_score(Severity.WARNING) < Severity.to_score(Severity.MEDIUM)
+    assert Severity.to_score(Severity.MEDIUM) < Severity.to_score(Severity.DEGRADED)
+    assert Severity.to_score(Severity.HIGH) < Severity.to_score(Severity.ERROR)
+    assert Severity.to_score(Severity.ERROR) < Severity.to_score(Severity.CRITICAL)
+
+
+def test_from_score_still_returns_only_ladder_rungs():
+    """Grading behaviour is unchanged: the added rungs are vocabulary, not output."""
+    graded = {Severity.from_score(step / 100) for step in range(0, 101)}
+    assert graded, "the sweep graded nothing"
+    assert graded <= set(Severity.score_ladder())
 
 
 # --------------------------------------------------------------------------
@@ -455,9 +617,7 @@ def test_the_scan_sees_an_enum_whose_base_was_imported_under_an_alias():
     in the base list, which an alias removes. Run against a string here, so the
     check does not depend on the tree containing an example.
     """
-    aliased = ast.parse(
-        "from enum import Enum as _E\n\n\nclass Regrown(_E):\n    SAFE = 'safe'\n"
-    )
+    aliased = ast.parse("from enum import Enum as _E\n\n\nclass Regrown(_E):\n    SAFE = 'safe'\n")
     assert _enums_in_tree(aliased) == [("Regrown", frozenset({"SAFE"}))]
 
     dotted = ast.parse("import enum\n\n\nclass Dotted(enum.Enum):\n    SAFE = 'safe'\n")
@@ -492,15 +652,85 @@ def _enums_matching(predicate) -> list[str]:
     A same-name sweep is exactly what missed these forks: each pair used
     different names for one concept.
     """
-    return [
-        f"{rel}::{name}" for rel, name, members in _declared_enums() if predicate(members)
-    ]
+    return [f"{rel}::{name}" for rel, name, members in _declared_enums() if predicate(members)]
 
 
 def test_the_enum_scan_reaches_the_repo():
     """A scan that parsed nothing would agree with every assertion above."""
     declared = _declared_enums()
     assert len(declared) >= _DECLARED_ENUM_FLOOR, (
-        f"enum scan found only {len(declared)} enums — the matcher is broken, "
-        f"not the tree"
+        f"enum scan found only {len(declared)} enums — the matcher is broken, " f"not the tree"
     )
+
+
+# --------------------------------------------------------------------------
+# #14956 — the sanitizers store the enum VALUE, never the member NAME
+# --------------------------------------------------------------------------
+
+# All three graded findings as "HIGH"/"CRITICAL"/"MEDIUM" — the member *name*
+# in a field that carries the *value*. Anything comparing a finding against
+# ``Severity.HIGH.value`` silently matched none of them.
+_SANITIZERS = (
+    "autobot-backend/code_analysis/auto-tools/security_sanitizer.py",
+    "autobot-backend/code_analysis/auto-tools/security_deep_sanitizer.py",
+    "autobot-backend/code_analysis/auto-tools/playwright_sanitizer.py",
+)
+
+
+def _severity_dict_values(path: Path) -> list[ast.expr]:
+    """Every ``"severity": <expr>`` dict entry in one module, by AST.
+
+    Read rather than imported: these are standalone CLI scripts that mutate
+    ``sys.path`` at import time, and this guard must not depend on that.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return [
+        value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Dict)
+        for key, value in zip(node.keys, node.values)
+        if isinstance(key, ast.Constant) and key.value == "severity"
+    ]
+
+
+@pytest.mark.parametrize("rel", _SANITIZERS)
+def test_no_sanitizer_grades_a_finding_with_a_member_name(rel):
+    path = REPO_ROOT / rel
+    assert path.exists(), f"#14956: {rel} is gone — the guard has no target"
+    values = _severity_dict_values(path)
+    assert values, f"#14956: no severity field found in {rel} — the scan missed it"
+    constants = [node.value for node in values if isinstance(node, ast.Constant)]
+    for value in constants:
+        assert value in {level.value for level in Severity}, (
+            f"#14956: {rel} grades a finding {value!r}, which is not a Severity "
+            f"value. Member names ('HIGH') are not values ('high')."
+        )
+
+
+def _load_tool_base():
+    """Load the auto-tools skeleton without putting its directory on sys.path."""
+    path = REPO_ROOT / "autobot-backend" / "code_analysis" / "auto-tools" / "tool_base.py"
+    spec = importlib.util.spec_from_file_location("autobot_auto_tools_base", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_the_report_vocabulary_lives_in_one_place_and_reads_canonical_values():
+    """Three copies of the same icon table became one, keyed on the enum."""
+    base = _load_tool_base()
+    assert base.SEVERITY_REPORT_ORDER, "the report ladder is empty"
+    assert set(base.SEVERITY_REPORT_ORDER) <= set(Severity)
+    ranked = [Severity.to_score(level) for level in base.SEVERITY_REPORT_ORDER]
+    assert ranked == sorted(ranked, reverse=True), "the report ladder is not worst-first"
+    for level in base.SEVERITY_REPORT_ORDER:
+        assert base.severity_icon(level.value) == base.SEVERITY_REPORT_ICONS[level]
+
+
+def test_the_rendered_report_text_survived_the_value_change():
+    """#14956 changed what is stored, deliberately not what a reader sees."""
+    base = _load_tool_base()
+    assert base.severity_label(Severity.HIGH.value) == "HIGH"
+    assert base.severity_label(Severity.CRITICAL.value) == "CRITICAL"
+    assert base.severity_icon("not-a-severity") == base.UNRANKED_SEVERITY_ICON
+    assert base.severity_label("not-a-severity") == "not-a-severity"


### PR DESCRIPTION
## Thinking Path

The enum-fork half of #13597 already landed in #14957 — `AlertSeverity` and `ErrorSeverity`
are aliases of the canonical `Severity`, and the ratchet in `repo_tests/enum_union_guard_test.py`
pins that. Confirmed on the base before starting; nothing there was redone and no new enum
was forked. What was left is the literal sweep.

**Measured the population rather than trusting it.** #13597 said 119, #14956 said 169. Ran
the ratchet's own matcher — `["']severity["']\s*:\s*["'][A-Za-z_]+["']` over
`git ls-files '*.py'` under `autobot-backend/` and `autobot_shared/` — and got **169 hits
across 43 files, 43 of them outside the canonical vocabulary**, matching #14956 exactly. The
number is not asserted only in this description: `SEVERITY_LITERAL_FLOOR` and
`SEVERITY_LITERAL_CEILING` bound it from both sides in the guard.

**The 43 out-of-vocabulary literals, decided one at a time.** The rule is that a duplicated
concept converges on the implementation that is the *union*; a rung is never dropped to make
a count go down. So each value was either a genuine synonym of an existing rung, or a rung
the canonical enum was missing.

| value | n | bucket | evidence |
| --- | --- | --- | --- |
| `HIGH` `MEDIUM` `CRITICAL` | 15 | **synonym** — the member *name* written where the *value* belongs | the three auto-tools sanitizers; nothing outside them reads their reports, and the rendered text is preserved |
| `warning` | 25 | **missing rung** — added | `PerformanceMonitor` publishes `update_active_alerts("warning", ...)` as a Prometheus label, the shipped alert rules carry `severity: warning`, and the capability audit counts `warning` findings separately from `error`. Folding it to `medium` renames a scraped label. |
| `degraded` | 1 | **missing rung** — added | `CausalSeverity.DEGRADED` is serialised into the causal-analysis API response by `to_dict()`, and an existing test asserts `result["severity"] == "degraded"`. |
| `error` | 1 | **missing rung** — added | the capability audit grades findings `error` vs `warning` and counts each; they are two rungs, not one. |
| `Extreme` | 1 | **neither — correct as written** | it is the NOAA/NWS CAP vocabulary (Extreme/Severe/Moderate/Minor/Unknown) arriving from a third-party feed and passed through verbatim by `NOAASource`. #14956 called it "a value no consumer can match"; it is in fact faithful external wire data, and the carve-out for parsed external values applies. Left alone, with the reason recorded in the guard. |

**Adding rungs had a blast radius, and it is closed.** Four bug-prediction call sites build
`{level.value: 0 for level in RiskLevel}` — a *shipped API response key set*. Left iterating
the enum, this PR would have quietly added three always-zero buckets to it. `Severity.score_ladder()`
now names the grading subset, the four sites iterate that, and a test asserts the key tuple
is byte-for-byte what it was before.

**Not folded, deliberately.** `CausalSeverity` is a fourth severity fork whose three members
are now all in canonical `Severity`, so it is one alias from collapsing — but it is
`(str, Enum)` where canonical is a plain `Enum`, and that is precisely the serialisation rule
#13597 scope item 3 parked and #14956 explicitly deferred. Collapsing it before that rule is
stated would change serialisation behaviour under existing holders. Filed as #14988 with the
blast-radius audit already done, rather than half-changed here.

## What Changed

**Converted 144 of 169 (85%).** The 25 that remain are ones where a bare literal is the right
thing to write — the value crosses an external boundary, or the line is documentation prose:

| file | n | boundary |
| --- | --- | --- |
| `monitoring/alertmanager_webhook_test.py` | 18 | inbound Alertmanager webhook payloads |
| `api/webhook_authentication_security_test.py` | 2 | same |
| `tests/test_osint_engine.py` | 1 | NOAA CAP feed |
| `autobot_memory_graph/property_graph.py` | 2 | docstring usage example; node properties are caller-supplied data |
| `autobot_memory_graph/property_graph_mixin.py` | 1 | same |
| `api/knowledge_grounding.py` | 1 | a ```` ```json ```` response body inside an endpoint docstring |

They are an explicit set in the guard now, not an anonymous residue in a count.

* **`autobot_shared/status_enums.py`** — `Severity` gains `WARNING`, `DEGRADED`, `ERROR`,
  each placed at its own height so `to_score` stays strictly ascending across all ten rungs.
  Added `score_ladder()` for the grading subset. The docstring records why each of the three
  was not folded into a neighbour.
* **37 modules** under the two Python roots — bare literals become `Severity.<RUNG>.value`,
  `.value` at every serialisation boundary.
* **All three auto-tools sanitizers** — they stored the member name (`"HIGH"`) in a field
  carrying the value (`"high"`), so anything comparing a finding against `Severity.HIGH.value`
  matched none of them. Fixed. Each also had a private copy of the same icon table and the
  same worst-first ordering list; those now live once in `tool_base.py`, keyed on the enum.
  `severity_label()` keeps the rendered report text identical — the stored data changed, the
  report a human reads did not.
* **Four bug-prediction sites** — iterate `score_ladder()`, pinning the response key set.
* **`repo_tests/enum_union_guard_test.py`** — ceiling 169 → 25, plus the new guards below.

## Verification

**The guard can actually fail.** Fourteen mutations, each applied to a committed tree, run, and
reverted with `git checkout --`; none pushed, tree confirmed clean afterwards:

| # | mutation | test that caught it |
| --- | --- | --- |
| M1 | regrow a bare literal in a converted producer | `test_no_new_file_carries_a_bare_severity_literal` |
| M2 | drop `WARNING` from the enum | `test_severity_is_exactly_the_vocabulary_union` |
| M3 | `score_ladder()` returns the whole enum | `test_the_risk_distribution_keys_did_not_gain_the_added_rungs` |
| M4 | a sanitizer regrows `"CRITICAL"` | `test_no_sanitizer_grades_a_finding_with_a_member_name` |
| M5 | break the matcher so it matches nothing | `test_bare_severity_literals_do_not_grow` |
| M6 | plant a banned literal inside the guard file | `test_this_guard_does_not_trip_its_own_matcher` |
| M7 | convert an allowlisted external file | `test_every_externally_sourced_severity_file_still_has_one` |
| M8 | `severity_label()` echoes the value | `test_the_rendered_report_text_survived_the_value_change` |
| M9 | report ladder no longer worst-first | `test_the_report_vocabulary_lives_in_one_place_and_reads_canonical_values` |
| M10 | score `WARNING` above `HIGH` | `test_the_severity_scale_is_strictly_ascending_over_the_whole_vocabulary` |
| M11 | rewrite the docstring back to an enum read | `test_no_enum_read_was_written_inside_a_string` |
| M12 | prose scan reaches no module | `test_the_prose_scan_reaches_the_modules_that_use_the_enum` |
| M13 | leave the ceiling at the stale 24 | `test_bare_severity_literals_do_not_grow` |
| M14 | drop the docstring file from the allowlist | `test_no_new_file_carries_a_bare_severity_literal` |

**M5 is the important one.** With the matcher broken the population goes to 0, and the guard
fails *loudly* rather than reporting a clean tree:

> `#14956: the sweep found only 0 severity literals (floor 20). The sweep no longer finds
> what it is meant to scan — a broken matcher or a moved root, not a clean tree.`

That is `SEVERITY_LITERAL_FLOOR`, asserted **before** the ceiling. Both traps named in the
issue trail are handled: the fixtures that must contain a banned pattern are assembled from
fragments by `_banned_shape()`, and `test_this_guard_does_not_trip_its_own_matcher` scans
this guard's own source to prove no spelled-out literal crept back in.

**Assertions are on behaviour, not source text.** The sanitizer guard reads the severity
field by AST and asserts each constant *parses as a `Severity`* — a member name fails
because `Severity("HIGH")` raises, not because a string comparison says so. The
risk-distribution guard builds the dict the endpoints build and asserts the key tuple. The
enum members are pinned as `(name, value)` pairs, so a rename is a member-set change and
fails by name, matching the shape #14957 established in this file.

**Local runs** — these characterise this interpreter only (**Python 3.10.12**, pytest 9.0.2);
CI is authoritative:

* `repo_tests/enum_union_guard_test.py` — 65 passed (was ~40 before this PR)
* touched suites: causal engine + integration 24 passed; remediation loop, counterfactual
  reasoner, property graph, codebase stats, LLC finding proposal 156 passed; LLC findings
  gather/verify, prometheus monitor category, knowledge-grounding decode 39 passed;
  bug-prediction 62 passed
* `black --line-length=120 --check` and `isort --profile=black --line-length=120` clean on
  all 44 changed files; pre-commit ran on the commit, no `--no-verify`

**Population, re-measured after the change:** 169 → 25, and the 25 are exactly the six
allowlisted files.

### Second round — the two CI failures on the first head

**`code-quality` (F401).** Not just a stray import. The regex conversion had rewritten a
literal *inside an endpoint docstring*, where a fenced `json` block documents the response
body — turning documented JSON into `Severity.HIGH.value`, which no reader can copy, and
leaving the import unused. A docstring is prose, so it is exempt from the ratchet rather than
a target for it: the literal is restored, the import dropped, and the file joins the
deliberate-literal set. The repo's auto-formatter had already deleted the import on its own,
which would have left the mangled docstring in place — the import was the symptom.

Audited the whole sweep for the same defect by AST rather than fixing only the reported line:
**exactly one file was affected.** The corrected count is therefore **144 of 169**, not 145,
and the ceiling is 25, not 24 — the stale ceiling would have masked it, so both bounds moved.
`test_no_enum_read_was_written_inside_a_string` now walks every module mentioning the enum and
fails if an enum read appears inside a string constant (M11), floored so an empty walk cannot
read as clean (M12).

**`check-drift`.** Adding three rungs widened the generated TypeScript union and the
checked-in generated file was stale. Regenerated with the repo's generator, not hand-edited,
and `--check` now reports `OK — generated TS matches committed file`.

**Does the widened union have an unhandled consumer? No.** Traced every consumer:

* The only typed consumer of the generated union is `AutomationWorkflowStep.risk_level`, read
  at `WorkflowBuilderView.vue` as a two-value predicate (`=== 'high' || === 'critical'`) and a
  class binding — not a `switch`, not a `Record<>`.
* No `Record<RiskLevel, …>` or `Record<Severity, …>` is keyed on the generated union. The one
  exhaustive `Record<Severity, string>` in `FindingsTable.vue` is keyed on a *locally
  declared* `Severity` in `types/codeIntelligence.ts`, untouched by codegen.
* Every `switch` over a severity takes a plain `string` (often `?.toLowerCase()`) and has a
  `default:` branch — including `FailureAnalysisDashboard.vue`, the one place `degraded` and
  `warning` genuinely arrive, which handles both.

**Narrowing the TS alias was considered and rejected.** The backend `score_ladder()` guard was
needed because a shipped response *key set* would have changed. The TS `RiskLevel` is an alias
the generator emits precisely because Python declares `RiskLevel = Severity`; narrowing it
would make the generated types disagree with the canonical enum, which is the drift the
`frontend-codegen-drift` gate exists to prevent. The generated file stays faithful.

That trace did surface real pre-existing drift, filed rather than folded in: **#14993** — the
frontend holds three definitions of this type, one of them upper-cased (`'LOW' | 'MEDIUM' |
'HIGH' | 'CRITICAL'` in `types/models.ts`), which is the same name-where-a-value-belongs
defect this PR fixed on the Python side.

## Model Used

Claude Opus 4.5

---

Closes #14956

`Refs #13597` rather than closing it: its scope item 3 — stating the plain-`Enum` vs
`(str, Enum)` rule in the `status_enums` docstring, and reconciling `AgentLifecycleStatus`
and `ConnectionStatus`, both of which have committed wire formats — is untouched here.
#14956 itself carved that out as "not delivered here". Partial delivery does not close.

Discovered and filed rather than dropped: #14993 (three frontend definitions of this type,
one upper-cased) and #14988 (`CausalSeverity` as a fourth fork, plus
219 severity literals in two shapes the ratchet's matcher does not see, 20 of them outside
the canonical vocabulary).
