### PR TITLE
fix(observability): make a check that cannot run say so instead of returning a plausible answer (#14869, #13570, #13281, #12969)

### DIFF
--- a/autobot-backend/services/agent_terminal/approval_handler.py
+++ b/autobot-backend/services/agent_terminal/approval_handler.py
@@ -12,13 +12,37 @@ import asyncio
 import time
 from typing import Dict
 
+from redis.exceptions import RedisError
+
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.retry_mechanism import RETRYABLE_EXCEPTIONS
 from autobot_shared.status_enums import CommandRisk
 from services.command_approval_manager import CommandApprovalManager
 
 from .models import AgentTerminalSession
 
 logger = get_logger(__name__)
+
+# The only failures this file degrades over: a Redis blip, a socket timeout, a
+# disk error (#13281).
+#
+# Every handler below used to be `except Exception`, logged "non-fatal", and
+# continued. That is why the wrong-keyword defect survived: `add_message` was
+# called with `role=` and `metadata=`, keywords its signature does not accept,
+# so it raised `TypeError` on EVERY invocation and approval status was never
+# written to chat history — not once, for as long as the call existed. The turn
+# carried on and the log said non-fatal, so nothing surfaced it.
+#
+# A TypeError or an AttributeError from a signature mismatch is a programming
+# error, not a transient failure. It has to reach the caller, CI and the error
+# tracker rather than being folded into a generic degraded path that a caller
+# cannot tell from success.
+#
+# Built from the canonical retryable set (ConnectionError, TimeoutError, OSError)
+# rather than a second hand-written list, so the two cannot drift. `RedisError`
+# is added because redis-py's ConnectionError/TimeoutError descend from it, not
+# from the builtins.
+TRANSIENT_PERSISTENCE_ERRORS: tuple[type[BaseException], ...] = RETRYABLE_EXCEPTIONS + (RedisError,)
 
 
 class ApprovalHandler:
@@ -189,13 +213,24 @@ class ApprovalHandler:
                     f"command={command}, "
                     f"comment={comment}"
                 )
-            except Exception as broadcast_error:
-                logger.warning(f"Failed to broadcast approval status (non-fatal): {broadcast_error}")
-                # Continue - don't fail the approval process if broadcast fails
+            except TRANSIENT_PERSISTENCE_ERRORS as broadcast_error:
+                # A dropped connection to the event bus is genuinely transient and
+                # must not fail the approval. A TypeError in the payload is not,
+                # and now surfaces instead of being logged as "non-fatal" (#13281).
+                logger.warning(
+                    "Approval status broadcast for %s dropped — transport error %s: %s",
+                    session.conversation_id,
+                    type(broadcast_error).__name__,
+                    broadcast_error,
+                )
 
-        except Exception as e:
-            logger.error("Error in approval status update: %s", e, exc_info=True)
-            # Don't fail the approval process if broadcast fails
+        except TRANSIENT_PERSISTENCE_ERRORS as exc:
+            logger.error(
+                "Approval status update failed — transport error %s: %s",
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
 
     async def _persist_chat_approval_update(
         self,
@@ -261,8 +296,17 @@ class ApprovalHandler:
             return
         try:
             await self._persist_chat_approval_update(session, command, approved, user_id, comment)
-        except Exception as e:
-            logger.error(f"Failed to update chat approval status (non-fatal): {e}", exc_info=True)
+        except TRANSIENT_PERSISTENCE_ERRORS as exc:
+            # Degrade only on storage that might work next time, and name the
+            # exception TYPE — "non-fatal: <message>" told a log reader nothing
+            # about whether this was a blip or a permanent code defect (#13281).
+            logger.error(
+                "Approval status for %s was NOT persisted to chat history — storage error %s: %s",
+                session.conversation_id,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )
 
     async def update_command_queue_status(
         self,
@@ -314,5 +358,11 @@ class ApprovalHandler:
                 )
                 logger.info(f"✅ [QUEUE] Command {command_id} denied in queue by {user_id or 'web_user'}")
 
-        except Exception as e:
-            logger.error("Failed to update command queue status: %s", e, exc_info=True)
+        except TRANSIENT_PERSISTENCE_ERRORS as exc:
+            logger.error(
+                "Command queue status for %s was NOT updated — storage error %s: %s",
+                command_id,
+                type(exc).__name__,
+                exc,
+                exc_info=True,
+            )

--- a/autobot-backend/services/agent_terminal/approval_handler_error_surfacing_test.py
+++ b/autobot-backend/services/agent_terminal/approval_handler_error_surfacing_test.py
@@ -1,0 +1,170 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A broad `except Exception` hid a TypeError on every approval-state write (#13281).
+
+`update_chat_approval_status` wrapped its persistence call in `except Exception`
+and logged "non-fatal". The call passed `role=` and `metadata=`, two keywords
+`MessagesMixin.add_message` does not accept, so it raised `TypeError` on EVERY
+invocation — approval status was never written to chat history, not once. The
+turn continued, the log said non-fatal, and nothing surfaced it.
+
+The keyword fix shipped separately. What these tests hold is the handler shape
+that let it survive: a signature mismatch must reach the caller, while a genuine
+storage blip still degrades. Both outcomes are asserted, because narrowing that
+merely re-raised everything would also pass a test for the first alone.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+from services.agent_terminal.approval_handler import ApprovalHandler
+from services.agent_terminal.models import AgentTerminalSession
+from services.command_approval_manager import AgentRole
+
+
+class _Boom:
+    """A chat-history double whose write raises whatever it was handed."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def update_message_metadata(self, **_kwargs) -> bool:
+        return True
+
+    async def add_message(self, **_kwargs):
+        raise self._exc
+
+
+class _BoomQueue:
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def approve_command(self, **_kwargs):
+        raise self._exc
+
+    async def deny_command(self, **_kwargs):
+        raise self._exc
+
+
+def _session() -> AgentTerminalSession:
+    return AgentTerminalSession(
+        session_id="term-1",
+        agent_id="agent-1",
+        agent_role=AgentRole.CHAT_AGENT,
+        conversation_id="conv-1",
+    )
+
+
+def _handler(*, chat=None, queue=None) -> ApprovalHandler:
+    return ApprovalHandler(approval_manager=object(), chat_history_manager=chat, command_queue=queue)
+
+
+@pytest.mark.asyncio
+async def test_a_signature_mismatch_reaches_the_caller():
+    """The exact defect: a wrong keyword must not be logged away as non-fatal."""
+    exc = TypeError("MessagesMixin.add_message() got an unexpected keyword argument 'role'")
+    handler = _handler(chat=_Boom(exc))
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await handler.update_chat_approval_status(_session(), "ls -la", approved=True)
+
+
+@pytest.mark.asyncio
+async def test_an_attribute_error_reaches_the_caller():
+    """An unwired storage object is a programming error too, not a degraded write."""
+    handler = _handler(chat=_Boom(AttributeError("'NoneType' object has no attribute 'add_message'")))
+
+    with pytest.raises(AttributeError):
+        await handler.update_chat_approval_status(_session(), "ls -la", approved=True)
+
+
+@pytest.mark.asyncio
+async def test_a_transient_storage_error_still_degrades(caplog):
+    """Narrowing must not turn a Redis blip into a failed approval turn.
+
+    The oracle for the tests above is only meaningful if the handler still
+    catches something — a handler that re-raised everything would satisfy them
+    while being a different bug.
+    """
+    handler = _handler(chat=_Boom(RedisConnectionError("connection reset by peer")))
+
+    with caplog.at_level("ERROR"):
+        await handler.update_chat_approval_status(_session(), "ls -la", approved=True)
+
+    assert "was NOT persisted" in caplog.text, "a dropped write was not reported at all"
+    assert "ConnectionError" in caplog.text, "the log does not name the exception type"
+
+
+@pytest.mark.asyncio
+async def test_the_queue_handler_surfaces_a_programming_error():
+    """The sibling handler in the same file carried the identical shape."""
+    handler = _handler(queue=_BoomQueue(TypeError("approve_command() got an unexpected keyword argument")))
+
+    with pytest.raises(TypeError):
+        await handler.update_command_queue_status("cmd-1", approved=True)
+
+
+@pytest.mark.asyncio
+async def test_the_queue_handler_still_degrades_on_a_storage_blip(caplog):
+    handler = _handler(queue=_BoomQueue(RedisConnectionError("connection reset by peer")))
+
+    with caplog.at_level("ERROR"):
+        await handler.update_command_queue_status("cmd-1", approved=True)
+
+    assert "was NOT updated" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_the_broadcast_handler_surfaces_a_programming_error(monkeypatch):
+    """The two handlers inside broadcast_approval_status had the same shape."""
+    import events.bus as bus
+
+    async def _bad_publish(*_args, **_kwargs):
+        raise TypeError("publish_event() got an unexpected keyword argument 'payload'")
+
+    monkeypatch.setattr(bus, "publish_event", _bad_publish)
+    handler = _handler()
+
+    with pytest.raises(TypeError):
+        await handler.broadcast_approval_status(_session(), "ls -la", approved=True)
+
+
+@pytest.mark.asyncio
+async def test_the_broadcast_handler_still_degrades_on_a_transport_blip(monkeypatch, caplog):
+    import events.bus as bus
+
+    async def _dropped(*_args, **_kwargs):
+        raise RedisConnectionError("event bus unreachable")
+
+    monkeypatch.setattr(bus, "publish_event", _dropped)
+    handler = _handler()
+
+    with caplog.at_level("WARNING"):
+        await handler.broadcast_approval_status(_session(), "ls -la", approved=True)
+
+    assert "broadcast" in caplog.text.lower()
+    assert "ConnectionError" in caplog.text
+
+
+def test_no_broad_except_exception_remains_in_the_handler():
+    """The removal criterion, grepped rather than assumed.
+
+    Four handlers carried `except Exception` — two in broadcast_approval_status,
+    one in update_chat_approval_status, one in update_command_queue_status.
+    """
+    import services.agent_terminal.approval_handler as module
+
+    source = Path(module.__file__).read_text(encoding="utf-8")
+    offenders = [
+        f"{n}: {line.strip()}"
+        for n, line in enumerate(source.splitlines(), 1)
+        if re.match(r"^\s*except\s+Exception\b", line)
+    ]
+    assert not offenders, "a broad handler is back — that is the bug:\n" + "\n".join(offenders)

--- a/autobot-backend/utils/error_catalog_resolution_test.py
+++ b/autobot-backend/utils/error_catalog_resolution_test.py
@@ -147,3 +147,25 @@ def test_the_health_probe_distinguishes_the_fallback(monkeypatch, source, expect
 
     assert deployed is expected_ok
     assert data["error_catalog_source"] == source
+
+
+def test_the_real_loader_path_finds_the_deployed_catalog():
+    """No monkeypatching at all: the loader as every service calls it (#12969).
+
+    The tests above prove the resolver copes when ``PATH`` is blind. That is the
+    reproduction, not the guarantee — a resolver whose every candidate was wrong
+    could still satisfy them by reporting its fallback honestly. This drives
+    ``load_catalog()`` exactly as the backend and celery do, with the real SSOT
+    constants in place, and asserts it lands on the YAML rather than the 42
+    built-ins that happen to agree with it.
+    """
+    catalog = ErrorCatalog()
+
+    assert catalog.load_catalog() is True, (
+        "the deployed catalog was not loaded through the unmodified path — this is "
+        "the live symptom: 'Error catalog YAML not found' about a file that exists"
+    )
+    assert catalog.source == SOURCE_YAML
+    assert catalog.catalog_path.name == CATALOG_FILENAME
+    assert catalog.catalog_path.exists()
+    assert catalog.get_catalog_stats()["version"], "loaded the built-ins, which carry no version"

--- a/autobot-backend/workers/audit_queries.py
+++ b/autobot-backend/workers/audit_queries.py
@@ -1,0 +1,132 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""External queries the audit worker makes, and whether they observed anything (#13570).
+
+The incident this module exists for: `gh` was unauthenticated for the service
+account, so audit findings came back "deferred to the dead-letter queue" while
+the queue held nothing. The reassuring message was worse than an error, because
+it stated the findings were preserved when they were not.
+
+The same shape survived one level down, in the queries the tasks make *before*
+they file. Both returned an empty list on failure — the identical value a
+successful query returns when there is genuinely nothing:
+
+* `gh issue list` failing returned `[]`, which empties the dedupe set. A run that
+  could not see the open issues then looked exactly like a run against a repo
+  with no open issues, and would happily re-file every finding already filed;
+* `vulture` failing to start returned `[]`, and the task reported
+  `total_findings: 0`, `new_findings: 0`, `status: "success"` — a clean bill of
+  health from a scan that never ran.
+
+Every function here therefore returns ``(result, observed)``. ``observed`` is
+False whenever the query did not actually happen, and callers must treat that as
+"no information", never as "no findings".
+
+Both take the subprocess runner as an argument rather than importing it, so the
+worker keeps a single canonical ``_run`` and these stay independently testable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+from autobot_shared.logging_manager import get_logger
+
+logger = get_logger(__name__)
+
+# Max characters of CLI output kept in logs on failure.
+MAX_LOG_CHARS = 500
+
+# (returncode, stdout, stderr)
+Runner = Callable[..., "tuple[int, str, str]"]
+
+
+def _tail(text: str) -> str:
+    """The trimmed CLI output, or an explicit note that there was none."""
+    return (text or "").strip()[:MAX_LOG_CHARS] or "no output"
+
+
+def list_open_issue_titles(
+    repo: str,
+    label: str | None,
+    env: dict[str, str],
+    runner: Runner,
+) -> tuple[list[str], bool]:
+    """Titles of open GitHub issues, and whether the listing actually happened.
+
+    ``(titles, observed)``. ``observed`` False means the caller is BLIND to
+    duplicates for this run — it must not conclude "nothing is open" and file
+    everything again.
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--json",
+        "title",
+        "--limit",
+        "500",
+    ]
+    if label:
+        cmd += ["--label", label]
+    code, out, err = runner(cmd, env=env)
+    if code != 0:
+        logger.error(
+            "audit: `gh issue list` for %s exited %d — this run cannot see which "
+            "issues are already open, so it is blind to duplicates and will defer "
+            "rather than re-file. gh said: %s",
+            repo,
+            code,
+            _tail(err),
+        )
+        return [], False
+    try:
+        return [item["title"] for item in json.loads(out)], True
+    except (ValueError, TypeError, KeyError) as exc:
+        logger.error(
+            "audit: `gh issue list` for %s returned output this worker cannot read "
+            "(%s) — treating the listing as unobserved rather than as an empty repo.",
+            repo,
+            type(exc).__name__,
+        )
+        return [], False
+
+
+def vulture_scan(repo_root: Path, runner: Runner, python_executable: str) -> tuple[list[str], bool]:
+    """Dead-code lines from vulture, and whether the scan actually ran.
+
+    vulture exits 0 when it finds nothing and 1 when it finds dead code. Exit 1
+    with an EMPTY stdout is neither outcome: it is the interpreter refusing to
+    run the module at all — not installed, or an import error inside it. That
+    case used to return the same empty list a clean scan returns, and the task
+    reported success for a scan that never happened.
+    """
+    cmd = [
+        python_executable,
+        "-m",
+        "vulture",
+        "autobot-backend",
+        "--min-confidence",
+        "80",
+        "--exclude",
+        "*/migrations/*,*/__pycache__/*,*/tests/*",
+    ]
+    code, out, err = runner(cmd, cwd=str(repo_root))
+    lines = [line.strip() for line in out.splitlines() if line.strip()]
+    if code not in (0, 1) or (code == 1 and not lines):
+        logger.error(
+            "audit: vulture could not run (exit %d) — this run made NO dead-code "
+            "observation, which is not the same as finding none. vulture said: %s",
+            code,
+            _tail(err),
+        )
+        return [], False
+    return lines, True

--- a/autobot-backend/workers/audit_queries_test.py
+++ b/autobot-backend/workers/audit_queries_test.py
@@ -1,0 +1,204 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+""" "Deferred" and "found nothing" must not be the same output (#13570).
+
+`gh` was unauthenticated for the service account. The worker logged CRITICAL —
+"N audit finding(s) deferred to the Redis dead-letter queue instead of being
+filed" — and `LLEN audit:deferred_findings` was 0. The reassuring message stated
+the findings were preserved when they were not.
+
+The filing path itself was fixed. These tests hold the two queries the tasks make
+*before* they file, which carried the identical defect one level down: each
+returned an empty list whether the query succeeded and found nothing or failed
+outright, so the caller could not tell an observation from the absence of one.
+
+Every test pairs the failure case with its success twin. A query that always
+reported "unobserved" would satisfy the failure half alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from workers.audit_queries import list_open_issue_titles, vulture_scan
+from workers.audit_tasks import _STATUS_DEGRADED, _STATUS_SUCCESS, audit_dead_code, audit_testgaps
+
+_ENV: dict[str, str] = {}
+
+
+def _runner(code: int, out: str = "", err: str = ""):
+    return lambda *_args, **_kwargs: (code, out, err)
+
+
+# ---------------------------------------------------------------------------
+# gh issue list
+# ---------------------------------------------------------------------------
+
+
+def test_an_unauthenticated_listing_is_not_an_empty_repo(caplog):
+    with caplog.at_level("ERROR"):
+        titles, observed = list_open_issue_titles(
+            "owner/repo", "observability", _ENV, _runner(1, err="gh auth status: not logged in")
+        )
+
+    assert titles == []
+    assert observed is False, "a failed listing reported itself as an observed empty repo"
+    assert "blind to duplicates" in caplog.text
+    assert "not logged in" in caplog.text, "the CLI's own reason was swallowed"
+
+
+def test_a_genuinely_empty_listing_is_observed():
+    """The other half of the discrimination — and the reason the bug hid."""
+    titles, observed = list_open_issue_titles("owner/repo", None, _ENV, _runner(0, out="[]"))
+
+    assert titles == []
+    assert observed is True
+
+
+def test_titles_come_back_when_the_listing_works():
+    titles, observed = list_open_issue_titles(
+        "owner/repo", None, _ENV, _runner(0, out='[{"title": "discovery: a"}, {"title": "discovery: b"}]')
+    )
+
+    assert titles == ["discovery: a", "discovery: b"]
+    assert observed is True
+
+
+@pytest.mark.parametrize("payload", ["not json at all", '[{"headline": "wrong key"}]', '{"not": "a list"}'])
+def test_output_the_worker_cannot_read_is_unobserved(payload):
+    titles, observed = list_open_issue_titles("owner/repo", None, _ENV, _runner(0, out=payload))
+
+    assert titles == []
+    assert observed is False, "unreadable output was reported as a clean, empty listing"
+
+
+# ---------------------------------------------------------------------------
+# vulture
+# ---------------------------------------------------------------------------
+
+
+def test_a_vulture_that_cannot_start_is_not_a_clean_scan(caplog):
+    """`python -m vulture` with the module absent exits 1 and prints nothing.
+
+    Exit 1 is also vulture's "I found dead code" code, so the old check let this
+    through and returned the empty list a clean scan returns.
+    """
+    with caplog.at_level("ERROR"):
+        lines, observed = vulture_scan(Path("/repo"), _runner(1, err="No module named vulture"), "python3")
+
+    assert lines == []
+    assert observed is False
+    assert "NO dead-code observation" in caplog.text
+
+
+def test_a_clean_vulture_scan_is_observed():
+    lines, observed = vulture_scan(Path("/repo"), _runner(0), "python3")
+
+    assert lines == []
+    assert observed is True, "a genuinely clean scan was reported as un-run"
+
+
+def test_vulture_findings_are_observed():
+    lines, observed = vulture_scan(
+        Path("/repo"), _runner(1, out="a.py:1: unused function 'f' (80% confidence)\n"), "python3"
+    )
+
+    assert lines == ["a.py:1: unused function 'f' (80% confidence)"]
+    assert observed is True
+
+
+def test_a_crashed_vulture_is_unobserved():
+    lines, observed = vulture_scan(Path("/repo"), _runner(2, err="traceback"), "python3")
+
+    assert (lines, observed) == ([], False)
+
+
+# ---------------------------------------------------------------------------
+# What the tasks do with an unobserved query
+# ---------------------------------------------------------------------------
+
+
+def _finding(title: str = "discovery: missing test — a.py") -> dict:
+    return {"title": title, "body": "body"}
+
+
+def _redis_double() -> MagicMock:
+    """A Redis stand-in whose dead-letter key is genuinely absent, not unreadable."""
+    return MagicMock(**{"exists.return_value": 0})
+
+
+def test_a_run_blind_to_duplicates_defers_instead_of_refiling(tmp_path):
+    """An empty dedupe set for want of an answer must not license re-filing.
+
+    `gh` works, the listing does not. Filing here would re-open every issue the
+    daemon has ever filed.
+    """
+    stored: dict[str, object] = {}
+
+    with (
+        patch("workers.audit_tasks._get_redis", return_value=_redis_double()),
+        patch("workers.audit_tasks._gh_available", return_value=True),
+        patch("workers.audit_tasks._redis_get", side_effect=lambda _r, k: stored.get(k)),
+        patch("workers.audit_tasks._redis_set", side_effect=lambda _r, k, v, **_kw: stored.__setitem__(k, v) or True),
+        patch("workers.audit_tasks._repo_root", return_value=tmp_path),
+        patch("workers.audit_tasks._testgap_findings", return_value=[_finding()]),
+        patch("workers.audit_tasks._changed_python_modules", return_value=[tmp_path / "a.py"]),
+        patch("workers.audit_tasks._list_open_issues", return_value=([], False)),
+        patch("workers.audit_tasks._file_issue", return_value=True) as file_issue,
+    ):
+        result = audit_testgaps.run()
+
+    assert file_issue.call_count == 0, "a run that could not see the open issues filed anyway"
+    assert result["issues_filed"] == 0
+    assert result["issues_deferred"] == 1, "the finding was neither filed nor parked"
+    assert result["filing_available"] is False
+    assert result["status"] == _STATUS_DEGRADED, "a blind run reported success"
+
+
+def test_a_dead_code_scan_that_never_ran_never_reports_success(tmp_path):
+    """`total_findings: 0, status: success` for a scan that did not happen."""
+    stored: dict[str, object] = {"audit:dead_code:last_inventory": ["a.py:1: unused function 'f'"]}
+
+    with (
+        patch("workers.audit_tasks._get_redis", return_value=_redis_double()),
+        patch("workers.audit_tasks._gh_available", return_value=True),
+        patch("workers.audit_tasks._redis_get", side_effect=lambda _r, k: stored.get(k)),
+        patch("workers.audit_tasks._redis_set", side_effect=lambda _r, k, v, **_kw: stored.__setitem__(k, v) or True),
+        patch("workers.audit_tasks._repo_root", return_value=tmp_path),
+        patch("workers.audit_tasks._run_vulture", return_value=([], False)),
+        patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
+        patch("workers.audit_tasks._file_issue", return_value=True),
+    ):
+        result = audit_dead_code.run()
+
+    assert result["scan_ran"] is False
+    assert result["status"] == _STATUS_DEGRADED, "a scan that never ran reported success"
+    assert stored["audit:dead_code:last_inventory"] == [
+        "a.py:1: unused function 'f'"
+    ], "an un-run scan wiped the baseline — the next real run would re-file everything"
+
+
+def test_a_scan_that_did_run_and_found_nothing_still_reports_success(tmp_path):
+    """The success twin: 'no dead code' remains a perfectly good clean result."""
+    stored: dict[str, object] = {"audit:dead_code:last_inventory": ["a.py:1: unused function 'f'"]}
+
+    with (
+        patch("workers.audit_tasks._get_redis", return_value=_redis_double()),
+        patch("workers.audit_tasks._gh_available", return_value=True),
+        patch("workers.audit_tasks._redis_get", side_effect=lambda _r, k: stored.get(k)),
+        patch("workers.audit_tasks._redis_set", side_effect=lambda _r, k, v, **_kw: stored.__setitem__(k, v) or True),
+        patch("workers.audit_tasks._repo_root", return_value=tmp_path),
+        patch("workers.audit_tasks._run_vulture", return_value=([], True)),
+        patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
+        patch("workers.audit_tasks._file_issue", return_value=True),
+    ):
+        result = audit_dead_code.run()
+
+    assert result["scan_ran"] is True
+    assert result["status"] == _STATUS_SUCCESS
+    assert stored["audit:dead_code:last_inventory"] == [], "an observed clean scan must refresh the baseline"

--- a/autobot-backend/workers/audit_tasks.py
+++ b/autobot-backend/workers/audit_tasks.py
@@ -31,6 +31,7 @@ from autobot_shared.async_compat import run_or_schedule
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.time_utils import utc_timestamp
 from celery_app import celery_app
+from workers.audit_queries import MAX_LOG_CHARS, list_open_issue_titles, vulture_scan
 
 logger = get_logger(__name__)
 
@@ -67,9 +68,6 @@ _FILING_CREDENTIAL_VAULT_KEY = "github_issue_filing_token"
 
 # Labels applied to all discovery issues filed by this daemon
 _AUDIT_LABELS = "enhancement,observability,priority: medium"
-
-# Max characters of gh output kept in logs on failure
-_MAX_LOG_CHARS = 500
 
 # Cap on the full-findings dump written when the dead-letter queue itself cannot
 # be persisted (#13570). Generous: at that point the log IS the queue, and a
@@ -352,30 +350,14 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent.parent
 
 
-def _list_open_issues(label: str | None = None) -> list[str]:
-    """Return titles of open GitHub issues (optionally filtered by label)."""
-    cmd = [
-        "gh",
-        "issue",
-        "list",
-        "--repo",
-        _GH_REPO,
-        "--state",
-        "open",
-        "--json",
-        "title",
-        "--limit",
-        "500",
-    ]
-    if label:
-        cmd += ["--label", label]
-    code, out, _ = _run(cmd, env=_gh_env()[0])
-    if code != 0:
-        return []
-    try:
-        return [item["title"] for item in json.loads(out)]
-    except Exception:
-        return []
+def _list_open_issues(label: str | None = None) -> tuple[list[str], bool]:
+    """Titles of open issues, and whether the listing was actually observed.
+
+    #13570: this returned a bare `[]` on failure, which is what a repo with no
+    open issues returns. "I could not look" and "there is nothing there" were
+    one answer, and the caller acted on the second.
+    """
+    return list_open_issue_titles(_GH_REPO, label, _gh_env()[0], _run)
 
 
 def _gh_available() -> bool:
@@ -416,7 +398,7 @@ def _gh_available() -> bool:
             _FILING_CREDENTIAL_VAULT_KEY,
             # stdout as well as stderr: gh routes this message to stderr today,
             # but a build that changed that would gut the diagnostic silently.
-            ((err or "").strip() or (out or "").strip())[:_MAX_LOG_CHARS] or "no output",
+            ((err or "").strip() or (out or "").strip())[:MAX_LOG_CHARS] or "no output",
         )
     return code == 0
 
@@ -440,7 +422,7 @@ def _file_issue(title: str, body: str, labels: str = _AUDIT_LABELS) -> bool:
         env=_gh_env()[0],
     )
     if code != 0:
-        logger.error("gh issue create failed (%s): %s", title, err[:_MAX_LOG_CHARS])
+        logger.error("gh issue create failed (%s): %s", title, err[:MAX_LOG_CHARS])
         return False
     return True
 
@@ -549,6 +531,7 @@ def _dedupe_and_file(
     existing_titles: set[str],
     label: str,
     redis=None,
+    dedupe_ok: bool = True,
 ) -> FilingOutcome:
     """File GitHub issues for new findings; persist any that cannot be filed.
 
@@ -564,7 +547,12 @@ def _dedupe_and_file(
     a queue that could not be written reported ``deferred == 0``, exactly like a
     clean run (#13570).
     """
-    gh_ok = _gh_available()
+    # `dedupe_ok` False means the open-issue listing never happened, so
+    # `existing_titles` is empty for want of an answer rather than because the
+    # repo is clean. Filing on that would re-file everything already open.
+    # Deferring instead is the only outcome that does not act on an
+    # unobserved fact -- the queue is retried once the query works (#13570).
+    gh_ok = _gh_available() and dedupe_ok
     pending, queue_readable = _load_deferred(redis)
 
     filed = 0
@@ -817,8 +805,8 @@ def audit_testgaps(self) -> dict:
     modules = _changed_python_modules(last_run, repo_root)
 
     findings = _testgap_findings(modules, repo_root)
-    existing_titles = set(_list_open_issues(label="observability"))
-    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    existing_titles, dedupe_ok = _list_open_issues(label="observability")
+    outcome = _dedupe_and_file(findings, set(existing_titles), _AUDIT_LABELS, redis, dedupe_ok=dedupe_ok)
 
     _redis_set(redis, _TESTGAPS_LAST_RUN_KEY, run_at)
 
@@ -850,23 +838,9 @@ def audit_testgaps(self) -> dict:
 # ---------------------------------------------------------------------------
 
 
-def _run_vulture(repo_root: Path) -> list[str]:
-    """Run vulture on the backend and return lines identifying dead code."""
-    cmd = [
-        sys.executable,
-        "-m",
-        "vulture",
-        "autobot-backend",
-        "--min-confidence",
-        "80",
-        "--exclude",
-        "*/migrations/*,*/__pycache__/*,*/tests/*",
-    ]
-    code, out, err = _run(cmd, cwd=str(repo_root))
-    if code not in (0, 1):  # vulture exits 1 when dead code found
-        logger.warning("vulture exited %d: %s", code, err[:_MAX_LOG_CHARS])
-        return []
-    return [line.strip() for line in out.splitlines() if line.strip()]
+def _run_vulture(repo_root: Path) -> tuple[list[str], bool]:
+    """Dead-code lines from vulture, and whether the scan actually ran (#13570)."""
+    return vulture_scan(repo_root, _run, sys.executable)
 
 
 def _dead_code_fingerprint(line: str) -> str:
@@ -890,7 +864,7 @@ def audit_dead_code(self) -> dict:
     last_set = set(last_inventory)
 
     repo_root = _repo_root()
-    current_lines = _run_vulture(repo_root)
+    current_lines, scan_ran = _run_vulture(repo_root)
     current_fps = {_dead_code_fingerprint(ln): ln for ln in current_lines}
 
     new_findings_raw = [v for k, v in current_fps.items() if k not in last_set]
@@ -907,15 +881,19 @@ def audit_dead_code(self) -> dict:
         )
         findings.append({"title": title, "body": body})
 
-    existing_titles = set(_list_open_issues(label="observability"))
-    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    existing_titles, dedupe_ok = _list_open_issues(label="observability")
+    outcome = _dedupe_and_file(findings, set(existing_titles), _AUDIT_LABELS, redis, dedupe_ok=dedupe_ok)
 
-    # Persist current full inventory for next run's diff
-    _redis_set(redis, _DEAD_CODE_INVENTORY_KEY, list(current_fps.keys()))
+    # Persist current full inventory for next run's diff -- but ONLY when there
+    # was a scan. Writing an empty inventory from a scan that never ran wipes the
+    # baseline, so the next successful run sees every finding as new (#13570).
+    if scan_ran:
+        _redis_set(redis, _DEAD_CODE_INVENTORY_KEY, list(current_fps.keys()))
 
     result = {
-        "status": _run_status(outcome),
+        "status": _run_status(outcome) if scan_ran else _STATUS_DEGRADED,
         "run_at": utc_timestamp(),
+        "scan_ran": scan_ran,
         "total_findings": len(current_lines),
         "new_findings": len(new_findings_raw),
         "issues_filed": outcome.filed,
@@ -1071,8 +1049,8 @@ def audit_claims(self) -> dict:
         )
         findings.append({"title": title, "body": body})
 
-    existing_titles = set(_list_open_issues(label="observability"))
-    outcome = _dedupe_and_file(findings, existing_titles, _AUDIT_LABELS, redis)
+    existing_titles, dedupe_ok = _list_open_issues(label="observability")
+    outcome = _dedupe_and_file(findings, set(existing_titles), _AUDIT_LABELS, redis, dedupe_ok=dedupe_ok)
 
     _redis_set(redis, _CLAIMS_LAST_RUN_KEY, run_at)
     _redis_set(

--- a/autobot-backend/workers/audit_tasks_test.py
+++ b/autobot-backend/workers/audit_tasks_test.py
@@ -326,7 +326,7 @@ class TestAuditTestgaps:
             return True
 
         def fake_list_open(label=None):
-            return list(open_issues)
+            return list(open_issues), True
 
         with (
             patch("workers.audit_tasks._get_redis", return_value=MagicMock()),
@@ -353,7 +353,7 @@ class TestAuditTestgaps:
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._changed_python_modules", return_value=[]),
             patch("workers.audit_tasks._repo_root", return_value=tmp_path),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
             result = audit_testgaps.run()
@@ -386,8 +386,8 @@ class TestAuditDeadCode:
                 side_effect=lambda _, k: inventory.get(k),
             ),
             patch("workers.audit_tasks._redis_set"),
-            patch("workers.audit_tasks._run_vulture", return_value=[finding]),
-            patch("workers.audit_tasks._list_open_issues", return_value=list(open_issues)),
+            patch("workers.audit_tasks._run_vulture", return_value=([finding], True)),
+            patch("workers.audit_tasks._list_open_issues", return_value=(list(open_issues), True)),
             patch("workers.audit_tasks._file_issue", side_effect=fake_file_issue),
         ):
             result = audit_dead_code.run()
@@ -408,8 +408,8 @@ class TestAuditDeadCode:
             patch("workers.audit_tasks._gh_available", return_value=True),
             patch("workers.audit_tasks._redis_get", return_value=[]),  # empty prior inventory
             patch("workers.audit_tasks._redis_set"),
-            patch("workers.audit_tasks._run_vulture", return_value=[finding]),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._run_vulture", return_value=([finding], True)),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._file_issue", side_effect=fake_file_issue),
         ):
             result = audit_dead_code.run()
@@ -434,10 +434,10 @@ class TestAuditDeadCode:
                 "workers.audit_tasks._redis_set",
                 side_effect=lambda _, k, v, **kw: stored.update({k: v}),
             ),
-            patch("workers.audit_tasks._run_vulture", return_value=[finding]),
+            patch("workers.audit_tasks._run_vulture", return_value=([finding], True)),
             patch(
                 "workers.audit_tasks._list_open_issues",
-                side_effect=lambda **kw: list(open_issues),
+                side_effect=lambda **kw: (list(open_issues), True),
             ),
             patch("workers.audit_tasks._file_issue", side_effect=fake_file_issue),
         ):
@@ -471,7 +471,7 @@ class TestAuditClaims:
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._repo_root", return_value=tmp_path),
             patch("workers.audit_tasks._verify_claim", return_value=False),
-            patch("workers.audit_tasks._list_open_issues", return_value=list(open_issues)),
+            patch("workers.audit_tasks._list_open_issues", return_value=(list(open_issues), True)),
             patch("workers.audit_tasks._file_issue") as mock_file,
         ):
             result = audit_claims.run()
@@ -491,7 +491,7 @@ class TestAuditClaims:
             patch("workers.audit_tasks._redis_set"),
             patch("workers.audit_tasks._repo_root", return_value=tmp_path),
             patch("workers.audit_tasks._verify_claim", return_value=False),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._file_issue", return_value=True) as mock_file,
         ):
             result = audit_claims.run()
@@ -1146,7 +1146,7 @@ class TestTaskResultsCarryTheStatus:
             patch("workers.audit_tasks._get_redis", return_value=None),
             patch("workers.audit_tasks._redis_get", return_value=None),
             patch("workers.audit_tasks._redis_set", return_value=True),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._changed_python_modules", return_value=[]),
             patch(
                 "workers.audit_tasks._dedupe_and_file",
@@ -1166,7 +1166,7 @@ class TestTaskResultsCarryTheStatus:
             patch("workers.audit_tasks._get_redis", return_value=None),
             patch("workers.audit_tasks._redis_get", return_value=None),
             patch("workers.audit_tasks._redis_set", return_value=True),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._changed_python_modules", return_value=[]),
             patch(
                 "workers.audit_tasks._dedupe_and_file",
@@ -1184,7 +1184,7 @@ class TestTaskResultsCarryTheStatus:
             patch("workers.audit_tasks._get_redis", return_value=None),
             patch("workers.audit_tasks._redis_get", return_value=None),
             patch("workers.audit_tasks._redis_set", return_value=True),
-            patch("workers.audit_tasks._list_open_issues", return_value=[]),
+            patch("workers.audit_tasks._list_open_issues", return_value=([], True)),
             patch("workers.audit_tasks._changed_python_modules", return_value=[]),
             patch(
                 "workers.audit_tasks._dedupe_and_file",

--- a/autobot-infrastructure/shared/scripts/deployment/validate_access_control.sh
+++ b/autobot-infrastructure/shared/scripts/deployment/validate_access_control.sh
@@ -22,7 +22,27 @@
 #   ./validate_access_control.sh --full
 ################################################################################
 
+# `set -e` stays (#14869): removing it would trade one silent failure for
+# another -- an unexpected abort would then continue on a broken interpreter and
+# report verdicts it never measured. What changes is that no check reaches the
+# shell as a bare failing command any more:
+#
+#   * every python probe runs through `run_python_check`, whose invocation sits
+#     in an `if` condition, so a crash is a captured return code rather than an
+#     abort;
+#   * the counters use arithmetic ASSIGNMENT. `((TESTS_PASSED++))` is a
+#     post-increment: with the counter at 0 the expression evaluates to 0, which
+#     `((...))` reports as exit status 1. Under `set -e` that aborted the run on
+#     the FIRST PASS -- the suite printed one verdict, never printed a summary,
+#     and exited 1, which reads as "some tests failed";
+#   * `pipefail` so a failing producer in a pipeline cannot be masked by a
+#     succeeding consumer.
+#
+# `set -u` is deliberately NOT set: several lookups here are legitimately
+# optional and use `${VAR:-default}`, and adding -u now would convert those into
+# the same class of mid-run abort this file exists to remove.
 set -e
+set -o pipefail
 
 # Colors
 RED='\033[0;31m'
@@ -31,6 +51,13 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
 NC='\033[0m'
+
+# Exit code a python probe uses to say "I ran, and the thing I check is broken".
+# Any OTHER non-zero code means the probe could not run at all -- a missing
+# import, an unreachable service, a syntax error. The two must not collapse into
+# one verdict: an uncaught exception also exits 1, so before this the shell read
+# "the check failed" and "the check never happened" as the same answer (#14869).
+CHECK_FAILED_RC=20
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -65,6 +92,15 @@ PERFORMANCE_ONLY=false
 TESTS_PASSED=0
 TESTS_FAILED=0
 TESTS_WARNED=0
+# Checks that could not run. Counted separately from FAIL because they are a
+# different fact: FAIL is a measurement, ERROR is the absence of one. Both make
+# the run exit non-zero, so neither can be mistaken for a clean suite.
+TESTS_ERRORED=0
+
+# Set by print_summary. The EXIT trap uses it to tell "the suite finished and
+# reported" apart from "the suite died partway and the last thing on screen was
+# an unrelated PASS" -- the exact reading that hid #14869.
+VALIDATION_COMPLETED=false
 
 # Logging functions
 log_header() {
@@ -83,28 +119,85 @@ log_test() {
 
 log_pass() {
     echo -e "${GREEN}PASS${NC}"
-    ((TESTS_PASSED++))
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 log_fail() {
     echo -e "${RED}FAIL${NC} - $1"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
 log_warn() {
     echo -e "${YELLOW}WARN${NC} - $1"
-    ((TESTS_WARNED++))
+    TESTS_WARNED=$((TESTS_WARNED + 1))
+}
+
+# A check that could not run. Never PASS, and never a bare FAIL: the operator
+# has to know the difference between "access control is broken" and "this suite
+# could not tell you anything about access control".
+log_error() {
+    echo -e "${RED}ERROR${NC} - could not run: $1"
+    if [ -n "${2:-}" ]; then
+        echo "$2" | tail -n 5 | sed 's/^/      | /'
+    fi
+    TESTS_ERRORED=$((TESTS_ERRORED + 1))
+}
+
+# Usage/config errors, which are not a test verdict and must not move a counter.
+log_fatal() {
+    echo -e "${RED}FATAL${NC} - $1" >&2
 }
 
 log_info() {
     echo -e "${GREEN}[INFO]${NC} $1"
 }
 
+# Run a python3 probe without ever aborting the suite (#14869).
+#
+# Publishes PY_RC / PY_OUT / PY_ERR. The invocation lives in an `if` condition,
+# which is the one context `set -e` exempts, so a traceback becomes a return
+# code the caller can classify instead of killing the run before the caller's
+# own `if [ $? -eq 0 ]` is ever reached.
+run_python_check() {
+    local err_file
+    PY_OUT=""
+    PY_ERR=""
+    PY_RC=0
+    err_file="$(mktemp)"
+    if PY_OUT="$(python3 -c "$1" 2>"${err_file}")"; then
+        PY_RC=0
+    else
+        PY_RC=$?
+    fi
+    PY_ERR="$(cat "${err_file}")"
+    rm -f "${err_file}"
+    return 0
+}
+
+# Numeric less-than without bc. `bc` is absent from most base images, and the
+# old `(( $(echo "$x < 10" | bc -l) ))` form evaluated an EMPTY string there,
+# which is 0, which reported the target as missed -- a fabricated WARN about a
+# measurement that was never compared (#14869).
+num_lt() {
+    awk -v a="$1" -v b="$2" 'BEGIN { exit !(a + 0 < b + 0) }'
+}
+
+# Report an ERROR when a probe could not run, or a FAIL when it ran and failed.
+classify_probe() {
+    local what="$1"
+    if [ "${PY_RC}" -eq "${CHECK_FAILED_RC}" ]; then
+        log_fail "${what}"
+    else
+        log_error "${what} (probe exited ${PY_RC})" "${PY_ERR}"
+    fi
+}
+
 # Test: Feature flags system exists
 test_feature_flags_exists() {
     log_test "Feature flags system exists"
 
-    if python3 -c "from services.feature_flags import get_feature_flags"; then
+    run_python_check "from services.feature_flags import get_feature_flags"
+    if [ "${PY_RC}" -eq 0 ]; then
         log_pass
     else
         log_fail "Cannot import feature_flags module"
@@ -115,23 +208,30 @@ test_feature_flags_exists() {
 test_get_enforcement_mode() {
     log_test "Get current enforcement mode"
 
-    local mode=$(python3 -c "
+    local program
+    program="$(cat <<'PY'
 import asyncio
 from services.feature_flags import get_feature_flags
+
 
 async def main():
     flags = await get_feature_flags()
     mode = await flags.get_enforcement_mode()
     print(mode.value)
 
-asyncio.run(main())
-")
 
-    if [ -n "$mode" ]; then
+asyncio.run(main())
+PY
+)"
+    run_python_check "${program}"
+
+    if [ "${PY_RC}" -ne 0 ]; then
+        log_error "enforcement-mode probe" "${PY_ERR}"
+    elif [ -n "${PY_OUT}" ]; then
         log_pass
-        log_info "Current mode: $mode"
+        log_info "Current mode: ${PY_OUT}"
     else
-        log_fail "Cannot get enforcement mode"
+        log_fail "Enforcement mode resolved to an empty value"
     fi
 }
 
@@ -139,54 +239,62 @@ asyncio.run(main())
 test_ownership_coverage() {
     log_test "Session ownership coverage"
 
-    local result=$(python3 -c "
+    local program total owned coverage
+    program="$(cat <<'PY'
 import asyncio
+
 from autobot_shared.redis_client import get_redis_client as get_redis_manager
 from security.session_ownership import SessionOwnershipValidator
+
+
+async def _count(redis, pattern):
+    cursor = 0
+    seen = 0
+    while True:
+        cursor, keys = await redis.scan(cursor, match=pattern, count=100)
+        seen += len(keys)
+        if cursor == 0:
+            return seen
+
 
 async def main():
     # Exactly what security/session_ownership.py:836 does. Calling it bare
     # returns the SYNC client (async_client defaults to False), so awaiting it
     # raises TypeError, and a .main() attribute exists on neither client. That
     # turned an import-time failure into a call-time one, which is the same
-    # defect a step later (#14866). Written without backticks on purpose: this
-    # block is a DOUBLE-QUOTED shell argument, so a backtick is command
-    # substitution -- bash ran the words inside it and handed python a mangled
-    # program, which no amount of import fixing could have made work (#14880).
+    # defect a step later (#14866). This program is now fed to python through a
+    # SINGLE-QUOTED heredoc, so the shell no longer touches its contents at all
+    # -- previously it was a double-quoted argument, where a backtick was
+    # command substitution and bash handed python a mangled program (#14880).
     redis = await get_redis_manager(async_client=True, database="main")
-
-    # Count total sessions
-    cursor = 0
-    total = 0
-    while True:
-        cursor, keys = await redis.scan(cursor, match='chat_session:*', count=100)
-        total += len(keys)
-        if cursor == 0:
-            break
-
-    # Count owned sessions
-    validator = SessionOwnershipValidator(redis)
-    cursor = 0
-    owned = 0
-    while True:
-        cursor, keys = await redis.scan(cursor, match='chat_session_owner:*', count=100)
-        owned += len(keys)
-        if cursor == 0:
-            break
-
+    SessionOwnershipValidator(redis)
+    total = await _count(redis, 'chat_session:*')
+    owned = await _count(redis, 'chat_session_owner:*')
     coverage = (owned / total * 100) if total > 0 else 100
     print(f'{total}|{owned}|{coverage:.1f}')
 
+
 asyncio.run(main())
-")
+PY
+)"
+    run_python_check "${program}"
 
-    IFS='|' read -r total owned coverage <<< "$result"
+    if [ "${PY_RC}" -ne 0 ]; then
+        log_error "ownership-coverage probe" "${PY_ERR}"
+        return 0
+    fi
 
-    if [ "$coverage" = "100.0" ] || [ "$total" = "0" ]; then
+    IFS='|' read -r total owned coverage <<< "${PY_OUT}"
+    if [ -z "${coverage}" ]; then
+        # The probe exited 0 without producing the triple it promises. That is a
+        # broken probe, not incomplete coverage -- reporting "Incomplete
+        # coverage: % (/ sessions)" here is what the old code did.
+        log_error "ownership-coverage probe returned no measurement" "${PY_OUT}"
+    elif [ "${coverage}" = "100.0" ] || [ "${total}" = "0" ]; then
         log_pass
-        log_info "Coverage: $coverage% ($owned/$total sessions)"
+        log_info "Coverage: ${coverage}% (${owned}/${total} sessions)"
     else
-        log_fail "Incomplete coverage: $coverage% ($owned/$total sessions)"
+        log_fail "Incomplete coverage: ${coverage}% (${owned}/${total} sessions)"
     fi
 }
 
@@ -194,39 +302,41 @@ asyncio.run(main())
 test_audit_logging() {
     log_test "Audit logging system"
 
-    python3 -c "
+    local program
+    program="$(cat <<'PY'
 import asyncio
+import sys
+
 from services.audit_logger import get_audit_logger
+
+CHECK_FAILED_RC = 20
+
 
 async def main():
     logger = await get_audit_logger()
-
-    # Test log write
     await logger.log(
         operation='validation.test',
         result='success',
         user_id='validator',
-        details={'test': True}
+        details={'test': True},
     )
     await logger.flush()
-
-    # Get statistics
     stats = await logger.get_statistics()
-    if stats.get('redis_available'):
-        print('OK')
-        return 0
-    else:
-        print('FAIL')
-        return 1
+    # Exit 0 or CHECK_FAILED_RC only. An uncaught exception exits 1, which is
+    # how "audit logging is broken" and "this probe never ran" used to be the
+    # same answer to the shell (#14869).
+    return 0 if stats.get('redis_available') else CHECK_FAILED_RC
 
-import sys
+
 sys.exit(asyncio.run(main()))
-"
+PY
+)"
+    run_python_check "${program}"
 
-    if [ $? -eq 0 ]; then
+    if [ "${PY_RC}" -eq 0 ]; then
         log_pass
     else
-        log_fail "Audit logging not working"
+        classify_probe "Audit logging not working"
     fi
 }
 
@@ -234,6 +344,10 @@ sys.exit(asyncio.run(main()))
 test_redis_connectivity() {
     log_test "Redis connectivity"
 
+    if ! command -v redis-cli > /dev/null 2>&1; then
+        log_error "redis-cli is not installed, so connectivity was never tested"
+        return 0
+    fi
     if redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping > /dev/null 2>&1; then
         log_pass
     else
@@ -245,6 +359,10 @@ test_redis_connectivity() {
 test_backend_health() {
     log_test "Backend API health"
 
+    if ! command -v curl > /dev/null 2>&1; then
+        log_error "curl is not installed, so backend health was never tested"
+        return 0
+    fi
     if curl -s -f -o /dev/null "http://$BACKEND_HOST:$BACKEND_PORT/api/health"; then
         log_pass
     else
@@ -252,108 +370,90 @@ test_backend_health() {
     fi
 }
 
+# Report a latency probe: ERROR when it produced no number, PASS/WARN otherwise.
+report_latency() {
+    local what="$1" target_ms="$2"
+    if [ "${PY_RC}" -ne 0 ]; then
+        log_error "${what} probe" "${PY_ERR}"
+    elif [ -z "${PY_OUT}" ]; then
+        log_error "${what} probe returned no measurement"
+    elif num_lt "${PY_OUT}" "${target_ms}"; then
+        log_pass
+        log_info "Average: ${PY_OUT}ms"
+    else
+        log_warn "Slower than target: ${PY_OUT}ms (target: <${target_ms}ms)"
+    fi
+}
+
 # Test: Ownership validation performance
 test_ownership_performance() {
     log_test "Ownership validation performance (<10ms)"
 
-    local result=$(python3 -c "
+    local program
+    program="$(cat <<'PY'
 import asyncio
 import time
+
 from autobot_shared.redis_client import get_redis_client as get_redis_manager
 from security.session_ownership import SessionOwnershipValidator
 
+
 async def main():
-    # Exactly what security/session_ownership.py:836 does. Calling it bare
-    # returns the SYNC client (async_client defaults to False), so awaiting it
-    # raises TypeError, and a .main() attribute exists on neither client. That
-    # turned an import-time failure into a call-time one, which is the same
-    # defect a step later (#14866). Written without backticks on purpose: this
-    # block is a DOUBLE-QUOTED shell argument, so a backtick is command
-    # substitution -- bash ran the words inside it and handed python a mangled
-    # program, which no amount of import fixing could have made work (#14880).
     redis = await get_redis_manager(async_client=True, database="main")
-
     validator = SessionOwnershipValidator(redis)
-
-    # Create test session
     test_session = 'test_perf_session_123'
     await validator.set_session_owner(test_session, 'testuser')
 
-    # Measure performance
     iterations = 100
     start = time.time()
-
     for _ in range(iterations):
         await validator.get_session_owner(test_session)
+    avg_ms = (time.time() - start) * 1000 / iterations
 
-    elapsed = (time.time() - start) * 1000  # ms
-    avg_ms = elapsed / iterations
-
-    # Cleanup
-    ownership_key = validator._get_ownership_key(test_session)
-    await redis.delete(ownership_key)
-
+    await redis.delete(validator._get_ownership_key(test_session))
     print(f'{avg_ms:.2f}')
 
-asyncio.run(main())
-")
 
-    if [ -n "$result" ]; then
-        if (( $(echo "$result < 10" | bc -l) )); then
-            log_pass
-            log_info "Average: ${result}ms"
-        else
-            log_warn "Slower than target: ${result}ms (target: <10ms)"
-        fi
-    else
-        log_fail "Performance test failed"
-    fi
+asyncio.run(main())
+PY
+)"
+    run_python_check "${program}"
+    report_latency "ownership-validation performance" 10
 }
 
 # Test: Audit logging performance
 test_audit_performance() {
     log_test "Audit logging performance (<5ms)"
 
-    local result=$(python3 -c "
+    local program
+    program="$(cat <<'PY'
 import asyncio
 import time
+
 from services.audit_logger import get_audit_logger
+
 
 async def main():
     logger = await get_audit_logger()
-
-    # Measure performance
     iterations = 100
     start = time.time()
-
     for i in range(iterations):
         await logger.log(
             operation='performance.test',
             result='success',
             user_id='perftest',
-            details={'iteration': i}
+            details={'iteration': i},
         )
-
-    elapsed = (time.time() - start) * 1000  # ms
-    avg_ms = elapsed / iterations
-
+    avg_ms = (time.time() - start) * 1000 / iterations
     await logger.flush()
-
     print(f'{avg_ms:.2f}')
 
-asyncio.run(main())
-")
 
-    if [ -n "$result" ]; then
-        if (( $(echo "$result < 5" | bc -l) )); then
-            log_pass
-            log_info "Average: ${result}ms"
-        else
-            log_warn "Slower than target: ${result}ms (target: <5ms)"
-        fi
-    else
-        log_fail "Audit performance test failed"
-    fi
+asyncio.run(main())
+PY
+)"
+    run_python_check "${program}"
+    report_latency "audit-logging performance" 5
 }
 
 # Test: Security - unauthorized access blocked
@@ -362,31 +462,34 @@ test_security_enforcement() {
 
     # This test would require actual HTTP requests to protected endpoints
     # Simplified version checks if enforcement mode can be set
-
-    python3 -c "
+    local program
+    program="$(cat <<'PY'
 import asyncio
-from services.feature_flags import get_feature_flags, EnforcementMode
+import sys
+
+from services.feature_flags import EnforcementMode, get_feature_flags
+
+CHECK_FAILED_RC = 20
+
 
 async def main():
     flags = await get_feature_flags()
-
-    # Test setting each mode
-    for mode in [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED]:
+    for mode in (EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED):
         await flags.set_enforcement_mode(mode)
-        current = await flags.get_enforcement_mode()
-        if current != mode:
-            return 1
-
+        if await flags.get_enforcement_mode() != mode:
+            return CHECK_FAILED_RC
     return 0
 
-import sys
-sys.exit(asyncio.run(main()))
-"
 
-    if [ $? -eq 0 ]; then
+sys.exit(asyncio.run(main()))
+PY
+)"
+    run_python_check "${program}"
+
+    if [ "${PY_RC}" -eq 0 ]; then
         log_pass
     else
-        log_fail "Cannot set enforcement modes"
+        classify_probe "Cannot set enforcement modes"
     fi
 }
 
@@ -430,22 +533,44 @@ print_summary() {
     echo
     log_header "Validation Summary"
 
-    local total=$((TESTS_PASSED + TESTS_FAILED + TESTS_WARNED))
+    local total=$((TESTS_PASSED + TESTS_FAILED + TESTS_WARNED + TESTS_ERRORED))
 
     echo "  Total Tests:     $total"
     echo -e "  ${GREEN}Passed:${NC}          $TESTS_PASSED"
     echo -e "  ${RED}Failed:${NC}          $TESTS_FAILED"
+    echo -e "  ${RED}Errored:${NC}         $TESTS_ERRORED (could not run)"
     echo -e "  ${YELLOW}Warnings:${NC}        $TESTS_WARNED"
     echo
 
-    if [ $TESTS_FAILED -eq 0 ]; then
-        echo -e "${GREEN}✓ All tests passed successfully${NC}"
-        return 0
-    else
-        echo -e "${RED}✗ Some tests failed - review errors above${NC}"
+    VALIDATION_COMPLETED=true
+
+    if [ "$TESTS_ERRORED" -gt 0 ]; then
+        echo -e "${RED}✗ ${TESTS_ERRORED} check(s) could not run - this suite cannot vouch for access control${NC}"
         return 1
     fi
+    if [ "$TESTS_FAILED" -eq 0 ]; then
+        echo -e "${GREEN}✓ All tests passed successfully${NC}"
+        return 0
+    fi
+    echo -e "${RED}✗ Some tests failed - review errors above${NC}"
+    return 1
 }
+
+# Say so when the suite dies before it reports (#14869).
+#
+# A run that aborts partway looks exactly like a run that finished: the last
+# line on screen is a passing check and the shell exits non-zero. Without this
+# there is nothing on screen that distinguishes the two.
+report_incomplete_run() {
+    local rc=$?
+    if [ "$VALIDATION_COMPLETED" != true ]; then
+        echo -e "${RED}✗ VALIDATION ABORTED before its summary (exit ${rc}).${NC}" >&2
+        echo "  Checks that had reported by then: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed, ${TESTS_ERRORED} errored, ${TESTS_WARNED} warned." >&2
+        echo "  Every check after the abort point NEVER RAN. Do not read this run as a result." >&2
+    fi
+    return 0
+}
+trap report_incomplete_run EXIT
 
 # Show usage
 show_usage() {
@@ -489,11 +614,16 @@ main() {
                 ;;
             -h|--help)
                 show_usage
+                VALIDATION_COMPLETED=true
                 exit 0
                 ;;
             *)
-                log_error "Unknown option: $1"
+                # `log_error` was called here and had never been defined, so
+                # under `set -e` this exited 127 from a "command not found"
+                # instead of printing the usage it goes on to print (#14869).
+                log_fatal "Unknown option: $1"
                 show_usage
+                VALIDATION_COMPLETED=true
                 exit 1
                 ;;
         esac

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -450,7 +450,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/utils/tool_pattern_analyzer.py": 918,
     "autobot-backend/utils/validators.py": 696,
     "autobot-backend/voice_interface.py": 910,
-    "autobot-backend/workers/audit_tasks.py": 1107,
+    "autobot-backend/workers/audit_tasks.py": 1085,
     "autobot-backend/workers/audit_tasks_test.py": 1197,
     "autobot-backend/workflow_scheduler.py": 1070,
     "autobot-frontend/tests/frontend_comprehensive_corrected_test.py": 1009,

--- a/repo_tests/validate_access_control_reporting_test.py
+++ b/repo_tests/validate_access_control_reporting_test.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The access-control validation suite must report, not abort (#14869).
+
+`validate_access_control.sh` ran under a bare `set -e` with two defects that
+both turned "something failed" into "the run finished":
+
+* ``((TESTS_PASSED++))`` is a POST-increment. With the counter at 0 the
+  expression evaluates to 0, which ``((...))`` reports as exit status 1, which
+  ``set -e`` treats as a fatal error. The suite therefore died on its FIRST
+  verdict -- one check printed, eight never ran, no summary, exit 1. On screen
+  that is indistinguishable from "the suite ran and something failed";
+* ``test_audit_logging`` and ``test_security_enforcement`` invoked ``python3 -c``
+  as bare statements, so a non-zero exit aborted the run before the
+  ``if [ $? -eq 0 ]`` beneath it could report FAIL.
+
+These tests drive the real script with stubbed ``python3`` / ``redis-cli`` on
+PATH, so no probe touches Redis, the backend, or the enforcement mode. The stub
+exit code is the whole experiment: 0 = healthy, 20 = the probe ran and the thing
+it checks is broken, anything else = the probe could not run at all.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts" / "deployment" / "validate_access_control.sh"
+
+# --security-only exercises the six checks that need no network: the three basic
+# ones and the three security ones. It skips the performance and infrastructure
+# sections, which is why curl never has to be stubbed.
+_MODE = "--security-only"
+
+_STUB = """#!/bin/sh
+if [ -n "${STUB_STDOUT}" ]; then printf '%s\\n' "${STUB_STDOUT}"; fi
+if [ -n "${STUB_STDERR}" ]; then printf '%s\\n' "${STUB_STDERR}" >&2; fi
+exit "${STUB_RC:-0}"
+"""
+
+# Every check label the suite prints. A run that reports fewer than all of them
+# stopped early, which is the defect.
+_CHECK_LABELS = (
+    "Feature flags system exists",
+    "Get current enforcement mode",
+    "Redis connectivity",
+    "Session ownership coverage",
+    "Audit logging system",
+    "Unauthorized access enforcement",
+)
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _stub_bin(tmp_path: Path) -> Path:
+    """A PATH front-end whose python3/redis-cli obey STUB_RC and STUB_STDOUT."""
+    bin_dir = tmp_path / "stub-bin"
+    bin_dir.mkdir()
+    for name in ("python3", "redis-cli"):
+        stub = bin_dir / name
+        stub.write_text(_STUB, encoding="utf-8")
+        stub.chmod(0o755)
+    return bin_dir
+
+
+def _run_suite(tmp_path: Path, *, rc: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = f"{_stub_bin(tmp_path)}{os.pathsep}{env['PATH']}"
+    env["STUB_RC"] = str(rc)
+    env["STUB_STDOUT"] = stdout
+    env["STUB_STDERR"] = stderr
+    result = subprocess.run(  # nosec B603 B607 - fixed path, no shell
+        ["bash", str(SCRIPT), _MODE],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+        check=False,
+    )
+    result.stdout = _ANSI.sub("", result.stdout)
+    result.stderr = _ANSI.sub("", result.stderr)
+    return result
+
+
+def _summary_count(output: str, label: str) -> int:
+    match = re.search(rf"^\s*{label}:\s+(\d+)", output, re.MULTILINE)
+    assert match, f"the summary has no '{label}' line:\n{output}"
+    return int(match.group(1))
+
+
+def test_a_healthy_run_reports_all_six_checks_and_a_summary(tmp_path):
+    """The counter regression, head on.
+
+    Against the old script this stops after the first PASS: one check reported,
+    five never run, no summary, exit 1 -- a healthy system reported as a failing
+    one, which is why nobody read the exit code as meaningful.
+    """
+    result = _run_suite(tmp_path, rc=0, stdout="4|4|100.0")
+
+    for label in _CHECK_LABELS:
+        assert label in result.stdout, f"the run never reached '{label}' — it aborted partway"
+    assert "Validation Summary" in result.stdout, "the run produced no summary at all"
+    assert _summary_count(result.stdout, "Passed") == len(_CHECK_LABELS)
+    assert result.returncode == 0, f"a clean run exited {result.returncode}:\n{result.stdout}"
+
+
+def test_a_crashing_probe_reports_error_and_the_run_continues(tmp_path):
+    """A probe that could not run says so, and does not take the suite with it."""
+    result = _run_suite(tmp_path, rc=1, stderr="ModuleNotFoundError: no such module")
+
+    for label in _CHECK_LABELS:
+        assert label in result.stdout, f"a crashing probe aborted the run before '{label}'"
+    # The two probes the issue names. Both exit 1 here, which is ALSO the code a
+    # genuine assertion failure used to use, so a classifier that collapses the
+    # two would report FAIL on this line.
+    assert "Audit logging system ... ERROR" in result.stdout
+    assert "Unauthorized access enforcement ... ERROR" in result.stdout
+    assert _summary_count(result.stdout, "Errored") > 0, "a crashed probe was not counted as un-run"
+    assert _summary_count(result.stdout, "Failed") == 2, (
+        "a crashed probe was counted as a measured failure — only the two checks whose "
+        "own semantics make a non-zero exit a real FAIL should be there"
+    )
+    assert "ModuleNotFoundError" in result.stdout, "the probe's own error was swallowed"
+    assert result.returncode != 0
+
+
+def test_a_failing_probe_reports_fail_not_error(tmp_path):
+    """'The check ran and it is broken' must not read as 'the check never ran'.
+
+    Both used to reach the shell as exit status 1 — an uncaught Python exception
+    exits 1 too — so the two verdicts were the same output. The probes now exit
+    20 for a real failure and the classifier keeps them apart.
+    """
+    result = _run_suite(tmp_path, rc=20)
+
+    assert "Audit logging system ... FAIL" in result.stdout
+    assert "Unauthorized access enforcement ... FAIL" in result.stdout
+    assert (
+        "Audit logging not working (probe exited" not in result.stdout
+    ), "a genuine FAIL was reported as an un-run check"
+    assert _summary_count(result.stdout, "Failed") > 0
+    assert result.returncode != 0
+
+
+def test_un_run_checks_dominate_the_verdict(tmp_path):
+    """An un-run check is the loudest thing in the summary, not a footnote.
+
+    The operator has to be told the difference between "access control is
+    broken" and "this suite could not tell you anything about access control".
+    The second is the reading that hid the original defect, so it takes
+    precedence in the closing verdict.
+    """
+    result = _run_suite(tmp_path, rc=127, stderr="python3: not found")
+
+    errored = _summary_count(result.stdout, "Errored")
+    assert errored > 0, "a missing interpreter was not counted as an un-run check"
+    assert f"{errored} check(s) could not run" in result.stdout
+    assert "All tests passed" not in result.stdout, "a suite that measured nothing reported success"
+    assert result.returncode != 0
+
+
+def test_an_unknown_option_prints_usage_instead_of_dying_on_a_missing_function(tmp_path):
+    """`log_error` was called here and had never been defined: exit 127, no usage."""
+    env = dict(os.environ)
+    env["PATH"] = f"{_stub_bin(tmp_path)}{os.pathsep}{env['PATH']}"
+    result = subprocess.run(  # nosec B603 B607 - fixed path, no shell
+        ["bash", str(SCRIPT), "--not-an-option"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 1, f"expected a usage error, got exit {result.returncode}"
+    assert "command not found" not in result.stderr
+    assert "Usage:" in _ANSI.sub("", result.stdout)
+
+
+@pytest.mark.parametrize(
+    "shape,why",
+    [
+        (r"\(\(\s*TESTS_\w+\+\+\s*\)\)", "post-increment returns 1 on the first bump and `set -e` aborts the run"),
+        (r"^\s*python3 -c", "a bare `python3 -c` statement under `set -e` aborts before its verdict is read"),
+    ],
+)
+def test_the_script_carries_neither_abort_shape(shape, why):
+    """Static floor: the two shapes that made a failure look like a finished run."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    offenders = [
+        f"{n}: {line.strip()}"
+        for n, line in enumerate(source.splitlines(), 1)
+        if re.search(shape, line) and not line.lstrip().startswith("#")
+    ]
+    assert not offenders, f"{why}:\n" + "\n".join(offenders)

--- a/repo_tests/validate_access_control_reporting_test.py
+++ b/repo_tests/validate_access_control_reporting_test.py
@@ -76,7 +76,7 @@ def _run_suite(tmp_path: Path, *, rc: int, stdout: str = "", stderr: str = "") -
     env["STUB_RC"] = str(rc)
     env["STUB_STDOUT"] = stdout
     env["STUB_STDERR"] = stderr
-    result = subprocess.run(  # nosec B603 B607 - fixed path, no shell
+    result = subprocess.run(  # nosec B603 B607  # fixed path, no shell
         ["bash", str(SCRIPT), _MODE],
         capture_output=True,
         text=True,
@@ -170,7 +170,7 @@ def test_an_unknown_option_prints_usage_instead_of_dying_on_a_missing_function(t
     """`log_error` was called here and had never been defined: exit 127, no usage."""
     env = dict(os.environ)
     env["PATH"] = f"{_stub_bin(tmp_path)}{os.pathsep}{env['PATH']}"
-    result = subprocess.run(  # nosec B603 B607 - fixed path, no shell
+    result = subprocess.run(  # nosec B603 B607  # fixed path, no shell
         ["bash", str(SCRIPT), "--not-an-option"],
         capture_output=True,
         text=True,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -445,7 +445,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/utils/tool_pattern_analyzer.py": 918,
     "autobot-backend/utils/validators.py": 696,
     "autobot-backend/voice_interface.py": 910,
-    "autobot-backend/workers/audit_tasks.py": 1107,
+    "autobot-backend/workers/audit_tasks.py": 1085,
     "autobot-backend/workers/audit_tasks_test.py": 1197,
     "autobot-backend/workflow_scheduler.py": 1070,
     "autobot-frontend/tests/frontend_comprehensive_corrected_test.py": 1009,


### PR DESCRIPTION
Closes #14869, #13281, #12969
Refs #13570

## Thinking Path

Four issues, one defect class: **something fails, and the failure presents as a
different, milder outcome — or as success.** A script that aborts mid-way looks
like a script that finished. A query that could not run returns the same empty
list a successful query returns when there is nothing there. A missing message
file yields "not found", which is itself a legitimate-looking error. A swallowed
`TypeError` becomes a generic degraded path. The user-visible symptom is never
"this broke" — it is "this said something reasonable that happened to be wrong",
which is why all four survived.

I derived each population rather than trusting the issue text, and in two cases
it was materially larger than reported.

**#14869 — the population is 9 checks, not 2.** The issue names two `python3 -c`
blocks that run as bare statements under `set -e`. Both are real. But the
dominant defect is one line up: `log_pass` ended in `((TESTS_PASSED++))`. That is
a post-increment — with the counter at `0` the expression *evaluates* to `0`,
which `((...))` reports as **exit status 1**, which `set -e` treats as fatal.
`log_fail` and `log_warn` are identical. So the suite died on its **first
verdict of any kind**, printed no summary, and exited 1. Reproduced against the
pre-change file with stubbed `python3`:

```
▶ Basic Functionality Tests
  Testing: Feature flags system exists ... PASS
EXIT=1                      # ← 5 further checks never ran; no summary
```

On a *healthy* system that reads as "the suite ran and something failed". Full
measured population in the table below.

**#13570 — the sharpest case, and the part that had not landed.** The filing
path itself was already fixed by #13859/#13860: the DLQ reports what it actually
stored, `FilingOutcome.lost` exists, and `check_filing_credential_at_startup`
runs on both `worker_ready` and `beat_init`. What survived is the identical
shape one level *up*, in the two queries the tasks make **before** they file:

| `file:line` (pre-change) | failure returned | success-with-nothing returned |
|---|---|---|
| `audit_tasks.py:373-378` `_list_open_issues` | `[]` | `[]` |
| `audit_tasks.py:866-869` `_run_vulture` | `[]` | `[]` |

Neither logged anything on the failure branch. The consequences are the ones the
issue is about: an unauthenticated `gh issue list` empties the dedupe set, so a
blind run would **re-file every issue the daemon has ever filed**; and a
`vulture` that cannot start made `audit_dead_code` report `total_findings: 0`,
`new_findings: 0`, `status: "success"` — a clean bill of health from a scan that
never ran — *and* overwrite the dead-code baseline with the empty result.

**#13281 — the keyword defect had already shipped; the handler shape had not.**
The `role=`/`metadata=` fix landed in PR #13279. What remained is the reason it
survived for so long: four broad handlers, all logging "non-fatal".

**#12969 — already fixed in code; what was missing was the oracle.** The
resolver anchors on this module's own location as well as `PATH.STATIC_DIR`, and
the fallback reports failure with every path it searched. Verified on the live
host (below). The gap was that every existing test monkeypatches `PATH` — a
resolver whose *every* candidate was wrong would still pass them all by
reporting its fallback honestly. Added the missing floor: `load_catalog()`
driven with no monkeypatching at all.

## What Changed

### `#14869` — `autobot-infrastructure/shared/scripts/deployment/validate_access_control.sh`

Measured population of "a failure changes the run's outcome without saying so":

| # | Old `file:line` | Shape | Now reports |
|---|---|---|---|
| 1 | `:86`, `:91`, `:96` | `((TESTS_PASSED++))` / `_FAILED` / `_WARNED` — post-increment returns 1 on the first bump | arithmetic **assignment**; the run reaches its summary |
| 2 | `:197-230` `test_audit_logging` | bare `python3 -c` under `set -e`; the `if [ $? -eq 0 ]` beneath was unreachable | runs via `run_python_check` (an `if` condition), reports FAIL or ERROR |
| 3 | `:366-390` `test_security_enforcement` | same | same |
| 4 | `:118`, `:142`, `:259`, `:317` | `local v=$(python3 …)` — `local` returns its **own** status, masking the probe's | probe rc captured separately; a crashed probe is ERROR, not a fabricated domain verdict |
| 5 | `:495` | `log_error` called and **never defined** → exit 127, usage never printed | `log_fatal` exists; unknown option exits 1 *and* prints usage |
| 6 | `:302`, `:348` | `(( $(echo "$x < 10" \| bc -l) ))` — with `bc` absent this evaluates an empty string, i.e. 0, i.e. "target missed" | `num_lt` via `awk`; no `bc` dependency |
| 7 | `:237`, `:248` | `redis-cli` / `curl` absent reported as "cannot connect" | `command -v` guard → ERROR, "connectivity was never tested" |

Item 4 is the subtlest: `test_ownership_coverage` printed
`FAIL - Incomplete coverage: % (/ sessions)` — a *domain verdict about access
control* — whenever the probe crashed.

`set -e` is **kept**, deliberately. Removing it would trade one silent failure
for another: the run would continue on a broken interpreter and report verdicts
it never measured. What changed is that no check reaches the shell as a bare
failing command. `set -o pipefail` added. `set -u` deliberately not added — several
lookups here are legitimately optional and use `${VAR:-default}`.

Two things are new rather than fixed:

* **an `ERROR` verdict distinct from `FAIL`**, with its own counter and summary
  line. FAIL is a measurement; ERROR is the absence of one. The probes now exit
  **20** for a measured failure, because an uncaught Python exception also exits
  1 — so before this, "audit logging is broken" and "this probe never ran" were
  the same output. `TESTS_ERRORED > 0` fails the run and takes precedence in the
  closing verdict;
* **an `EXIT` trap** that says so when the suite dies before its summary, naming
  what had reported by then and that everything after never ran.

The python programs also moved into single-quoted heredocs, so the shell no
longer touches their contents — the hazard #14880 was about.

### `#13570` — `autobot-backend/workers/audit_queries.py` (new)

The two queries moved out and now return `(result, observed)`. `observed` is
False whenever the query did not happen, and callers treat it as *no
information*, never as *no findings*. Both log the CLI's own reason.

`vulture_scan` discriminates on `exit 1 with empty stdout`: vulture exits 0 clean
and 1 when it *found* dead code, so exit 1 with nothing on stdout is neither — it
is the interpreter refusing to run the module.

In `audit_tasks.py`: `_dedupe_and_file` takes `dedupe_ok`, and a run blind to
duplicates **defers instead of filing** (`gh_ok = _gh_available() and dedupe_ok`);
`audit_dead_code` reports `scan_ran` and `status: degraded` for an un-run scan,
and no longer overwrites the baseline from one.

`audit_tasks.py` 1107 → **1085** lines; both ratchet entries lowered to 1085,
since the ratchet only turns down.

### `#13281` — `autobot-backend/services/agent_terminal/approval_handler.py`

Population: **4** broad handlers, all reachable on the approval path.

| Old `file:line` | Handler | Now |
|---|---|---|
| `:192` | `broadcast_approval_status`, inner publish | transient only |
| `:196` | `broadcast_approval_status`, outer wrapper | transient only |
| `:264` | `update_chat_approval_status` — **the one the issue names** | transient only |
| `:317` | `update_command_queue_status` | transient only |

`TRANSIENT_PERSISTENCE_ERRORS` is built from `autobot_shared.retry_mechanism.RETRYABLE_EXCEPTIONS`
(`ConnectionError`, `TimeoutError`, `OSError`) plus `RedisError` — not a second
hand-written list, so the two cannot drift. `RedisError` is needed because
redis-py's `ConnectionError`/`TimeoutError` descend from it, not from the
builtins.

No broad catch remains, so nothing needed the "log the type and re-raise"
fallback. Every message now names the exception **type**: `"non-fatal: <message>"`
told a reader nothing about whether it was a blip or a permanent code defect.

This is the behaviour change the issue flagged as needing its own review: a
`TypeError` on the approval path is now fatal to the turn rather than silently
discarding the write. That is the issue's stated intent — an approval whose
status is not recorded is worse than a visible failure.

### `#12969` — `autobot-backend/utils/error_catalog_resolution_test.py`

One test added, no production change needed. Also confirmed the "the fallback
mirrors `infrastructure/…` exactly" claim: the two repo copies differ **only** by
a 2-line copyright header (`diff` after trailing-space normalisation), and the
ansible role ships the `static/` copy, so no drift exists to fix.

## Verification

### Per-issue acceptance criteria

**#14869 — `Closes`**

| Criterion | Status | Evidence |
|---|---|---|
| Both blocks report FAIL and let the run continue | ✅ | `test_audit_logging` / `test_security_enforcement` use `run_python_check` + `classify_probe`; `test_a_failing_probe_reports_fail_not_error` asserts both print `... FAIL` |
| A failing check does not prevent later checks from running | ✅ | `test_a_crashing_probe_reports_error_and_the_run_continues` asserts all 6 labels appear |
| Audit the rest of the script for the same shape | ✅ | 7-row table above; 5 of the 7 rows are shapes the issue did not name |

**#13570 — `Refs`** (see "What remains")

| Fix item | Status | Evidence |
|---|---|---|
| 1. Token from the credential store, not ambient CLI auth | ✅ in code | `_resolve_filing_token` / `_read_filing_token` read the system vault via `EnvelopeSecretsService`; `_gh_env` reports `came_from_vault` rather than deriving it |
| 2. DLQ path verifiable — a failed push is an error, not a CRITICAL claiming success | ✅ | `_redis_set` returns a bool, `_log_unwritable_queue` dumps the findings, `FilingOutcome.lost`, `_report_deferral_outcome` emits only after the write was observed |
| 3. Fail loudly at startup, not per-finding | ✅ in code | `check_filing_credential_at_startup` on `worker_ready` **and** `beat_init`; writes the queryable `audit:filing_status` |
| (added) "deferred" and "found nothing" must not be the same output | ✅ | `audit_queries.py`; 13 tests in `audit_queries_test.py` |

**#12969 — `Closes`**

| Done when | Status | Evidence |
|---|---|---|
| Deployed catalog loaded on a live host — INFO naming the real path, no fallback warning | ✅ | live host logs, both processes, 2026-08-25: `utils.error_catalog - INFO - Loaded error catalog: 42 errors from <deployed backend>/static/error_messages.yaml` — one from the backend at 07:02:10, one from a celery ForkPoolWorker at 08:30:19. No `not found` line present |
| The failure message names the paths searched | ✅ | `error_catalog.py:526` logs `"Searched, in order: %s"` at **ERROR**; `test_the_failure_message_names_every_path_it_searched` |
| (this PR) an oracle that drives the real loader path | ✅ | `test_the_real_loader_path_finds_the_deployed_catalog` — no monkeypatching, asserts `source == yaml` and a non-empty catalog version |

**#13281 — `Closes`**

| Criterion | Status | Evidence |
|---|---|---|
| Catch only what is genuinely transient | ✅ | `TRANSIENT_PERSISTENCE_ERRORS`, derived from the canonical retryable set |
| Let `TypeError` / `AttributeError` propagate | ✅ | `test_a_signature_mismatch_reaches_the_caller`, `test_an_attribute_error_reaches_the_caller` |
| Check the sibling handlers in the same file | ✅ | 4/4 narrowed; `test_no_broad_except_exception_remains_in_the_handler` greps the removal rather than assuming it |
| Still degrade on a real storage failure | ✅ | 3 tests — narrowing that merely re-raised everything would be a different bug |

### Tests

```
166 passed
```

`repo_tests/validate_access_control_reporting_test.py` (7, new) ·
`autobot-backend/workers/audit_queries_test.py` (13, new) ·
`autobot-backend/workers/audit_tasks_test.py` (66, existing — updated for the
tuple returns, line count unchanged at its frozen 1197) ·
`.../approval_handler_error_surfacing_test.py` (8, new) ·
`error_catalog_resolution_test.py` (8) · `error_catalog_test.py` ·
`repo_tests/python_file_size_ratchet_test.py` (31).

The shell tests drive the **real script** with stubbed `python3`/`redis-cli` on
`PATH`, so no probe touches Redis, the backend, or the enforcement mode.

`black` · `isort` · `ruff check` (all pass) · `flake8 --max-line-length=120`
(0) · `bandit` (0 medium/high) · `test_ssot_config_lib.sh` (38 passed, required
whenever a `.sh` changes) · `lint-conventions.sh --staged` (clean).

### Mutation evidence

Every guarded line was mutated to prove its test can fail, then restored;
byte-identical restoration confirmed by `diff` against pre-mutation copies. No
mutation is pushed.

| # | Mutation | Result |
|---|---|---|
| M1 | `TESTS_PASSED=$((TESTS_PASSED + 1))` → `((TESTS_PASSED++))` | **2 failed** — the healthy-run test *and* the static shape guard |
| M2 | `classify_probe` → always `log_fail` (collapse ERROR into FAIL) | **survived first**; test tightened to assert `Audit logging system ... ERROR` and `Failed == 2` specifically, then **1 failed** |
| M3 | restore `except Exception` in `update_chat_approval_status` | **3 failed** |
| M4 | `list_open_issue_titles` returns `[], True` on a failed listing | **1 failed** |
| M5 | `vulture_scan` drops the empty-stdout discriminator | **1 failed** |
| M6 | `audit_dead_code` persists the inventory even when the scan never ran | **1 failed** |
| M6b | `_dedupe_and_file` ignores `dedupe_ok` | **1 failed** — `_file_issue.call_count == 1` |
| M7 | `load_catalog` returns `True` over the built-in fallback | **2 failed** |

M2 is worth calling out: it initially **passed**, because two *other* probes
were already reporting ERROR through their own paths, so `Errored > 0` held
while the classifier was broken. The oracle was measuring the wrong thing. A
mutation that a guard survives is the guard telling you what it does not check.

Each mutation was also checked for the "deletes its own oracle" failure mode:
none of them removes the assertion that catches it — M1 and M3 are caught by a
behavioural test *and* an independent static grep.

### What remains (why `#13570` is `Refs`, not `Closes`)

Fix items 1–3 are delivered and evidenced in code, and this PR closes the
"deferred vs found nothing" hole above them. What is **not** delivered is host
state, and nothing in a PR can deliver it:

* the system vault has no `github_issue_filing_token` entry, so the worker still
  falls back to ambient CLI auth. Storing it is an operator action through the
  secrets manager — introducing any code path that writes it would be exactly
  the parallel credential path this issue argues against;
* `audit:filing_status` is absent from every Redis DB on the live host, which
  means the startup guard has not run there yet — the deployed worker predates
  it. It appears on the next restart via the builtin updater.

Both are host actions on an issue whose title is a host fact, so it stays open
with the code side complete.

Also found and **not** fixed here, because it is a different task and a different
risk: `audit_tasks.py` `_verify_claim` returns `True` — *verified* — for any
claim whose token it cannot extract, and conflates `git grep`'s "no match" exit
with a genuine error. That inflates `audit_claims`' `verified` count with claims
nothing ever checked. Same defect class, filed as #15046 rather than folded in.

## Model Used

Claude Opus 5 (1M context)
