### PR TITLE
fix: Use exact path matching in check_python_file_size to prevent false exclusions (closes #13162)

### DIFF
--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -30,7 +30,8 @@ def main() -> int:
         p = pathlib.Path(arg)
         # Normalise to forward-slash relative path for set lookup
         rel = str(p).replace("\\", "/")
-        if any(rel.endswith(known.replace("\\", "/")) for known in KNOWN_LARGE):
+        # Compare normalized paths exactly to avoid matching unrelated files that share a suffix
+        if any(rel == known.replace("\\", "/") for known in KNOWN_LARGE):
             continue
         try:
             line_count = sum(1 for _ in p.open(encoding="utf-8"))


### PR DESCRIPTION
## What
The pre-commit hook scripts/check_python_file_size.py uses `endswith()` to match files listed in KNOWN_LARGE. This is too permissive: any file whose path ends with the same suffix (e.g., 'manager.py') is skipped, even if it's not a grandfathered file. This could allow large Python files to pass the size check, undermining the hook's purpose.

## Fix
Changed the check to compare normalized paths exactly (forward slashes) instead of using a suffix match. Now only the exact files listed in KNOWN_LARGE are excluded from the line-count check.

Closes #13162