### PR TITLE
fix(secrets): stop advertising the requirement wildcard on the secrets API (#14974)

### DIFF
--- a/autobot-backend/api/schemas_secrets.py
+++ b/autobot-backend/api/schemas_secrets.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The boundary type for a secret's own kind (#14974).
+
+Lives beside ``schemas_system`` rather than inside it: that module is a
+grandfathered file under a size ceiling that may not rise, and this is a
+self-contained pair -- one narrowing annotation and the validator it carries --
+with no other tie to the several hundred models around it.
+
+``SecretModel`` and ``SecretCreateRequest`` in ``api/schemas_system.py`` import
+``StorableSecretType`` from here, so ``api.schemas_system.StorableSecretType``
+resolves exactly as it did before the move.
+"""
+
+from typing import Annotated
+
+from pydantic import AfterValidator, WithJsonSchema
+
+from autobot_shared.status_enums import SecretType
+
+
+def _reject_the_wildcard(value: SecretType) -> SecretType:
+    """``ANY`` is a requirement quantifier, never a stored classification.
+
+    #13846: the canonical ``SecretType`` carries the wildcard so an agent
+    mapping can say "any available secret". Persisting it would put the
+    string "any" in the ``secrets.type`` column, where it matches no kind
+    and every by-type query would step over it.
+    """
+    if value is SecretType.ANY:
+        raise ValueError(
+            f"secret type '{SecretType.ANY.value}' is a requirement wildcard, "
+            "not a storable kind; pick a concrete type"
+        )
+    return value
+
+
+# The half of the canonical taxonomy a secret may actually be (#14974).
+#
+# ``SecretType`` is one enum on purpose (#13846), and ``ANY`` is a genuine
+# member of it — but it is a wildcard *quantifier* over the taxonomy, legal
+# only in the requirement layer, where ``SecretType.expand`` resolves it into
+# the concrete kinds before any lookup happens. At this boundary there is
+# nothing to quantify: a secret has exactly one kind. So the asymmetry is
+# stated here rather than left implicit — the enum keeps the wildcard, and
+# every request/response field that classifies a single secret uses this.
+#
+# It carries both halves of the narrowing, so the declared type and the
+# accepted type cannot drift apart again:
+#
+# * ``AfterValidator`` rejects the wildcard at runtime (422 on the request,
+#   a loud parse failure on a stored row that somehow carries "any").
+# * ``WithJsonSchema`` narrows the *advertised* schema to the same set, so a
+#   caller reading the generated client types is never offered a value the
+#   endpoint will always refuse.
+#
+# The member list is derived from ``SecretType.concrete()``, never written
+# out, so a kind added to the enum appears here with no second edit — that
+# hand-listing is exactly the drift #13846 was filed about.
+StorableSecretType = Annotated[
+    SecretType,
+    AfterValidator(_reject_the_wildcard),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "enum": [member.value for member in SecretType.concrete()],
+            "title": "StorableSecretType",
+            "description": (
+                "A single credential kind. The canonical SecretType taxonomy "
+                "without its 'any' wildcard, which quantifies over the "
+                "taxonomy in agent requirements and is never a secret's own "
+                "kind."
+            ),
+        }
+    ),
+]

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -10,13 +10,13 @@ import re
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import AfterValidator, BaseModel, Field, WithJsonSchema, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from api.schemas_common import MAX_THOUGHT_COUNT, SuccessDataResponse, SuccessMessageResponse
+from api.schemas_secrets import StorableSecretType
 from api.system_health import HealthStatus
-from autobot_shared.status_enums import SecretType
 from constants.threshold_constants import RetryConfig
 from services.audit_logger import AuditResult
 from services.feature_flags import EnforcementMode
@@ -3506,63 +3506,6 @@ class ChatSecretScope(str, Enum):
     SHARED = "shared"
     GROUP = "group"
     ORGANIZATION = "organization"
-
-
-def _reject_the_wildcard(value: SecretType) -> SecretType:
-    """``ANY`` is a requirement quantifier, never a stored classification.
-
-    #13846: the canonical ``SecretType`` carries the wildcard so an agent
-    mapping can say "any available secret". Persisting it would put the
-    string "any" in the ``secrets.type`` column, where it matches no kind
-    and every by-type query would step over it.
-    """
-    if value is SecretType.ANY:
-        raise ValueError(
-            f"secret type '{SecretType.ANY.value}' is a requirement wildcard, "
-            "not a storable kind; pick a concrete type"
-        )
-    return value
-
-
-# The half of the canonical taxonomy a secret may actually be (#14974).
-#
-# ``SecretType`` is one enum on purpose (#13846), and ``ANY`` is a genuine
-# member of it — but it is a wildcard *quantifier* over the taxonomy, legal
-# only in the requirement layer, where ``SecretType.expand`` resolves it into
-# the concrete kinds before any lookup happens. At this boundary there is
-# nothing to quantify: a secret has exactly one kind. So the asymmetry is
-# stated here rather than left implicit — the enum keeps the wildcard, and
-# every request/response field that classifies a single secret uses this.
-#
-# It carries both halves of the narrowing, so the declared type and the
-# accepted type cannot drift apart again:
-#
-# * ``AfterValidator`` rejects the wildcard at runtime (422 on the request,
-#   a loud parse failure on a stored row that somehow carries "any").
-# * ``WithJsonSchema`` narrows the *advertised* schema to the same set, so a
-#   caller reading the generated client types is never offered a value the
-#   endpoint will always refuse.
-#
-# The member list is derived from ``SecretType.concrete()``, never written
-# out, so a kind added to the enum appears here with no second edit — that
-# hand-listing is exactly the drift #13846 was filed about.
-StorableSecretType = Annotated[
-    SecretType,
-    AfterValidator(_reject_the_wildcard),
-    WithJsonSchema(
-        {
-            "type": "string",
-            "enum": [member.value for member in SecretType.concrete()],
-            "title": "StorableSecretType",
-            "description": (
-                "A single credential kind. The canonical SecretType taxonomy "
-                "without its 'any' wildcard, which quantifies over the "
-                "taxonomy in agent requirements and is never a secret's own "
-                "kind."
-            ),
-        }
-    ),
-]
 
 
 class SecretModel(BaseModel):

--- a/autobot-backend/api/schemas_system.py
+++ b/autobot-backend/api/schemas_system.py
@@ -10,9 +10,9 @@ import re
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AfterValidator, BaseModel, Field, WithJsonSchema, field_validator
 
 from api.schemas_common import MAX_THOUGHT_COUNT, SuccessDataResponse, SuccessMessageResponse
 from api.system_health import HealthStatus
@@ -3508,12 +3508,69 @@ class ChatSecretScope(str, Enum):
     ORGANIZATION = "organization"
 
 
+def _reject_the_wildcard(value: SecretType) -> SecretType:
+    """``ANY`` is a requirement quantifier, never a stored classification.
+
+    #13846: the canonical ``SecretType`` carries the wildcard so an agent
+    mapping can say "any available secret". Persisting it would put the
+    string "any" in the ``secrets.type`` column, where it matches no kind
+    and every by-type query would step over it.
+    """
+    if value is SecretType.ANY:
+        raise ValueError(
+            f"secret type '{SecretType.ANY.value}' is a requirement wildcard, "
+            "not a storable kind; pick a concrete type"
+        )
+    return value
+
+
+# The half of the canonical taxonomy a secret may actually be (#14974).
+#
+# ``SecretType`` is one enum on purpose (#13846), and ``ANY`` is a genuine
+# member of it — but it is a wildcard *quantifier* over the taxonomy, legal
+# only in the requirement layer, where ``SecretType.expand`` resolves it into
+# the concrete kinds before any lookup happens. At this boundary there is
+# nothing to quantify: a secret has exactly one kind. So the asymmetry is
+# stated here rather than left implicit — the enum keeps the wildcard, and
+# every request/response field that classifies a single secret uses this.
+#
+# It carries both halves of the narrowing, so the declared type and the
+# accepted type cannot drift apart again:
+#
+# * ``AfterValidator`` rejects the wildcard at runtime (422 on the request,
+#   a loud parse failure on a stored row that somehow carries "any").
+# * ``WithJsonSchema`` narrows the *advertised* schema to the same set, so a
+#   caller reading the generated client types is never offered a value the
+#   endpoint will always refuse.
+#
+# The member list is derived from ``SecretType.concrete()``, never written
+# out, so a kind added to the enum appears here with no second edit — that
+# hand-listing is exactly the drift #13846 was filed about.
+StorableSecretType = Annotated[
+    SecretType,
+    AfterValidator(_reject_the_wildcard),
+    WithJsonSchema(
+        {
+            "type": "string",
+            "enum": [member.value for member in SecretType.concrete()],
+            "title": "StorableSecretType",
+            "description": (
+                "A single credential kind. The canonical SecretType taxonomy "
+                "without its 'any' wildcard, which quantifies over the "
+                "taxonomy in agent requirements and is never a secret's own "
+                "kind."
+            ),
+        }
+    ),
+]
+
+
 class SecretModel(BaseModel):
     """Secret data model."""
 
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
-    type: SecretType
+    type: StorableSecretType
     scope: ChatSecretScope
     chat_id: str | None = None
     description: str | None = ""
@@ -3528,7 +3585,7 @@ class SecretCreateRequest(BaseModel):
     """Request model for creating secrets."""
 
     name: str = Field(..., min_length=1, max_length=256)
-    type: SecretType
+    type: StorableSecretType
     scope: ChatSecretScope
     value: str = Field(..., min_length=1, max_length=65536)
     chat_id: str | None = Field(None, max_length=128)
@@ -3540,23 +3597,6 @@ class SecretCreateRequest(BaseModel):
     org_id: str | None = Field(None, max_length=128, description="Organization ID for org-level secrets")
     team_ids: List[str] = Field(default_factory=list, description="Team IDs for group-level secrets")
     shared_with: List[str] = Field(default_factory=list, description="User IDs to share with")
-
-    @field_validator("type")
-    @classmethod
-    def _reject_the_wildcard(cls, value: SecretType) -> SecretType:
-        """``ANY`` is a requirement quantifier, never a stored classification.
-
-        #13846: the canonical ``SecretType`` carries the wildcard so an agent
-        mapping can say "any available secret". Persisting it would put the
-        string "any" in the ``secrets.type`` column, where it matches no kind
-        and every by-type query would step over it.
-        """
-        if value is SecretType.ANY:
-            raise ValueError(
-                f"secret type '{SecretType.ANY.value}' is a requirement wildcard, "
-                "not a storable kind; pick a concrete type"
-            )
-        return value
 
     @field_validator("name")
     @classmethod

--- a/autobot-backend/api/secrets_test.py
+++ b/autobot-backend/api/secrets_test.py
@@ -194,3 +194,163 @@ class TestGetSecretDualRead:
         with patch("api.secrets.load_imported_json_secret", AsyncMock(return_value=unified)):
             with pytest.raises(PermissionError):
                 await _get_secret_dual_read("s3", chat_id="chat-b")
+
+
+# ---------------------------------------------------------------------------
+# #14974 — the wildcard must not be advertised where it is refused
+# ---------------------------------------------------------------------------
+#
+# `SecretType.ANY` is a quantifier over the taxonomy, not a kind of credential.
+# It is legal in the requirement layer (`AgentSecretMapping`, resolved by
+# `SecretType.expand`) and illegal at the secrets API boundary, where a secret
+# has exactly one kind. Before #14974 the boundary *declared* it and *refused*
+# it: the generated client type offered "any" on the request body and the
+# server answered 422. These tests pin both halves to the same population, so
+# neither can widen without the other.
+
+
+def _secrets_app():
+    """A real app carrying the real secrets router, admin check overridden.
+
+    Drives what a caller actually gets — the served OpenAPI document and real
+    request validation — rather than the enum in isolation.
+    """
+    from fastapi import FastAPI
+
+    from api.secrets import router
+    from auth_middleware import check_admin_permission
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/secrets")
+    app.dependency_overrides[check_admin_permission] = lambda: True
+    return app
+
+
+def _served_type_schema():
+    """The `type` property of SecretCreateRequest as the OpenAPI document serves it."""
+    schema = _secrets_app().openapi()["components"]["schemas"]["SecretCreateRequest"]
+    return schema["properties"]["type"]
+
+
+class TestTheWildcardIsNotAdvertised:
+    """#14974: the declared secret type must equal the accepted secret type."""
+
+    def test_served_schema_offers_only_the_concrete_taxonomy(self):
+        """The generated client type is the narrowing, not a superset of it."""
+        served = _served_type_schema()
+        assert served["enum"] == [member.value for member in SecretType.concrete()]
+        assert EXPECTED_WILDCARD not in served["enum"]
+        # Inline, not a `$ref` to the whole enum — a `$ref` would drag the
+        # wildcard back in however the schema was narrowed alongside it.
+        assert "$ref" not in served
+        assert "allOf" not in served
+
+    def test_served_schema_is_derived_not_hand_listed(self):
+        """A kind added to the enum reaches the API with no second edit.
+
+        Hand-listing the members here is the drift #13846 was filed about, so
+        this asserts the served list tracks `SecretType.concrete()` exactly —
+        including order — rather than a copy that can silently fall behind.
+        """
+        served = _served_type_schema()
+        assert served["enum"] == [t["value"] for t in EXPECTED_TYPES]
+        assert len(served["enum"]) == len(SecretType) - 1
+
+    def test_no_reachable_property_anywhere_offers_the_wildcard(self):
+        """Nothing a caller can send or receive names "any" as a kind.
+
+        Resolves `$ref` before looking: a property pointing at the canonical
+        enum advertises the wildcard just as loudly as an inline copy of it.
+        """
+        schemas = _secrets_app().openapi()["components"]["schemas"]
+
+        def _values(spec):
+            ref = spec.get("$ref", "")
+            target = schemas.get(ref.rsplit("/", 1)[-1], {}) if ref else spec
+            return target.get("enum") or []
+
+        offenders = [
+            f"{name}.{prop}"
+            for name, body in schemas.items()
+            for prop, spec in (body.get("properties") or {}).items()
+            if EXPECTED_WILDCARD in _values(spec)
+        ]
+        assert offenders == []
+
+    def test_post_refuses_the_wildcard_as_a_body_field_error(self):
+        """POST /api/secrets/ answers 422 and blames the `type` field."""
+        from fastapi.testclient import TestClient
+
+        with TestClient(_secrets_app()) as client:
+            response = client.post(
+                "/api/secrets/",
+                json={
+                    "name": "wildcard_attempt",
+                    "type": EXPECTED_WILDCARD,
+                    "scope": ChatSecretScope.GENERAL.value,
+                    "value": "irrelevant",
+                },
+            )
+        assert response.status_code == 422
+        locations = [tuple(error["loc"]) for error in response.json()["detail"]]
+        assert ("body", "type") in locations
+
+    def test_post_still_accepts_every_concrete_kind(self):
+        """The runtime narrowing refuses only the wildcard — not one real kind.
+
+        `AfterValidator` sits on every secret-classifying field, so a check
+        that grew past `ANY` would silently make real credential kinds
+        unstorable. Over-narrowing the *advertised* enum is a different
+        failure, caught by the two schema tests above.
+        """
+        from fastapi.testclient import TestClient
+
+        for member in SecretType.concrete():
+            with (
+                patch("api.secrets.check_rate_limit", AsyncMock(return_value=None)),
+                patch("api.secrets._mirror_llm_provider_key", AsyncMock(return_value=None)),
+                patch("api.secrets.audit_log", MagicMock()),
+                patch("api.secrets.audit_record", MagicMock()),
+                patch("api.secrets.get_auth_middleware", MagicMock()),
+                patch("api.secrets.secrets_manager") as manager,
+            ):
+                manager.create_secret = MagicMock(side_effect=_stored_secret)
+                with TestClient(_secrets_app()) as client:
+                    response = client.post(
+                        "/api/secrets/",
+                        json={
+                            "name": f"concrete_{member.value}",
+                            "type": member.value,
+                            "scope": ChatSecretScope.GENERAL.value,
+                            "value": "irrelevant",
+                        },
+                    )
+            assert response.status_code == 201, f"{member.value}: {response.text}"
+            assert response.json()["secret"]["type"] == member.value
+
+    def test_a_stored_wildcard_row_fails_to_parse(self):
+        """`SecretModel` is also the parse boundary over persisted rows.
+
+        `update_secret` rebuilds a `SecretModel` straight from the stored row,
+        so a row carrying "any" — however it got there — must fail loudly
+        rather than be served back as a secret of kind "any".
+        """
+        from pydantic import ValidationError
+
+        from api.schemas_system import SecretModel
+
+        row = {
+            "name": "smuggled",
+            "type": EXPECTED_WILDCARD,
+            "scope": ChatSecretScope.GENERAL.value,
+        }
+        with pytest.raises(ValidationError):
+            SecretModel(**row)
+
+        row["type"] = SecretType.API_KEY.value
+        assert SecretModel(**row).type is SecretType.API_KEY
+
+
+def _stored_secret(request):
+    """Stand in for the encrypting store: echo the validated request back."""
+    return request.to_secret_model()

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -92061,7 +92061,12 @@ export interface components {
         SecretCreateRequest: {
             /** Name */
             name: string;
-            type: components["schemas"]["SecretType"];
+            /**
+             * StorableSecretType
+             * @description A single credential kind. The canonical SecretType taxonomy without its 'any' wildcard, which quantifies over the taxonomy in agent requirements and is never a secret's own kind.
+             * @enum {string}
+             */
+            type: "ssh_key" | "password" | "api_key" | "token" | "oauth_refresh_token" | "connector_oauth_token" | "certificate" | "database_url" | "infrastructure_host" | "other";
             scope: components["schemas"]["ChatSecretScope"];
             /** Value */
             value: string;

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -148,7 +148,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/api/schemas_chat.py": 751,
     "autobot-backend/api/schemas_code.py": 3286,
     "autobot-backend/api/schemas_knowledge.py": 5167,
-    "autobot-backend/api/schemas_system.py": 4326,
+    "autobot-backend/api/schemas_system.py": 4309,
     "autobot-backend/api/schemas_workflows.py": 3011,
     "autobot-backend/api/secrets.py": 1053,
     "autobot-backend/api/security_assessment.py": 913,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -143,7 +143,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/api/schemas_chat.py": 751,
     "autobot-backend/api/schemas_code.py": 3286,
     "autobot-backend/api/schemas_knowledge.py": 5167,
-    "autobot-backend/api/schemas_system.py": 4326,
+    "autobot-backend/api/schemas_system.py": 4309,
     "autobot-backend/api/schemas_workflows.py": 3011,
     "autobot-backend/api/secrets.py": 1053,
     "autobot-backend/api/security_assessment.py": 913,


### PR DESCRIPTION
## Thinking Path

The issue names two API surfaces that advertise `SecretType.ANY` and then reject it, and asks
for a decision rather than a patch. I derived the population myself instead of trusting the
inventory, and the inventory turned out to be wrong in a way that matters.

**What `ANY` means, everywhere it is used**

| Layer | Meaning of `ANY` | Mechanism |
|---|---|---|
| Agent requirements (`AgentSecretMapping.required_types` / `optional_types`, `get_secrets_for_agent(secret_types=...)`) | **Real**: "any available secret" — a quantifier *over* the taxonomy | `SecretType.expand()` resolves it into the concrete kinds before any lookup |
| Presentation (`GET /api/secrets/types`) | Absent | serves `SecretType.concrete()` |
| Persistence (`secrets.type`) | Illegal — a stored `"any"` matches no kind and every by-type query steps over it | `_reject_the_wildcard` |
| Request (`SecretCreateRequest.type`) | **Advertised, always refused** | schema said yes, validator said 422 |
| Response / stored-row parse (`SecretModel.type`) | **Silently accepted** | nothing checked it at all |

So `ANY` is a genuine wildcard in exactly one layer, and a category error in the others. That
asymmetry is the answer, and it is now stated in the code rather than left implicit.

**Two corrections to the issue's premise, both found by deriving the population:**

1. `SecretModel` is **not** in the served schema at all — the routes answer with
   `SecretCreatedData.secret: Dict[str, Any]`, so `components["schemas"]["SecretType"]` was
   referenced from exactly **one** place, the request body. `SecretModel` is instead the
   *parse boundary over stored rows*: `update_secret` rebuilds one directly from the persisted
   record. It had no wildcard check, so a row carrying `"any"` would have parsed clean and been
   served back. That is the more interesting half of the defect and the issue does not mention it.
2. The other two `SecretType` definitions are already accounted for.
   `autobot-infrastructure/shared/scripts/secrets_manager.py` is a deliberate standalone copy
   (documented, never imports application packages), and the OAuth producer in
   `credential_store.py` already persists `CONNECTOR_OAUTH_TOKEN` rather than a bare string.
   Neither is reachable from these surfaces.

**Resolution chosen: Option B, done derivation-correctly.** Not Option A: the schema is the only
thing a caller reads, and the issue itself names the risk that a type permitting what the endpoint
always rejects gets "fixed" later by relaxing the validator. Not Option C: `#13846` requires one
enum, wildcard included, and moving it out reintroduces the second vocabulary the whole exercise
removed. The issue said B is worth doing "only if someone verifies the generated output rather
than predicting it" — that verification is below, run through the repo's own generator.

**Security reading — the checks are unioned, the allowances are not.** Accepting `ANY` here would
have been the bug, not the fix. A stored secret of kind `"any"` matches no agent requirement today,
and the obvious later "repair" for that — treating a stored `"any"` as satisfying every requirement —
turns one row into a credential injected into every agent regardless of its declared
`required_types`/`optional_types`. That is a wildcard grant in the exact shape to avoid. So the
strictest defensible reading wins: keep the refusal, *and* stop advertising the thing being refused,
*and* extend the same refusal to the boundary that had none. No grant was widened anywhere; the only
runtime behaviour change is that one more surface now refuses `"any"`. No HTTP surface reaches
`expand()`, so the wildcard remains unreachable from a request.

## What Changed

**`autobot-backend/api/schemas_system.py`**

* `_reject_the_wildcard` moves from a `SecretCreateRequest`-only `field_validator` to a module-level
  function — same name, same condition, same message. It is not relaxed or deleted; it is reused.
* New `StorableSecretType = Annotated[SecretType, AfterValidator(...), WithJsonSchema(...)]`.
  The Python type stays `SecretType` (one vocabulary, no second enum, mypy-clean); the annotation
  adds the runtime refusal and narrows the advertised schema to the same population.
  The member list is `[member.value for member in SecretType.concrete()]` — derived, never
  hand-listed, so a kind added to the enum reaches the API with no second edit.
* `SecretCreateRequest.type` and `SecretModel.type` both use it. `SecretModel` gaining the check
  is the new coverage: it is the parse boundary over stored rows.

**`autobot-frontend/src/types/generated/api.ts`** — regenerated, not hand-edited (see below).

**`autobot-backend/api/secrets_test.py`** — six tests driving the real router through a real app.

Not changed on purpose: `SecretType` itself, `concrete()`, `expand()`, `GET /secrets/types`, and
the requirement layer. `#13846`'s AC that `ANY` is preserved as an enum member still holds.

## Verification

**Generated-type drift — verified against a real dump, not predicted.** Dumped the whole backend
schema with the repo's own `scripts/audit_api_wiring.py --dump-openapi` (2194 paths), stripped
`x-websocket-paths`, and ran the repo's pinned `openapi-typescript` 7.13.0 with the same flags the
CI workflow uses. Diff against the committed `api.ts` is **9 lines, all in `SecretCreateRequest`** —
proving both that the dump is faithful and that nothing else moved:

```
-            type: components["schemas"]["SecretType"];
+            /**
+             * StorableSecretType
+             * @description A single credential kind. The canonical SecretType taxonomy without its 'any' wildcard, ...
+             * @enum {string}
+             */
+            type: "ssh_key" | "password" | "api_key" | "token" | "oauth_refresh_token" | "connector_oauth_token" | "certificate" | "database_url" | "infrastructure_host" | "other";
```

The `check-drift` gate over `src/types/_generated/workflow.ts` is unaffected — that generator's
MANIFEST does not cover `SecretType`, and this change does not touch `status_enums.py`.

*Known and deliberate:* FastAPI's definition collection still emits the canonical `SecretType`
enum as an **unreferenced** component, so `api.ts` keeps a `SecretType` type alias that includes
`"any"`. No request or response field points at it any more, and it is an accurate record of the
requirement-layer vocabulary, so it is left as documentation rather than suppressed with a hack.
`test_no_reachable_property_anywhere_offers_the_wildcard` resolves `$ref`s specifically so that a
field pointing back at it would fail.

**Tests** — `autobot-backend/api/secrets_test.py`, 16 passed (6 new, 10 pre-existing). Related
files re-run together: `repo_tests/enum_union_guard_test.py` +
`autobot-backend/models/secret_test.py` → 116 passed, 3 skipped.

The new tests drive the real `api.secrets` router mounted on a real app with the admin dependency
overridden, and assert what a caller receives — the served OpenAPI document and real 422/201
responses — never source text.

**Mutation evidence** — every guarded line mutated, failure confirmed, then restored (no mutation
pushed):

| # | Mutation | Result |
|---|---|---|
| 1 | drop `AfterValidator(_reject_the_wildcard)` | 2 failed — `post_refuses_the_wildcard`, `stored_wildcard_row_fails_to_parse` |
| 2 | `SecretType.concrete()` → `SecretType` in the schema list | 3 failed — all three schema tests |
| 3 | `if value is SecretType.ANY:` → `if False:` | 2 failed — both runtime-refusal tests |
| 4 | drop `WithJsonSchema` (field falls back to `$ref`) | 3 failed — incl. the `$ref`-resolving sweep |
| 5 | over-narrow the schema to `concrete()[:5]` | 2 failed — both derived-list tests |
| 6 | widen the check to `(ANY, TOKEN)` | 1 failed — `post_still_accepts_every_concrete_kind` |

Baseline before and after the mutation run: 6 passed. Working tree restored and verified clean.

**Discovered, filed not fixed** (different scope, both cross-linked):

* `useSessionActivityLogger.ts` hand-maintains its own `SecretType` union carrying 7 of the 10
  concrete kinds — the same hand-listing drift `#13846` was filed about, on the frontend side. → #15008
* `services/provider_key_vault.py` passes a bare `"api_key"` string where the canonical enum
  member exists. → #15009

## Model Used

Claude Opus 5 (1M context)

Closes #14974
