### PR TITLE
chore(skills): mirror the 11 AutoBot-specific skills into docs/developer/skills (#14994)

### DIFF
--- a/docs/developer/skills/README.md
+++ b/docs/developer/skills/README.md
@@ -22,9 +22,22 @@ incident.
 | File | Role |
 |---|---|
 | `batch-implement.md` | Drives `/batch-implement <issues>` — full implement→review→merge→close→discover loop with self-healing retry, Phase 0c verification mandate, and Phase 0d behavioral grep for extraction PRs |
+| `implement.md` | Drives `/implement <issue>` — umbrella gate, worktree, design, code, verify, PR, CI, three-gate closure |
+| `pr.md` | PR creation with pre-flight branch checks, the four required body headings, targeting `Dev_new_gui` |
+| `pre-merge-validate.md` | Pre-merge validation — syntax, imports, call-site impact, tests, types, linting |
+| `github-cli.md` | `gh` CLI usage for every GitHub operation — issues, PRs, reviews, merges, local workarounds |
+| `debug-autobot.md` | Full-stack debugging — parallel per-layer investigators then a synthesis protocol |
+| `api-wiring-audit.md` | Frontend/backend API contract wiring audit — unmounted routers, dead buttons, 404s, drift |
+| `dead-code-audit.md` | Unwired-code audit — unregistered routers, uninvoked hooks, orphaned components → wire-in issues |
+| `review-fleet.md` | 10-angle parallel PR review fleet — finders + adversarial verifiers, one deduped comment |
+| `review.md` | PR review cycle — CI diagnosis, three-angle finder pass, lint-only auto-fix, merge decision |
+| `session-lifecycle.md` | Start/end-of-session protocol — worktree setup, stale-branch cleanup, rebase, handoff |
+| `drain.md` | Selects backlog issues needing no decision; delegates execution to `batch-implement` |
 
-Other skills (e.g. `commit`, `pr`, `issue`) are not yet mirrored here. Add
-them as they need updates worth reviewing.
+The 11 AutoBot-specific skills above were mirrored here in #14994. General-purpose
+skills were extracted to a separate public collection instead (`process`, `commit`,
+`review-lenses`, `gap-audit`, `web-audit`, `ui-design`, `memory-cleanup`,
+`canonical-coding`).
 
 `team-implement.md` was consolidated into `batch-implement.md` in #5454 —
 the two skills' scopes overlapped (both did parallel-issue implementation),

--- a/docs/developer/skills/_index.md
+++ b/docs/developer/skills/_index.md
@@ -15,3 +15,14 @@ Documentation for AutoBot-AI's skill system — reusable capability modules that
 | --- | --- |
 | [[README]] | Skills system overview and usage |
 | [[batch-implement]] | Batch implementation skill reference |
+| [[implement]] | Drives `/implement <issue>` |
+| [[pr]] | PR creation with pre-flight branch checks, the four required body headings, targeting `Dev_new_gui` |
+| [[pre-merge-validate]] | Pre-merge validation |
+| [[github-cli]] | `gh` CLI usage for every GitHub operation |
+| [[debug-autobot]] | Full-stack debugging |
+| [[api-wiring-audit]] | Frontend/backend API contract wiring audit |
+| [[dead-code-audit]] | Unwired-code audit |
+| [[review-fleet]] | 10-angle parallel PR review fleet |
+| [[review]] | PR review cycle |
+| [[session-lifecycle]] | Start/end-of-session protocol |
+| [[drain]] | Selects backlog issues needing no decision; delegates execution to `batch-implement` |

--- a/docs/developer/skills/api-wiring-audit.md
+++ b/docs/developer/skills/api-wiring-audit.md
@@ -1,0 +1,87 @@
+---
+name: api-wiring-audit
+description: Audit and enforce frontend/backend API contract wiring in AutoBot-AI (or any FastAPI + SPA monorepo). Use this skill whenever the user mentions unwired features, dead buttons, 404s from the GUI, API contract drift, endpoints that "don't exist", unmounted routers, frontend/backend mismatch, or before marking ANY frontend feature complete. Also use it when implementing or modifying any frontend API call, any FastAPI route, or any router registration — run the audit as a completion gate, not just when explicitly asked.
+---
+
+# API Wiring Audit
+
+Detects and fixes the three classes of frontend/backend contract drift:
+
+1. **Unwired frontend calls** — UI code calling `/api/...` paths that no backend route serves (silent 404s, dead buttons).
+2. **Unmounted routers** — FastAPI router modules that exist but are never registered in the router registry / app factory.
+3. **Dead backend surface** — routes no frontend consumer uses (optional report).
+
+## The script
+
+`scripts/audit_api_wiring.py` (bundled here; in AutoBot it lives at `scripts/audit_api_wiring.py` in the repo root). Copy it there if missing.
+
+### Authoritative mode (always prefer when backend deps are installed)
+
+```bash
+# 1. Dump the real route table by building the app:
+python scripts/audit_api_wiring.py --dump-openapi openapi.json
+# (or fetch from a running server: --openapi http://localhost:8001/openapi.json)
+
+# 2. Audit, failing the build on any finding:
+python scripts/audit_api_wiring.py --openapi openapi.json --fail-on-unwired
+```
+
+Exit codes: `0` clean · `1` unwired frontend calls · `2` unmounted routers · `3` both.
+
+### Static mode (no deps; triage only)
+
+```bash
+python scripts/audit_api_wiring.py
+```
+
+Regex-based with heuristic prefix resolution (`APIRouter(prefix=...)` + `include_router(prefix=...)`). Expect a few false positives from multi-level prefix chains — verify each finding with grep before fixing. Never present static-mode results as definitive.
+
+### Suggestions and baseline health (#12738)
+
+Every unwired finding now prints its closest surviving routes:
+
+```
+  /api/browser/navigate
+      ?  did you mean /api/browser/mcp/navigate
+      <- autobot-frontend/src/composables/useBrowser.ts
+```
+
+Suggestions are segment-aware, weighted toward leading-segment agreement (a rename usually changes the last segment) and suppressed below a similarity floor — no suggestion means no confident match, not "no route exists".
+
+With `--baseline`, a `BASELINE HEALTH` section classifies what the baseline is absorbing:
+
+- `REMOVED-ENDPOINT DRIFT` — baselined call with a close surviving route; almost always a rename. **Rewire it; do not leave it baselined** — this is the case where the gate stays green while the button is dead.
+- `RESOLVED (prune from baseline)` — now matches a real route; the entry is stale.
+- `NO LONGER CALLED (prune from baseline)` — no caller left; residue.
+
+Non-gating by design. Trust these classifications only in authoritative (`--openapi`) mode: static mode's route table combines every registry prefix with every route, so it both invents matches and hides real ones.
+
+### Dead surface report
+
+```bash
+python scripts/audit_api_wiring.py --openapi openapi.json --dead-surface
+```
+
+## Workflow
+
+1. **Run the audit first**, before reading or changing any code. The output is the task list.
+2. **For each unwired frontend call**, decide which side is canonical:
+   - Backend route exists under a *different* path (e.g. `budgets` vs `budget`, `approvals/{id}/approve` vs `work-items/{id}/review/approve`) → fix the **frontend** path. Backend is canonical unless the user says otherwise.
+   - No backend exists at all → ask the user (or check the issue tracker): implement a minimal backend, or feature-flag/remove the UI. **Never leave a dead button shipped.**
+3. **For each unmounted router**: if anything in `autobot-frontend/src` consumes its paths, mount it in `initialization/router_registry/`. If nothing consumes it and git history shows it stale, propose deletion — don't silently delete.
+4. **Re-run with `--fail-on-unwired` until exit code 0.** One commit per logical fix.
+5. **Regenerate frontend types** after any backend route change:
+   ```bash
+   cd autobot-frontend && npm run gen:types
+   ```
+
+## Rules (apply even when the skill wasn't explicitly invoked)
+
+- Never write a frontend API call against a path absent from `openapi.json`. If the endpoint doesn't exist yet, implement the backend route first, dump the spec, then write the frontend call.
+- Frontend components must derive request/response types from `src/types/generated/api.ts`, not hand-typed strings/interfaces. If the generated file lacks the endpoint, that *is* the wiring check failing — fix the backend or regenerate, don't hand-type around it.
+- Before declaring any frontend feature complete, run the authoritative audit and resolve all findings touching the files you changed.
+- When adding a new FastAPI router module, register it in the router registry in the same commit. A router file with no registration is a defect, not a draft.
+
+## Adapting to other repos
+
+The script assumes AutoBot's layout (`autobot-backend/`, `autobot-frontend/src/`, `app_factory.create_app()`). For other FastAPI + SPA monorepos, edit the `BACKEND`, `FRONTEND_SRC`, and `dump_openapi()` constants at the top of the script — everything else is layout-agnostic.

--- a/docs/developer/skills/dead-code-audit.md
+++ b/docs/developer/skills/dead-code-audit.md
@@ -1,0 +1,506 @@
+---
+name: dead-code-audit
+description: Systematic codebase audit for unwired code — identify unregistered routers, uninvoked hooks, orphaned components, and file discovery issues. All findings become "wire it in" issues — never deletion issues.
+---
+
+# /dead-code-audit — Codebase Unwired Code Audit
+
+**POLICY: Code is never deleted. It was created for a reason. Every finding becomes a "wire it in" issue.**
+
+Performs a comprehensive scan of the AutoBot codebase to find:
+- **Not wired** — complete, implemented code that exists but isn't connected to the app
+- **Intentionally isolated** — test fixtures, examples, stubs (marked SKIP)
+
+There is no "DEAD" classification. Code with zero references is still NOT_WIRED — find the right place to connect it.
+
+Findings are classified, deduplicated against existing issues, and batch-filed as GitHub issues for human review. No automatic deletion or wiring.
+
+## Usage
+
+```bash
+/dead-code-audit
+```
+
+Scans the entire codebase (no arguments). Runs 3 audit agents in parallel, classifies findings, and files issues.
+
+---
+
+# Workflow
+
+## Phase 0: Tracker Cross-Reference Pre-flight (REQUIRED)
+
+Before launching agents, run the automated tracker-cross-reference audit. This catches a class of findings the structural agents miss: **production modules whose docstring cites a CLOSED tracker issue but have zero production callers**. This is the systemic premature-closure pattern surfaced by #6836.
+
+```bash
+python3 pipeline-scripts/audit-unwired-trackers.py --json > /tmp/tracker-findings.json
+jq 'length' /tmp/tracker-findings.json
+```
+
+Each entry in the output represents a feature whose tracker was closed before the integration step. Treat each as a `NOT_WIRED` finding for Phase 2 below.
+
+The same script runs weekly via `.github/workflows/unwired-tracker-audit.yml` and files capped batches automatically — but running it interactively at audit time gives full visibility.
+
+---
+
+## Phase 1: Parallel Audit Agents
+
+Three agents run simultaneously, each scanning a different domain:
+
+### Agent A: Backend — Unregistered API Routers
+
+**Task:** Find all Python files in `autobot-backend/api/` that define an APIRouter but are not registered in any router registry.
+
+**Scan steps:**
+
+1. Find all files defining routers:
+   ```bash
+   grep -rl "router = APIRouter" autobot-backend/api/ --include="*.py"
+   ```
+
+2. Find all router files actually imported in registries:
+   ```bash
+   grep -rh "from api\." autobot-backend/initialization/router_registry/ --include="*.py" | sort -u
+   grep -rh "import.*api\." autobot-backend/initialization/router_registry/ --include="*.py" | sort -u
+   ```
+
+3. Compare: files in step 1 but not referenced in step 2 = unregistered
+
+4. For each unregistered router:
+   - Read the file and extract endpoint definitions
+   - Check if it's imported anywhere else (tests, docstrings)
+   - Check if there's already a GitHub issue for it (`gh issue list --search "<filename>"`)
+   - Classify:
+     - Has complete endpoints + never imported anywhere → `NOT_WIRED`
+     - Has only placeholder/empty endpoints → `DEAD`
+     - Imported only in tests → `SKIP` (test fixtures are intentional)
+
+5. For NOT_WIRED findings, extract:
+   - Endpoints defined (path + method)
+   - Module name and prefix
+   - Any git blame to understand why it wasn't wired
+
+**Report back with:**
+```
+ROUTERS_FOUND: <count>
+NOT_WIRED_ROUTERS: <list of filenames>
+DEAD_ROUTERS: <list of filenames>
+SKIPPED_ROUTERS: <list of filenames>
+
+Per router:
+<filename>: <count> endpoints, <endpoint_list>, classified as <NOT_WIRED|DEAD|SKIP>
+```
+
+### Agent B: Backend — Uninvoked HookPoints + Unregistered Extensions
+
+**Task:** Find HookPoint enum values that are defined but never emitted, and extensions that are defined but never registered.
+
+**HookPoint scan:**
+
+1. Get all defined HookPoints:
+   ```bash
+   grep "    [A-Z_]*" autobot-backend/extensions/hooks.py | sed 's/[[:space:]]*\([A-Z_]*\).*/\1/'
+   ```
+
+2. Find actual invocation sites (where hooks are emitted):
+   ```bash
+   grep -rn "invoke_hook\|\.invoke(" autobot-backend/ \
+     --include="*.py" \
+     --exclude="hooks.py" \
+     --exclude="manager.py" \
+     --exclude="*_test.py"
+   ```
+
+3. Extract which HookPoints are actually invoked from step 2
+
+4. Compare: HookPoints in step 1 but not in step 2 = uninvoked
+
+5. Classify all uninvoked HookPoints as `NOT_WIRED` (they were defined with intent, never used)
+
+**Extension registration scan:**
+
+1. List all extensions in builtin:
+   ```bash
+   ls -1 autobot-backend/extensions/builtin/ | grep -E "\.py$" | sed 's/\.py$//'
+   ```
+
+2. Find which extensions are registered at startup:
+   ```bash
+   grep -rn "register_extension\|add_extension\|ExtensionManager" autobot-backend/initialization/ \
+     --include="*.py"
+   ```
+
+3. Compare: extensions in builtin/ but not registered = `NOT_WIRED`
+
+4. For each NOT_WIRED extension:
+   - Read class definition
+   - Check if it's referenced anywhere (tests, docs, plugins)
+   - Classify as `NOT_WIRED` or `SKIP` if only in tests
+
+**Report back with:**
+```
+HOOKPOINTS_TOTAL: <count>
+HOOKPOINTS_INVOKED: <count> (e.g., 3 of 24)
+HOOKPOINTS_NOT_WIRED: <list of names>
+
+EXTENSIONS_IN_BUILTIN: <list>
+EXTENSIONS_REGISTERED: <list>
+EXTENSIONS_NOT_WIRED: <list>
+
+Per hookpoint:
+<NAME>: defined in hooks.py, 0 invocation sites, classified as NOT_WIRED
+
+Per extension:
+<ClassName>: defined in <file>, not registered at startup, classified as NOT_WIRED
+```
+
+### Agent C: Frontend — Orphaned Views + Components + Shadow Files
+
+**Task:** Find Vue views not in the router, orphaned components, and duplicate/shadow router files.
+
+**Orphaned views scan:**
+
+1. List all Vue files in views directory:
+   ```bash
+   find autobot-frontend/src/views -name "*.vue" | sed 's|.*/||;s|\.vue||'
+   ```
+
+2. Find all component registrations in routers:
+   ```bash
+   cat autobot-frontend/src/router/index.ts | grep -oE "[A-Z][a-zA-Z]*View"
+   cat autobot-frontend/src/App.vue | grep -oE "[A-Z][a-zA-Z]*View"
+   ```
+
+3. Compare: views in step 1 but not in step 2 = orphaned
+
+4. For each orphaned view:
+   - Read file to check if it has real content or is a scaffold/placeholder
+   - Check if it's imported anywhere else (other files, tests)
+   - Classify as `DEAD` (empty/placeholder) or `NOT_WIRED` (has real content but not in router)
+
+**Orphaned components scan:**
+
+1. List all components:
+   ```bash
+   find autobot-frontend/src/components -name "*.vue"
+   ```
+
+2. For each component, check if it's imported anywhere:
+   ```bash
+   grep -r "import.*ComponentName\|ComponentName" autobot-frontend/src \
+     --include="*.vue" --include="*.ts" --include="*.tsx" | grep -v "<filename>" | wc -l
+   ```
+
+3. If import count = 0: component is orphaned
+
+4. Classify as `DEAD` (empty) or `NOT_WIRED` (has content)
+
+**Shadow router files:**
+
+1. List all router files:
+   ```bash
+   ls -1 autobot-frontend/src/router*
+   ```
+
+2. Check which one is actually imported by main.ts:
+   ```bash
+   grep -n "import.*router" autobot-frontend/src/main.ts
+   ```
+
+3. Any router file NOT imported = shadow → classify as `DEAD`
+
+**Report back with:**
+```
+VIEWS_TOTAL: <count>
+VIEWS_IN_ROUTER: <count>
+VIEWS_ORPHANED: <list of names>
+
+COMPONENTS_TOTAL: <count>
+COMPONENTS_ORPHANED: <list of filenames>
+
+ROUTER_FILES: <list>
+ROUTER_ACTIVE: <filename used by main.ts>
+ROUTER_SHADOW: <list of unused router files>
+
+Per finding:
+<filename>: <lines of code>, classified as NOT_WIRED|DEAD|SKIP
+```
+
+---
+
+## Phase 2: Collect and Classify Results
+
+After all 3 agents complete, compile their reports into a master findings table:
+
+```
+BACKEND_ROUTERS:
+- api/diagnostics.py: 3 endpoints, NOT_WIRED
+- api/analytics_agents.py: 2 endpoints, NOT_WIRED
+...
+
+HOOKPOINTS:
+- BEFORE_LLM_CALL: not invoked, NOT_WIRED
+- AFTER_LLM_RESPONSE: not invoked, NOT_WIRED
+...
+
+EXTENSIONS:
+- LoggingExtension: defined, not registered, NOT_WIRED
+- SecretMaskingExtension: defined, not registered, NOT_WIRED
+
+FRONTEND_VIEWS:
+- HomeView: orphaned, has content, NOT_WIRED
+- AboutView: orphaned, has content, NOT_WIRED
+...
+
+FRONTEND_COMPONENTS:
+- <ComponentName>: orphaned, has content, NOT_WIRED
+...
+
+FRONTEND_ROUTERS:
+- src/router.ts: shadow file, not imported by main.ts, DEAD
+```
+
+**Counts:**
+```
+NOT_WIRED: <count> (code exists, not connected)
+DEAD: <count> (code unused, safe to remove)
+SKIP: <count> (intentional — tests, docs, fixtures)
+```
+
+---
+
+## Phase 3: Deduplication Check
+
+Before filing any issues, check if they already exist:
+
+```bash
+for finding in <all_findings>; do
+  # Search for existing issue
+  existing=$(gh issue list --state open --search "$finding" --json number)
+  
+  if [ -n "$existing" ]; then
+    echo "SKIP: Issue already exists for $finding"
+    mark as SKIP_DUPLICATE
+  else
+    echo "NEW: Ready to file issue for $finding"
+    mark as READY_TO_FILE
+  fi
+done
+```
+
+Only file issues for READY_TO_FILE findings.
+
+---
+
+## Phase 4: Create GitHub Labels
+
+Ensure labels exist for categorizing findings:
+
+```bash
+# Create dead-code label if missing
+gh label create "dead-code" \
+  --color "e4e669" \
+  --description "Code with no call sites — safe to remove" 2>/dev/null || true
+
+# Create not-wired label if missing
+gh label create "not-wired" \
+  --color "0075ca" \
+  --description "Implemented but not connected to app — needs wiring or deletion decision" 2>/dev/null || true
+
+# Ensure tech-debt label exists
+gh label create "tech-debt" \
+  --color "fbca04" \
+  --description "Technical debt and cleanup" 2>/dev/null || true
+```
+
+---
+
+## Phase 5: Batch File Issues
+
+For each READY_TO_FILE finding, create a GitHub issue.
+
+**A NOT_WIRED issue carries an implementation plan, never a vague `todo`.** Before filing, work out and include: what the feature was intended to do (infer from the import, type, or stub), which files change and what the wiring looks like, any prerequisite or dependency, and a complexity estimate. An issue that only says "this isn't wired" gets closed unread.
+
+**For NOT_WIRED backend router:**
+```
+Title: feat(router): register unregistered router api/<module>
+
+Type: Not Wired
+
+File: autobot-backend/api/<module>.py
+Endpoints:
+- <METHOD> <path> — <description>
+- ...
+
+What's needed:
+Add to autobot-backend/initialization/router_registry/feature_routers.py:
+RouterConfig("api.<module>", "<module>_router", prefix="<prefix>", tags=["<tag>"])
+
+Or to core_routers.py if it should fail-fast on import error.
+
+Action: Decide whether to wire this router into the app or delete the file.
+
+Labels: not-wired, tech-debt
+```
+
+**For NOT_WIRED HookPoint:**
+```
+Title: feat(hooks): wire hookpoint HOOK_NAME invocation
+
+Type: Not Wired
+
+Hook: HookPoint.HOOK_NAME (defined in extensions/hooks.py)
+Invocation sites found: 0
+
+Intended behavior (from name):
+<Infer from hook name semantics, e.g., "Fire before LLM API call">
+
+Suggested location:
+<Location in codebase where hook should be emitted, e.g., llm_handler.py line X>
+
+Code to add:
+```python
+extension_manager = get_extension_manager()
+await extension_manager.invoke_hook(HookPoint.HOOK_NAME, context={...})
+```
+
+Action: Decide whether to wire this hook or remove it from the enum.
+
+Labels: not-wired, tech-debt
+```
+
+**For DEAD code:**
+```
+Title: refactor(cleanup): remove dead code <filename>
+
+Type: Dead Code
+
+File: <path>
+Lines: <count>
+References found: 0
+
+This file/function/component is not referenced anywhere in the codebase and can be safely removed.
+
+Action: Delete this file and verify no tests break.
+
+Labels: dead-code, tech-debt
+```
+
+**For NOT_WIRED frontend view:**
+```
+Title: feat(views): wire orphaned view <ViewName>
+
+Type: Not Wired
+
+File: <path>
+Content: Real implementation (not placeholder)
+
+This view is defined but not registered in router/index.ts. 
+
+To wire it in, add to autobot-frontend/src/router/index.ts:
+```javascript
+{
+  path: '<path>',
+  name: '<name>',
+  component: () => import('<path>')
+}
+```
+
+Action: Decide whether to wire this view into the router or delete it.
+
+Labels: not-wired, tech-debt
+```
+
+**Filing loop:**
+```bash
+for finding in <READY_TO_FILE>; do
+  gh issue create \
+    --title "<title>" \
+    --body "<body>" \
+    --label "not-wired,tech-debt"  # or "dead-code,tech-debt"
+  
+  echo "✅ Filed: $finding"
+done
+```
+
+---
+
+## Phase 6: Summary Report
+
+After filing, present a summary to the user:
+
+```
+# Dead Code Audit — Complete
+
+## Summary
+- **Total findings:** X
+- **Not Wired (needs decision):** X issues filed
+- **Dead Code (safe to delete):** X issues filed
+- **Skipped (intentional):** X
+
+## By Category
+
+### Backend Routers (Not Wired)
+| File | Endpoints | Issue |
+|------|-----------|-------|
+| api/diagnostics.py | 3 | #XXXX |
+| api/analytics_agents.py | 2 | #XXXX |
+
+### HookPoints (Not Wired)
+| Name | Invocations | Issue |
+|------|-------------|-------|
+| BEFORE_LLM_CALL | 0 | #XXXX |
+| AFTER_TOOL_EXECUTE | 0 | #XXXX |
+
+### Extensions (Not Wired)
+| Name | Registered | Issue |
+|------|-----------|-------|
+| LoggingExtension | No | #XXXX |
+| SecretMaskingExtension | No | #XXXX |
+
+### Frontend Views (Orphaned)
+| File | Lines | Issue |
+|------|-------|-------|
+| HomeView.vue | 45 | #XXXX |
+| AboutView.vue | 38 | #XXXX |
+
+### Frontend Routers (Shadow)
+| File | Reason | Issue |
+|------|--------|-------|
+| src/router.ts | Not imported by main.ts | #XXXX |
+
+## Next Steps
+
+1. Review each issue: decide whether to wire it in or delete it
+2. For "not wired" items that should be wired: update the code and close the issue
+3. For "not wired" items that should be deleted: delete the file and close the issue
+4. For "dead code" items: verify dependencies, delete, and close the issue
+
+All issues are labeled `not-wired` or `dead-code` for filtering.
+```
+
+---
+
+# Red Flags (STOP if you see these)
+
+- **Deleting code without checking all references** — use `grep` to verify something is truly unreferenced before classifying as DEAD
+- **Missing imports in registry check** — dynamic imports via `importlib` may hide router registrations; always check the actual registration files
+- **Skipping test fixtures** — code in `tests/` or `*_test.py` that looks unreferenced is usually intentional; mark as SKIP
+- **Filing duplicate issues** — check `gh issue list --search` before filing; dedup in Phase 3
+- **Not verifying hook invocation sites** — must actually grep for `invoke_hook(HookPoint.X)` calls; don't just check enum usage
+
+# Benefits
+
+- **Visibility:** See exactly what's wired vs not wired in the codebase
+- **Decision-making:** Issues allow team discussion before deleting or wiring
+- **Debt tracking:** Clear labels (`not-wired`, `dead-code`) let you filter and prioritize cleanup
+- **No auto-deletion:** Human always decides, reducing risk of removing code in active development
+
+# Success Criteria
+
+- [ ] All 3 agents complete their scans
+- [ ] Findings classified (NOT_WIRED, DEAD, SKIP)
+- [ ] Existing duplicates skipped (not re-filed)
+- [ ] Labels created (dead-code, not-wired, tech-debt)
+- [ ] All NOT_WIRED and DEAD findings filed as issues
+- [ ] Summary report shows issue numbers
+- [ ] No code was deleted (only filed for review)

--- a/docs/developer/skills/debug-autobot.md
+++ b/docs/developer/skills/debug-autobot.md
@@ -1,0 +1,531 @@
+---
+name: debug-autobot
+description: Debug any AutoBot failure across the full stack — dispatches parallel investigators per layer (Vue, FastAPI, Redis, ChromaDB, NPU, Browser, AI Stack), then synthesises their reports into a single root cause. Use for any bug whose layer is unknown, any cross-layer symptom, or when a fix in one layer did not hold.
+---
+
+# /debug-autobot - Complete AutoBot Stack Debugging
+
+Investigates bugs across AutoBot's distributed architecture using parallel specialized agents.
+
+## AutoBot Architecture
+
+```
+┌─────────────┐
+│  Frontend   │ Vue 3 (autobot-user-frontend/)
+│  :5173      │
+└──────┬──────┘
+       ↓ HTTP/WS
+┌─────────────┐
+│  Backend    │ FastAPI :8001 (autobot-user-backend/)
+│  Main       │
+└──┬───┬───┬──┘
+   │   │   │
+   ↓   ↓   ↓
+┌─────┐ ┌──────┐ ┌──────────┐
+│Redis│ │Chroma│ │NPU Worker│
+│:6379│ │ DB   │ │:8081     │
+└─────┘ └──────┘ └──────────┘
+   ↓
+┌──────────┐ ┌──────────┐
+│Browser   │ │AI Stack  │
+│Worker    │ │:8080     │
+│:3000     │ │          │
+└──────────┘ └──────────┘
+```
+
+## Usage
+
+```bash
+/debug-autobot "<symptom>" [--layers <specific layers>]
+
+# Full stack investigation
+/debug-autobot "Chat responses are slow"
+
+# Specific layers only
+/debug-autobot "NPU inference failing" --layers npu,backend,redis
+```
+
+## Investigation Agents
+
+### Agent 1: Frontend (Vue)
+**Investigates:**
+- Component state/props
+- API calls (fetch/axios)
+- WebSocket connections
+- Browser console errors
+- Network tab inspection
+- Vue DevTools data
+
+**Common Issues:**
+- API endpoint URLs wrong
+- WebSocket not connecting
+- State not updating
+- CORS errors
+- Missing error handling
+
+---
+
+### Agent 2: Backend (FastAPI)
+**Investigates:**
+- API endpoint logic
+- Request/response handling
+- Authentication/RBAC
+- Async operations
+- Error handling
+- Logging output
+
+**Common Issues:**
+- Unhandled exceptions
+- Wrong HTTP status codes
+- Missing CORS headers
+- Async/await issues
+- Database connection errors
+
+---
+
+### Agent 3: Redis Stack
+**Investigates:**
+- Connection status
+- Key/value data
+- Session storage
+- Cache hit/miss rates
+- Memory usage
+- Slow queries
+
+**Commands:**
+```bash
+redis-cli -h 172.16.168.23 ping
+redis-cli -h 172.16.168.23 info
+redis-cli -h 172.16.168.23 keys "*"
+redis-cli -h 172.16.168.23 monitor  # Real-time
+```
+
+**Common Issues:**
+- Connection timeout
+- Key expiration too aggressive
+- Memory full (maxmemory reached)
+- Wrong database selected
+- Serialization errors
+
+---
+
+### Agent 4: ChromaDB (Vector Store)
+**Investigates:**
+- Collection existence
+- Embedding dimensions
+- Query performance
+- Document retrieval
+- Similarity search results
+
+**Common Issues:**
+- Collection not found
+- Embedding dimension mismatch
+- Empty results
+- Slow queries
+- Out of memory
+
+---
+
+### Agent 5: NPU Worker (OpenVINO)
+**Investigates:**
+- Model loading
+- Inference requests
+- Queue depth
+- NPU utilization
+- Model caching
+
+**Health Check:**
+```bash
+curl http://172.16.168.22:8081/health
+```
+
+**Common Issues:**
+- Model not loaded
+- NPU driver issues
+- Queue overflow
+- Memory allocation failed
+- Wrong model format
+
+---
+
+### Agent 6: Browser Worker (Playwright)
+**Investigates:**
+- Browser instances
+- Automation scripts
+- Page load times
+- Screenshot generation
+- Network requests
+
+**Health Check:**
+```bash
+curl http://172.16.168.25:3000/health
+```
+
+**Common Issues:**
+- Browser timeout
+- Too many instances
+- Page not loading
+- Element not found
+- Screenshot fails
+
+---
+
+### Agent 7: AI Stack (LLM Services)
+**Investigates:**
+- LLM API calls
+- Token usage
+- Response generation
+- Prompt formatting
+- API rate limits
+
+**Health Check:**
+```bash
+curl http://172.16.168.24:8080/health
+```
+
+**Common Issues:**
+- API key invalid
+- Rate limit exceeded
+- Prompt too long
+- Response truncated
+- Timeout waiting for completion
+
+---
+
+## Workflow
+
+### 1. Triage: Identify Affected Layers
+
+```bash
+# Quick health checks
+curl http://localhost:8001/api/health          # Backend
+redis-cli -h 172.16.168.23 ping                # Redis
+curl http://172.16.168.22:8081/health          # NPU
+curl http://172.16.168.25:3000/health          # Browser
+curl http://172.16.168.24:8080/health          # AI Stack
+```
+
+### 2. Launch Parallel Agents (Affected Layers Only)
+
+**Example: "Chat responses are slow"**
+
+Likely layers: Frontend → Backend → Redis → AI Stack
+
+```python
+# Launch 4 parallel investigators
+agents = [
+    Task(subagent_type="frontend-engineer", ...),  # Check WebSocket, loading states
+    Task(subagent_type="senior-backend-engineer", ...),  # Check API performance, async handling
+    Task(subagent_type="database-engineer", ...),  # Check Redis latency, caching
+    Task(subagent_type="ai-ml-engineer", ...),  # Check LLM API response times
+]
+```
+
+### 3. Investigation Reports
+
+Each agent provides:
+
+```markdown
+## [Layer] Report
+
+**Status:** ✅ Healthy / ⚠️ Degraded / ❌ Failed
+
+**Performance Metrics:**
+- Response time: XXms
+- Throughput: XX req/s
+- Error rate: X%
+
+**Findings:**
+1. [What's working correctly]
+2. [What's suspicious]
+3. [What's definitely broken]
+
+**Root Cause Assessment:**
+- Confidence: High/Medium/Low
+- Evidence: [Logs, metrics, tests]
+
+**Proposed Fix:**
+[If issue is in this layer]
+```
+
+### 4. Cross-Layer Analysis
+
+**Common patterns:**
+
+```
+Slow responses:
+Frontend (200ms) → Backend (1000ms) → Redis (50ms) → AI Stack (5000ms)
+                                                        ↑ BOTTLENECK
+
+Authentication fails:
+Frontend → Backend → Redis ← User session expired
+                      ↑ ROOT CAUSE
+
+NPU inference timeout:
+Backend → NPU Worker ← Model not loaded
+           ↑ ROOT CAUSE
+```
+
+### 5. Create Fix Issue & Implement
+
+```bash
+gh issue create --title "Fix: <root cause>" \
+  --body "**Symptom:** <original bug>
+
+**Investigation:** Parallel debugging across 4 layers
+
+**Root Cause:** <identified cause with evidence>
+
+**Affected Layer:** <specific component>
+
+**Fix Approach:** <proposed solution>"
+
+/implement <issue-number>
+```
+
+## Example: Real AutoBot Bug
+
+### Symptom
+"Knowledge retrieval returns empty results even though documents exist"
+
+### Investigation (Parallel)
+
+**Agent: Frontend**
+- ✅ Search query is sent correctly
+- ✅ API call to /api/knowledge/search
+- ✅ No console errors
+
+**Agent: Backend**
+```python
+# autobot-user-backend/api/knowledge.py
+@app.get("/api/knowledge/search")
+async def search_knowledge(query: str):
+    results = await chromadb_client.query(
+        collection_name="documents",
+        query_texts=[query],
+        n_results=10
+    )
+    return results  # Returns empty array
+```
+- ⚠️ ChromaDB query returns empty
+- ⚠️ No error handling
+
+**Agent: ChromaDB**
+```bash
+$ redis-cli -h 172.16.168.23
+> KEYS chroma:*
+(empty list or set)
+```
+- ❌ **ROOT CAUSE**: ChromaDB collection "documents" doesn't exist!
+- No documents were ever indexed
+
+**Agent: Redis**
+- ✅ Redis is healthy
+- ✅ Connection working
+- ⚠️ No ChromaDB keys found
+
+### Root Cause
+**ChromaDB collection was never initialized.** Documents exist in filesystem but weren't indexed.
+
+### Fix
+```bash
+# Create issue
+gh issue create --title "Fix: Initialize ChromaDB collection on startup"
+
+# Implement
+/implement <issue>
+```
+
+## Multi-Layer Debugging Patterns
+
+| Bug Type | Layers to Check | Typical Root Cause |
+|----------|----------------|-------------------|
+| **Slow responses** | All layers | AI Stack (LLM latency), NPU (queue depth) |
+| **Empty results** | Backend → DB → ChromaDB | Collection empty, wrong query |
+| **Authentication fails** | Frontend → Backend → Redis | Session expired, token invalid |
+| **NPU errors** | Backend → NPU | Model not loaded, wrong format |
+| **Browser automation fails** | Backend → Browser Worker | Timeout, element not found |
+| **WebSocket disconnect** | Frontend → Backend | Connection timeout, CORS |
+
+## Success Criteria
+
+- [ ] Symptom clearly described
+- [ ] Affected layers identified
+- [ ] Parallel agents launched for each layer
+- [ ] Each agent completed investigation
+- [ ] Reports collected and analyzed
+- [ ] Single root cause identified with evidence
+- [ ] Fix approach determined
+- [ ] Issue created and linked
+- [ ] Fix implemented and verified across layers
+
+## Red Flags
+
+- Investigating too many layers (scope creep)
+- Agents proposing fixes before root cause found
+- No performance metrics collected
+- Assuming issue without evidence
+- Not testing cross-layer interactions
+
+---
+
+# Synthesis protocol
+
+Carried from the former `debug-stack` skill — the agent-dispatch half above is AutoBot-specific,
+this half is how their reports get turned into a root cause.
+
+### 1. Symptom Description
+
+User provides:
+- **What's broken:** "Login fails"
+- **Expected behavior:** "Should authenticate user"
+- **Actual behavior:** "Returns 'Invalid credentials'"
+- **Reproduction steps:** "1) Go to /login 2) Enter valid credentials 3) Click submit"
+
+### 3. Collect Investigation Reports
+
+**After all agents complete (5-10 minutes):**
+
+```markdown
+## Investigation Summary
+
+### Frontend Report (Agent F)
+**Findings:**
+- Login form sends POST to /api/auth/login
+- Password is sent in plaintext (expected for HTTPS)
+- Request format: { "username": "...", "password": "..." }
+- No client-side hashing
+
+**Suspicious:**
+- None - frontend looks correct
+
+**Root Cause:** NOT in frontend
+
+---
+
+### Backend Report (Agent B)
+**Findings:**
+- Endpoint: /api/auth/login receives credentials
+- Uses bcrypt.checkpw() for password verification
+- Retrieves user from database by username
+- Error message "Invalid credentials" returned for failed check
+
+**Suspicious:**
+- bcrypt.checkpw() returns False even for correct password
+- Password hash format in database: $2b$12$...
+- Code uses bcrypt.hashpw() for registration
+
+**Root Cause Candidate:**
+Password hashing rounds mismatch?
+Registration uses 12 rounds, but maybe login expects different format?
+
+**Next Layer:** Check database password hashes
+
+---
+
+### Database Report (Agent D)
+**Findings:**
+- Users table has password_hash column (VARCHAR(255))
+- Test user password hash: $2a$10$... (NOTE: $2a not $2b!)
+- Hash was created with older bcrypt version
+
+**Suspicious:**
+- Hash prefix is $2a (bcrypt version 2a)
+- Backend code expects $2b (bcrypt version 2b)
+- Incompatibility between hash versions
+
+**Root Cause:** **DATABASE - Password hashes use old bcrypt version**
+
+Data sample:
+```
+username: testuser
+password_hash: $2a$10$E9F8...  ← OLD VERSION
+created_at: 2024-01-15
+```
+```
+
+### 4. Root Cause Analysis (You Coordinate)
+
+Based on all three reports:
+
+```
+ROOT CAUSE: Bcrypt version mismatch
+- Database has $2a hashes (old version)
+- Backend bcrypt.checkpw() expects $2b (new version)
+- Python bcrypt library was upgraded but existing hashes not migrated
+
+SOLUTION OPTIONS:
+1. Migrate all password hashes to $2b (requires password reset or migration script)
+2. Update backend to accept both $2a and $2b versions
+3. Add hash format detection and handle both
+
+RECOMMENDED: Option 2 (backward compatible)
+```
+
+## Investigation Report Template
+
+Each agent reports:
+
+```markdown
+## [Layer] Investigation Report
+
+**Status:** ✅ Complete / ⚠️ Needs More Info / ❌ Blocked
+
+**Findings:**
+1. [What you found]
+2. [What you verified]
+3. [What you tested]
+
+**Suspicious Items:**
+- [Anything unusual]
+- [Potential issues]
+
+**Root Cause Assessment:**
+- **Is issue in this layer?** YES/NO/MAYBE
+- **Confidence:** High/Medium/Low
+- **Evidence:** [Why you think so]
+
+**Recommendations:**
+- [If issue is here: proposed fix]
+- [If not here: which layer to check next]
+
+**Code Snippets:**
+```[language]
+[Relevant code with line numbers]
+```
+
+**Logs/Output:**
+```
+[Relevant logs, queries, or output]
+```
+```
+
+## Common Full-Stack Bug Patterns
+
+| Symptom | Frontend Issue | Backend Issue | Database Issue |
+|---------|---------------|---------------|----------------|
+| **Authentication fails** | Wrong credentials sent | Password comparison broken | Hash format wrong |
+| **Data not displaying** | Fetch call broken | API returns wrong data | Query returns empty |
+| **Slow performance** | Too many re-renders | N+1 queries | Missing indexes |
+| **404 errors** | Wrong route | Endpoint doesn't exist | - |
+| **500 errors** | - | Unhandled exception | Connection timeout |
+| **Stale data** | Not refetching | Caching too aggressive | Replication lag |
+
+## Red Flags (STOP if you see these)
+
+- Agents investigating wrong components (frontend agent looking at database)
+- Agents not sharing context (each assumes different user/test case)
+- Agents proposing fixes without identifying root cause
+- Multiple "root causes" identified (should be ONE)
+- No clear evidence for suspected root cause
+
+## Success Criteria
+
+- [ ] All three layers investigated in parallel
+- [ ] Each agent provided detailed report
+- [ ] Reports collected and analyzed
+- [ ] Single root cause identified with evidence
+- [ ] Fix approach determined
+- [ ] GitHub issue created for fix
+- [ ] Fix implemented and verified
+

--- a/docs/developer/skills/drain.md
+++ b/docs/developer/skills/drain.md
@@ -1,0 +1,69 @@
+---
+name: drain
+description: Pick and solve the backlog issues that need no decision. Use when asked to work the backlog, drain issues, "solve what you can", run the loop autonomously, or whenever a loop tick has no assigned issue. Selects work; delegates execution to batch-implement.
+---
+
+# /drain — spend the loop's attention on what it can actually finish
+
+The loop's scarce resource is **attention**, not filing capacity. Picking the
+oldest open issue blindly burns a tick whenever it turns out to need an answer
+only the owner can give. This selects work that is finishable now.
+
+Selection only. Execution belongs to `batch-implement`; PR mechanics to
+`ci-pipelining.md`. Do not reimplement either here.
+
+## 1. Drain the PR queue first
+
+In-flight PRs before new work, every time:
+
+```bash
+gh pr list --state open --json number,title --jq '.[]|"\(.number) \(.title)"'
+~/.claude/scripts/backlog-governor.sh status     # advisory signal only
+```
+
+Sweep → review → merge green → close with evidence → remove worktree/branch.
+A merged PR closes an issue; a new issue closes nothing. If PRs are stacked up,
+draining them IS the tick.
+
+## 2. Select
+
+```bash
+~/.claude/scripts/backlog-next.py -n 10 --why
+```
+
+Ranks problems → enhancements → features, FIFO within each. Judged from issue
+content, not labels — labels do not carry this signal (1 of 400 open issues
+carries `needs-decision`). An issue is excluded when it is an umbrella, requests
+a decision, has an open `depends on #N` blocker, or states no acceptance
+criteria.
+
+Take the head of the list that does not collide with an in-flight PR's files.
+Skipping for collision is a deferral, not a reorder.
+
+## 3. Confirm readiness before starting
+
+The picker is a heuristic. Read the issue and abandon it if:
+
+- the acceptance criteria are not actually checkable
+- it needs a product or architecture call
+- delivering it means choosing between two reasonable designs
+
+Put it back with a `needs-decision` label and options + a recommendation posted
+on the issue, then take the next candidate **in the same tick**. Never end a
+tick because one issue turned out to be decision-gated.
+
+## 4. Execute
+
+Hand the chosen numbers to `batch-implement`, which owns worktree → implement →
+review → merge → close → cleanup.
+
+## Hard rules
+
+- **Never file issues as busywork.** Filing is never blocked, but a filed issue
+  is not progress. If nothing is solvable, say so and stop — do not manufacture
+  backlog to look busy.
+- **Discovered problems still get filed** (that rule is absolute), just never as
+  a substitute for solving something.
+- **A decision-gated issue is posted and skipped, never waited on.**
+- **Evidence before done** — `batch-implement` and the closure gate own this;
+  do not claim a close without the verifying output.

--- a/docs/developer/skills/github-cli.md
+++ b/docs/developer/skills/github-cli.md
@@ -1,0 +1,100 @@
+---
+name: github-cli
+description: Use when performing any GitHub operation — issues, PRs, comments, labels, reviews, merges, file contents, branch management, or repository queries. Always prefer gh CLI over GitHub MCP tools.
+---
+
+# GitHub CLI (gh)
+
+Use `gh` for all GitHub operations. Never use browser automation or GitHub MCP tools when `gh` will do.
+
+## Issues
+
+```bash
+# View / list
+gh issue view <number>
+gh issue list --state open --label "bug,backend"
+gh issue list --assignee @me
+
+# Create
+gh issue create --title "Bug: <desc>" --body "..." --label "bug,backend,priority: high"
+
+# Update / close
+gh issue comment <number> --body "..."
+gh issue close <number>
+gh issue edit <number> --add-label "priority: high" --title "New title"
+
+# Check state
+gh issue view <number> --json state -q '.state'
+```
+
+## Pull Requests
+
+```bash
+# View / list
+gh pr view [number]
+gh pr list --state open
+gh pr diff [number]
+
+# Create (always target Dev_new_gui)
+gh pr create --base Dev_new_gui --title "..." --body "..."
+
+# Review / merge
+gh pr review <number> --approve
+gh pr merge <number> --squash
+
+# Status checks
+gh pr status
+gh pr checks <number>
+```
+
+## Files & Code
+
+```bash
+# Get file from any branch/ref
+gh api repos/mrveiss/AutoBot-AI/contents/<path>?ref=<branch> --jq '.content' | base64 -d
+
+# Search code
+gh search code "query" --repo mrveiss/AutoBot-AI
+```
+
+## Comments & Reviews
+
+```bash
+gh pr comment <number> --body "..."
+gh issue comment <number> --body "..."
+gh pr review <number> --comment --body "..."
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| View issue | `gh issue view <n>` |
+| Create issue | `gh issue create --title "..." --label "..."` |
+| Close issue | `gh issue close <n>` |
+| Create PR | `gh pr create --base Dev_new_gui ...` |
+| View PR diff | `gh pr diff <n>` |
+| Merge PR | `gh pr merge <n> --squash` |
+| List labels | `gh label list` |
+| View checks | `gh pr checks <n>` |
+
+## AutoBot Conventions
+
+- **Repo:** `mrveiss/AutoBot-AI`
+- **Base branch:** Always `Dev_new_gui` (never `main`) for PRs
+- **Required labels:** type (`bug`, `enhancement`, `technical-debt`) + area (`backend`, `frontend`) + priority (`priority: high`, etc.)
+- **Commit/PR title format:** `<type>(scope): <description> (#issue-number)`
+- **Auto-close limitation:** `Closes #NNN` in a PR body **does not auto-close issues** when merging into `Dev_new_gui` (only works for the default branch). **Always close the GH issue manually after merge:**
+  ```bash
+  gh pr merge <pr> --squash --delete-branch
+  gh issue close <number> --comment "Closed via PR #<pr> merged into Dev_new_gui."
+  gh issue view <number> --json state  # confirm state=CLOSED
+  ```
+
+## Common Mistakes
+
+- Targeting `main` instead of `Dev_new_gui` for PRs
+- Forgetting required labels on new issues
+- Assuming `Closes #NNN` in PR body auto-closes the issue (it doesn't for `Dev_new_gui`)
+- Merging a PR without immediately closing the linked GH issue — issues stay open forever otherwise
+- Using Playwright/browser for GitHub when `gh` handles it in one command

--- a/docs/developer/skills/implement.md
+++ b/docs/developer/skills/implement.md
@@ -1,0 +1,114 @@
+---
+name: implement
+description: End-to-end GitHub issue implementation — umbrella gate, worktree, design, code, verify, PR, CI, and the three-gate closure check. Use when told to implement, fix, or solve a specific issue number, or when picking the next issue off the backlog. Supersedes the former `issue` skill.
+---
+
+# /implement — End-to-End Issue Implementation
+
+Read your assigned step from the umbrella issue before proceeding.
+
+## Step 0 — Umbrella gate (MANDATORY)
+- The task must hang off a GitHub umbrella issue with a task/subtask breakdown. Missing → create it first.
+- Add this issue as a subtask checklist item on the umbrella before coding.
+
+## Step 1 — Verify the issue is real and unclaimed
+- `gh issue view <n> --json state` — closed or missing → STOP.
+- `gh pr list --search "<n>"` and `git branch -a | grep -i "<n>"` — no existing PR or branch.
+- **No PR-count gate.** There is no open-PR limit; dispatch gates on review capacity. PRs piling up means review is the bottleneck — review, don't defer.
+
+## Step 2 — Investigate, then design (do NOT code yet)
+- Grep/Glob for the affected files; confirm each exists.
+- Post the plan in ≤10 lines: files, changes, edge cases, risks.
+- Seek approval only if >10 files are touched; otherwise proceed.
+- Write a TodoWrite checklist of discrete, testable tasks.
+
+## Step 3 — Worktree (MANDATORY, never edit the main tree)
+```bash
+git worktree add ../worktrees/issue-<n> -b issue-<n> origin/Dev_new_gui
+```
+- Branch off the PR base branch, never the GitHub default. Never touch another session's worktree.
+- Commit incrementally inside the worktree — never `git stash` (it is shared repo-wide).
+
+## Step 4 — Implement
+- <8 files: Read → Edit → verify syntax → next file. No subagents.
+- ≥8 files or genuinely parallel work: subagents.
+- Run the relevant tests after each task; fix failures before continuing.
+
+## Step 5 — Verify
+```bash
+pytest <test_dir>
+git diff --name-only | grep '\.py$' | xargs flake8 --max-line-length=100
+mypy <files>
+```
+
+## Step 6 — Commit
+```bash
+git add <files>
+git commit -m "<type>(scope): <description> (#<n>)"
+```
+- Format is `<type>(scope): <description> (#issue)`. `tech-debt` is NOT a valid type.
+- **No commit trailers.** mrveiss is sole author — never add `Co-Authored-By`.
+- Never `--no-verify`.
+
+## Step 7 — Pre-push quality checks (MANDATORY)
+```bash
+# print() outside tests → use get_logger(__name__)
+grep -r 'print(' autobot-backend/ autobot_shared/ --include='*.py' | grep -v '#' | grep -v 'test_'
+# console.* in TS/Vue → use createLogger()
+grep -r 'console\.' autobot-frontend/src/ --include='*.ts' --include='*.vue'
+black autobot-backend/ autobot_shared/ autobot-slm-backend/
+isort autobot-backend/ autobot_shared/ autobot-slm-backend/
+ruff check --fix autobot-backend/ autobot_shared/
+git add -u && git diff --cached --quiet || git commit -m "style(format): auto-format (#<n>)"
+```
+- Frontend lint is oxlint AND eslint — `npx eslint` alone passes while CI fails.
+
+## Step 8 — Push and open the PR
+```bash
+git push -u origin issue-<n>
+gh pr create --base Dev_new_gui --title "<type>(scope): <title> (#<n>)" --body-file <file>
+```
+- Target `Dev_new_gui`. `main`/`master` are blocked by the pre-commit hook.
+- PR body uses these exact headings — never Summary/Test Plan:
+  `## Thinking Path` · `## What Changed` · `## Verification` · `## Model Used`
+- Use `--body-file`, never an inline `--body`: backticks inside it execute as shell commands.
+
+## Step 9 — CI (do not exit until green)
+- `gh pr checks <PR>` — repeat until nothing is PENDING; `smoke-test` must be SUCCESS.
+- Dedupe check-runs to the latest push; sort by `startedAt` — rollup order is not chronological.
+- **Red CI never merges.** Root-cause it; a tracking issue is not a substitute. Never `--admin`.
+- Never merge a branch behind base — a green run describes a merge base that may have moved.
+
+## Step 10 — Merge or hand off
+- Merge: `gh pr merge <n> --squash --delete-branch` (verify the remote tip first).
+- Must wait: post ONE comment, set status `in_review`, STOP. Never busy-poll.
+- `Closes #N` NEVER auto-closes on this repo — always close by hand.
+
+## Step 11 — Three-gate closure check (MANDATORY)
+```bash
+pipeline-scripts/check-new-module-callers.sh
+pipeline-scripts/check-issue-close-refs.sh <n>   # exit 1 = forward refs dangle → do NOT close
+```
+- **Gate 1 — verbatim ACs:** quote each issue-body AC word-for-word with evidence, or `❌ NOT met → follow-up #X`. Never restate what shipped instead.
+- **Gate 2 — dangling refs:** the script above; also eyeball the credited PR diff for `#<n>`.
+- **Gate 3 — no partial close:** a bundled PR's `Closes #A, #B` requires each issue's FULL AC set. Subset delivery → check off the subtask, leave the issue open or name the follow-up in the same comment.
+- New module with 0 production callers → wire it in, or file a `wire-in:` issue first and reference it.
+- Host-behaviour ACs need HOST evidence, never merge evidence.
+
+```bash
+gh issue comment <n> --body-file <file>   # implementation ACs + integration ACs, with evidence
+gh issue close <n>
+gh issue view <n> --json state            # confirm
+```
+
+## Step 12 — Dispose
+- Remove the worktree only after the PR is merged and the content is verified in base.
+
+## Success checklist
+- [ ] Umbrella issue with step breakdown exists; issue verified open, no duplicate PR/branch
+- [ ] Work done in a worktree off `origin/Dev_new_gui`, committed incrementally
+- [ ] Tests + lint + mypy pass; no `print(`/`console.` violations; formatted
+- [ ] Commit format correct, no trailers, no `--no-verify`
+- [ ] PR targets `Dev_new_gui` with the four required headings; smoke-test green; not behind base
+- [ ] Every new module has ≥1 caller, or a wire-in issue is filed and referenced
+- [ ] All three closure gates run; issue closed by hand and confirmed

--- a/docs/developer/skills/pr.md
+++ b/docs/developer/skills/pr.md
@@ -1,0 +1,122 @@
+---
+name: pr
+description: Create a pull request with pre-flight branch checks, targeting Dev_new_gui by default
+---
+
+# /pr - Create Pull Request
+
+Target: `Dev_new_gui` (never `main`). PR_LIMIT=10.
+
+## Step 0 — PR Queue Gate (MANDATORY)
+
+```bash
+OPEN_COUNT=$(gh pr list --repo mrveiss/AutoBot-AI --state open --json number | jq length)
+```
+
+- If `$OPEN_COUNT < PR_LIMIT`: skip to Step 1.
+- If at limit: audit CI state, merge GREEN PRs, fix straightforward FAILING PRs, re-check.
+
+```bash
+# Audit CI state
+gh pr list --repo mrveiss/AutoBot-AI --state open --json number,title,statusCheckRollup \
+  | jq '.[] | {number, title, ci: ([.statusCheckRollup[]?.state] | if all(. == "SUCCESS" or . == "NEUTRAL" or . == "SKIPPED") then "GREEN" elif any(. == "FAILURE" or . == "ERROR") then "FAILING" else "PENDING" end)}'
+# Merge green PRs
+gh pr merge <number> --squash --delete-branch
+```
+
+- All open PRs have unfixable failures → post Paperclip comment listing blockers, set issue `blocked`, stop.
+
+## Step 1 — Pre-Flight Checks
+
+```bash
+git branch --show-current          # must NOT be Dev_new_gui or main
+git status && git diff             # must be clean; if not, run /commit first
+git log --oneline origin/Dev_new_gui..HEAD
+```
+
+## Step 1.5 — Pre-Push Quality Check (MANDATORY)
+
+```bash
+# Catch violations before they fail CI
+grep -rn 'print(' autobot-backend/ autobot_shared/ --include='*.py' | grep -v '#' | grep -v 'test_'
+grep -rn 'console\.\(log\|error\|warn\)' autobot-frontend/src/ --include='*.ts' --include='*.vue'
+# Auto-format Python
+black autobot-backend/ autobot_shared/ autobot-slm-backend/ 2>/dev/null || true
+isort autobot-backend/ autobot_shared/ autobot-slm-backend/ 2>/dev/null || true
+ruff check --fix autobot-backend/ autobot_shared/ 2>/dev/null || true
+# Commit formatting changes if any
+git add -u && git diff --cached --quiet || git commit -m "style: auto-format code (black/isort/ruff)"
+```
+
+- `print()` → `logging.getLogger(__name__)`; `console.*` → `createLogger()` from `@/utils/debugUtils`
+- Fix all violations before proceeding.
+
+## Step 2 — Push Branch
+
+```bash
+git push -u origin <current-branch>
+# Rejected? git pull --rebase origin Dev_new_gui && git push
+```
+
+## Step 3 — Create PR
+
+PR body must include these four headings: **Thinking Path · What Changed · Verification · Model Used**
+
+```bash
+gh pr create --base Dev_new_gui \
+  --title "<type>(scope): <description> (#issue-number)" \
+  --body "$(cat <<'EOF'
+## Thinking Path
+- <key decision>
+## What Changed
+- <change>
+## Verification
+- [ ] <test step>
+## Model Used
+Claude Sonnet 4.6
+
+Closes #<issue-number>
+EOF
+)"
+```
+
+## Step 4 — Wait for CI (MANDATORY — do not exit until green)
+
+```bash
+PR=$(gh pr view --json number -q .number)
+until [ "$(gh pr checks $PR --json state | jq '[.[]|select(.state=="PENDING" or .state=="QUEUED")]|length')" -eq 0 ]; do
+  echo "Waiting..."; sleep 30; done
+gh pr checks $PR
+```
+
+- CI failing: push a fix commit; loop re-runs automatically.
+
+## Step 5 — Close Issue After Merge
+
+`Closes #NNN` does NOT auto-close when targeting `Dev_new_gui`. Close manually after merge:
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+gh issue close <number> --comment "Closed via PR #<pr-number> merged into Dev_new_gui."
+```
+
+## Step 6: Worktree Cleanup (After Merge)
+
+After the PR merges, immediately clean up both local worktree and branch:
+
+```bash
+git worktree remove .worktrees/<name>
+git branch -d <branch-name>
+# remote branch deleted automatically by --delete-branch; if not:
+git push origin --delete <branch-name>
+```
+
+Do not leave merged worktrees on disk. Stale worktrees waste disk and confuse `git worktree list`.
+
+## Red Flags (STOP)
+
+- Branch is `Dev_new_gui` or `main`
+- Uncommitted changes present
+- No issue reference in title or body
+- Skipped pre-push quality checks (Step 1.5)
+- Exiting before CI is green

--- a/docs/developer/skills/pre-merge-validate.md
+++ b/docs/developer/skills/pre-merge-validate.md
@@ -1,0 +1,75 @@
+---
+name: pre-merge-validate
+description: Validate code before merging — syntax, imports, call-site impact, tests, types, and linting
+---
+
+# /pre-merge-validate — Pre-Merge Validation Gates
+
+## Usage
+```
+/pre-merge-validate <PR-number>     # resolve branch via gh pr view
+/pre-merge-validate issue-<branch>  # use branch name directly
+/pre-merge-validate                 # validate current branch vs Dev_new_gui
+```
+
+## Gates
+
+**Setup**
+1. Resolve branch: `gh pr view <number> --json headRefName -q '.headRefName'`
+2. Fetch and verify: `git fetch origin Dev_new_gui && git rev-parse origin/Dev_new_gui origin/$BRANCH`
+
+**Gate 0 — Squash-Duplicate Detection**
+3. Count total vs truly-new commits:
+   ```bash
+   TOTAL=$(git log origin/Dev_new_gui...$BRANCH --oneline | wc -l)
+   NEW=$(git log --cherry-pick --right-only origin/Dev_new_gui...$BRANCH --oneline | wc -l)
+   ```
+   - Block if `NEW -eq 0` (all already merged — close the PR)
+   - Warn if `DUPES -gt 0 && NEW -gt 0` (partial duplicate — don't block)
+
+**Gate 1 — Python Syntax + Imports**
+4. Get changed files: `git diff origin/Dev_new_gui...$BRANCH --name-only -- '*.py' | grep -E '^autobot-backend|^autobot-shared'`
+5. Per file — syntax: `python -c "import ast; ast.parse(open('$file').read())"`
+6. Per file — imports: `python -m py_compile "$file"`
+7. For `api/schemas_*.py` — runtime import: `(cd autobot-backend && python3 -c "from api import $SCHEMA_MOD")`
+   - Block on any SyntaxError, ImportError, or NameError
+
+**Gate 2 — Call-Site Impact Analysis**
+8. Find removed symbols:
+   ```bash
+   git diff origin/Dev_new_gui...$BRANCH -- '*.py' | grep '^-def \|^-    def \|^-class ' | sed 's/^-//;s/(.*//;s/^[[:space:]]*//' | sort -u
+   ```
+9. Per symbol — find callers outside changed files:
+   ```bash
+   grep -r "$symbol" autobot-backend/ autobot-shared/ --include="*.py" --exclude-dir="tests" -l | grep -v "$(git diff --name-only ...)"
+   ```
+   - Block if any callers found
+10. For changed signatures — compare old vs new `def $symbol(` line; block if unchanged callers exist
+
+**Gate 3 — Targeted Test Run**
+11. Map `autobot-backend/services/kb_service.py` → `autobot-backend/tests/test_kb_service.py`
+12. Run: `cd autobot-backend && pytest $TEST_FILES -x --tb=short -q`
+    - Block on test failure; Skip if no matching test files found
+
+**Gate 4 — Frontend Type Check (conditional)**
+13. Check: `git diff origin/Dev_new_gui...$BRANCH --name-only | grep -c "^autobot-frontend"`
+14. If changed: `cd autobot-frontend && npm run type-check`
+    - Block on TypeScript errors; Skip if no frontend changes
+
+**Gate 5 — Linting**
+15. Backend: `cd autobot-backend && flake8 --config=.flake8 $BACKEND_CHANGED`
+    - Block on E/F codes; W/C codes reported only
+16. Frontend (non-blocking): `cd autobot-frontend && npm run lint -- --quiet`
+
+## Verdict
+```bash
+# Print gate summary table, then:
+[ "$VERDICT" = "BLOCKED" ] && exit 1 || exit 0
+# CLEAR TO MERGE  or  BLOCKED — fix failures before merging
+```
+
+## Integration with /team-implement
+17. In SUCCESS path before `gh pr create`:
+    ```bash
+    /pre-merge-validate issue-$issue || { mark RETRY_QUEUED, Last Failure=VALIDATION_FAILED; return; }
+    ```

--- a/docs/developer/skills/review-fleet.md
+++ b/docs/developer/skills/review-fleet.md
@@ -1,0 +1,141 @@
+---
+name: review-fleet
+description: Dispatch a 10-angle parallel PR review fleet (finder agents + verifier agents) that posts only confirmed, deduplicated findings to a single PR comment. Use when asked for a high-effort or recall-biased PR review.
+metadata:
+  type: skill
+---
+
+# Review Fleet
+
+Dispatches 10 parallel finder agents against a PR diff, runs verifiers on candidates, deduplicates by cross-angle agreement, and posts a single structured comment.
+
+## Pre-flight
+
+```bash
+# Get PR diff file list and patch
+PR_NUMBER=<number>
+gh pr diff $PR_NUMBER --name-only > /tmp/fleet-files.txt
+gh pr diff $PR_NUMBER > /tmp/fleet-diff.patch
+cat /tmp/fleet-files.txt
+```
+
+If `--dry-run` is passed: print the agent prompts and file list, then stop. Do not dispatch agents.
+
+## Phase 1 — Parallel Finder Agents
+
+Dispatch all 10 angles at once with `Agent` tool calls in a single message. Each agent:
+
+**Required in every agent prompt:**
+- The exact file list from `cat /tmp/fleet-files.txt`
+- Instruction: "Use Read on these paths only. Do NOT Glob for other files."
+- The angle-specific focus (see below)
+- Output format: JSON array of findings
+
+**10 angles:**
+
+| # | Name | Focus |
+|---|------|-------|
+| 1 | security | authz bypasses, IDOR, injection, secrets in code, missing ownership checks |
+| 2 | correctness | off-by-one, null/undefined, error paths skipped, incorrect logic |
+| 3 | api-contract | breaking changes to API signatures, missing/wrong response_model, schema drift |
+| 4 | test-coverage | new code paths with no test, tests that only assert happy path, missing edge cases |
+| 5 | deps | new imports from removed modules, version mismatches, circular deps |
+| 6 | migrations | schema changes without migration, migration without rollback, missing index |
+| 7 | observability | missing logging, silent error catches, metrics not recorded |
+| 8 | a11y | missing aria attributes, non-semantic HTML, color-only indicators (frontend only) |
+| 9 | i18n | hardcoded user-facing strings not wrapped in i18n, locale-sensitive formatting |
+| 10 | dead-code | functions defined but never called, imports never used, unreachable branches |
+
+**Finder agent output format** (each agent returns this JSON):
+```json
+[
+  {
+    "angle": "security",
+    "file": "autobot-backend/api/analytics_quality.py",
+    "line": 142,
+    "severity": "BLOCKER|HIGH|MEDIUM",
+    "title": "Short description",
+    "evidence": "Exact quote from the diff or file showing the issue"
+  }
+]
+```
+
+If no findings: return `[]`. Do not fabricate. Do not include speculative issues.
+
+## Phase 2 — Verifier Agents
+
+For each finding from Phase 1, dispatch a verifier agent (batch to max 5 parallel):
+
+**Verifier prompt must include:**
+- The specific finding (file, line, evidence)
+- The file list from `/tmp/fleet-files.txt`
+- Instruction: "Read the actual file at the given line. Confirm this finding exists in HEAD code, not just the diff context. Return JSON with confirmed: true/false and confidence: 0.0-1.0."
+
+**Verifier output format:**
+```json
+{
+  "confirmed": true,
+  "confidence": 0.92,
+  "note": "Optional clarification"
+}
+```
+
+Drop any finding where `confirmed: false` OR `confidence < 0.7`.
+
+## Phase 3 — Deduplicate and Rank
+
+1. **Deduplicate by file:line** — if multiple angles flagged the same location, merge into one finding, listing all angles: `"angles": ["security", "correctness"]`
+2. **Rank by cross-angle agreement** — findings confirmed by 2+ angles rank highest
+3. **Within tier:** rank BLOCKER > HIGH > MEDIUM
+
+## Phase 4 — Ownership Check and Post
+
+```bash
+# Confirm the target issue is ours before posting
+ISSUE_ID=<issue-or-tracking-id>
+gh issue view $ISSUE_ID --json assignees -q '.assignees[].login'
+```
+
+If not assigned to this agent: post to the PR comment directly instead of the issue.
+
+Post a single PR comment:
+```bash
+gh pr comment $PR_NUMBER --body "$(cat <<'EOF'
+## Review Fleet — PR #<number>
+
+**Angles run:** 10 | **Candidates:** <N> | **Confirmed:** <M>
+
+### BLOCKERS
+<!-- Only if any -->
+- **[security + correctness]** `file.py:142` — Title
+  > Evidence quote
+
+### HIGH
+- **[security]** `file.py:88` — Title
+  > Evidence quote
+
+### MEDIUM
+- **[observability]** `file.py:201` — Title
+  > Evidence quote
+
+---
+*Review Fleet: 10 finder angles + verifier pass. Unconfirmed findings dropped.*
+EOF
+)"
+```
+
+If zero confirmed findings: post "Review Fleet found no confirmed issues across 10 angles."
+
+## Wiring into Paperclip Wake Payload
+
+When a wake payload contains `{"type": "pr_review", "effort": "high"}` or `{"type": "pr_review", "fleet": true}`, trigger this skill automatically by including `/review-fleet <PR_NUMBER>` in the agent prompt.
+
+## Regression Test
+
+To verify the fleet catches known bugs, run against a PR known to have issues:
+```bash
+# Pick a PR with known IDOR or privilege escalation finding from history
+KNOWN_BUGGY_PR=<pr-number-from-history>
+/review-fleet $KNOWN_BUGGY_PR --dry-run   # Verify prompts look right
+/review-fleet $KNOWN_BUGGY_PR             # Run and confirm finding appears in output
+```

--- a/docs/developer/skills/review.md
+++ b/docs/developer/skills/review.md
@@ -1,0 +1,78 @@
+---
+name: review
+description: Run a PR review cycle — CI diagnosis, a three-angle finder pass, lint-only auto-fix, and the merge decision. Use when reviewing open PRs, working the review queue, or when a heartbeat tick has no assigned issue.
+---
+
+# Review Skill
+
+Use this skill when running a PR review cycle — either from a heartbeat or manually.
+
+## Pre-Flight
+
+1. List the open PRs: `gh pr list --state open --json number -q 'length'` — for scope, not for gating.
+   - **There is no open-PR limit.** Dispatch gates on review capacity, not PR count. PRs
+     accumulating means review is the bottleneck — do that, don't defer new work.
+2. Check model availability and remaining usage. If low, switch to Haiku for status-only tasks.
+3. Filter task queue: skip anything blocked on human action (OAuth, branch-protection admin). Log why each was skipped — do not retry.
+
+## CI Diagnosis (Before Any Action)
+
+For each PR, classify CI status as **passing**, **failing**, or **queued/running**:
+```bash
+gh pr checks <number> --json name,state,conclusion
+```
+- **Do not cancel or retrigger queued checks** — they are running normally on self-hosted runners
+- Only act on checks in state `failure` or `error`
+- Treat `code-quality` as a required blocking check
+
+## Review Each PR (3-Angle Protocol)
+
+For each PR with green or actionable CI:
+
+1. Get exact file list: `gh pr diff $PR --name-only`
+2. Dispatch 3 parallel finder agents with scoped prompts:
+   - Security/auth/tenancy angle
+   - Correctness/logic angle
+   - Data-layer/edge-cases angle
+3. Each agent: read only the listed files, return JSON `{file, line, severity, evidence}`
+4. Verification pass: re-read each cited location, reject findings not grounded in real code
+
+## Auto-Fix (Lint/Format Only)
+
+For PRs blocked only on Black/isort/flake8/mypy:
+1. Check out on a feature branch (if branch-protected, never push direct)
+2. Run: `black . && isort . && ruff check --fix .`
+3. Commit and push to the PR branch
+
+## Merge Decision
+
+Merge when:
+- All required checks pass (not just code-quality)
+- No blocking findings from the review pass
+- The branch is not behind base — a green run describes a merge base that may have moved
+
+Do NOT merge when:
+- CI checks are queued (wait for them)
+- Blocking security or correctness findings exist
+- CI is red — root-cause it; a tracking issue is not a substitute
+
+## PR Description Format
+
+When creating or editing PR bodies, use these exact headings:
+```
+## Thinking Path
+## What Changed
+## Verification
+## Model Used
+```
+Never use standard GitHub template sections (Summary, Test Plan, etc.).
+
+## Checkpoint
+
+After each PR cycle, write a brief status comment on the review's source issue:
+- PRs reviewed: list with outcome
+- PRs merged: list
+- PRs still blocked: list with reason
+- Next action: what the next heartbeat should do
+
+This ensures the next heartbeat resumes cleanly instead of re-doing the same work.

--- a/docs/developer/skills/session-lifecycle.md
+++ b/docs/developer/skills/session-lifecycle.md
@@ -1,0 +1,118 @@
+---
+name: session-lifecycle
+description: Mandatory start-of-session and end-of-session protocol for every Claude Code session in this repository. Use this skill at the BEGINNING of every session (worktree setup, stale-branch inheritance cleanup, rebase onto latest base) and at the END of every session or when the user says wrap up, finish, end session, hand off, or when the mission is complete or cannot proceed. Also use when resuming or taking over a previous session's work, or when the working tree contains another session's leftovers. This skill applies to ALL sessions regardless of task — coding, docs, audits, reviews.
+---
+
+# Session Lifecycle Protocol
+
+Sessions are mortal: they terminate before their PRs merge, so a session can
+never clean up after its own merge. This protocol inverts responsibility —
+**every session cleans up after its predecessors at start, and leaves a
+machine-readable handoff at end.**
+
+Base branch: `Dev_new_gui` (adjust if the dispatch says otherwise).
+
+## SESSION START (do this before any task work)
+
+1. **Sync, and REPORT — do not sweep:**
+   ```bash
+   git fetch --prune
+   git worktree prune          # safe: only drops admin refs whose dir is already gone
+   git worktree list           # read-only inventory
+   ```
+
+   **Never delete a worktree or branch you did not create.** Other sessions run
+   concurrently, and a worktree that is clean with zero commits ahead is
+   indistinguishable from a finished one — it is usually a session that has just
+   started. A prior version of this step force-removed anything that looked
+   merged and destroyed an in-progress worktree mid-task.
+
+   Exceptions, and only these two: the user asks, or the leftover belongs to the
+   issue you were dispatched to work on. Otherwise list what you found in the
+   report and move on.
+
+   When an exception applies, **cleanup means finishing the work, not deleting it**
+   — see `~/.claude/docs/worktrees.md`:
+   - **Landed** (the branch's own work is solved and merged, verified in base)
+     → dispose, even if an umbrella issue is still open. A worktree is cheap to
+     recreate; unfinished work is not.
+   - **Stale** (untouched for several days, not landed) → rebase onto base →
+     link or file its issue → solve it → PR → review → merge → *then* dispose.
+   - **Active** (touched recently, or zero commits — a session that just
+     started) → leave alone.
+   - never `--force` (a dirty tree refusing removal is unfinished work, not an obstacle)
+   - never `-d`/`-D` on ancestry alone; squash-merge makes ancestry lie — confirm
+     via the branch's PR state
+   - skip anything `locked`
+
+2. **Create YOUR isolated worktree**, then claim it so a concurrent sweep cannot
+   take it (never work in a shared checkout; never two sessions in one directory):
+   ```bash
+   git worktree add ../wt-<short-task-name> -b <type>/<task-name> origin/Dev_new_gui
+   cd ../wt-<short-task-name>
+   git worktree lock . --reason "in use: <task> (session started $(date -u +%FT%TZ))"
+   git commit --allow-empty -m "chore: claim worktree for <task>"
+   ```
+   `lock` makes `git worktree remove --force` fail outright (it demands `-f -f`),
+   and the claim commit stops "no unique commits" heuristics from classifying the
+   worktree as finished. Unlock at the end: `git worktree unlock <path>`.
+3. **Read predecessor handoffs:** check `.session/` directory on the base
+   branch for HANDOFF files from unmerged sessions touching your area. If one
+   exists and its branch is unmerged, decide: continue their branch (rebase it
+   onto base first) or start fresh — never duplicate their work blind.
+4. **Confirm gates run locally** before relying on them: the wiring audit,
+   duplication guard, and test suite relevant to your task.
+
+## DURING THE SESSION
+
+- One commit per logical change; reference issues (`fixes #NNNN`).
+- LICENSE, NOTICE, SPDX headers, and licensing statements are READ-ONLY.
+  Flag concerns in the report; never modify.
+- Never push directly to the base branch. Never merge — merging is the
+  human's action.
+- If you discover another session has landed overlapping work: rebase onto
+  latest base immediately and reconcile before continuing.
+
+## SESSION END (mandatory before terminating — also run when blocked)
+
+1. **Leave nothing uncommitted:** `git status` must be clean. Work-in-progress
+   that can't be completed gets committed to your branch with a `wip:` prefix
+   and explained in the handoff — never left dangling in the worktree.
+2. **Rebase onto latest base, re-run gates:**
+   ```bash
+   git fetch origin && git rebase origin/Dev_new_gui
+   # re-run: wiring audit, duplication guard, relevant tests
+   ```
+   If the rebase conflicts and resolution is non-trivial, STOP — resolve only
+   what you are confident about; otherwise note the conflict precisely in the
+   handoff for the next session. NEVER commit conflict markers (grep
+   `^<<<<<<< ` across the tree before the final push).
+3. **Push and open/update the PR** with `gh pr create` (or `gh pr edit`):
+   title = mission, body = summary + link to the report.
+4. **Write the handoff file** `.session/HANDOFF-<branch-name>.md` committed on
+   your branch:
+   ```markdown
+   # Handoff: <branch>
+   status: complete | blocked | partial
+   pr: #NNNN
+   base_at_push: <sha of origin/Dev_new_gui you rebased onto>
+   gates: wiring=PASS duplication=PASS tests=PASS|details
+   needs_rebase_before_merge: yes|no
+   remaining: <bullet list, empty if complete>
+   blocked_on: <only if status=blocked — be precise>
+   worktree: ../wt-<name>  (safe to remove after merge)
+   ```
+5. **Write the mission report** (`*_REPORT.md` per the dispatch prompt) — the
+   handoff is for machines/next sessions; the report is for the human.
+6. **Self-cleanup of scratch only:** remove temp files, caches, and anything
+   not belonging on the branch. Do NOT remove your own worktree — it must
+   survive until merge; the next session's start-protocol removes it after
+   the branch merges.
+
+## FAILURE MODES THIS PREVENTS
+- Orphaned branches drifting behind base (start-step 1 + end-step 2)
+- Committed conflict markers (end-step 2 grep)
+- Two sessions colliding in one checkout (start-step 2)
+- Duplicate work on the same problem (start-step 3 handoffs)
+- Posthumous cleanup that never happens (inheritance model)
+- Silent license/business-model changes (during-session read-only rule)


### PR DESCRIPTION
## Thinking Path

Skills live only in each developer's `~/.claude/skills/` — user-local, unreviewed, lost on a
clean home directory. #5094 established that project skills belong in the repo, version-controlled
and PR-gated; only `batch-implement.md` had been mirrored so far. This mirrors the 11
AutoBot-specific skills.

The split matters: a companion set of *general-purpose* skills (process, commit, review-lenses,
gap-audit, web-audit, ui-design, memory-cleanup, canonical-coding) was extracted to a separate
public collection so the reusable practice travels beyond this project. The 11 here are
AutoBot-coupled — they hardcode `Dev_new_gui`, `mrveiss/AutoBot-AI`, `/opt/autobot`,
`autobot_shared`, the required PR-body headings, and the SLM/deploy workflow — so they belong
here, where those conventions are correct.

The `team-implement`→`batch-implement` consolidation was NOT touched: the repo already carries it
from #5454 (self-healing table, Phase 0c/0d). Re-adding it was redundant and is deliberately omitted.

## What Changed

- Added 11 skills as `docs/developer/skills/<name>.md`, frontmatter intact: `implement`, `pr`,
  `pre-merge-validate`, `github-cli`, `debug-autobot`, `api-wiring-audit`, `dead-code-audit`,
  `review-fleet`, `review`, `session-lifecycle`, `drain`.
- `README.md` Files table + `_index.md` list all 11 and note the general-skills split.
- No general-purpose skill added; no change to `batch-implement.md`.

## Verification

- All 11 files carry valid `---` frontmatter (`name`/`description`); confirmed on copy.
- `tools/install_skills.sh` symlinks every `docs/developer/skills/*.md` into
  `~/.claude/skills/<name>/SKILL.md`, so these become the canonical source after a one-time run.
- README Files table: 12 skill rows (batch-implement + 11); `_index.md`: 13 rows.
- No code paths touched — docs-only addition. Main tree untouched; work done in worktree
  `issue-14994` off `origin/Dev_new_gui`.

## Model Used

Claude Opus 5.

Closes #14994
