### PR TITLE
fix(python): verify #13747's ensure_venv_version guard and correct stale 3.11 NPU declarations (#13747)

### DIFF
--- a/.github/workflows/ansible-role-facts-test.yml
+++ b/.github/workflows/ansible-role-facts-test.yml
@@ -146,11 +146,21 @@ jobs:
         run: |
           ansible-playbook --check --connection=local -i 'localhost,' tests/playbooks/test_clean_yml_loops.yml
 
+      # #13747 AC4: "verified by deliberate failure: the guard rejects a venv
+      # left at the old version." Runs for real (not --check) against a
+      # fabricated venv, so it needs no NPU hardware and no python3.14 binary
+      # on the runner — see the playbook header for what it proves.
+      - name: "Run ensure_venv_version deliberate-failure test (#13747)"
+        working-directory: autobot-slm-backend/ansible
+        run: |
+          ansible-playbook --connection=local -i 'localhost,' tests/playbooks/test_ensure_venv_version.yml
+
       - name: Lint test playbook + inventory YAML
         working-directory: autobot-slm-backend/ansible
         run: |
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_role_active_facts_no_group_vars.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_clean_yml_loops.yml'))"
+          python3 -c "import yaml; yaml.safe_load(open('tests/playbooks/test_ensure_venv_version.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/inventory/test_role_facts.yml'))"
           python3 -c "import yaml; yaml.safe_load(open('tests/inventory/group_vars/all.yml'))"

--- a/autobot-slm-backend/ansible/inventory/production.yml
+++ b/autobot-slm-backend/ansible/inventory/production.yml
@@ -145,8 +145,11 @@ all:
         # NPU Worker-specific configuration
         npu_worker_port: 8081
         openvino_device: "AUTO"  # Auto-detect NPU > GPU > CPU
-        # Python 3.11 pinned: OpenVINO/NPU runtime has no 3.14 wheels (do not bump with the rest of the fleet)
-        python_version: "3.11"
+        # #13747: openvino/torch/numpy all ship cp314 wheels, so the OpenVINO/NPU
+        # runtime moved to 3.14 with the rest of the fleet. Kept in sync with
+        # roles/python314/defaults/main.yml even though nothing in
+        # roles/npu-worker or roles/python314 currently reads this exact var name.
+        python_version: "3.14"
         worker_threads: 2
         inference_optimization: true
         # Hardware access configuration

--- a/autobot-slm-backend/ansible/tests/check_venv_producers.py
+++ b/autobot-slm-backend/ansible/tests/check_venv_producers.py
@@ -5,10 +5,12 @@
 # Author: mrveiss
 """Guard: one venv path is never built by two interpreters (#13746).
 
-Three producers built ``/opt/autobot/venv`` — ``roles/backend_services`` and the
-``aiml`` play with python3.14, the ``npu`` play with python3.11. Co-location is a
-supported layout (the role-facts test inventory covers a single host carrying
-several roles), so those producers can land on one machine. The last one to run
+Three producers built ``/opt/autobot/venv`` — ``roles/backend_services``, the
+``aiml`` play, and (before #13747) the ``npu`` play on a different interpreter.
+All three now target python3.14, but this guard still runs on every change:
+co-location is a supported layout (the role-facts test inventory covers a
+single host carrying several roles), so a future producer landing on a
+different interpreter would reproduce the same hazard. The last one to run
 rewrites ``pyvenv.cfg`` while ``site-packages`` still holds binaries built by the
 other interpreter.
 

--- a/autobot-slm-backend/ansible/tests/playbooks/test_ensure_venv_version.yml
+++ b/autobot-slm-backend/ansible/tests/playbooks/test_ensure_venv_version.yml
@@ -1,0 +1,119 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - Test playbook: ensure_venv_version deliberate-failure guard (#13747 AC4)
+#
+# roles/python314/tasks/ensure_venv_version.yml is the shared env-drift guard
+# every service role calls before creating its venv (backend, backend_services,
+# agent_config, tts-worker, redis/chromadb, npu-worker). #13747 moved the NPU
+# worker's target from 3.11 to 3.14 and requires the guard to be "verified by
+# deliberate failure: the guard rejects a venv left at the old version" — this
+# playbook is that verification, run against a fabricated venv rather than a
+# real interpreter, so it needs no NPU hardware and no python3.14 binary on the
+# runner.
+#
+# Two cases:
+#   1. Stale venv (reports "Python 3.11.9", target is python3.14) -> REMOVED.
+#   2. Current venv (reports "Python 3.14.2", target is python3.14) -> KEPT.
+# Without case 2, a guard that always deletes would pass case 1 for the wrong
+# reason.
+#
+# Usage:
+#   cd autobot-slm-backend/ansible
+#   ansible-playbook --connection=local -i 'localhost,' \
+#                    tests/playbooks/test_ensure_venv_version.yml
+---
+- name: "Test: ensure_venv_version rejects a stale-version venv (#13747 AC4)"
+  hosts: localhost
+  gather_facts: false
+  any_errors_fatal: true
+
+  tasks:
+    - name: "Create a scratch dir for the fabricated venvs"
+      ansible.builtin.tempfile:
+        state: directory
+        prefix: ensure_venv_version_test_
+      register: _scratch_dir
+
+    - name: "Case 1 setup: fabricate a stale (3.11) venv"
+      vars:
+        stale_venv: "{{ _scratch_dir.path }}/stale-venv"
+      block:
+        - name: "Create stale-venv bin/ dir"
+          ansible.builtin.file:
+            path: "{{ stale_venv }}/bin"
+            state: directory
+            mode: "0755"
+
+        - name: "Write a fake python that reports 3.11.9"
+          ansible.builtin.copy:
+            dest: "{{ stale_venv }}/bin/python"
+            mode: "0755"
+            content: |
+              #!/bin/sh
+              echo "Python 3.11.9"
+
+        - name: "Run ensure_venv_version against the stale venv, targeting python3.14"
+          ansible.builtin.include_tasks: "{{ playbook_dir }}/../../roles/python314/tasks/ensure_venv_version.yml"
+          vars:
+            venv_path: "{{ stale_venv }}"
+            venv_python: python3.14
+
+        - name: "Assert the stale venv was removed (deliberate-failure case)"
+          ansible.builtin.stat:
+            path: "{{ stale_venv }}"
+          register: _stale_venv_after
+
+        - name: "Fail loudly if the stale venv survived"
+          ansible.builtin.assert:
+            that:
+              - not _stale_venv_after.stat.exists
+            fail_msg: >-
+              ensure_venv_version left a venv reporting 'Python 3.11.9' in place
+              while targeting python3.14 — the deliberate-failure guard did not
+              fire. This is the exact hazard #13747 exists to close: 3.11-built
+              OpenVINO binaries surviving into what looks like a 3.14 venv.
+            success_msg: "Stale venv correctly removed."
+
+    - name: "Case 2 setup: fabricate a current (3.14) venv"
+      vars:
+        current_venv: "{{ _scratch_dir.path }}/current-venv"
+      block:
+        - name: "Create current-venv bin/ dir"
+          ansible.builtin.file:
+            path: "{{ current_venv }}/bin"
+            state: directory
+            mode: "0755"
+
+        - name: "Write a fake python that reports 3.14.2"
+          ansible.builtin.copy:
+            dest: "{{ current_venv }}/bin/python"
+            mode: "0755"
+            content: |
+              #!/bin/sh
+              echo "Python 3.14.2"
+
+        - name: "Run ensure_venv_version against the current venv, targeting python3.14"
+          ansible.builtin.include_tasks: "{{ playbook_dir }}/../../roles/python314/tasks/ensure_venv_version.yml"
+          vars:
+            venv_path: "{{ current_venv }}"
+            venv_python: python3.14
+
+        - name: "Assert the matching-version venv was kept"
+          ansible.builtin.stat:
+            path: "{{ current_venv }}"
+          register: _current_venv_after
+
+        - name: "Fail loudly if a matching-version venv was deleted"
+          ansible.builtin.assert:
+            that:
+              - _current_venv_after.stat.exists
+            fail_msg: >-
+              ensure_venv_version removed a venv already reporting 'Python
+              3.14.2' while targeting python3.14 — the guard is over-firing,
+              which would delete a correct venv on every single deploy.
+            success_msg: "Matching-version venv correctly kept."
+
+    - name: "Clean up the scratch dir"
+      ansible.builtin.file:
+        path: "{{ _scratch_dir.path }}"
+        state: absent

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1527,12 +1527,12 @@ _COMPONENT_PIP_PATHS: Dict[str, Tuple[str, str]] = {
 }
 
 # Target CPython interpreter per backend component (#11323).
-# NPU worker uses py3.11 (OpenVINO ABI); every other Python service uses py3.14.
-# This is the single authoritative mapping — do not hardcode elsewhere.
+# Every Python service, including the NPU worker, targets py3.14 (#13747) —
+# this is the single authoritative mapping; do not hardcode elsewhere.
 _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
     "autobot-backend": "python3.14",
     "autobot-slm-backend": "python3.14",
-    "autobot-npu-worker": "python3.11",
+    "autobot-npu-worker": "python3.14",
 }
 
 # Ansible assets that provision the target interpreter on THIS host (#11343).
@@ -1598,7 +1598,7 @@ _WORKER_COMPONENTS: frozenset = frozenset(
 # an explicit package LIST rather than a requirements file, so there is nothing
 # a code sync can legitimately re-install:
 #   - autobot-npu-worker: roles/npu-worker/tasks/main.yml:188-218 pip-installs a
-#     named list (FastAPI + OpenVINO) into its py3.11 venv. The repo does ship
+#     named list (FastAPI + OpenVINO) into its py3.14 venv (#13747). The repo does ship
 #     autobot-npu-worker/requirements.txt, but ansible never uses it — installing
 #     from it could pull a different OpenVINO build and brick the NPU worker.
 #   - autobot-browser-worker: roles/browser/tasks/main.yml:132-140 installs

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -100,10 +100,10 @@ def test_constraints_source_subdir_constant() -> None:
 
 
 def test_component_python_target_has_backends() -> None:
-    """Both pip-backend components have a python target defined."""
+    """Every mapped component targets python3.14 (#13747: NPU worker moved off 3.11)."""
     assert _COMPONENT_PYTHON_TARGET["autobot-backend"] == "python3.14"
     assert _COMPONENT_PYTHON_TARGET["autobot-slm-backend"] == "python3.14"
-    assert _COMPONENT_PYTHON_TARGET["autobot-npu-worker"] == "python3.11"
+    assert _COMPONENT_PYTHON_TARGET["autobot-npu-worker"] == "python3.14"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/audit/python_314_consistency.md
+++ b/docs/audit/python_314_consistency.md
@@ -201,3 +201,35 @@ re-establishing before anything is deleted. Filed separately.
   Removing it is a separate question from the interpreter version.
 - **Changing the local dev box** — out of repo scope. Worth knowing that it runs 3.10, which is
   what made #13727 look like five broken contracts; see the memory note on local-env floors.
+
+## Update — 2026-08-25 (#13747/#13748 follow-up)
+
+**F1a landed** in PR #13800 (merged as `317723efa9`, 2026-08-09) and the two defects it exposed on
+a real provisioning run (`openvino-dev` unsatisfiable against `openvino` 2026.x — #14447/#14449,
+#14452, #14453) are also merged. Re-measured against PyPI on 2026-08-25: `openvino` 2026.3.0,
+`torch` 2.13.0 and `numpy` 2.5.2 all still publish `cp314` `manylinux` wheels for `x86_64`; the
+repo's floor is now `openvino>=2026.3.0`, one point above what F1 measured, and still cp314.
+
+**#13747 stays open.** Every file in its stated scope (`roles/npu-worker`,
+`deploy-native-services.yml`, `deploy-full.yml`, `configure-python-provision-permissions.yml`,
+`provision-local-python.yml`) is on `python3.14`, and AC4 ("verified by deliberate failure: the
+guard rejects a venv left at the old version") now has a runnable, host-independent regression
+test: `tests/playbooks/test_ensure_venv_version.yml`, wired into `ansible-role-facts-test.yml`.
+What remains is AC1-3 — the worker actually starting and serving inference on a 3.14 venv on real
+NPU hardware. That is not a code change; no session without a route to fleet hardware can supply
+it, and this audit update does not claim to.
+
+**The Windows-worker question F1 left open is answered: no.** `redis_client.py` and
+`http_retry.py` are the only Windows-worker files that mention `autobot_shared`, and both do so
+only in a docstring explaining why they deliberately do *not* import it — the Windows worker is a
+PyInstaller standalone that cannot import `autobot_shared` at runtime, a documented exception
+(`docs/developer/ARCHITECTURE_EXCEPTIONS.md`, issue #5438). Grep for an actual `from
+autobot_shared` / `import autobot_shared` statement anywhere under
+`autobot-npu-worker/resources/windows-npu-worker/` returns zero matches. So bumping black's
+`target-version` will not reformat any code the Windows worker imports — that half of #13748's
+"Open question to settle first" is closed.
+
+**#13748 stays blocked regardless**, on the other half: its AC3 requires "every Python interpreter
+that imports `autobot_shared` is on 3.14 at the time this merges," and the Linux NPU worker's
+*running* version is exactly the unresolved AC1-3 above. The order from #13743 is unchanged —
+#13748 does not move until #13747 has host evidence, not merge evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,24 @@
 [tool.black]
 line-length = 120
-# Stays py312 (NOT py314): the backend runs Python 3.14, but the NPU/OpenVINO
-# worker runs Python 3.11 (roles/npu-worker/tasks/main.yml). A py314 target
-# makes black emit PEP 758 unparenthesized `except A, B:`, a SyntaxError on
-# that worker's cross-imported shared code.
+# Stays py312 (NOT py314). A py314 target makes black emit PEP 758
+# unparenthesized `except A, B:`, a SyntaxError on any interpreter below
+# 3.11 that imports the reformatted code.
 #
-# Bump only when the worker itself is on 3.14 — never before, or the reformat
-# lands syntax the running worker cannot parse. As of 2026-08-08 that move is
-# unblocked for the Linux worker: openvino 2026.3.0, torch 2.13.0 and numpy
-# 2.5.1 all ship cp314 wheels, so #10877's "OpenVINO has no 3.14 wheels" no
-# longer holds. The Windows worker still pins onnxruntime-openvino, which has
-# no cp314 — settle whether it shares this code before bumping (#10877).
+# roles/npu-worker/tasks/main.yml (#13747) now targets python3.14, and
+# openvino 2026.3.0, torch 2.13.0 and numpy 2.5.2 all ship cp314 wheels, so
+# #10877's "OpenVINO has no 3.14 wheels" no longer holds. The Windows worker
+# (autobot-npu-worker/resources/windows-npu-worker/) still pins
+# onnxruntime-openvino, which has no cp314 and stays on its current
+# interpreter — but it does not import autobot_shared at runtime (PyInstaller
+# standalone, docs/developer/ARCHITECTURE_EXCEPTIONS.md #5438), so it does not
+# gate this bump.
+#
+# What still gates it: #13747's config change is merged, but its AC requires
+# the worker to be verified running 3.14 on real NPU hardware — a pip install
+# or a syntax-check proves the config, not the runtime, and OpenVINO failures
+# are native-extension failures that surface at import or first inference.
+# Bump only once that host evidence lands on #13747, never on merge evidence
+# alone (#13748).
 # Audit: docs/audit/python_314_consistency.md
 target-version = ["py312"]
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -74,7 +74,8 @@ fi
 #
 # Note the two versions are different things: black *runs* under 3.14, while
 # `target-version` in pyproject.toml controls the syntax it *emits* and stays
-# at py312 for the 3.11 NPU worker (#10877).
+# at py312 until #13747 has host evidence that the NPU worker is actually
+# running 3.14, not merely configured for it (see pyproject.toml).
 PYTHON_BIN=""
 for candidate in python3.14 python3.13 python3.12 python3.11 python3.10 python3; do
     command -v "$candidate" >/dev/null 2>&1 || continue


### PR DESCRIPTION
## Thinking Path

Read #13743, #13747, #13748 in full, then re-verified the epic's central claim
independently rather than trusting it: resolved `openvino`, `torch`, `numpy`
against PyPI's JSON API for the exact floor the repo pins
(`autobot-npu-worker/requirements.txt`: `openvino>=2026.3.0`, `torch>=2.13.0`,
`numpy>=2.5.2` via `constraints/shared.txt`) and confirmed `cp314`
`manylinux_x86_64` wheels exist for all three. `onnxruntime-openvino` (Windows
worker only) still has none — matches the issue.

Next found that #13747's config work was **already merged** in a prior session
(PR #13800, plus #14447/#14449 and closed siblings #14452/#14453 fixing a real
`openvino-dev` resolver defect that a live provisioning attempt exposed). The
issue is deliberately still open: its own history shows it was closed once on
merge evidence and reopened for lacking host evidence, with an explicit
checklist of what a host run must show (venv builds, `import openvino`
succeeds, inference is served, the guard rejects a stale venv).

Confirmed this session has no path to that evidence — no network route to any
fleet host, and the project rule is CI/the builtin updater only, never ad-hoc
ssh/ansible against a live host. So AC1–3 of #13747 (worker starts and serves
inference, verified on a host) cannot be delivered from here. Per instruction,
that means **stopping before #13748** — this PR does not touch
`target-version`.

What *was* achievable without a host: AC4 ("verified by deliberate failure:
the guard rejects a venv left at the old version") is a pure logic property of
`ensure_venv_version.yml`, testable against a fabricated venv. Wrote that
test, and while sweeping for other stale `python3.11`/NPU declarations to
answer the "real exception list" question, found five more genuinely stale
ones outside #13747's originally-stated scope (`code_sync.py`'s
self-described "authoritative mapping", its test, `inventory/production.yml`,
a guard-script docstring, and the black-pin comments) and corrected all of
them to reflect reality — none change runtime behaviour.

## What Changed

| File | Change |
|---|---|
| `autobot-slm-backend/ansible/tests/playbooks/test_ensure_venv_version.yml` | New. Runs `ensure_venv_version.yml` against a fabricated stale (3.11) venv and a fabricated current (3.14) venv; asserts remove/keep respectively. No NPU hardware or real `python3.14` binary needed. |
| `.github/workflows/ansible-role-facts-test.yml` | Wires the new test in (real run, plus YAML lint step). |
| `autobot-slm-backend/api/code_sync.py` | `_COMPONENT_PYTHON_TARGET["autobot-npu-worker"]`: `python3.11` → `python3.14`. Currently unreachable for this key (worker components bypass the only two readers of this dict — documented in place) but was wrong under a claim of sole authority. |
| `autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py` | Test assertion updated to match. |
| `autobot-slm-backend/ansible/inventory/production.yml` | `python_version: "3.11"` → `"3.14"` for the npu group, comment corrected (var is currently unread by any role, noted as such). |
| `autobot-slm-backend/ansible/tests/check_venv_producers.py` | Docstring no longer describes the pre-#13747 two-interpreter state as current. |
| `pyproject.toml`, `scripts/format.sh` | Black `target-version` comments no longer cite "the 3.11 NPU worker" as the reason `py314` is unset — the real, current reason is host evidence, named explicitly. `target-version` itself is unchanged (`py312`). |
| `docs/audit/python_314_consistency.md` | Dated follow-up section: re-measurement, current blocker state, and the Windows-worker question resolved (below). |

## Acceptance criteria

### #13747 — move the Linux NPU worker to 3.14

| AC | Status | Evidence |
|---|---|---|
| Venv built with 3.14, full requirements installs | Done (prior session) | PR #13800 + #14447/#14449 fixed a real `openvino-dev` resolver failure found on an actual provisioning run; `roles/npu-worker/tasks/main.yml` targets `python3.14` throughout. |
| Worker starts and serves inference on 3.14, verified on a host | **Not done — cannot be delivered from this session** | No network route to any fleet host from this sandbox; project rule forbids ad-hoc ssh/ansible against a live host. This is the reason the issue was reopened before, and it is still unresolved. Needs an operator deploy + host check. |
| `ensure_venv_version.yml` applied so an existing 3.11 venv is replaced | Done (prior session) | `roles/npu-worker/tasks/main.yml:162-168` calls it before venv creation. |
| Verified by deliberate failure: guard rejects a stale venv | **Done, this PR** | `tests/playbooks/test_ensure_venv_version.yml`, wired into CI. Locally: both cases pass; a mutation neutering the removal condition makes the test fail as designed. |

**#13747 is not closed by this PR.** 3 of 4 AC are met; the remaining one is
an infrastructure action, not a code change, and is out of reach from this
session per the constraints given.

### #13748 — bump black target-version to py314

Not started, deliberately. #13743/#13747 are explicit that #13748 must not
land before #13747 is verified running 3.14 on a host — bumping first
reformats `autobot_shared` into PEP 758 syntax a still-unverified worker might
not survive. Since #13747's host evidence could not be produced this session,
this PR stops before #13748, per instruction. One part of its AC *is* answered
here as a byproduct of the sweep:

| AC | Status | Evidence |
|---|---|---|
| Established whether the Windows worker consumes shared code this change would reformat | **Done, this PR** | Zero real `from autobot_shared` / `import autobot_shared` statements anywhere under `autobot-npu-worker/resources/windows-npu-worker/` (grep swept the whole tree). The two files that mention `autobot_shared` do so only in docstrings explaining why they deliberately do *not* import it — documented architectural exception #5438 (`docs/developer/ARCHITECTURE_EXCEPTIONS.md`). Recorded in the audit doc. |
| `target-version = ["py314"]`, whole repo reformatted in one commit | Not done | Blocked on #13747 host evidence. |
| Every interpreter importing `autobot_shared` is on 3.14 at merge time | Not done | Same blocker — the Linux NPU worker's *running* version is exactly what's unverified. |
| `pyproject.toml` comment and `scripts/format.sh` updated | Partially — comments corrected to name the real current blocker, but `target-version` itself unchanged | See diff. |

### #13743 — epic

Stays open; it closes when its children do. This PR narrows #13747 to a
single outstanding item (host verification) and answers one of two open
questions blocking #13748, but delivers neither child issue's closing state.

## Verification

- **This dev box runs Python 3.10.12** (stated constraint) — did not install
  or switch interpreters. All version-sensitive claims below are qualified
  accordingly; CI (3.14) is authoritative.
- Independently verified against PyPI's JSON API (2026-08-25): `openvino`
  2026.3.0, `torch` 2.13.0, `numpy` 2.5.2+ all publish `cp314` `manylinux`
  wheels for `x86_64` — matches the repo's actual floor
  (`autobot-npu-worker/requirements.txt`), not just the issue's cited
  `>=2026.2.1`.
- `ansible-playbook --connection=local -i 'localhost,' tests/playbooks/test_ensure_venv_version.yml` — 20 ok, 0 failed, both cases pass.
- Mutation check: neutering `ensure_venv_version.yml`'s removal condition makes the new test's deliberate-failure case fail with the expected assertion message; reverted cleanly (`git diff --stat` empty on that file afterward).
- `python3 autobot-slm-backend/ansible/tests/check_venv_producers.py` — passes, 9 venv paths, one interpreter each.
- `python3 scripts/check_python_file_size.py autobot-slm-backend/api/code_sync.py autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py` — passes; both files are on the ratchet ceiling (6065 / 2098 lines) and edits were kept net-zero.
- `python3 -m py_compile` on both edited `.py` files — no syntax errors (not a semantic run).
- `black --check --target-version py312 --line-length 120` on all three edited `.py` files — unchanged (warning about the 3.10 AST-safety check is expected and pre-existing, documented in `scripts/format.sh`).
- YAML-loaded every edited/added YAML file with `yaml.safe_load`.
- No new `sys.version_info` guard work was needed: `autobot-backend/llc/scheduler/base.py`'s guard already fails loudly at import below the 3.14 floor (decision made deliberately in #13369, documented in-file and in the two test modules that assert rather than skip on it) — this is the correct, already-settled state, not something this PR needed to touch. The minor duplicate-assert pattern (#13844) is unrelated and already tracked.

## Model Used

Claude Sonnet 5

Refs #13747
