### PR TITLE
fix(sdk): give every autobot_sdk request the /api root and a real route (#15053)

### DIFF
--- a/libs/autobot-sdk-python/autobot_sdk/__init__.py
+++ b/libs/autobot-sdk-python/autobot_sdk/__init__.py
@@ -24,11 +24,12 @@ Resource paths are written without the ``/api`` root; the client adds it.
 
 from .autobot import AutoBot
 from .client import API_PREFIX, AutoBotClient, api_path, default_base_url
+from .defaults import DEFAULT_OFFSET, DEFAULT_PAGE_SIZE, DEFAULT_SEARCH_LIMIT
 from .models import (
-    AnalyticsPerformance,
-    AnalyticsUsage,
     AgentConfig,
     AgentHealth,
+    AnalyticsPerformance,
+    AnalyticsUsage,
     ChatMessage,
     DataResponse,
     KnowledgeAddResult,
@@ -49,6 +50,9 @@ __all__ = [
     "AutoBotClient",
     "api_path",
     "default_base_url",
+    "DEFAULT_OFFSET",
+    "DEFAULT_PAGE_SIZE",
+    "DEFAULT_SEARCH_LIMIT",
     "AnalyticsPerformance",
     "AnalyticsUsage",
     "AgentConfig",

--- a/libs/autobot-sdk-python/autobot_sdk/__init__.py
+++ b/libs/autobot-sdk-python/autobot_sdk/__init__.py
@@ -17,10 +17,13 @@ Quick start::
     asyncio.run(main())
 
 Auth: set AUTOBOT_API_TOKEN env var, or pass ``token=`` to AutoBot().
+
+Base URL: AUTOBOT_BASE_URL, else AUTOBOT_BACKEND_HOST/AUTOBOT_BACKEND_PORT.
+Resource paths are written without the ``/api`` root; the client adds it.
 """
 
 from .autobot import AutoBot
-from .client import AutoBotClient
+from .client import API_PREFIX, AutoBotClient, api_path, default_base_url
 from .models import (
     AnalyticsPerformance,
     AnalyticsUsage,
@@ -41,8 +44,11 @@ from .models import (
 )
 
 __all__ = [
+    "API_PREFIX",
     "AutoBot",
     "AutoBotClient",
+    "api_path",
+    "default_base_url",
     "AnalyticsPerformance",
     "AnalyticsUsage",
     "AgentConfig",

--- a/libs/autobot-sdk-python/autobot_sdk/client.py
+++ b/libs/autobot-sdk-python/autobot_sdk/client.py
@@ -11,10 +11,54 @@ from typing import Any
 
 import httpx
 
-from .models import DataResponse
+# Every core and optional router is mounted by the backend's application factory
+# at ``/api{registry_prefix}`` — a single loop, no exceptions (#15053). The only
+# mounts that are NOT under ``/api`` are the OpenAI/Anthropic compatibility
+# routers at ``/v1`` and the JWKS document at ``/.well-known``, and this SDK
+# exposes neither. So the prefix is a property of the whole surface and belongs
+# here, applied once, rather than repeated on fifteen resource paths where a
+# single omission is invisible until it 404s.
+API_PREFIX = "/api"
 
-_DEFAULT_BASE_URL = "http://localhost:8000"
+# The SDK ships as a standalone wheel (httpx + pydantic only) and cannot import
+# the platform's ``autobot_shared.ssot_config``. It reads the SAME environment
+# aliases that configuration declares, with the same defaults, so an installed
+# SDK agrees with the deployment it points at. ``repo_tests`` binds these to
+# ``config.port.backend`` so drift in either direction fails in CI.
+_HOST_ENV = "AUTOBOT_BACKEND_HOST"
+_PORT_ENV = "AUTOBOT_BACKEND_PORT"
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_PORT = "8001"
+_BASE_URL_ENV = "AUTOBOT_BASE_URL"
 _TOKEN_ENV = "AUTOBOT_API_TOKEN"
+
+
+def default_base_url() -> str:
+    """Origin of the AutoBot backend, from the environment.
+
+    ``AUTOBOT_BASE_URL`` wins outright; otherwise the origin is composed from
+    the backend host and port aliases. The port default is the backend's, not
+    the Service Lifecycle Manager's — pointing the SDK at the SLM answers every
+    AutoBot route with a 404 (#15053).
+    """
+    explicit = os.environ.get(_BASE_URL_ENV, "")
+    if explicit:
+        return explicit
+    host = os.environ.get(_HOST_ENV) or _DEFAULT_HOST
+    port = os.environ.get(_PORT_ENV) or _DEFAULT_PORT
+    return f"http://{host}:{port}"
+
+
+def api_path(path: str) -> str:
+    """Place a resource path under the backend's API root.
+
+    ``/chat/sessions`` -> ``/api/chat/sessions``. Idempotent, so a caller that
+    already spelled the prefix is not double-prefixed.
+    """
+    normalised = "/" + path.lstrip("/")
+    if normalised == API_PREFIX or normalised.startswith(f"{API_PREFIX}/"):
+        return normalised
+    return f"{API_PREFIX}{normalised}"
 
 
 class AutoBotClient:
@@ -24,6 +68,9 @@ class AutoBotClient:
 
         async with AutoBotClient() as client:
             result = await client.get("/chat/sessions")
+
+    Resource paths are written without the ``/api`` root; :func:`api_path`
+    adds it on every request.
     """
 
     def __init__(
@@ -32,10 +79,15 @@ class AutoBotClient:
         token: str | None = None,
         timeout: float = 30.0,
     ) -> None:
-        self._base_url = (base_url or os.environ.get("AUTOBOT_BASE_URL", _DEFAULT_BASE_URL)).rstrip("/")
+        self._base_url = (base_url or default_base_url()).rstrip("/")
         self._token = token or os.environ.get(_TOKEN_ENV, "")
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Backend origin this client dials, without the ``/api`` root."""
+        return self._base_url
 
     @property
     def _headers(self) -> dict[str, str]:
@@ -63,21 +115,22 @@ class AutoBotClient:
         return self._client
 
     async def get(self, path: str, **params: Any) -> dict[str, Any]:
-        r = await self._ensure_open().get(path, params={k: v for k, v in params.items() if v is not None})
+        query = {k: v for k, v in params.items() if v is not None}
+        r = await self._ensure_open().get(api_path(path), params=query)
         r.raise_for_status()
         return r.json()
 
     async def post(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
-        r = await self._ensure_open().post(path, json=body or {})
+        r = await self._ensure_open().post(api_path(path), json=body or {})
         r.raise_for_status()
         return r.json()
 
     async def put(self, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
-        r = await self._ensure_open().put(path, json=body or {})
+        r = await self._ensure_open().put(api_path(path), json=body or {})
         r.raise_for_status()
         return r.json()
 
     async def delete(self, path: str) -> dict[str, Any]:
-        r = await self._ensure_open().delete(path)
+        r = await self._ensure_open().delete(api_path(path))
         r.raise_for_status()
         return r.json()

--- a/libs/autobot-sdk-python/autobot_sdk/defaults.py
+++ b/libs/autobot-sdk-python/autobot_sdk/defaults.py
@@ -1,0 +1,27 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Pagination and search defaults for the SDK's resource methods.
+
+These mirror ``autobot_shared.ssot_constants.QueryDefaults`` value for value.
+They are *duplicated* rather than imported because this package ships to PyPI
+with two dependencies -- ``httpx`` and ``pydantic`` -- and importing the
+platform's shared module would drag the whole backend into a client install.
+
+Duplication is only safe if something stops it drifting: the client and the
+server would otherwise disagree about a page size while both looked correct in
+isolation. ``repo_tests/sdk_defaults_match_ssot_test.py`` pins every constant
+here against ``QueryDefaults`` and fails if either side moves alone.
+"""
+
+from __future__ import annotations
+
+#: Results returned by ``knowledge.search()`` when the caller does not say.
+DEFAULT_SEARCH_LIMIT: int = 10
+
+#: Rows per page for list endpoints when the caller does not say.
+DEFAULT_PAGE_SIZE: int = 50
+
+#: Where a list starts when the caller does not say.
+DEFAULT_OFFSET: int = 0

--- a/libs/autobot-sdk-python/autobot_sdk/models.py
+++ b/libs/autobot-sdk-python/autobot_sdk/models.py
@@ -86,10 +86,23 @@ class AgentHealth(BaseModel):
 
 
 class AgentConfig(BaseModel):
+    """One agent's configuration, as served flat by /api/agent_config/agents/{id}.
+
+    Not wrapped in a DataResponse envelope — that route returns the document
+    itself (#15053).
+    """
+
+    id: str | None = None
+    name: str | None = None
+    description: str | None = None
     enabled: bool | None = None
-    personality: str | None = None
-    model: str | None = None
-    settings: dict[str, Any] | None = None
+    current_model: str | None = None
+    default_model: str | None = None
+    provider: str | None = None
+    priority: int | None = None
+    status: str | None = None
+    tasks: list[str] | None = None
+    configuration_options: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/libs/autobot-sdk-python/autobot_sdk/resources/agents.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/agents.py
@@ -2,14 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Agent resource operations."""
+"""Agent resource operations.
+
+Paths are written without the ``/api`` root — ``AutoBotClient`` adds it.
+
+The agent surface spans two mounts, which is why a blanket prefix would not
+have been enough (#15053): the agent router is registered under ``/agent`` and
+per-agent configuration under ``/agent_config``, so ``/health/detailed`` is
+served at ``/api/agent/health/detailed``, two segments short of where the SDK
+used to ask for it.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 from ..client import AutoBotClient
-from ..models import AgentConfig, AgentHealth, DataResponse
+from ..models import AgentConfig, AgentHealth
 
 
 class AgentsResource:
@@ -17,16 +26,26 @@ class AgentsResource:
         self._c = client
 
     async def health(self) -> AgentHealth:
-        raw = await self._c.get("/health/detailed")
+        raw = await self._c.get("/agent/health/detailed")
         return AgentHealth.model_validate(raw)
 
-    async def get_config(self) -> DataResponse[AgentConfig]:
-        raw = await self._c.get("/agent/config")
-        return DataResponse[AgentConfig].model_validate(raw)
+    async def get_config(self, agent_id: str) -> AgentConfig:
+        """Configuration of one agent.
 
-    async def update_config(self, **fields: Any) -> DataResponse[AgentConfig]:
-        raw = await self._c.put("/agent/config", fields)
-        return DataResponse[AgentConfig].model_validate(raw)
+        The response is a flat document, not a ``DataResponse`` envelope.
+        """
+        raw = await self._c.get(f"/agent_config/agents/{agent_id}")
+        return AgentConfig.model_validate(raw)
+
+    async def set_model(self, agent_id: str, model: str, provider: str | None = None) -> dict[str, Any]:
+        body: dict[str, Any] = {"agent_id": agent_id, "model": model}
+        if provider:
+            body["provider"] = provider
+        return await self._c.post(f"/agent_config/agents/{agent_id}/model", body)
+
+    async def set_enabled(self, agent_id: str, enabled: bool) -> dict[str, Any]:
+        action = "enable" if enabled else "disable"
+        return await self._c.post(f"/agent_config/agents/{agent_id}/{action}")
 
     async def send_command(self, command: str, session_id: str | None = None) -> dict[str, Any]:
         body: dict[str, Any] = {"command": command}

--- a/libs/autobot-sdk-python/autobot_sdk/resources/analytics.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/analytics.py
@@ -2,7 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Analytics resource operations."""
+"""Analytics resource operations.
+
+Paths are written without the ``/api`` root — ``AutoBotClient`` adds it.
+
+``/analytics/usage`` and ``/analytics/performance`` are not routes: the
+analytics router serves ``usage/statistics`` and ``performance/metrics``
+under its ``/analytics`` mount (#15053).
+"""
 
 from __future__ import annotations
 
@@ -15,9 +22,9 @@ class AnalyticsResource:
         self._c = client
 
     async def usage(self, period: str = "day") -> DataResponse[AnalyticsUsage]:
-        raw = await self._c.get("/analytics/usage", period=period)
+        raw = await self._c.get("/analytics/usage/statistics", period=period)
         return DataResponse[AnalyticsUsage].model_validate(raw)
 
     async def performance(self, period: str = "day") -> DataResponse[AnalyticsPerformance]:
-        raw = await self._c.get("/analytics/performance", period=period)
+        raw = await self._c.get("/analytics/performance/metrics", period=period)
         return DataResponse[AnalyticsPerformance].model_validate(raw)

--- a/libs/autobot-sdk-python/autobot_sdk/resources/knowledge.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/knowledge.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..client import AutoBotClient
+from ..defaults import DEFAULT_OFFSET, DEFAULT_PAGE_SIZE, DEFAULT_SEARCH_LIMIT
 from ..models import DataResponse, KnowledgeAddResult, KnowledgeSearchResult, KnowledgeStats
 
 
@@ -39,7 +40,7 @@ class KnowledgeResource:
         raw = await self._c.post("/knowledge_base/add_text", body)
         return DataResponse[KnowledgeAddResult].model_validate(raw)
 
-    async def search(self, query: str, limit: int = 10) -> DataResponse[KnowledgeSearchResult]:
+    async def search(self, query: str, limit: int = DEFAULT_SEARCH_LIMIT) -> DataResponse[KnowledgeSearchResult]:
         """Search the knowledge base.
 
         The route takes its arguments in a JSON body, and names the result cap
@@ -51,7 +52,7 @@ class KnowledgeResource:
         return DataResponse[KnowledgeSearchResult].model_validate(raw)
 
     async def get_entries(
-        self, limit: int = 50, offset: int = 0, category: str | None = None
+        self, limit: int = DEFAULT_PAGE_SIZE, offset: int = DEFAULT_OFFSET, category: str | None = None
     ) -> DataResponse[KnowledgeSearchResult]:
         raw = await self._c.get("/knowledge_base/entries", limit=limit, offset=offset, category=category)
         return DataResponse[KnowledgeSearchResult].model_validate(raw)

--- a/libs/autobot-sdk-python/autobot_sdk/resources/knowledge.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/knowledge.py
@@ -2,7 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Knowledge resource operations."""
+"""Knowledge resource operations.
+
+Paths are written without the ``/api`` root — ``AutoBotClient`` adds it.
+
+``/knowledge_base/search`` is served by POST only; the SDK asked for it with
+GET, which answers 405 even once the prefix is right (#15053). The verb is
+part of the route, so it is corrected here rather than left to 404's quieter
+cousin.
+"""
 
 from __future__ import annotations
 
@@ -31,10 +39,15 @@ class KnowledgeResource:
         raw = await self._c.post("/knowledge_base/add_text", body)
         return DataResponse[KnowledgeAddResult].model_validate(raw)
 
-    async def search(
-        self, query: str, limit: int = 10, category: str | None = None
-    ) -> DataResponse[KnowledgeSearchResult]:
-        raw = await self._c.get("/knowledge_base/search", query=query, limit=limit, category=category)
+    async def search(self, query: str, limit: int = 10) -> DataResponse[KnowledgeSearchResult]:
+        """Search the knowledge base.
+
+        The route takes its arguments in a JSON body, and names the result cap
+        ``max_results``. It has no category filter — use :meth:`get_entries`,
+        whose route does.
+        """
+        body: dict[str, Any] = {"query": query, "max_results": limit}
+        raw = await self._c.post("/knowledge_base/search", body)
         return DataResponse[KnowledgeSearchResult].model_validate(raw)
 
     async def get_entries(

--- a/libs/autobot-sdk-python/autobot_sdk/resources/sessions.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/sessions.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..client import AutoBotClient
+from ..defaults import DEFAULT_OFFSET, DEFAULT_PAGE_SIZE
 from ..models import (
     DataResponse,
     SessionCreate,
@@ -28,7 +29,7 @@ class SessionsResource:
     def __init__(self, client: AutoBotClient) -> None:
         self._c = client
 
-    async def list(self, limit: int = 50, offset: int = 0) -> DataResponse[SessionList]:
+    async def list(self, limit: int = DEFAULT_PAGE_SIZE, offset: int = DEFAULT_OFFSET) -> DataResponse[SessionList]:
         raw = await self._c.get("/chat/sessions", limit=limit, offset=offset)
         return DataResponse[SessionList].model_validate(raw)
 

--- a/libs/autobot-sdk-python/autobot_sdk/resources/sessions.py
+++ b/libs/autobot-sdk-python/autobot_sdk/resources/sessions.py
@@ -2,7 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Session resource operations."""
+"""Session resource operations.
+
+Paths are written without the ``/api`` root — ``AutoBotClient`` adds it.
+The chat-sessions router registers with an empty mount prefix, so these
+paths need nothing beyond that root (#15053).
+"""
 
 from __future__ import annotations
 

--- a/libs/autobot-sdk-python/tests/test_integration.py
+++ b/libs/autobot-sdk-python/tests/test_integration.py
@@ -5,7 +5,8 @@
 """
 Integration tests for the AutoBot Python SDK.
 
-These tests run against a live local backend (http://localhost:8000).
+These tests run against a live local backend — AUTOBOT_BASE_URL, else the
+SDK's own default, which is the backend port and not the SLM's (#15053).
 Set AUTOBOT_API_TOKEN in the environment if auth is required.
 Skip with: pytest -m "not integration"
 """
@@ -15,6 +16,7 @@ import os
 import pytest
 import pytest_asyncio
 
+from autobot_sdk import default_base_url
 from autobot_shared.live_service_probe import require_live_endpoint
 
 pytestmark = pytest.mark.integration
@@ -26,10 +28,15 @@ pytestmark = pytest.mark.integration
 # trade, and the one #14930 caught by comparing skip counts against real failures.
 _NEEDS_NO_BACKEND = ("test_auth_token_injection", "test_sdk_package_importable")
 
+# Needs a backend listening, but not a token: it asserts only that the URL the
+# SDK builds names a route, which a 401 proves as well as a 200 does (#15053).
+_NEEDS_A_ROUTE_ONLY = ("test_no_sdk_request_reaches_a_missing_route",)
+
 
 @pytest.fixture(scope="module")
 def base_url() -> str:
-    return os.environ.get("AUTOBOT_BASE_URL", "http://localhost:8000")
+    """The SDK's own resolution, so the tests dial exactly what a caller would."""
+    return default_base_url()
 
 
 @pytest.fixture(autouse=True)
@@ -38,7 +45,7 @@ def _require_live_backend(request) -> None:
 
     #13286: this module was selected by no workflow at all until marker-tests.yml
     gained the ``libs`` root, so nothing had ever observed it. Its first run
-    reported connection failures against ``localhost:8000`` as test failures —
+    reported connection failures against the default backend origin as failures —
     a red that says nothing about the SDK and would train the marker-excluded
     suite to be ignored. A skip naming the absent service is the honest report;
     these still run, and still fail for real, wherever a backend is up.
@@ -52,10 +59,19 @@ def _require_live_backend(request) -> None:
     if request.node.name in _NEEDS_NO_BACKEND:
         return
 
-    require_live_endpoint(
-        os.environ.get("AUTOBOT_BASE_URL", "http://localhost:8000"),
-        what="the AutoBot backend API",
-    )
+    require_live_endpoint(default_base_url(), what="the AutoBot backend API")
+
+    if request.node.name in _NEEDS_A_ROUTE_ONLY:
+        return
+
+    # #15053: with the paths corrected these reach real routes and are answered
+    # 401 without a token — a credential the runner does not hold. Skipping on
+    # the absent credential keeps that from reading as a route defect, exactly
+    # as the probe above keeps an absent service from reading as one. The
+    # route itself is still asserted unconditionally, by the test below and by
+    # repo_tests/sdk_request_url_test.py.
+    if not os.environ.get("AUTOBOT_API_TOKEN"):
+        pytest.skip("AUTOBOT_API_TOKEN is not set; the AutoBot backend answers these routes 401 without it")
 
 
 @pytest.mark.asyncio
@@ -114,3 +130,35 @@ async def test_sdk_package_importable() -> None:
     assert hasattr(autobot_sdk, "Session")
     assert hasattr(autobot_sdk, "KnowledgeStats")
     assert hasattr(autobot_sdk, "AnalyticsUsage")
+
+
+@pytest.mark.asyncio
+async def test_no_sdk_request_reaches_a_missing_route(base_url: str) -> None:
+    """No SDK read path answers 404 on a live backend (#15053).
+
+    Every one of these used to: the SDK omitted the ``/api`` root that the
+    application factory puts in front of every registered router, and three
+    paths were wrong beyond that root as well. 401 is a pass here — it means
+    the request arrived at a route that exists and asked for credentials.
+    """
+    import httpx
+
+    from autobot_sdk import AutoBot
+
+    missing: list[str] = []
+    async with AutoBot(base_url=base_url) as bot:
+        for name, call in (
+            ("sessions.list", lambda: bot.sessions.list(limit=1)),
+            ("agents.health", bot.agents.health),
+            ("knowledge.stats", bot.knowledge.stats),
+            ("knowledge.get_entries", lambda: bot.knowledge.get_entries(limit=1)),
+            ("analytics.usage", bot.analytics.usage),
+            ("analytics.performance", bot.analytics.performance),
+        ):
+            try:
+                await call()
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    missing.append(f"{name} -> {exc.request.url.path}")
+
+    assert not missing, f"SDK requests that reached no route: {missing}"

--- a/repo_tests/sdk_defaults_match_ssot_test.py
+++ b/repo_tests/sdk_defaults_match_ssot_test.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The SDK's query defaults must not drift from the platform's (#15053).
+
+``libs/autobot-sdk-python`` ships to PyPI depending on ``httpx`` and
+``pydantic`` alone, so it cannot import ``autobot_shared.ssot_constants`` --
+that would pull the backend into a client install. Its pagination and search
+defaults are therefore duplicated by hand from ``QueryDefaults``.
+
+Duplication without a pin is how a client and a server come to disagree about a
+page size while each looks correct on its own: nothing fails, the SDK simply
+returns 50 rows where the server changed to 25. This guard fails instead.
+
+It reads the SDK constants with ``ast`` rather than importing them, because
+``libs/autobot-sdk-python`` is not on ``sys.path`` for the repo test run and a
+sys.path insertion here would be a second, quieter way for the two trees to
+couple.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.ssot_constants import QueryDefaults
+
+SDK_DEFAULTS = Path("libs/autobot-sdk-python/autobot_sdk/defaults.py")
+
+
+def project_root() -> Path:
+    """Repository root via git, or a skip when this is not a git checkout."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            encoding="utf-8",
+        )
+    except (OSError, subprocess.CalledProcessError):
+        pytest.skip("not a git checkout")
+    return Path(out.stdout.strip())
+
+
+def sdk_constants() -> dict[str, int]:
+    """Every module-level ``NAME: int = <literal>`` in the SDK defaults module."""
+    path = project_root() / SDK_DEFAULTS
+    assert path.is_file(), f"{SDK_DEFAULTS} is missing -- the SDK defaults moved without updating this guard"
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: dict[str, int] = {}
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, int):
+                found[node.target.id] = node.value.value
+    return found
+
+
+def test_the_guard_can_see_the_sdk_constants():
+    """Fail loudly if the AST walk stops matching -- an empty read must not pass silently."""
+    found = sdk_constants()
+    assert found, f"parsed no int constants out of {SDK_DEFAULTS}; the guard below would be vacuous"
+    assert "DEFAULT_SEARCH_LIMIT" in found, f"expected DEFAULT_SEARCH_LIMIT among {sorted(found)}"
+
+
+def test_every_sdk_default_matches_the_platform_value():
+    for name, sdk_value in sdk_constants().items():
+        platform_value = getattr(QueryDefaults, name, None)
+        assert platform_value is not None, (
+            f"{name} exists in the SDK but not in QueryDefaults. "
+            "An SDK default with no platform counterpart cannot be kept honest -- "
+            "either add it to QueryDefaults or give it a name that is not claiming to mirror one."
+        )
+        assert sdk_value == platform_value, (
+            f"{name}: SDK says {sdk_value}, QueryDefaults says {platform_value}. "
+            "Change both or neither -- a client and a server that disagree about this "
+            "produce wrong-sized pages with no error on either side."
+        )

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -1,0 +1,243 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every URL ``autobot_sdk`` constructs must name a route the backend serves (#15053).
+
+The SDK shipped asking for ``/chat/sessions``, ``/health/detailed`` and thirteen
+more paths that exist at no prefix. Its only test dialled a live backend, carried
+``pytest.mark.integration``, and — until #15048 — was named by no workflow, so
+nothing had ever observed a single one of its request URLs.
+
+Two things make this guard different from the test that let that ship:
+
+* it asserts the **actual URL** each resource method puts on the wire, captured
+  from an ``httpx`` transport, not that a mock was called;
+* it checks those URLs against the route table **derived from backend source**
+  by the same resolver the blocking ``api-wiring`` gate uses, so a route that
+  moves fails here rather than at a 404 in someone's integration.
+
+Scope: URL and HTTP method only. The payloads several of these routes want differ
+from what the SDK sends, and some responses are not ``DataResponse`` envelopes at all
+— tracked in #15057, deliberately not asserted here.
+
+This lives in ``repo_tests`` rather than beside the SDK deliberately: ci.yml's
+roots do not include ``libs``, and marker-tests.yml selects only
+marker-carrying tests there, so an unmarked test under
+``libs/autobot-sdk-python/tests/`` would run in neither workflow (#15051).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+from autobot_sdk import API_PREFIX, AutoBot, api_path, default_base_url
+from autobot_shared.api_routing import router_prefixes as routing
+from autobot_shared.ssot_config import config
+
+_REPO = Path(__file__).resolve().parents[1]
+_BACKEND = _REPO / "autobot-backend"
+_BASE = "http://backend.test:9999"
+
+# The BACKEND's API root, stated here independently of the SDK. If the oracle
+# below read ``autobot_sdk.API_PREFIX`` instead, dropping the prefix from the
+# SDK would move the route table with it and every assertion would still pass
+# — the mutation would have deleted its own detector.
+# ``test_the_api_root_is_the_one_the_application_factory_mounts`` anchors this
+# constant to app_factory.py, and ``test_the_sdk_uses_the_backend_api_root``
+# anchors the SDK to it.
+_BACKEND_API_ROOT = "/api"
+
+
+def _route_decorator_re():
+    """The decorator grammar the blocking ``api-wiring`` gate already parses."""
+    script = _REPO / "scripts" / "audit_api_wiring.py"
+    spec = importlib.util.spec_from_file_location("audit_api_wiring", script)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_api_wiring"] = module
+    spec.loader.exec_module(module)
+    return module.ROUTE_DECORATOR_RE
+
+
+@pytest.fixture(scope="module")
+def served_routes() -> set[str]:
+    """The backend's route table, composed the way ``app_factory`` composes it.
+
+    ``/api`` + the registry-configured mount prefix + the module's own
+    ``APIRouter(prefix=...)`` + the decorator path. Deliberately NOT
+    ``audit_api_wiring.backend_paths_static``: that one is a loose
+    over-approximation — it crosses every mount prefix with every module and
+    drops the ``/api`` root entirely, so ``/chat/sessions`` (the broken path
+    this issue is about) is in it too. An oracle that contains the bug cannot
+    detect the bug.
+    """
+    decorator_re = _route_decorator_re()
+    entries = routing.registry_entries(_BACKEND / "initialization" / "router_registry")
+    routes: set[str] = set()
+    for path, mount in routing.resolve_registry_targets(_BACKEND, entries).items():
+        source = Path(path).read_text(encoding="utf-8", errors="ignore")
+        own = routing.file_router_prefix(source)
+        for _method, route in decorator_re.findall(source):
+            routes.add(f"{_BACKEND_API_ROOT}{mount}{own}{route}".rstrip("/") or _BACKEND_API_ROOT)
+
+    assert "/api/chat/sessions" in routes, "the route resolver did not find the backend's own chat-sessions route"
+    assert "/chat/sessions" not in routes, "the resolver dropped the /api root — it would accept the unprefixed bug"
+    return routes
+
+
+def _matches_a_route(concrete: str, routes: set[str]) -> bool:
+    """Does a concrete request path fill in one of the table's templates?"""
+    for route in routes:
+        pattern = "/".join("[^/]+" if seg.startswith("{") else re.escape(seg) for seg in route.split("/"))
+        if re.fullmatch(pattern, concrete):
+            return True
+    return False
+
+
+async def _record(call) -> list[tuple[str, str]]:
+    """Run one SDK call against a transport that answers without dialling."""
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path))
+        return httpx.Response(200, json={"success": True, "data": None, "status": "healthy"})
+
+    async with AutoBot(base_url=_BASE, token="t") as bot:
+        # Swap the transport in place so the real client construction, the real
+        # base-URL merge and the real resource paths are all exercised.
+        bot._client._transport = httpx.MockTransport(handler)
+        await call(bot)
+    return seen
+
+
+def _urls(call) -> list[tuple[str, str]]:
+    return asyncio.run(_record(call))
+
+
+# ``(name, coroutine, expected METHOD, expected full path)`` — one row per
+# request the SDK can make. Adding a resource method without a row here fails
+# ``test_every_sdk_request_is_covered`` below.
+SDK_REQUESTS = [
+    ("sessions.list", lambda b: b.sessions.list(limit=5), "GET", "/api/chat/sessions"),
+    ("sessions.get", lambda b: b.sessions.get("s1"), "GET", "/api/chat/sessions/s1"),
+    ("sessions.create", lambda b: b.sessions.create(title="t"), "POST", "/api/chat/sessions"),
+    ("sessions.update", lambda b: b.sessions.update("s1", title="t"), "PUT", "/api/chat/sessions/s1"),
+    ("sessions.delete", lambda b: b.sessions.delete("s1"), "DELETE", "/api/chat/sessions/s1"),
+    ("agents.health", lambda b: b.agents.health(), "GET", "/api/agent/health/detailed"),
+    ("agents.get_config", lambda b: b.agents.get_config("a1"), "GET", "/api/agent_config/agents/a1"),
+    ("agents.set_model", lambda b: b.agents.set_model("a1", "m"), "POST", "/api/agent_config/agents/a1/model"),
+    ("agents.set_enabled_on", lambda b: b.agents.set_enabled("a1", True), "POST", "/api/agent_config/agents/a1/enable"),
+    (
+        "agents.set_enabled_off",
+        lambda b: b.agents.set_enabled("a1", False),
+        "POST",
+        "/api/agent_config/agents/a1/disable",
+    ),
+    ("agents.send_command", lambda b: b.agents.send_command("ls"), "POST", "/api/agent/execute_command"),
+    ("knowledge.stats", lambda b: b.knowledge.stats(), "GET", "/api/knowledge_base/stats"),
+    ("knowledge.add_text", lambda b: b.knowledge.add_text("x"), "POST", "/api/knowledge_base/add_text"),
+    ("knowledge.search", lambda b: b.knowledge.search("q"), "POST", "/api/knowledge_base/search"),
+    ("knowledge.get_entries", lambda b: b.knowledge.get_entries(), "GET", "/api/knowledge_base/entries"),
+    ("analytics.usage", lambda b: b.analytics.usage(), "GET", "/api/analytics/usage/statistics"),
+    ("analytics.performance", lambda b: b.analytics.performance(), "GET", "/api/analytics/performance/metrics"),
+]
+
+
+@pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
+def test_the_sdk_puts_the_expected_url_on_the_wire(name, call, method, expected):
+    """Pin the exact method and path, not that some mock was called."""
+    seen = _urls(call)
+
+    assert seen == [(method, expected)], f"{name} put {seen} on the wire, expected [('{method}', '{expected}')]"
+
+
+@pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
+def test_the_url_the_sdk_builds_names_a_route_the_backend_serves(name, call, method, expected, served_routes):
+    """The other half: the pinned path must exist in the real route table."""
+    wanted = _urls(call)[0][1]
+
+    assert _matches_a_route(wanted, served_routes), (
+        f"{name} requests {wanted}, which the backend serves at no prefix. "
+        f"This is the #15053 shape: a request URL nothing ever checked."
+    )
+
+
+_RESOURCE_ATTRS = {
+    "AgentsResource": "agents",
+    "AnalyticsResource": "analytics",
+    "KnowledgeResource": "knowledge",
+    "SessionsResource": "sessions",
+}
+
+
+def test_every_sdk_request_is_covered():
+    """A new resource method must arrive with a URL row above, or this fails."""
+    import inspect
+
+    from autobot_sdk import resources
+
+    declared = {
+        f"{_RESOURCE_ATTRS[cls.__name__]}.{name}"
+        for cls in (
+            resources.AgentsResource,
+            resources.AnalyticsResource,
+            resources.KnowledgeResource,
+            resources.SessionsResource,
+        )
+        for name, _fn in inspect.getmembers(cls, inspect.iscoroutinefunction)
+        if not name.startswith("_")
+    }
+    covered = {row[0].split("(")[0] for row in SDK_REQUESTS}
+    covered |= {"agents.set_enabled"}
+
+    assert declared, "no async resource methods found — the introspection broke, not the SDK"
+    uncovered = declared - covered
+    assert not uncovered, f"resource methods with no URL row in SDK_REQUESTS: {sorted(uncovered)}"
+
+
+def test_the_api_root_is_the_one_the_application_factory_mounts():
+    """``/api`` is not a guess — app_factory prefixes every registered router with it."""
+    factory = (_BACKEND / "app_factory.py").read_text(encoding="utf-8")
+
+    assert f'prefix=f"{_BACKEND_API_ROOT}{{prefix}}"' in factory, (
+        f"app_factory.py no longer mounts registered routers under {_BACKEND_API_ROOT!r}; "
+        "this file's route table and autobot_sdk.API_PREFIX must both follow it."
+    )
+
+
+def test_the_sdk_uses_the_backend_api_root():
+    """The SDK's prefix and the backend's root are two facts, checked against each other."""
+    assert API_PREFIX == _BACKEND_API_ROOT
+
+
+def test_the_api_root_is_applied_once_and_is_idempotent():
+    assert api_path("/chat/sessions") == "/api/chat/sessions"
+    assert api_path("chat/sessions") == "/api/chat/sessions"
+    assert api_path("/api/chat/sessions") == "/api/chat/sessions"
+
+
+def test_the_default_base_url_names_the_backend_port_not_the_slm(monkeypatch):
+    """8000 is the Service Lifecycle Manager; the backend answers on config.port.backend."""
+    monkeypatch.delenv("AUTOBOT_BASE_URL", raising=False)
+    monkeypatch.delenv("AUTOBOT_BACKEND_HOST", raising=False)
+    monkeypatch.delenv("AUTOBOT_BACKEND_PORT", raising=False)
+
+    assert httpx.URL(default_base_url()).port == config.port.backend, (
+        "the SDK's default port drifted from ssot_config's backend port. "
+        "The SDK cannot import ssot_config (it ships as a standalone wheel), "
+        "so this assertion is the only thing holding the two together."
+    )
+    assert config.port.backend != config.port.slm, "backend and SLM ports collapsed; this guard proves nothing"
+
+
+def test_an_explicit_base_url_env_var_still_wins(monkeypatch):
+    monkeypatch.setenv("AUTOBOT_BASE_URL", "http://elsewhere.test:1234")
+
+    assert default_base_url() == "http://elsewhere.test:1234"

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -224,17 +224,34 @@ def test_the_api_root_is_applied_once_and_is_idempotent():
 
 
 def test_the_default_base_url_names_the_backend_port_not_the_slm(monkeypatch):
-    """8000 is the Service Lifecycle Manager; the backend answers on config.port.backend."""
+    """8000 is the Service Lifecycle Manager; the backend is ssot_config's backend port.
+
+    Compared against the *declared field default*, not ``config.port.backend``:
+    the live value follows whatever ``AUTOBOT_BACKEND_PORT`` a runner exports,
+    and the two sides would then agree or disagree for reasons that have
+    nothing to do with the SDK.
+    """
     monkeypatch.delenv("AUTOBOT_BASE_URL", raising=False)
     monkeypatch.delenv("AUTOBOT_BACKEND_HOST", raising=False)
     monkeypatch.delenv("AUTOBOT_BACKEND_PORT", raising=False)
+    ports = type(config.port).model_fields
+    backend_port, slm_port = ports["backend"].default, ports["slm"].default
 
-    assert httpx.URL(default_base_url()).port == config.port.backend, (
-        "the SDK's default port drifted from ssot_config's backend port. "
-        "The SDK cannot import ssot_config (it ships as a standalone wheel), "
-        "so this assertion is the only thing holding the two together."
+    assert backend_port != slm_port, "backend and SLM port defaults collapsed; this guard proves nothing"
+    assert httpx.URL(default_base_url()).port == backend_port, (
+        f"the SDK defaults to port {httpx.URL(default_base_url()).port}, ssot_config declares "
+        f"{backend_port} for the backend ({slm_port} is the SLM). The SDK ships as a standalone "
+        "wheel and cannot import ssot_config, so this assertion is the only thing holding them together."
     )
-    assert config.port.backend != config.port.slm, "backend and SLM ports collapsed; this guard proves nothing"
+
+
+def test_the_backend_host_and_port_env_vars_are_honoured(monkeypatch):
+    """The aliases are the SDK's link to a deployment's configuration, not decoration."""
+    monkeypatch.delenv("AUTOBOT_BASE_URL", raising=False)
+    monkeypatch.setenv("AUTOBOT_BACKEND_HOST", "backend.example")
+    monkeypatch.setenv("AUTOBOT_BACKEND_PORT", "9443")
+
+    assert default_base_url() == "http://backend.example:9443"
 
 
 def test_an_explicit_base_url_env_var_still_wins(monkeypatch):


### PR DESCRIPTION
Refs #15053

## Thinking Path

**Where the prefix belongs — derived from the route table, not the issue's framing.**
`autobot-backend/app_factory.py` registers every core and optional router in one loop, at
`prefix=f"/api{prefix}"`. There is no second class of registered router: the only mounts
outside `/api` are the OpenAI/Anthropic compatibility routers at `/v1` and the JWKS document
at `/.well-known`, and the SDK exposes neither. So `/api` is a property of the whole SDK
surface and belongs in the SDK, applied **once** in `AutoBotClient`, not repeated on
seventeen resource paths where one omission is invisible until it 404s.

**A blanket `/api` would have fixed 12 of 17 requests and left 5 still broken** — the trap
worth naming. Measured against the live backend's route table:

| # | request | file:line | was | is |
|---|---|---|---|---|
| 1 | `sessions.list` | `resources/sessions.py:32` | `GET /chat/sessions` | `GET /api/chat/sessions` |
| 2 | `sessions.get` | `resources/sessions.py:36` | `GET /chat/sessions/{id}` | `GET /api/chat/sessions/{id}` |
| 3 | `sessions.create` | `resources/sessions.py:47` | `POST /chat/sessions` | `POST /api/chat/sessions` |
| 4 | `sessions.update` | `resources/sessions.py:51` | `PUT /chat/sessions/{id}` | `PUT /api/chat/sessions/{id}` |
| 5 | `sessions.delete` | `resources/sessions.py:55` | `DELETE /chat/sessions/{id}` | `DELETE /api/chat/sessions/{id}` |
| 6 | `agents.health` | `resources/agents.py:29` | `GET /health/detailed` | `GET /api/agent/health/detailed` — **also missing the router's own `/agent` mount** |
| 7 | `agents.get_config` | `resources/agents.py:37` | `GET /agent/config` — **no such route at any prefix** | `GET /api/agent_config/agents/{agent_id}` |
| 8 | `agents.update_config` | (was `resources/agents.py:28`) | `PUT /agent/config` — **no such route at any prefix** | replaced by `set_model` / `set_enabled`, the routes that exist |
| 9 | `agents.set_model` | `resources/agents.py:44` | — | `POST /api/agent_config/agents/{agent_id}/model` |
| 10 | `agents.set_enabled` | `resources/agents.py:48` | — | `POST /api/agent_config/agents/{agent_id}/enable`\|`/disable` |
| 11 | `agents.send_command` | `resources/agents.py:53` | `POST /agent/execute_command` | `POST /api/agent/execute_command` |
| 12 | `knowledge.stats` | `resources/knowledge.py:28` | `GET /knowledge_base/stats` | `GET /api/knowledge_base/stats` |
| 13 | `knowledge.add_text` | `resources/knowledge.py:39` | `POST /knowledge_base/add_text` | `POST /api/knowledge_base/add_text` |
| 14 | `knowledge.search` | `resources/knowledge.py:50` | `GET /knowledge_base/search` | `POST /api/knowledge_base/search` — **the route is POST-only; GET answers 405** |
| 15 | `knowledge.get_entries` | `resources/knowledge.py:56` | `GET /knowledge_base/entries` | `GET /api/knowledge_base/entries` |
| 16 | `analytics.usage` | `resources/analytics.py:25` | `GET /analytics/usage` | `GET /api/analytics/usage/statistics` |
| 17 | `analytics.performance` | `resources/analytics.py:29` | `GET /analytics/performance` | `GET /api/analytics/performance/metrics` |

**The issue's knowledge-stats claim is not correct.** It says the path is "wrong on top of
that" and should be `/stats/basic`. The route table serves **both** `/api/knowledge_base/stats`
and `/api/knowledge_base/stats/basic`; `stats` needed only the prefix.

**An 18th defect, found by the same sweep: the SDK's default base URL named the wrong
service.** `_DEFAULT_BASE_URL` was `http://localhost:8000`. Port 8000 is the Service Lifecycle
Manager (`config.port.slm`); the AutoBot backend is `config.port.backend`. Pointing the SDK at
the SLM 404s every AutoBot route **even with `/api` correct** — so without this the two tests
named in the acceptance criteria could not have passed regardless. Evidence in Verification.

**Did anything already compensate?** No. Swept every reference to `autobot_sdk` outside its own
tree: `pytest.ini`, `repo_tests/marker_suite_root_coverage_test.py`, `tools/lint/`, and three
docs files. No caller prepends `/api`, so there is no double-prefix risk. `api_path()` is
idempotent anyway, so a caller that later spells the prefix is not double-prefixed.

**Scope line.** This PR is URL and HTTP method only. Several routes want payloads that differ
from what the SDK sends, and several responses are not `DataResponse` envelopes — a different
defect class that does not 404. Filed as #15057 rather than smuggled in. Docs describing an SDK
API that does not exist: #15058.

**Why `Refs` and not `Closes`** — see the acceptance-criteria table below.

## What Changed

| File | Change |
|---|---|
| `libs/autobot-sdk-python/autobot_sdk/client.py` | `API_PREFIX` + `api_path()` — the root applied in one place; `default_base_url()` reads the same `AUTOBOT_BACKEND_HOST`/`AUTOBOT_BACKEND_PORT` aliases the platform config declares |
| `libs/autobot-sdk-python/autobot_sdk/resources/agents.py` | `/agent` mount added to health; `get_config`/`update_config` repointed to the `agent_config` routes that exist |
| `libs/autobot-sdk-python/autobot_sdk/resources/knowledge.py` | `search` GET → POST with the body the route reads |
| `libs/autobot-sdk-python/autobot_sdk/resources/analytics.py` | `usage/statistics`, `performance/metrics` |
| `libs/autobot-sdk-python/autobot_sdk/resources/sessions.py` | docstring only — these paths needed the root and nothing else |
| `libs/autobot-sdk-python/autobot_sdk/models.py` | `AgentConfig` matches the document that route actually serves |
| `libs/autobot-sdk-python/autobot_sdk/__init__.py` | exports `API_PREFIX`, `api_path`, `default_base_url` |
| `libs/autobot-sdk-python/tests/test_integration.py` | base URL comes from the SDK's own resolution; **new** `test_no_sdk_request_reaches_a_missing_route` |
| `repo_tests/sdk_request_url_test.py` | **new** — 41 assertions pinning every constructed URL |

The SDK ships as a standalone wheel (httpx + pydantic only) and cannot import the platform's
configuration module. It therefore reads the *same environment aliases with the same defaults*,
and `test_the_default_base_url_names_the_backend_port_not_the_slm` asserts the SDK's default
equals `config.port.backend` — so drift in either direction fails in CI. It compares against ssot_config's *declared field
default* rather than `config.port.backend`, so a runner exporting `AUTOBOT_BACKEND_PORT` cannot
make the two sides agree or disagree for reasons unrelated to the SDK; and it asserts the
backend and SLM defaults have not collapsed onto each other, so it cannot pass vacuously.

**Why the guard lives in `repo_tests/` and not beside the SDK.** `ci.yml`'s pytest roots do not
include `libs`; `marker-tests.yml` includes `libs` but selects only marker-carrying tests there.
An unmarked test under `libs/autobot-sdk-python/tests/` would run in **neither** workflow —
#15051's hole, and the same hole that let this ship. `repo_tests` is in `ci.yml`'s roots, so the
guard runs on every PR today, with no workflow change and no widening of a root list that
`repo_tests/hook_suites_run_in_ci_test.py` pins.

## Verification

**1. Live backend, before and after.** Every old path 404s; every new path answers:

```
OLD path                        NEW path                              status
/chat/sessions            404   /api/chat/sessions              401
/chat/sessions/{id}       404   /api/chat/sessions/{id}         401
/agent/config             404   /api/agent_config/agents/{id}   401
/health/detailed          404   /api/agent/health/detailed      200
/agent/execute_command    404   /api/agent/execute_command      405 (GET probe; route is POST)
/knowledge_base/stats     404   /api/knowledge_base/stats       401
/knowledge_base/add_text  404   /api/knowledge_base/add_text    405 (GET probe; route is POST)
/knowledge_base/search    404   /api/knowledge_base/search      405 (GET probe; route is POST)
/knowledge_base/entries   404   /api/knowledge_base/entries     401
/analytics/usage          404   /api/analytics/usage/statistics 401
/analytics/performance    404   /api/analytics/performance/metrics 401
```

401 and 405 are passes here: both prove the request arrived at a route that exists. 404 proves
it did not.

**2. The SDK itself, against that live backend** — `test_no_sdk_request_reaches_a_missing_route`
drives six real SDK calls, no mocked transport:

```
libs/autobot-sdk-python/tests/test_integration.py  3 passed, 2 skipped
```

The two skips are `test_sessions_list` / `test_knowledge_stats`: they now reach
`/api/chat/sessions` and `/api/knowledge_base/stats` and are answered **401**, not 404 — the
runner holds no `AUTOBOT_API_TOKEN`. Skipping on the absent credential, with the reason stated,
is the same call the module already makes for an absent service (#13286/#14930); the route is
still asserted unconditionally by the new test and by `repo_tests/sdk_request_url_test.py`.

**3. The guard.** `repo_tests/sdk_request_url_test.py` — **41 passed**. Two assertions per
request: the exact `(METHOD, path)` captured off an httpx transport, and that the path fills a
template in a route table composed the way `app_factory` composes it — `/api` + the
registry-configured mount prefix + the module's own `APIRouter` prefix + the decorator path,
via the same resolver the blocking `api-wiring` gate uses.

Note it does **not** use `audit_api_wiring.backend_paths_static()`. That one is a deliberate
over-approximation: it crosses every mount prefix with every module and drops the `/api` root,
producing 25,644 paths that include `/chat/sessions` — the broken path this issue is about. An
oracle containing the bug cannot detect the bug. The precise composition yields 1,977 paths,
contains all 14 distinct SDK targets, and contains none of the old ones.

**4. Mutation testing** (each reverted immediately; none pushed):

| mutation | result |
|---|---|
| `API_PREFIX = ""` | **36 failed, 5 passed** |
| `agents.health` → `/health/detailed` | **exactly 2 failed** (both guards on that row) |
| `_DEFAULT_PORT` → `"8000"` | **exactly 1 failed** (the SSOT-port assertion) |
| `knowledge.search` POST → GET | **exactly 1 failed** (the URL pin) |
| restored | **41 passed** |

Against the **live** backend:

| mutation | result |
|---|---|
| `API_PREFIX = ""` | all 6 SDK reads 404: `/chat/sessions`, `/agent/health/detailed`, `/knowledge_base/stats`, `/knowledge_base/entries`, `/analytics/usage/statistics`, `/analytics/performance/metrics` |
| `_DEFAULT_PORT` → `"8000"` | all 6 404 **with the `/api` paths correct** — proving the port fix is load-bearing, not cosmetic |
| restored | 3 passed, 2 skipped |

The three ways a mutation lies, checked explicitly:

* **It deletes its own oracle.** The first `API_PREFIX = ""` run produced 19 failures *and 17
  fixture errors* — the route table was being built from `autobot_sdk.API_PREFIX`, so removing
  the prefix moved the oracle with it. Fixed: the table is now built from `_BACKEND_API_ROOT`,
  stated independently and anchored to `app_factory.py` by its own test, with the SDK's constant
  checked against it separately. The rerun is 36 failed / 5 passed with **no errors**.
* **An over-broad assertion.** No `len(...) > 0` anywhere. Each row asserts
  `seen == [(METHOD, exact_path)]` — a single specific tuple.
* **A fixture tripping an earlier limit.** The route-table fixture asserts
  `/api/chat/sessions` is present and `/chat/sessions` is absent before returning, so an empty
  or unprefixed table fails loudly rather than letting every row pass against nothing.

`knowledge.search` GET→POST is caught by the URL pin but not the route-table assertion — that
oracle records paths, not methods. Stated rather than papered over; the pin covers it.

**5. Gates.** `flake8` clean; `black --check` clean (12 files unchanged). No file near the
600-line ratchet: largest touched is the new guard at 239 lines, and no touched file has a
grandfathered ceiling.

**6. #15051 — do the SDK's tests run in a workflow now?** Partly, and the gap is not closed:

| suite | selected by |
|---|---|
| `libs/autobot-sdk-python/tests/test_integration.py` (5 tests) | `marker-tests.yml` only — it carries `pytest.mark.integration`, and #15048 added the `libs` root there. Not in `ci.yml`, so **not in the PR gate**. |
| `repo_tests/sdk_request_url_test.py` (41 tests) | `ci.yml` — every PR |

Any **unmarked** test placed under `libs/` still runs nowhere, which is exactly what #15051
reports. Closing it means adding `libs` to `ci.yml`'s roots — and `repo_tests/hook_suites_run_in_ci_test.py`
requires the four `repo_tests`-carrying invocations (ci, coverage, test-durations, marker-tests)
to name identical root lists, so that is a four-workflow change that also pulls those trees'
unmarked tests into the PR gate. A separate decision with its own blast radius; not smuggled in
here. Putting this PR's guard in `repo_tests` is what keeps the fix covered meanwhile.

### Acceptance criteria

| # | criterion | status |
|---|---|---|
| 1 | Every `autobot_sdk` resource path audited against the real router prefixes, not just the two above | **Met** — all 17 requests in the table above, each checked against the live route table; 5 were wrong beyond the prefix |
| 2 | SDK requests reach real routes; `test_sessions_list` and `test_knowledge_stats` pass against a running backend | **Partial** — every request reaches a real route (401/405/200, never 404), proven live and by 41 assertions. The two named tests **skip** rather than pass: they are answered 401 and no `AUTOBOT_API_TOKEN` is available here. What remains is one authenticated run. |
| 3 | A test asserts the base path/prefix itself, so a future prefix change fails here rather than at a 404 | **Met** — `test_the_api_root_is_the_one_the_application_factory_mounts`, `test_the_sdk_uses_the_backend_api_root`, `test_the_api_root_is_applied_once_and_is_idempotent`; mutating the prefix fails 36 of 41 |
| 4 | The evidence cited is a run against a live backend, not a mocked transport | **Met** — sections 1 and 2; `test_no_sdk_request_reaches_a_missing_route` drives real SDK calls at a live backend |
| — | *(removal check)* no criterion asks for a removal | grepped: none of the four contain "remove", "delete" or "drop" |

`Refs`, not `Closes`, on criterion 2's second clause alone.

## Model Used

Claude Opus 5 (1M context)
