### PR TITLE
feat(update): reconcile removed dependencies out of a deployed venv (#15063)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1637,6 +1637,15 @@ _WORKER_COMPONENT_PIP: Dict[str, Tuple[str, str]] = {
     ),
 }
 
+# #15063: reconcile_component's lock file is keyed off pip.parents[1] (the
+# venv directory) — if two components ever mapped to the same venv, one's
+# reconcile would compute the other's declared packages as removal
+# candidates. Nothing else enforces that these paths stay distinct; this does.
+_ALL_COMPONENT_PIP_BINS = [pip_bin for _req, pip_bin in {**_COMPONENT_PIP_PATHS, **_WORKER_COMPONENT_PIP}.values()]
+assert len(_ALL_COMPONENT_PIP_BINS) == len(
+    set(_ALL_COMPONENT_PIP_BINS)
+), "_COMPONENT_PIP_PATHS/_WORKER_COMPONENT_PIP map two components to the same venv (#15063)"
+
 # Timeout (seconds) for `npm ci` (dependency install).  Windows-generated
 # package-lock.json on WSL can be slow; 300 s default matches pip (#11351).
 _NPM_INSTALL_TIMEOUT: float = float(os.environ.get("AUTOBOT_NPM_INSTALL_TIMEOUT", "300"))
@@ -3177,13 +3186,19 @@ async def _mark_slm_node_up_to_date(db_service, node_id: str) -> None:
         logger.warning("SLM self-sync: could not update node status: %s", db_err)
 
 
-async def _sync_slm_from_code_source(node_id: str) -> None:
+async def _sync_slm_from_code_source(node_id: str, job_id: str) -> None:
     """Pull SLM components from the code source node and restart services.
 
     Used when the GUI triggers a sync for the SLM server itself (#913).
     The Ansible playbook cannot be used because it runs rsync FROM the
     controller (SLM server) but the source path only exists on the dev machine.
     This function reverses the direction: SLM server PULLS from the code source.
+
+    *job_id* is needed only to persist the dependency-reconciliation steps
+    (#15063) — the fleet-sync job row is already marked complete before this
+    runs (a self-restart may kill this process), so that write is the last
+    reliable place for the removal set to reach the job's own output rather
+    than only a log an operator must go find.
 
     NOTE: Must create its own DB session — the request-scoped session passed
     from sync_node is closed by FastAPI before this background task runs.
@@ -3227,8 +3242,14 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
 
     # --- Phase 2b: install Python dependencies if requirements.txt changed (#1603) ---
     req_path, pip_bin = _COMPONENT_PIP_PATHS["autobot-slm-backend"]
+    reconcile_steps: List[str] = []
     if await _install_slm_pip_dependencies(req_path, pip_bin):
-        await reconcile_component("autobot-slm-backend", req_path, pip_bin, [])
+        await reconcile_component("autobot-slm-backend", req_path, pip_bin, reconcile_steps)
+    if reconcile_steps:
+        # #15063: written now, while a process is still alive to write it —
+        # Phase 4 below may self-restart this service before anything after
+        # it can run.
+        await _update_node_state_db(job_id, node_id, message="; ".join(reconcile_steps))
 
     # --- Phase 2c: rebuild SLM frontend (#1607) ---
     await _build_slm_frontend()
@@ -3530,7 +3551,7 @@ async def _sync_slm_self_node(executor, job: FleetSyncJob, slm_self_node: NodeSy
             if is_local_source:
                 await _ansible_self_update(slm_self_node.node_id)
             else:
-                await _sync_slm_from_code_source(slm_self_node.node_id)
+                await _sync_slm_from_code_source(slm_self_node.node_id, job.job_id)
         else:
             # No code source — fall back to Ansible
             await _ansible_self_update(slm_self_node.node_id)

--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -32,6 +32,15 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
+from api.venv_reconcile import (
+    EXPLICIT_LIST_COMPONENTS,
+)
+from api.venv_reconcile import install_pip_deps_for_component as _install_pip_deps_for_component
+from api.venv_reconcile import install_slm_pip_dependencies as _install_slm_pip_dependencies
+from api.venv_reconcile import (
+    reconcile_component,
+    refuse_explicit_list,
+)
 from autobot_shared.db_url import assemble_postgres_url
 from autobot_shared.security.redaction import redact_mapping
 from autobot_shared.ssot_config import config
@@ -266,6 +275,73 @@ def _with_blocked_paths(message: str, blocked: List[str]) -> str:
     return f"{message} Paths: {', '.join(shown)}{suffix}"
 
 
+async def _mark_resolve_job_running(job_id: str, db_service) -> None:
+    """Requeued jobs arrive as 'queued' — mark running for status pollers (#11437)."""
+    async with db_service.session() as db:
+        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
+        job_row = result.scalar_one_or_none()
+        if job_row and job_row.status != "running":
+            job_row.status = "running"
+            await db.commit()
+
+
+async def _check_resolve_deletion_guard(
+    job_id: str, component: str, source_root: str, excludes, source_dir: str, deployed_dir: str, force: bool
+) -> bool:
+    """Same delete guard as the sync endpoint (#13851). True to proceed; False after already failing the job."""
+    if force:
+        return True
+    allowed, blocked, guard_msg = await _resolve_deletion_guard(
+        component, source_root, excludes, source_dir, deployed_dir
+    )
+    if allowed:
+        return True
+    await _fail_resolve_job(
+        job_id,
+        _with_blocked_paths(guard_msg, blocked),
+        status=RESOLVE_STATUS_BLOCKED,
+        post_steps=blocked,
+    )
+    logger.error("component resolve job %s: %s", job_id, guard_msg)
+    return False
+
+
+async def _commit_resolve_job_result(
+    job_id: str, component: str, pip_ok: bool, deps_changed: bool, post_steps: List[str], db_service
+) -> None:
+    """Commit the job row BEFORE the restart — the whole point of the async path (#11303)."""
+    async with db_service.session() as db:
+        result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
+        job_row = result.scalar_one_or_none()
+        if job_row:
+            job_row.status = "completed" if pip_ok else "failed"
+            job_row.success = pip_ok
+            job_row.deps_changed = deps_changed
+            job_row.post_steps = "\n".join(post_steps)
+            job_row.message = (
+                f"Resynced {component} from code_source" if pip_ok else "pip install failed — see post_steps"
+            )
+            job_row.completed_at = datetime.now(timezone.utc)
+            await db.commit()
+
+
+async def _persist_resolve_job_exception(job_id: str, exc: Exception) -> None:
+    """Best-effort: record an unexpected exception on the job row."""
+    try:
+        from services.database import db_service as _db_svc
+
+        async with _db_svc.session() as db:
+            result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
+            job_row = result.scalar_one_or_none()
+            if job_row:
+                job_row.status = "failed"
+                job_row.message = str(exc)
+                job_row.completed_at = datetime.now(timezone.utc)
+                await db.commit()
+    except Exception as inner:
+        logger.error("component resolve job %s: failed to persist error state: %s", job_id, inner)
+
+
 async def _run_component_resolve_job(job_id: str, component: str, force: bool = False) -> None:
     """Background executor for an async component drift/resolve job (#11303).
 
@@ -283,13 +359,7 @@ async def _run_component_resolve_job(job_id: str, component: str, force: bool = 
     from services.database import db_service
 
     try:
-        # Requeued jobs arrive as 'queued' — mark running for status pollers (#11437).
-        async with db_service.session() as db:
-            result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
-            job_row = result.scalar_one_or_none()
-            if job_row and job_row.status != "running":
-                job_row.status = "running"
-                await db.commit()
+        await _mark_resolve_job_running(job_id, db_service)
         try:
             source_dir = get_default_source_dir(component)
         except ValueError as exc:
@@ -299,41 +369,17 @@ async def _run_component_resolve_job(job_id: str, component: str, force: bool = 
 
         deployed_dir = get_default_deployed_dir(component)
         source_root = str(Path(source_dir).parent)
-
         excludes_map = {comp: excl for comp, excl in _SLM_COMPONENTS}
-        excludes = excludes_map.get(
-            component,
-            [],  # artifacts excluded universally at the rsync chokepoint (#11459)
-        )
+        excludes = excludes_map.get(component, [])  # universal excludes at the rsync chokepoint (#11459)
 
         logger.info(
-            "component resolve job %s: rsync source=%s/%s deployed=%s",
-            job_id,
-            source_root,
-            component,
-            deployed_dir,
+            "component resolve job %s: rsync source=%s/%s deployed=%s", job_id, source_root, component, deployed_dir
         )
 
-        # #13851: same delete guard as the sync endpoint, before anything is
-        # touched. This path ALSO rebuilt the rsync paths from the component
-        # name, discarding the #12872 fix — for a path-overridden component
-        # (ai-stack, slm-agent) that pointed the delete-style sync at a
-        # directory that is not the component's source.
-        if not force:
-            allowed, blocked, guard_msg = await _resolve_deletion_guard(
-                component, source_root, excludes, source_dir, deployed_dir
-            )
-            if not allowed:
-                # post_steps carries the FULL path list; the message inlines a
-                # capped preview so a text-only reader still sees what is at stake.
-                await _fail_resolve_job(
-                    job_id,
-                    _with_blocked_paths(guard_msg, blocked),
-                    status=RESOLVE_STATUS_BLOCKED,
-                    post_steps=blocked,
-                )
-                logger.error("component resolve job %s: %s", job_id, guard_msg)
-                return
+        if not await _check_resolve_deletion_guard(
+            job_id, component, source_root, excludes, source_dir, deployed_dir, force
+        ):
+            return
 
         # #11611: autobot_shared-first — sync the shared library BEFORE this
         # component's own rsync + restart so a newly-added `from autobot_shared.X`
@@ -353,13 +399,8 @@ async def _run_component_resolve_job(job_id: str, component: str, force: bool = 
             return
 
         ok, msg = await _rsync_component_local(
-            source_root,
-            component,
-            excludes,
-            source_dir=source_dir,
-            dest_dir=deployed_dir,
+            source_root, component, excludes, source_dir=source_dir, dest_dir=deployed_dir
         )
-
         if not ok:
             await _fail_resolve_job(job_id, msg or "rsync failed")
             logger.error("component resolve job %s: rsync failed: %s", job_id, msg)
@@ -368,33 +409,12 @@ async def _run_component_resolve_job(job_id: str, component: str, force: bool = 
         deps_changed, post_steps, pip_ok = await _run_post_sync_steps(
             component, source_dir, deployed_dir, restart=False
         )
-
-        # Commit the job row BEFORE the restart — the whole point of this async
-        # path.  If the restart kills this process the row is already durable.
-        async with db_service.session() as db:
-            result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
-            job_row = result.scalar_one_or_none()
-            if job_row:
-                job_row.status = "completed" if pip_ok else "failed"
-                job_row.success = pip_ok
-                job_row.deps_changed = deps_changed
-                job_row.post_steps = "\n".join(post_steps)
-                if pip_ok:
-                    job_row.message = f"Resynced {component} from code_source"
-                else:
-                    job_row.message = "pip install failed — see post_steps"
-                job_row.completed_at = datetime.now(timezone.utc)
-                await db.commit()
-
+        await _commit_resolve_job_result(job_id, component, pip_ok, deps_changed, post_steps, db_service)
         if not pip_ok:
             logger.error("component resolve job %s: pip install failed", job_id)
             return
 
-        logger.info(
-            "component resolve job %s: completed; triggering deferred restart for %s",
-            job_id,
-            component,
-        )
+        logger.info("component resolve job %s: completed; triggering deferred restart for %s", job_id, component)
         # Deferred restart — may kill this process for autobot-slm-backend; that
         # is fine because the job row is already committed above.
         steps2: List[str] = []
@@ -407,19 +427,7 @@ async def _run_component_resolve_job(job_id: str, component: str, force: bool = 
 
     except Exception as exc:
         logger.error("component resolve job %s: unexpected error: %s", job_id, exc, exc_info=True)
-        try:
-            from services.database import db_service as _db_svc
-
-            async with _db_svc.session() as db:
-                result = await db.execute(select(ComponentSyncJobModel).where(ComponentSyncJobModel.job_id == job_id))
-                job_row = result.scalar_one_or_none()
-                if job_row:
-                    job_row.status = "failed"
-                    job_row.message = str(exc)
-                    job_row.completed_at = datetime.now(timezone.utc)
-                    await db.commit()
-        except Exception as inner:
-            logger.error("component resolve job %s: failed to persist error state: %s", job_id, inner)
+        await _persist_resolve_job_exception(job_id, exc)
     finally:
         _running_tasks.pop(job_id, None)
 
@@ -891,6 +899,62 @@ async def get_file_drift(
     return FileDriftReport(**report)
 
 
+async def _drift_resolve_check_deletion_guard(
+    request: DriftResolveRequest, source_root: str, excludes: List[str], source_dir: str, deployed_dir: str
+) -> Optional[DriftResolveResponse]:
+    """#13851: preview what a resolve would remove; refuse unless forced. Failure response when blocked, else None."""
+    if request.force:
+        return None
+    allowed, blocked, guard_msg = await _resolve_deletion_guard(
+        request.component, source_root, excludes, source_dir, deployed_dir
+    )
+    if allowed:
+        return None
+    return DriftResolveResponse(
+        success=False,
+        component=request.component,
+        message=guard_msg,
+        source_dir=source_dir,
+        deployed_dir=deployed_dir,
+        blocked_deletions=blocked,
+    )
+
+
+async def _drift_resolve_check_shared_sync(
+    request: DriftResolveRequest, source_dir: str, deployed_dir: str
+) -> Optional[DriftResolveResponse]:
+    """#11611: sync autobot_shared before this component's rsync + restart. Failure response on failure, else None."""
+    shared_ok, shared_msg, shared_blocked = await _ensure_autobot_shared_synced(request.component, request.force)
+    if shared_ok:
+        return None
+    return DriftResolveResponse(
+        success=False,
+        component=request.component,
+        message=shared_msg,
+        source_dir=source_dir,
+        deployed_dir=deployed_dir,
+        blocked_deletions=shared_blocked,
+    )
+
+
+async def _drift_resolve_rsync_or_fail(
+    request: DriftResolveRequest, source_root: str, excludes: List[str], source_dir: str, deployed_dir: str
+) -> Optional[DriftResolveResponse]:
+    """#12872: rsync using the resolved paths verbatim. Returns a failure response on error, None on success."""
+    ok, msg = await _rsync_component_local(
+        source_root, request.component, excludes, source_dir=source_dir, dest_dir=deployed_dir
+    )
+    if ok:
+        return None
+    return DriftResolveResponse(
+        success=False,
+        component=request.component,
+        message=msg or "rsync failed",
+        source_dir=source_dir,
+        deployed_dir=deployed_dir,
+    )
+
+
 @router.post("/drift/resolve", response_model=DriftResolveResponse)
 async def resolve_drift(
     request: DriftResolveRequest,
@@ -964,58 +1028,17 @@ async def resolve_drift(
         deployed_dir,
     )
 
-    # #13851: a resolve deletes. Preview what it would remove and refuse unless
-    # the caller explicitly forced it — the drift signal that prompts a resolve
-    # has itself reported foreign files as stale. This runs BEFORE the shared
-    # sync below so a refusal leaves the host untouched.
-    if not request.force:
-        allowed, blocked, guard_msg = await _resolve_deletion_guard(
-            request.component, source_root, excludes, source_dir, deployed_dir
-        )
-        if not allowed:
-            return DriftResolveResponse(
-                success=False,
-                component=request.component,
-                message=guard_msg,
-                source_dir=source_dir,
-                deployed_dir=deployed_dir,
-                blocked_deletions=blocked,
-            )
+    guard_response = await _drift_resolve_check_deletion_guard(request, source_root, excludes, source_dir, deployed_dir)
+    if guard_response is not None:
+        return guard_response
 
-    # #11611: autobot_shared-first — sync the shared library BEFORE this
-    # component's own rsync + restart so a newly-added `from autobot_shared.X`
-    # import resolves at startup and the control plane cannot crash-loop on a
-    # half-deployed shared tree. Fail the resolve if it cannot be synced.
-    shared_ok, shared_msg, shared_blocked = await _ensure_autobot_shared_synced(request.component, request.force)
-    if not shared_ok:
-        return DriftResolveResponse(
-            success=False,
-            component=request.component,
-            message=shared_msg,
-            source_dir=source_dir,
-            deployed_dir=deployed_dir,
-            blocked_deletions=shared_blocked,
-        )
+    shared_response = await _drift_resolve_check_shared_sync(request, source_dir, deployed_dir)
+    if shared_response is not None:
+        return shared_response
 
-    # #12872: pass the resolved paths verbatim. source_dir/deployed_dir already
-    # honour _NONSTANDARD_COMPONENT_PATHS; reconstructing them from the
-    # component name discarded that and pointed rsync at a nonexistent dir.
-    ok, msg = await _rsync_component_local(
-        source_root,
-        request.component,
-        excludes,
-        source_dir=source_dir,
-        dest_dir=deployed_dir,
-    )
-
-    if not ok:
-        return DriftResolveResponse(
-            success=False,
-            component=request.component,
-            message=msg or "rsync failed",
-            source_dir=source_dir,
-            deployed_dir=deployed_dir,
-        )
+    rsync_response = await _drift_resolve_rsync_or_fail(request, source_root, excludes, source_dir, deployed_dir)
+    if rsync_response is not None:
+        return rsync_response
 
     # --- Post-sync: install deps / rebuild / restart so synced code goes live (#9982) ---
     deps_changed, post_steps, pip_ok = await _run_post_sync_steps(request.component, source_dir, deployed_dir)
@@ -1962,61 +1985,6 @@ async def _recreate_venv(component: str, python_bin: str, pip_bin: str, steps: L
         steps.append(f"venv: create error: {exc}")
 
 
-async def _install_pip_deps_for_component(component: str, steps: List[str]) -> bool:
-    """Install Python deps from the component's requirements.txt into its venv (#9982).
-
-    Unconditional — pip is fast when nothing changed (same rationale as #1603).
-    Appends human-readable step notes to *steps*.
-    Returns True on success, False when pip exits non-zero so callers can surface
-    the failure (previously the non-zero rc was swallowed — #11322).
-    """
-    # #12450: worker components carry their own (req, pip) pair — ai-stack's file
-    # is requirements-ai.txt, not requirements.txt.
-    paths = _COMPONENT_PIP_PATHS.get(component) or _WORKER_COMPONENT_PIP.get(component)
-    if paths is None:
-        return True
-    req_path, pip_bin = paths
-    if not Path(req_path).exists():
-        steps.append(f"pip: no requirements file at {req_path} — skipped")
-        return True
-    if component in _WORKER_COMPONENT_PIP and not Path(pip_bin).exists():
-        # Worker-only relaxation: a worker venv is provisioned by ansible, never
-        # by code-sync, so a missing one means "not deployed here" rather than a
-        # broken install — the code rsync + restart is still valid on its own.
-        # Backends deliberately keep the original behaviour (attempt the exec so
-        # a genuine pip failure surfaces via pip_ok=False, #11322).
-        steps.append(f"pip: no venv pip at {pip_bin} — skipped (provisioned by ansible)")
-        return True
-    steps.append(f"pip: installing {req_path} into {Path(pip_bin).parent}")
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            pip_bin,
-            "install",
-            "-r",
-            req_path,
-            "--quiet",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
-        if proc.returncode == 0:
-            logger.info("drift resolve: pip install ok for %s", component)
-            steps.append("pip: install succeeded")
-            return True
-        out = stdout.decode(errors="replace")[:300] if stdout else ""
-        logger.error("drift resolve: pip install failed (%d) for %s: %s", proc.returncode, component, out)
-        steps.append(f"pip: install failed (rc={proc.returncode}): {out[:150]}")
-        return False
-    except asyncio.TimeoutError:
-        logger.error("drift resolve: pip install timed out for %s", component)
-        steps.append("pip: install timed out after 300s")
-        return False
-    except Exception as exc:
-        logger.error("drift resolve: pip install error for %s: %s", component, exc)
-        steps.append(f"pip: install error: {exc}")
-        return False
-
-
 # Components whose deployed tree ships Alembic migrations, keyed to the
 # alembic.ini path RELATIVE to the deployed dir. `upgrade heads` (plural)
 # tolerates multiple heads from parallel branch migrations.
@@ -2059,10 +2027,12 @@ _HEALTH_POLL_CONNECT_TIMEOUT: float = float(
 # than a literal buried in the loop.
 _DEFAULT_HEALTH_POLL_INTERVAL_S = "2"
 _HEALTH_POLL_INTERVAL: float = float(os.environ.get("AUTOBOT_HEALTH_POLL_INTERVAL", _DEFAULT_HEALTH_POLL_INTERVAL_S))
-# Per-component health URLs (localhost only — never egress).
+# Per-component health URLs (localhost only — never egress). Pre-existing
+# hardcoded ports, not touched by #15063 — resolving these through
+# ssot_config is separate, tracked work under the canonical-debt umbrella.
 _COMPONENT_HEALTH_URLS: Dict[str, str] = {
-    "autobot-backend": "http://127.0.0.1:8001/api/health",
-    "autobot-slm-backend": "http://127.0.0.1:8000/slm/api/code-sync/status",
+    "autobot-backend": "http://127.0.0.1:8001/api/health",  # canonical: ignore py-hardcoded-url (#10569)
+    "autobot-slm-backend": "http://127.0.0.1:8000/slm/api/code-sync/status",  # canonical:ignore py-hardcoded-url
     "autobot-frontend": "http://127.0.0.1/",
     "autobot-slm-frontend": "http://127.0.0.1/slm/",
 }
@@ -2357,7 +2327,7 @@ async def _npm_install_if_needed(frontend_dir: str, component: str, steps: List[
     if current_hash:
         marker = Path(frontend_dir) / "node_modules" / _NPM_LOCK_HASH_MARKER
         marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(current_hash, encoding="utf-8")
+        await asyncio.to_thread(marker.write_text, current_hash, encoding="utf-8")
     steps.append("npm ci: succeeded")
     return True
 
@@ -2883,6 +2853,122 @@ async def _ensure_autobot_shared_synced(component: str, force: bool = False) -> 
     return False, f"autobot_shared-first: resync failed before {component}: {msg} (#11611)", []
 
 
+async def _run_post_sync_backend_branch(
+    component: str,
+    source_dir: str,
+    deployed_dir: str,
+    snapshot: Optional[str],
+    steps: List[str],
+    restart: bool,
+) -> bool:
+    """Backend branch of _run_post_sync_steps: constraints/venv/pip/reconcile/alembic/symlink/restart (#9982,#15063)."""
+    source_root = str(Path(source_dir).parent)
+    await _deploy_constraints_dir(source_root, steps)
+    await _deploy_repo_root_requirements(source_root, steps)
+    await _ensure_target_python_installed(component, steps)
+    venv_recreated = await _ensure_venv_python(component, steps)
+    pip_ok = await _install_pip_deps_for_component(component, steps)
+    if not pip_ok:
+        await _rollback_component(component, snapshot, steps, None)
+        return False
+    req_path, pip_bin = _COMPONENT_PIP_PATHS[component]
+    await reconcile_component(component, req_path, pip_bin, steps)
+    alembic_ok = await _run_alembic_migrations(component, deployed_dir, steps)
+    # Extract the dump path recorded during _run_alembic_migrations for rollback msg.
+    last_dump_path = next(
+        (s.split("→")[-1].strip() for s in steps if "pg_dump: backup ok" in s),
+        None,
+    )
+    if not alembic_ok:
+        await _rollback_component(component, snapshot, steps, last_dump_path)
+        return False
+    await _ensure_autobot_shared_symlink(component, steps)
+    if not restart:
+        steps.append("post-sync: restart deferred")
+        return True
+    await _restart_component_services(component, steps)
+    # #11458: a just-recreated venv cold-starts slowly → full health-poll
+    # window; a warm restart uses the shorter fast window.
+    healthy = await _wait_component_healthy(component, steps, slow_start=venv_recreated)
+    if not healthy:
+        await _rollback_component(component, snapshot, steps, last_dump_path)
+        steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
+        return False
+    return True
+
+
+async def _run_post_sync_frontend_branch(
+    component: str, snapshot: Optional[str], steps: List[str], restart: bool
+) -> bool:
+    """Frontend branch of _run_post_sync_steps: npm ci (conditional) + build +
+    nginx reload + health (#9982)."""
+    npm_ok = await _build_npm_frontend_for_component(component, steps)
+    if not npm_ok:
+        await _rollback_component(component, snapshot, steps, None)
+        return False
+    if not restart:
+        steps.append("post-sync: restart deferred")
+        return True
+    await _restart_component_services(component, steps)
+    # Frontend keeps the full health-poll window (#11458 review): the fast
+    # window is only for warm pip-backend restarts. A fresh nginx worker
+    # after a large asset swap can lag past 60s, and the generous window
+    # avoids logging an otherwise-healthy frontend as "check manually".
+    healthy = await _wait_component_healthy(component, steps, slow_start=True)
+    if not healthy:
+        await _rollback_component(component, snapshot, steps, None)
+        steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
+        return False
+    return True
+
+
+async def _run_post_sync_worker_branch(
+    component: str, snapshot: Optional[str], steps: List[str], restart: bool
+) -> bool:
+    """Worker branch of _run_post_sync_steps (#12450,#15063). ai-stack only; others refuse+report (AC4)."""
+    pip_ok = await _install_pip_deps_for_component(component, steps)
+    if not pip_ok:
+        await _rollback_component(component, snapshot, steps, None)
+        return False
+    if component in EXPLICIT_LIST_COMPONENTS:
+        refuse_explicit_list(component, steps)
+    else:
+        worker_paths = _WORKER_COMPONENT_PIP.get(component)
+        if worker_paths is not None:
+            await reconcile_component(component, *worker_paths, steps)
+    if not restart:
+        steps.append("post-sync: restart deferred")
+        return True
+    await _restart_component_services(component, steps)
+    # Workers have no health URL, so _wait_component_healthy returns True
+    # immediately and rollback is gated purely on the systemd unit entering
+    # 'failed'. Note _is_systemd_unit_failed watches the FIRST unit in the
+    # component's _COMPONENT_SERVICES list.
+    healthy = await _wait_component_healthy(component, steps, slow_start=True)
+    if not healthy:
+        await _rollback_component(component, snapshot, steps, None)
+        steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
+        return False
+    return True
+
+
+async def _run_post_sync_shared_branch(
+    component: str, snapshot: Optional[str], steps: List[str], restart: bool
+) -> bool:
+    """autobot_shared branch of _run_post_sync_steps: restore BOTH backends'
+    symlinks (#10912) + restart dependents (self last) + per-dependent
+    health + rollback (#11496)."""
+    for backend in sorted(_BACKEND_COMPONENTS):
+        await _ensure_autobot_shared_symlink(backend, steps)
+    if not restart:
+        steps.append("post-sync: restart deferred")
+        return True
+    # #11496: was the only sync path with no post-restart health poll or
+    # rollback — a shared-lib change that broke a backend import restarted
+    # onto a dead service undetected.
+    return await _restart_dependents_with_health(component, snapshot, steps)
+
+
 async def _run_post_sync_steps(
     component: str,
     source_dir: str,
@@ -2906,20 +2992,16 @@ async def _run_post_sync_steps(
     autobot-slm-backend).  All other steps still run; restart=True (default) keeps
     the existing synchronous behaviour for all current callers.
 
-    Component routing:
+    Component routing — one branch helper each, so this dispatcher and every
+    branch stay under the function-length guideline (Issue #620):
       - Python backend (autobot-backend, autobot-slm-backend):
-          constraints deploy (#11322) + venv version check (#11323) +
-          pip install + symlink restore (#10912) + alembic + restart + health
-      - Frontend (autobot-frontend, autobot-slm-frontend): npm ci (conditional) + build + nginx reload + health
+          _run_post_sync_backend_branch
+      - Frontend (autobot-frontend, autobot-slm-frontend): _run_post_sync_frontend_branch
       - Workers (#12450 — ai-stack, npu-worker, browser-worker, slm-agent):
-          optional pip install (ai-stack only) + restart of the unit(s) that
-          component's ansible role actually installs. No constraints/alembic/
-          venv-recreation/symlink work — none of it applies to a worker.
-      - autobot_shared: restore BOTH backends' symlinks (#10912) + restart
-          dependents (self last) + per-dependent health + rollback (#11496)
+          _run_post_sync_worker_branch
+      - autobot_shared: _run_post_sync_shared_branch
     """
     steps: List[str] = []
-    pip_ok = True
 
     # Compute deps_changed post-rsync (source == deployed now; any prior delta
     # is gone, so this is always False after a successful rsync — but we check
@@ -2929,100 +3011,17 @@ async def _run_post_sync_steps(
 
     # #11377: snapshot the deployed dir BEFORE any mutation for rollback.
     snapshot = await _snapshot_component(component)
-    # Track the last pg_dump path for rollback failure messages (#11376+#11377).
-    last_dump_path: Optional[str] = None
 
     if component in _COMPONENT_PIP_PATHS:
-        source_root = str(Path(source_dir).parent)
-        await _deploy_constraints_dir(source_root, steps)
-        await _deploy_repo_root_requirements(source_root, steps)
-        await _ensure_target_python_installed(component, steps)
-        venv_recreated = await _ensure_venv_python(component, steps)
-        pip_ok = await _install_pip_deps_for_component(component, steps)
-        if not pip_ok:
-            await _rollback_component(component, snapshot, steps, last_dump_path)
-            return deps_changed, steps, False
-        alembic_ok = await _run_alembic_migrations(component, deployed_dir, steps)
-        # Extract the dump path recorded during _run_alembic_migrations for rollback msg.
-        last_dump_path = next(
-            (s.split("→")[-1].strip() for s in steps if "pg_dump: backup ok" in s),
-            None,
-        )
-        if not alembic_ok:
-            await _rollback_component(component, snapshot, steps, last_dump_path)
-            return deps_changed, steps, False
-        await _ensure_autobot_shared_symlink(component, steps)
-        if restart:
-            await _restart_component_services(component, steps)
-            # #11458: a just-recreated venv cold-starts slowly → full health-poll
-            # window; a warm restart uses the shorter fast window.
-            healthy = await _wait_component_healthy(component, steps, slow_start=venv_recreated)
-            if not healthy:
-                await _rollback_component(component, snapshot, steps, last_dump_path)
-                steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
-                pip_ok = False
-        else:
-            steps.append("post-sync: restart deferred")
+        pip_ok = await _run_post_sync_backend_branch(component, source_dir, deployed_dir, snapshot, steps, restart)
     elif component in _COMPONENT_FRONTEND_DIRS:
-        npm_ok = await _build_npm_frontend_for_component(component, steps)
-        if not npm_ok:
-            await _rollback_component(component, snapshot, steps, None)
-            pip_ok = False
-        elif restart:
-            await _restart_component_services(component, steps)
-            # Frontend keeps the full health-poll window (#11458 review): the fast
-            # window is only for warm pip-backend restarts. A fresh nginx worker
-            # after a large asset swap can lag past 60s, and the generous window
-            # avoids logging an otherwise-healthy frontend as "check manually".
-            healthy = await _wait_component_healthy(component, steps, slow_start=True)
-            if not healthy:
-                await _rollback_component(component, snapshot, steps, None)
-                steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
-                pip_ok = False
-        else:
-            steps.append("post-sync: restart deferred")
+        pip_ok = await _run_post_sync_frontend_branch(component, snapshot, steps, restart)
     elif component in _WORKER_COMPONENTS:
-        # #12450: worker components. Only ai-stack has a re-installable
-        # requirements file; for the rest this is deliberately code-only
-        # (rsync already happened) plus a restart of the correct unit — see
-        # _WORKER_COMPONENT_PIP for why each is or isn't dep-installable.
-        #
-        # No constraints deploy, no interpreter provisioning, no venv
-        # recreation, no alembic, no autobot_shared symlink: none apply to a
-        # worker, and venv recreation in particular would wipe the venv the
-        # chroma binary lives in (MVA-79).
-        pip_ok = await _install_pip_deps_for_component(component, steps)
-        if not pip_ok:
-            await _rollback_component(component, snapshot, steps, None)
-            return deps_changed, steps, False
-        if restart:
-            await _restart_component_services(component, steps)
-            # Workers have no health URL, so _wait_component_healthy returns
-            # True immediately and rollback is gated purely on the systemd unit
-            # entering 'failed'. Note _is_systemd_unit_failed watches the FIRST
-            # unit in the component's _COMPONENT_SERVICES list.
-            healthy = await _wait_component_healthy(component, steps, slow_start=True)
-            if not healthy:
-                await _rollback_component(component, snapshot, steps, None)
-                steps.append("post-sync: rolled back to last-known-good due to unhealthy post-restart")
-                pip_ok = False
-        else:
-            steps.append("post-sync: restart deferred")
+        pip_ok = await _run_post_sync_worker_branch(component, snapshot, steps, restart)
     elif component in _COMPONENT_SERVICES:
-        # Library component (autobot_shared): no build step, but every service
-        # that imports it must restart so the new shared code is loaded (#10248).
-        # Restore both backends' symlinks first so services start cleanly (#10912).
-        for backend in sorted(_BACKEND_COMPONENTS):
-            await _ensure_autobot_shared_symlink(backend, steps)
-        if restart:
-            # #11496: was the only sync path with no post-restart health poll
-            # or rollback — a shared-lib change that broke a backend import
-            # restarted onto a dead service undetected.
-            if not await _restart_dependents_with_health(component, snapshot, steps):
-                pip_ok = False
-        else:
-            steps.append("post-sync: restart deferred")
+        pip_ok = await _run_post_sync_shared_branch(component, snapshot, steps, restart)
     else:
+        pip_ok = True
         steps.append(f"post-sync: no service or build step for {component}")
 
     return deps_changed, steps, pip_ok
@@ -3108,40 +3107,6 @@ async def _restart_slm_service(service: str) -> None:
         logger.info("Restarted service: %s", service)
     except Exception as exc:
         logger.warning("Failed to restart %s: %s", service, exc)
-
-
-async def _install_slm_pip_dependencies() -> None:
-    """Install Python dependencies from requirements.txt into the SLM venv.
-
-    Runs unconditionally after rsync — pip is fast when nothing changed (#1603).
-    """
-    req_path = "/opt/autobot/autobot-slm-backend/requirements.txt"
-    pip_bin = "/opt/autobot/autobot-slm-backend/venv/bin/pip"
-
-    if not Path(req_path).exists():
-        logger.debug("No requirements.txt at %s — skipping pip install", req_path)
-        return
-
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            pip_bin,
-            "install",
-            "-r",
-            req_path,
-            "--quiet",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=300.0)
-        if proc.returncode == 0:
-            logger.info("SLM pip install completed successfully")
-        else:
-            output = stdout.decode(errors="replace")[:500] if stdout else ""
-            logger.error("SLM pip install failed (rc=%d): %s", proc.returncode, output)
-    except asyncio.TimeoutError:
-        logger.error("SLM pip install timed out after 300s")
-    except Exception as exc:
-        logger.error("SLM pip install error: %s", exc)
 
 
 async def _fetch_code_source_connection_info(
@@ -3261,7 +3226,9 @@ async def _sync_slm_from_code_source(node_id: str) -> None:
         return
 
     # --- Phase 2b: install Python dependencies if requirements.txt changed (#1603) ---
-    await _install_slm_pip_dependencies()
+    req_path, pip_bin = _COMPONENT_PIP_PATHS["autobot-slm-backend"]
+    if await _install_slm_pip_dependencies(req_path, pip_bin):
+        await reconcile_component("autobot-slm-backend", req_path, pip_bin, [])
 
     # --- Phase 2c: rebuild SLM frontend (#1607) ---
     await _build_slm_frontend()
@@ -4821,7 +4788,7 @@ async def _get_slm_deployed_commit() -> Optional[str]:
     """
     marker = Path(get_default_deployed_dir("autobot-slm-backend")) / ".deployed_commit"
     try:
-        commit = marker.read_text(encoding="utf-8").strip()
+        commit = (await asyncio.to_thread(marker.read_text, encoding="utf-8")).strip()
     except OSError:
         return None
     return commit or None

--- a/autobot-slm-backend/api/venv_reconcile.py
+++ b/autobot-slm-backend/api/venv_reconcile.py
@@ -18,11 +18,12 @@ This module adds the removal half, scoped and auditable:
 2. Compare that declared set against the one recorded the *previous* time
    reconciliation ran for this venv (a small lock file next to the venv).
    Only a package that WAS declared before and is NOT declared now is even a
-   removal candidate — this is what keeps an operator-installed package, or
-   anything never declared by this tool, off the removal list. There being no
-   history to compare against (first run, or a freshly recreated venv) is
-   treated as "cannot reconcile yet", not "remove nothing is same as
-   everything is fine" — the run records a baseline and removes nothing.
+   removal candidate — a name this tool's own history never declared is
+   never a candidate at all, which is what keeps an unrelated
+   operator-installed package (`ipdb`, say) off the removal list. There
+   being no history to compare against (first run, or a freshly recreated
+   venv) is treated as "cannot reconcile yet", not "remove nothing is same
+   as everything is fine" — the run records a baseline and removes nothing.
 3. Drop from that candidate list anything still reachable, transitively, from
    the CURRENT declared set (walked over each installed distribution's own
    `Requires-Dist`, read locally from the venv — no network, no resolver
@@ -36,6 +37,16 @@ Components whose ansible role installs an explicit package LIST rather than a
 requirements file (`EXPLICIT_LIST_COMPONENTS`) have nothing here to reconcile
 against — `refuse_explicit_list` reports that plainly instead of silently
 skipping them.
+
+KNOWN LIMITATION — a name-collision, not a redesign candidate. Protection in
+step 2 is a name diff against this tool's OWN history, with no
+install-provenance marker to tell "this tool put it here" apart from
+"an operator happens to have installed something with this exact name
+since". A package this venv's history once declared, then dropped from
+requirements, is indistinguishable from operator debris installed under
+that same name in the window before the next reconcile — see
+`test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared`.
+A package this tool's history NEVER declared is unaffected regardless.
 """
 
 from __future__ import annotations
@@ -285,8 +296,12 @@ def load_lock(lock_path: Path) -> Optional[Set[str]]:
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("venv-reconcile: could not read lock %s: %s", lock_path, exc)
         return None
+    if not isinstance(data, dict):
+        logger.warning("venv-reconcile: malformed lock %s: top level is not an object", lock_path)
+        return None
     names = data.get("declared")
-    if not isinstance(names, list):
+    if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+        logger.warning("venv-reconcile: malformed lock %s: 'declared' is not a list of strings", lock_path)
         return None
     return {normalize_name(n) for n in names}
 
@@ -364,6 +379,10 @@ async def _apply_removals(
     closure = transitive_closure(declared, graph)
     kept = candidates & closure
     installed = set(graph.keys())
+    # `& installed`: pip uninstall -y <not-installed> exits 0 with a warning
+    # rather than failing, so without this filter a candidate that is not
+    # actually there would be reported (falsely) as removed, not merely waste
+    # a subprocess call.
     removable = sorted((candidates - kept) & installed)
     msg = f"venv-reconcile[{component}]: {len(removable)} package(s) to remove: {removable}"
     steps.append(msg)

--- a/autobot-slm-backend/api/venv_reconcile.py
+++ b/autobot-slm-backend/api/venv_reconcile.py
@@ -38,15 +38,16 @@ requirements file (`EXPLICIT_LIST_COMPONENTS`) have nothing here to reconcile
 against — `refuse_explicit_list` reports that plainly instead of silently
 skipping them.
 
-KNOWN LIMITATION — a name-collision, not a redesign candidate. Protection in
-step 2 is a name diff against this tool's OWN history, with no
-install-provenance marker to tell "this tool put it here" apart from
-"an operator happens to have installed something with this exact name
-since". A package this venv's history once declared, then dropped from
+KNOWN LIMITATION — a name-collision, not a redesign candidate here. Tracked
+as #15067. Protection in step 2 is a name diff against this tool's OWN
+history, with no install-provenance marker to tell "this tool put it here"
+apart from "an operator happens to have installed something with this exact
+name since". A package this venv's history once declared, then dropped from
 requirements, is indistinguishable from operator debris installed under
 that same name in the window before the next reconcile — see
 `test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared`.
 A package this tool's history NEVER declared is unaffected regardless.
+#15067 is the follow-up to close this with real install provenance.
 """
 
 from __future__ import annotations

--- a/autobot-slm-backend/api/venv_reconcile.py
+++ b/autobot-slm-backend/api/venv_reconcile.py
@@ -1,0 +1,509 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Deployed-venv dependency reconciliation for the code-sync update path (#15063).
+
+`pip install -r requirements.txt` — the only Python dependency step the
+builtin updater ever ran — only adds and upgrades. A package deleted from a
+requirements file stayed installed in the deployed venv indefinitely, because
+nothing in the update path ever asked pip to remove anything.
+
+This module adds the removal half, scoped and auditable:
+
+1. Resolve the *declared set* for a component from its requirements file(s),
+   following `-r`/`-e` includes the same way pip does (`-c` constraint files
+   pin versions but do not themselves declare a package for install, so they
+   are validated but not added to the declared set).
+2. Compare that declared set against the one recorded the *previous* time
+   reconciliation ran for this venv (a small lock file next to the venv).
+   Only a package that WAS declared before and is NOT declared now is even a
+   removal candidate — this is what keeps an operator-installed package, or
+   anything never declared by this tool, off the removal list. There being no
+   history to compare against (first run, or a freshly recreated venv) is
+   treated as "cannot reconcile yet", not "remove nothing is same as
+   everything is fine" — the run records a baseline and removes nothing.
+3. Drop from that candidate list anything still reachable, transitively, from
+   the CURRENT declared set (walked over each installed distribution's own
+   `Requires-Dist`, read locally from the venv — no network, no resolver
+   call) — so a package another declared dependency still needs is never
+   removed just because it stopped being declared directly.
+4. Report the resulting removal set before touching anything, then uninstall
+   it. A package pip fails to remove stays in the lock's declared set so the
+   next run retries it, rather than the bookkeeping silently forgetting it.
+
+Components whose ansible role installs an explicit package LIST rather than a
+requirements file (`EXPLICIT_LIST_COMPONENTS`) have nothing here to reconcile
+against — `refuse_explicit_list` reports that plainly instead of silently
+skipping them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import configparser
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+from autobot_shared.time_utils import utc_timestamp
+
+# Plain stdlib logging, deliberately (mirrors code_sync.py itself, and the
+# password_epoch.py precedent CLAUDE.md documents): this module is imported
+# at collection time by tests that stub `config` as a MagicMock, and
+# `autobot_shared.logging_manager.get_logger()` reads real config at import
+# time to size its file handler — under that stub regime it raises before a
+# single test in the file can run.
+logger = logging.getLogger(__name__)
+
+# Timeouts are env-backed module constants, never a hardcoded bare number
+# scattered through call sites — mirrors the existing pip-install timeout
+# pattern in code_sync.py.
+_PIP_INSTALL_TIMEOUT = float(os.environ.get("AUTOBOT_PIP_INSTALL_TIMEOUT", "300"))
+_VENV_INSPECT_TIMEOUT = float(os.environ.get("AUTOBOT_VENV_INSPECT_TIMEOUT", "60"))
+_PIP_UNINSTALL_TIMEOUT = float(os.environ.get("AUTOBOT_PIP_UNINSTALL_TIMEOUT", "120"))
+
+# Recorded next to the venv itself (never in the deployed component tree, so
+# it is never rsynced away by a resync) — the previous run's declared set.
+_DECLARED_LOCK_FILENAME = ".autobot_declared_lock.json"
+
+# Worker components whose ansible role installs an explicit package LIST
+# rather than a requirements file — code_sync.py's `_WORKER_COMPONENT_PIP`
+# comment traces exactly why each one is absent from that dict. There is no
+# file for this module to reconcile against, so these must refuse and report,
+# never silently pass through as "nothing to do" (#15063 AC4).
+EXPLICIT_LIST_COMPONENTS: frozenset = frozenset({"autobot-npu-worker", "autobot-browser-worker", "autobot-slm-agent"})
+
+_NAME_BOUNDARY_RE = re.compile(r"[<>=!~;\[\s]")
+_NORMALIZE_RE = re.compile(r"[-_.]+")
+# Narrow, dependency-free extraction of a PEP 621 `[project] name = "..."` field —
+# a full TOML parser is unwarranted for the one string this needs, and `tomllib`
+# is 3.11+ only while this module must import under whatever interpreter the
+# test runner provides (#15063).
+_TOML_PROJECT_NAME_RE = re.compile(r'(?m)^\s*name\s*=\s*["\']([^"\']+)["\']')
+
+
+@dataclass(frozen=True)
+class ReconcileReport:
+    """Outcome of one `reconcile_component` run, for tests and callers."""
+
+    component: str
+    status: str  # "ok" | "baseline_recorded" | "refused" | "not_applicable"
+    reason: str
+    declared: Tuple[str, ...] = ()
+    removed: Tuple[str, ...] = ()
+    kept_transitive: Tuple[str, ...] = ()
+    failed: Tuple[str, ...] = ()
+
+
+def normalize_name(name: str) -> str:
+    """PEP 503 normalization — how pip itself compares distribution names."""
+    return _NORMALIZE_RE.sub("-", name).strip("-").lower()
+
+
+def extract_requirement_name(spec: str) -> Optional[str]:
+    """Bare, normalized package name from a requirement or Requires-Dist spec.
+
+    Deliberately ignores version specifiers, extras and markers — over-
+    including (treating a marker'd requirement as required) only makes the
+    transitive closure larger, which can only prevent a removal, never cause
+    an unsafe one.
+    """
+    spec = spec.strip()
+    if not spec:
+        return None
+    boundary = _NAME_BOUNDARY_RE.search(spec)
+    name = spec[: boundary.start()] if boundary else spec
+    name = name.strip()
+    return normalize_name(name) if name else None
+
+
+def _strip_inline_comment(line: str) -> str:
+    """A requirements-file comment is preceded by whitespace, never mid-token."""
+    return re.split(r"\s+#", line, maxsplit=1)[0].strip()
+
+
+def _editable_project_name(project_dir: Path) -> Optional[str]:
+    """Distribution name of a `-e <path>` local package, from its own metadata."""
+    pyproject = project_dir / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            text = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        match = _TOML_PROJECT_NAME_RE.search(text)
+        if match:
+            return normalize_name(match.group(1))
+    setup_cfg = project_dir / "setup.cfg"
+    if not setup_cfg.exists():
+        return None
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(setup_cfg, encoding="utf-8")
+    except configparser.Error:
+        return None
+    name = parser.get("metadata", "name", fallback=None)
+    return normalize_name(name) if name else None
+
+
+def _resolve_line(code: str, path: Path, declared: Set[str], warnings: List[str], seen: Set[Path]) -> None:
+    """Handle one parsed (comment-stripped) requirements-file line."""
+    if code.startswith(("-r ", "--requirement ")):
+        target = path.parent / code.split(None, 1)[1].strip()
+        _resolve_into(target, declared, warnings, seen)
+    elif code.startswith(("-c ", "--constraint ")):
+        # A constraint pins a version IF something else requires the package —
+        # it never declares the package for install on its own (#15063).
+        target = path.parent / code.split(None, 1)[1].strip()
+        if not target.exists():
+            warnings.append(f"constraints file not found: {target}")
+    elif code.startswith(("-e ", "--editable ")):
+        target = path.parent / code.split(None, 1)[1].strip()
+        name = _editable_project_name(target)
+        if name is None:
+            warnings.append(f"could not determine package name for editable install: {target}")
+        else:
+            declared.add(name)
+    elif code.startswith("-"):
+        return  # other pip options (--hash, --index-url, ...) name no package
+    else:
+        name = extract_requirement_name(code)
+        if name is None:
+            warnings.append(f"unparseable requirement line in {path}: {code!r}")
+        else:
+            declared.add(name)
+
+
+def _resolve_into(path: Path, declared: Set[str], warnings: List[str], seen: Set[Path]) -> None:
+    resolved = path.resolve()
+    if resolved in seen:
+        return
+    seen.add(resolved)
+    if not path.exists():
+        warnings.append(f"requirements file not found: {path}")
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        warnings.append(f"could not read {path}: {exc}")
+        return
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        code = _strip_inline_comment(stripped)
+        if code:
+            _resolve_line(code, path, declared, warnings, seen)
+
+
+def resolve_declared_names(entry_path: Path) -> Tuple[Set[str], List[str]]:
+    """The true declared set for *entry_path*, resolving `-r`/`-e` includes.
+
+    Returns (names, warnings). A non-empty warnings list means the declared
+    set could NOT be established with confidence — callers must refuse rather
+    than act on a partial result (#15063).
+    """
+    declared: Set[str] = set()
+    warnings: List[str] = []
+    _resolve_into(entry_path, declared, warnings, set())
+    return declared, warnings
+
+
+_INSPECT_SCRIPT = (
+    "import importlib.metadata as m, json\n"
+    "print(json.dumps({\n"
+    "    d.metadata['Name']: (d.requires or [])\n"
+    "    for d in m.distributions() if d.metadata.get('Name')\n"
+    "}))\n"
+)
+
+
+async def installed_state(venv_python: Path) -> Optional[Dict[str, List[str]]]:
+    """Every distribution installed in *venv_python*'s venv, with its raw
+    Requires-Dist strings — read locally via importlib.metadata, no network,
+    no resolver call. Returns None when the venv cannot be introspected."""
+    if not venv_python.exists():
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            str(venv_python),
+            "-c",
+            _INSPECT_SCRIPT,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_VENV_INSPECT_TIMEOUT)
+    except (asyncio.TimeoutError, OSError) as exc:
+        logger.error("venv-reconcile: could not introspect %s: %s", venv_python, exc)
+        return None
+    if proc.returncode != 0:
+        logger.error("venv-reconcile: introspection failed for %s: %s", venv_python, stdout)
+        return None
+    try:
+        return json.loads(stdout.decode("utf-8", errors="replace"))
+    except json.JSONDecodeError as exc:
+        logger.error("venv-reconcile: bad introspection output for %s: %s", venv_python, exc)
+        return None
+
+
+def build_dependency_graph(raw_state: Dict[str, List[str]]) -> Dict[str, Set[str]]:
+    """Normalize `installed_state`'s raw Requires-Dist strings into a name graph."""
+    graph: Dict[str, Set[str]] = {}
+    for name, requires in raw_state.items():
+        deps = {n for n in (extract_requirement_name(r) for r in requires) if n}
+        graph.setdefault(normalize_name(name), set()).update(deps)
+    return graph
+
+
+def transitive_closure(roots: Set[str], graph: Dict[str, Set[str]]) -> Set[str]:
+    """Every package reachable from *roots* by walking `graph` — deliberately
+    marker-blind (#15063): treating a conditional dependency as required only
+    ever prevents a removal, never causes one."""
+    seen: Set[str] = set()
+    stack = list(roots)
+    while stack:
+        name = stack.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        stack.extend(graph.get(name, ()))
+    return seen
+
+
+def load_lock(lock_path: Path) -> Optional[Set[str]]:
+    """The declared set recorded on the previous reconcile run, or None when
+    there isn't one (unreadable, absent, or malformed) — treated as "no
+    history to compare against" by the caller, never as "empty is fine"."""
+    if not lock_path.exists():
+        return None
+    try:
+        data = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("venv-reconcile: could not read lock %s: %s", lock_path, exc)
+        return None
+    names = data.get("declared")
+    if not isinstance(names, list):
+        return None
+    return {normalize_name(n) for n in names}
+
+
+def write_lock(lock_path: Path, declared: Set[str]) -> None:
+    payload = {"declared": sorted(declared), "recorded_at": utc_timestamp()}
+    lock_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+async def uninstall_packages(pip_bin: Path, names: List[str]) -> Tuple[List[str], List[str]]:
+    """`pip uninstall -y` one package at a time, for precise per-package
+    success/failure — never a single combined call whose failure would hide
+    which specific package survived."""
+    removed: List[str] = []
+    failed: List[str] = []
+    for name in names:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                str(pip_bin),
+                "uninstall",
+                "-y",
+                name,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_PIP_UNINSTALL_TIMEOUT)
+        except (asyncio.TimeoutError, OSError) as exc:
+            logger.error("venv-reconcile: uninstall %s errored: %s", name, exc)
+            failed.append(name)
+            continue
+        if proc.returncode == 0:
+            logger.info("venv-reconcile: removed %s", name)
+            removed.append(name)
+        else:
+            logger.error(
+                "venv-reconcile: uninstall %s failed (rc=%d): %s",
+                name,
+                proc.returncode,
+                stdout.decode("utf-8", errors="replace")[:200],
+            )
+            failed.append(name)
+    return removed, failed
+
+
+def _report(
+    component: str, status: str, reason: str, steps: List[str], *, declared: Optional[Set[str]] = None
+) -> ReconcileReport:
+    msg = f"venv-reconcile[{component}]: {status} — {reason}" if reason else f"venv-reconcile[{component}]: {status}"
+    steps.append(msg)
+    (logger.warning if status == "refused" else logger.info)(msg)
+    return ReconcileReport(component=component, status=status, reason=reason, declared=tuple(sorted(declared or ())))
+
+
+def refuse_explicit_list(component: str, steps: List[str]) -> ReconcileReport:
+    """Report — not silently skip — a component with no requirements file
+    to reconcile against (#15063 AC4)."""
+    reason = (
+        f"{component} dependencies are an explicit ansible-installed package list, "
+        "not a requirements file — reconciliation must go through that component's "
+        "ansible role (Update-All / per-role redeploy), not code-sync"
+    )
+    return _report(component, "refused", reason, steps)
+
+
+async def _apply_removals(
+    component: str,
+    declared: Set[str],
+    previous: Set[str],
+    graph: Dict[str, Set[str]],
+    lock_path: Path,
+    pip: Path,
+    steps: List[str],
+) -> ReconcileReport:
+    candidates = previous - declared
+    closure = transitive_closure(declared, graph)
+    kept = candidates & closure
+    installed = set(graph.keys())
+    removable = sorted((candidates - kept) & installed)
+    msg = f"venv-reconcile[{component}]: {len(removable)} package(s) to remove: {removable}"
+    steps.append(msg)
+    logger.info(msg)
+    removed, failed = await uninstall_packages(pip, removable) if removable else ([], [])
+    if kept:
+        kept_msg = f"venv-reconcile[{component}]: kept (still required transitively): {sorted(kept)}"
+        steps.append(kept_msg)
+        logger.info(kept_msg)
+    write_lock(lock_path, declared | set(failed))
+    return ReconcileReport(
+        component=component,
+        status="ok",
+        reason="",
+        declared=tuple(sorted(declared)),
+        removed=tuple(removed),
+        kept_transitive=tuple(sorted(kept)),
+        failed=tuple(failed),
+    )
+
+
+async def reconcile_component(component: str, req_path: str, pip_bin: str, steps: List[str]) -> ReconcileReport:
+    """Bring *component*'s venv to its declared dependency set, including
+    removals — or refuse and report exactly what could not be reconciled
+    (#15063). Never removes and discovers: every branch that cannot establish
+    the declared set or introspect the venv with confidence refuses instead.
+    """
+    req, pip = Path(req_path), Path(pip_bin)
+    if not req.exists():
+        return _report(component, "not_applicable", f"no requirements file at {req}", steps)
+    declared, warnings = resolve_declared_names(req)
+    if warnings:
+        return _report(component, "refused", "; ".join(warnings), steps, declared=declared)
+    raw_state = await installed_state(pip.parent / "python")
+    if raw_state is None:
+        reason = f"could not introspect venv at {pip.parent}"
+        return _report(component, "refused", reason, steps, declared=declared)
+    graph = build_dependency_graph(raw_state)
+    lock_path = pip.parents[1] / _DECLARED_LOCK_FILENAME
+    previous = load_lock(lock_path)
+    if previous is None:
+        write_lock(lock_path, declared)
+        reason = f"no prior declared-set snapshot — recorded baseline of {len(declared)} package(s)"
+        return _report(component, "baseline_recorded", reason, steps, declared=declared)
+    return await _apply_removals(component, declared, previous, graph, lock_path, pip, steps)
+
+
+async def install_pip_deps_for_component(component: str, steps: List[str]) -> bool:
+    """Install Python deps from the component's requirements.txt into its venv (#9982).
+
+    Unconditional — pip is fast when nothing changed (same rationale as #1603).
+    Appends human-readable step notes to *steps*.
+    Returns True on success, False when pip exits non-zero so callers can surface
+    the failure (previously the non-zero rc was swallowed — #11322).
+    """
+    from api.code_sync import _COMPONENT_PIP_PATHS, _WORKER_COMPONENT_PIP  # avoid circular import
+
+    # #12450: worker components carry their own (req, pip) pair — ai-stack's file
+    # is requirements-ai.txt, not requirements.txt.
+    paths = _COMPONENT_PIP_PATHS.get(component) or _WORKER_COMPONENT_PIP.get(component)
+    if paths is None:
+        return True
+    req_path, pip_bin = paths
+    if not Path(req_path).exists():
+        steps.append(f"pip: no requirements file at {req_path} — skipped")
+        return True
+    if component in _WORKER_COMPONENT_PIP and not Path(pip_bin).exists():
+        # Worker-only relaxation: a worker venv is provisioned by ansible, never
+        # by code-sync, so a missing one means "not deployed here" rather than a
+        # broken install — the code rsync + restart is still valid on its own.
+        # Backends deliberately keep the original behaviour (attempt the exec so
+        # a genuine pip failure surfaces via pip_ok=False, #11322).
+        steps.append(f"pip: no venv pip at {pip_bin} — skipped (provisioned by ansible)")
+        return True
+    return await _run_pip_install(component, req_path, pip_bin, steps)
+
+
+async def _run_pip_install(component: str, req_path: str, pip_bin: str, steps: List[str]) -> bool:
+    steps.append(f"pip: installing {req_path} into {Path(pip_bin).parent}")
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            pip_bin,
+            "install",
+            "-r",
+            req_path,
+            "--quiet",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_PIP_INSTALL_TIMEOUT)
+        if proc.returncode == 0:
+            logger.info("drift resolve: pip install ok for %s", component)
+            steps.append("pip: install succeeded")
+            return True
+        out = stdout.decode(errors="replace")[:300] if stdout else ""
+        logger.error("drift resolve: pip install failed (%d) for %s: %s", proc.returncode, component, out)
+        steps.append(f"pip: install failed (rc={proc.returncode}): {out[:150]}")
+        return False
+    except asyncio.TimeoutError:
+        logger.error("drift resolve: pip install timed out for %s", component)
+        steps.append("pip: install timed out after 300s")
+        return False
+    except Exception as exc:
+        logger.error("drift resolve: pip install error for %s: %s", component, exc)
+        steps.append(f"pip: install error: {exc}")
+        return False
+
+
+async def install_slm_pip_dependencies(req_path: str, pip_bin: str) -> bool:
+    """Install Python dependencies from requirements.txt into the SLM venv.
+
+    Runs unconditionally after rsync — pip is fast when nothing changed (#1603).
+    Returns True on success or when there is no requirements file to install,
+    False on pip failure — callers use this to gate removal reconciliation:
+    running removal after a failed install risks reading a venv the install
+    only partially updated (#15063).
+    """
+    if not Path(req_path).exists():
+        logger.debug("No requirements.txt at %s — skipping pip install", req_path)
+        return True
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            pip_bin,
+            "install",
+            "-r",
+            req_path,
+            "--quiet",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=_PIP_INSTALL_TIMEOUT)
+        if proc.returncode == 0:
+            logger.info("SLM pip install completed successfully")
+            return True
+        output = stdout.decode(errors="replace")[:500] if stdout else ""
+        logger.error("SLM pip install failed (rc=%d): %s", proc.returncode, output)
+        return False
+    except asyncio.TimeoutError:
+        logger.error("SLM pip install timed out after %ss", _PIP_INSTALL_TIMEOUT)
+        return False
+    except Exception as exc:
+        logger.error("SLM pip install error: %s", exc)
+        return False

--- a/autobot-slm-backend/tests/api/conftest.py
+++ b/autobot-slm-backend/tests/api/conftest.py
@@ -113,6 +113,20 @@ def _blocked_subprocess_exec(*cmd: object, **kwargs: object):
     pytest.fail(_LIVE_SUBPROCESS_MESSAGE.format(argv=argv), pytrace=False)
 
 
+async def _reconcile_component_default_stub(*args: object, **kwargs: object) -> None:
+    """Default no-op stand-in for api.code_sync.reconcile_component (#15063).
+
+    reconcile_component's own subprocess calls are already caught by the guard
+    above, but this host also carries a real deployed tree (#15063's own
+    premise), so an un-stubbed call reaches a REAL requirements.txt before it
+    ever spawns anything, and the failure that surfaces names venv internals
+    rather than whatever the test actually exercises. Tests that legitimately
+    drive reconciliation install their own AsyncMock inside the test body —
+    same "inner patch wins" contract as the guards above.
+    """
+    return None
+
+
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     """Fail fast instead of dead-waiting or touching the host."""
@@ -129,8 +143,15 @@ def pytest_runtest_call(item):
     saved_exec = asyncio.create_subprocess_exec
     httpx.AsyncClient = _LiveHealthPollBlocked
     asyncio.create_subprocess_exec = _blocked_subprocess_exec
+    code_sync = sys.modules.get("api.code_sync")
+    has_reconcile = code_sync is not None and hasattr(code_sync, "reconcile_component")
+    saved_reconcile = code_sync.reconcile_component if has_reconcile else None
+    if has_reconcile:
+        code_sync.reconcile_component = _reconcile_component_default_stub
     try:
         yield
     finally:
         httpx.AsyncClient = saved_client
         asyncio.create_subprocess_exec = saved_exec
+        if has_reconcile:
+            code_sync.reconcile_component = saved_reconcile

--- a/autobot-slm-backend/tests/api/test_venv_reconcile_wiring_15063.py
+++ b/autobot-slm-backend/tests/api/test_venv_reconcile_wiring_15063.py
@@ -144,3 +144,56 @@ def test_ai_stack_reconciles_with_its_own_requirements_ai_paths() -> None:
     called_component, called_req, called_pip, _steps = reconcile_mock.call_args.args
     assert called_component == "autobot-ai-stack"
     assert (called_req, called_pip) == cs._WORKER_COMPONENT_PIP["autobot-ai-stack"]
+
+
+def test_backend_pip_failure_never_calls_reconcile() -> None:
+    """A failed install must short-circuit before reconciliation ever runs —
+    removal candidates from a possibly-unfinished ADD are not safe to act on
+    (#15063)."""
+    import api.code_sync as cs
+
+    reconcile_mock = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)))
+        stack.enter_context(patch("api.code_sync._deploy_constraints_dir", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._ensure_target_python_installed", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync.reconcile_component", reconcile_mock))
+        stack.enter_context(patch("api.code_sync._rollback_component", AsyncMock()))
+        _, _steps, pip_ok = _run(
+            cs._run_post_sync_steps(
+                "autobot-backend",
+                "/opt/autobot/code_source/autobot-backend",
+                "/opt/autobot/autobot-backend",
+            )
+        )
+
+    assert pip_ok is False
+    reconcile_mock.assert_not_awaited()
+
+
+def test_worker_pip_failure_never_calls_reconcile() -> None:
+    """Same guard on the worker branch (ai-stack's requirements-ai.txt install
+    failing must not be followed by a reconcile against its own venv)."""
+    import api.code_sync as cs
+
+    reconcile_mock = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync.reconcile_component", reconcile_mock))
+        stack.enter_context(patch("api.code_sync._rollback_component", AsyncMock()))
+        _, _steps, pip_ok = _run(
+            cs._run_post_sync_steps(
+                "autobot-ai-stack",
+                "/opt/autobot/code_source/autobot-ai-stack",
+                "/opt/autobot/autobot-ai-stack",
+            )
+        )
+
+    assert pip_ok is False
+    reconcile_mock.assert_not_awaited()

--- a/autobot-slm-backend/tests/api/test_venv_reconcile_wiring_15063.py
+++ b/autobot-slm-backend/tests/api/test_venv_reconcile_wiring_15063.py
@@ -1,0 +1,146 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""_run_post_sync_steps dispatches to venv_reconcile correctly (#15063).
+
+Separate module from test_drift_resolve.py / test_code_sync_deploy_bugs.py —
+both are ratchet-grandfathered at their current line count and may not grow
+(#14236); this stays a normal, uncapped file instead of pushing either over.
+
+Same import shims as test_worker_component_resolve_12450.py: stub the
+conflicting multipart package and swap benign dicts in for MagicMock schema
+names so api.code_sync imports under the conftest stub regime.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_BACKEND_ROOT))
+
+if "multipart" in sys.modules and not hasattr(sys.modules["multipart"], "multipart"):
+    sys.modules.pop("multipart", None)
+_mp_stub = types.ModuleType("multipart")
+_mp_stub.multipart = types.ModuleType("multipart.multipart")  # type: ignore[attr-defined]
+sys.modules.setdefault("multipart", _mp_stub)
+sys.modules.setdefault("multipart.multipart", _mp_stub.multipart)  # type: ignore[attr-defined]
+
+_code_sync_src = (_BACKEND_ROOT / "api" / "code_sync.py").read_text(encoding="utf-8")
+_SCHEMA_NAMES = tuple(
+    sorted(
+        alias.name
+        for node in ast.walk(ast.parse(_code_sync_src))
+        if isinstance(node, ast.ImportFrom) and node.module == "models.schemas"
+        for alias in node.names
+    )
+)
+_schemas_stub = sys.modules.get("models.schemas")
+if isinstance(_schemas_stub, MagicMock):
+    for _name in _SCHEMA_NAMES:
+        setattr(_schemas_stub, _name, dict)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_backend_reconciles_with_component_pip_paths() -> None:
+    """A pip backend reconciles AFTER a successful install, with the SAME
+    (req_path, pip_bin) pair `_COMPONENT_PIP_PATHS` names for it — never a
+    second, independently-hardcoded path (#15063)."""
+    import api.code_sync as cs
+
+    reconcile_mock = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)))
+        stack.enter_context(patch("api.code_sync._deploy_constraints_dir", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._deploy_repo_root_requirements", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._ensure_target_python_installed", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._ensure_venv_python", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync.reconcile_component", reconcile_mock))
+        stack.enter_context(patch("api.code_sync._run_alembic_migrations", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync._ensure_autobot_shared_symlink", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._restart_component_services", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)))
+        _, steps, pip_ok = _run(
+            cs._run_post_sync_steps(
+                "autobot-backend",
+                "/opt/autobot/code_source/autobot-backend",
+                "/opt/autobot/autobot-backend",
+            )
+        )
+
+    assert pip_ok is True
+    reconcile_mock.assert_awaited_once()
+    called_component, called_req, called_pip, called_steps = reconcile_mock.call_args.args
+    assert called_component == "autobot-backend"
+    assert (called_req, called_pip) == cs._COMPONENT_PIP_PATHS["autobot-backend"]
+    assert called_steps is steps
+
+
+def test_worker_explicit_list_component_refuses_reconciliation() -> None:
+    """npu-worker has no requirements file — reconciliation must refuse and
+    report, never silently pass through as "nothing to do" (#15063 AC4)."""
+    import api.code_sync as cs
+
+    reconcile_mock = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync.reconcile_component", reconcile_mock))
+        stack.enter_context(patch("api.code_sync._restart_component_services", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync._rollback_component", AsyncMock()))
+        _, steps, pip_ok = _run(
+            cs._run_post_sync_steps(
+                "autobot-npu-worker",
+                "/opt/autobot/code_source/autobot-npu-worker",
+                "/opt/autobot/autobot-npu-worker",
+            )
+        )
+
+    assert pip_ok is True
+    reconcile_mock.assert_not_awaited()
+    assert any("autobot-npu-worker" in s and "refused" in s for s in steps)
+
+
+def test_ai_stack_reconciles_with_its_own_requirements_ai_paths() -> None:
+    """ai-stack is the one worker with a real requirements file — it must
+    reconcile against `_WORKER_COMPONENT_PIP`'s (requirements-ai.txt,
+    venv/bin/pip) pair, not the backend `_COMPONENT_PIP_PATHS` map
+    (#15063, #12450)."""
+    import api.code_sync as cs
+
+    reconcile_mock = AsyncMock()
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("api.code_sync._compute_deps_changed", AsyncMock(return_value=False)))
+        stack.enter_context(patch("api.code_sync._snapshot_component", AsyncMock(return_value=None)))
+        stack.enter_context(patch("api.code_sync._install_pip_deps_for_component", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync.reconcile_component", reconcile_mock))
+        stack.enter_context(patch("api.code_sync._restart_component_services", AsyncMock()))
+        stack.enter_context(patch("api.code_sync._wait_component_healthy", AsyncMock(return_value=True)))
+        stack.enter_context(patch("api.code_sync._rollback_component", AsyncMock()))
+        _, steps, pip_ok = _run(
+            cs._run_post_sync_steps(
+                "autobot-ai-stack",
+                "/opt/autobot/code_source/autobot-ai-stack",
+                "/opt/autobot/autobot-ai-stack",
+            )
+        )
+
+    assert pip_ok is True
+    reconcile_mock.assert_awaited_once()
+    called_component, called_req, called_pip, _steps = reconcile_mock.call_args.args
+    assert called_component == "autobot-ai-stack"
+    assert (called_req, called_pip) == cs._WORKER_COMPONENT_PIP["autobot-ai-stack"]

--- a/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
+++ b/autobot-slm-backend/tests/api/test_worker_component_resolve_12450.py
@@ -265,7 +265,7 @@ def test_missing_venv_skips_for_workers_but_still_fails_for_backends():
     with patch("pathlib.Path.exists", return_value=True):
         # Worker: requirements present, venv pip absent → skip, resolve survives.
         with patch.dict(cs._WORKER_COMPONENT_PIP, {"worker-comp": ("/req.txt", missing_pip)}):
-            with patch("api.code_sync.Path") as fake_path:
+            with patch("api.venv_reconcile.Path") as fake_path:
                 fake_path.side_effect = lambda p: _StubPath(p, missing_pip)
                 steps: list[str] = []
                 assert _run(cs._install_pip_deps_for_component("worker-comp", steps)) is True
@@ -273,7 +273,7 @@ def test_missing_venv_skips_for_workers_but_still_fails_for_backends():
 
     # Backend with the same absent pip must NOT take the skip path.
     with patch.dict(cs._COMPONENT_PIP_PATHS, {"backend-comp": ("/req.txt", missing_pip)}):
-        with patch("api.code_sync.Path") as fake_path:
+        with patch("api.venv_reconcile.Path") as fake_path:
             fake_path.side_effect = lambda p: _StubPath(p, missing_pip)
             with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
                 steps = []

--- a/autobot-slm-backend/tests/services/test_drift_resolve_paths_12872.py
+++ b/autobot-slm-backend/tests/services/test_drift_resolve_paths_12872.py
@@ -16,6 +16,7 @@ So detection honoured the override while resolution did not, and those
 components reported drift that could never be cleared.
 """
 
+import ast
 import importlib.util
 import re
 import sys
@@ -138,14 +139,54 @@ def test_rsync_helper_accepts_explicit_paths():
     assert "dest_dir or" in builder, "destination must prefer the explicit path"
 
 
-def test_drift_resolve_passes_the_resolved_paths():
-    """The resolve caller must hand over the override-aware paths."""
-    src = _code_sync_src()
-    call_start = src.index("ok, msg = await _rsync_component_local(\n        source_root,\n        request.component")
-    call = src[call_start : call_start + 400]
+def _rsync_calls_in(src: str, func_name: str) -> list:
+    """Every ``_rsync_component_local(...)`` call written inside ``func_name``.
 
-    assert "source_dir=source_dir" in call, "resolve still rebuilds the source path"
-    assert "dest_dir=deployed_dir" in call, "resolve still rebuilds the destination path"
+    Parsing beats reading the text: an argument list is laid out by the
+    formatter, so any literal rendering of a call is only as stable as the
+    surrounding line lengths.
+    """
+    tree = ast.parse(src)
+    owners = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name
+    ]
+
+    assert owners, f"api/code_sync.py no longer defines {func_name}()"
+    return [
+        node
+        for owner in owners
+        for node in ast.walk(owner)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "_rsync_component_local"
+    ]
+
+
+def test_drift_resolve_passes_the_resolved_paths():
+    """The resolve caller must hand over the override-aware paths, in order.
+
+    #15063: this used to locate the call by an exact source substring and then
+    assert against a fixed byte window after it. That broke when black joined
+    the argument list onto one line — the guarded property was untouched, the
+    transcription was not. Matching the AST instead binds each argument to *its
+    own* call, which is stronger than the old proximity window (a sibling
+    caller's keywords can no longer satisfy it), and states the positional
+    order as an assertion rather than smuggling it into a string literal.
+    """
+    src = _code_sync_src()
+    calls = _rsync_calls_in(src, "_drift_resolve_rsync_or_fail")
+
+    assert len(calls) == 1, f"expected exactly one rsync call in the resolve helper, found {len(calls)}"
+    positional = [ast.unparse(arg) for arg in calls[0].args]
+    keywords = {kw.arg: ast.unparse(kw.value) for kw in calls[0].keywords}
+
+    assert positional == ["source_root", "request.component", "excludes"], (
+        f"resolve passes {positional} positionally; _rsync_component_local takes "
+        "(source_path, component, excludes) in that order, so a reordering here "
+        "would rsync the wrong tree"
+    )
+    assert keywords.get("source_dir") == "source_dir", "resolve still rebuilds the source path"
+    assert keywords.get("dest_dir") == "deployed_dir", "resolve still rebuilds the destination path"
 
 
 def test_every_resolve_caller_passes_the_resolved_paths():

--- a/autobot-slm-backend/tests/test_code_sync_topology.py
+++ b/autobot-slm-backend/tests/test_code_sync_topology.py
@@ -141,7 +141,7 @@ async def test_slm_self_sync_remote_code_source_uses_ssh_rsync():
 
         await _CS._sync_slm_self_node(MagicMock(), job, node_state)
 
-    ssh_sync.assert_awaited_once_with("slm-node-1")
+    ssh_sync.assert_awaited_once_with("slm-node-1", "job-remote")
     ansible_update.assert_not_called()
     assert node_state.status == "success"
 

--- a/autobot-slm-backend/tests/test_venv_reconcile.py
+++ b/autobot-slm-backend/tests/test_venv_reconcile.py
@@ -189,16 +189,19 @@ async def test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive(
 async def test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared(
     real_venv: _RealVenv, tmp_path: Path
 ) -> None:
-    """KNOWN LIMITATION (module docstring): this is a name diff against the
-    tool's OWN prior-declared history, with no install-provenance marker.
-    A package this venv's history once declared, dropped from requirements,
-    then reinstalled by an operator under that exact name before the next
-    reconcile, is indistinguishable from tool debris and IS removed. Only a
-    name never declared by this tool's history (e.g. `ipdb`) is safe — see
-    test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive's
+    """KNOWN LIMITATION (module docstring), tracked as #15067: this is a
+    name diff against the tool's OWN prior-declared history, with no
+    install-provenance marker. A package this venv's history once declared,
+    dropped from requirements, then reinstalled by an operator under that
+    exact name before the next reconcile, is indistinguishable from tool
+    debris and IS removed — this test documents that, it does not endorse
+    it. Only a name never declared by this tool's history (e.g. `ipdb`) is
+    safe — see test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive's
     pkg-root/pkg-trans, which the lock never lets become candidates at all,
     and the untouched `pip`/`setuptools` in every real-venv test here, which
-    were never in any lock this tool wrote.
+    were never in any lock this tool wrote. #15067 is the follow-up to close
+    this gap with real install provenance — when it lands, this test's
+    assertion should flip to prove SURVIVAL, per its own acceptance criteria.
     """
     site = real_venv.site_packages
     _write_dist_info(site, "pkg-stale-collide", "pkg_stale_collide_15063", "1.0")

--- a/autobot-slm-backend/tests/test_venv_reconcile.py
+++ b/autobot-slm-backend/tests/test_venv_reconcile.py
@@ -186,6 +186,38 @@ async def test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive(
 
 
 @pytest.mark.asyncio
+async def test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared(
+    real_venv: _RealVenv, tmp_path: Path
+) -> None:
+    """KNOWN LIMITATION (module docstring): this is a name diff against the
+    tool's OWN prior-declared history, with no install-provenance marker.
+    A package this venv's history once declared, dropped from requirements,
+    then reinstalled by an operator under that exact name before the next
+    reconcile, is indistinguishable from tool debris and IS removed. Only a
+    name never declared by this tool's history (e.g. `ipdb`) is safe — see
+    test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive's
+    pkg-root/pkg-trans, which the lock never lets become candidates at all,
+    and the untouched `pip`/`setuptools` in every real-venv test here, which
+    were never in any lock this tool wrote.
+    """
+    site = real_venv.site_packages
+    _write_dist_info(site, "pkg-stale-collide", "pkg_stale_collide_15063", "1.0")
+
+    req = tmp_path / "requirements.txt"
+    req.write_text("\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    lock_path = real_venv.venv_dir / vr._DECLARED_LOCK_FILENAME
+    lock_path.write_text(json.dumps({"declared": ["pkg-stale-collide"]}), encoding="utf-8")  # noqa: async_blocking_io
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp-collide", str(req), str(real_venv.pip_bin), steps)
+
+    assert report.status == "ok"
+    assert report.removed == ("pkg-stale-collide",)
+    assert "pkg-stale-collide" not in _installed_names(real_venv)
+
+
+@pytest.mark.asyncio
 async def test_reconcile_never_attempts_to_remove_a_package_that_is_not_installed(
     real_venv: _RealVenv, tmp_path: Path
 ) -> None:
@@ -377,6 +409,26 @@ def test_resolve_declared_names_warns_on_missing_include(tmp_path: Path) -> None
 
     assert declared == set()
     assert any("nowhere.txt" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# load_lock — fails closed (returns None -> refused/baseline), never raises
+# ---------------------------------------------------------------------------
+
+
+def test_load_lock_returns_none_when_declared_entries_are_not_strings(tmp_path: Path) -> None:
+    """A hand-edited lock with non-string entries must refuse (None), never
+    raise inside normalize_name's regex — the same fail-closed contract as
+    a missing/truncated file, just a different malformed shape."""
+    lock_path = tmp_path / vr._DECLARED_LOCK_FILENAME
+    lock_path.write_text(json.dumps({"declared": [1, 2, 3]}), encoding="utf-8")
+    assert vr.load_lock(lock_path) is None
+
+
+def test_load_lock_returns_none_when_top_level_is_not_an_object(tmp_path: Path) -> None:
+    lock_path = tmp_path / vr._DECLARED_LOCK_FILENAME
+    lock_path.write_text(json.dumps([{"name": "x"}]), encoding="utf-8")
+    assert vr.load_lock(lock_path) is None
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/test_venv_reconcile.py
+++ b/autobot-slm-backend/tests/test_venv_reconcile.py
@@ -1,0 +1,407 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for api/venv_reconcile.py — the removal half of the update path (#15063).
+
+Loaded by file path, not via ``import api.venv_reconcile`` — the ``api``
+package's ``__init__.py`` imports every router (including ``code_sync``,
+which needs the Pydantic-schema stand-in dance the ``tests/api`` modules do).
+``venv_reconcile.py`` itself has no such dependency: its only non-stdlib
+import is ``autobot_shared.time_utils``, so loading it standalone keeps these
+tests independent of that machinery and — deliberately — outside
+``tests/api``, whose conftest blocks every real ``asyncio.create_subprocess_exec``
+call (#13312). The removal tests here need a REAL one, against a throwaway
+venv built entirely under ``tmp_path`` — never against the codebase or
+``/opt/autobot``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+_VENV_RECONCILE_SRC = _BACKEND_ROOT / "api" / "venv_reconcile.py"
+
+
+def _load_venv_reconcile():
+    spec = importlib.util.spec_from_file_location("_venv_reconcile_15063", _VENV_RECONCILE_SRC)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module  # dataclasses needs cls.__module__ resolvable
+    spec.loader.exec_module(module)
+    return module
+
+
+vr = _load_venv_reconcile()
+
+
+# ---------------------------------------------------------------------------
+# Real-venv fixture and dist-info builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RealVenv:
+    venv_dir: Path
+    python_bin: Path
+    pip_bin: Path
+    site_packages: Path
+
+
+@pytest.fixture(scope="module")
+def real_venv(tmp_path_factory) -> _RealVenv:
+    """A real, throwaway venv built once per module — offline, no network.
+
+    Built with THIS test run's own interpreter (whatever `sys.executable` is),
+    not the deployed platform's target Python — the mechanics under test
+    (introspect via importlib.metadata, `pip uninstall`) do not depend on the
+    interpreter version.
+    """
+    venv_dir = tmp_path_factory.mktemp("venv15063")
+    subprocess.run(  # noqa: S603 — fixed argv, no shell, local interpreter only
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        check=True,
+        timeout=60,
+        capture_output=True,
+    )
+    python_bin = venv_dir / "bin" / "python"
+    pip_bin = venv_dir / "bin" / "pip"
+    site_out = subprocess.run(  # noqa: S603
+        [str(python_bin), "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])"],
+        check=True,
+        timeout=30,
+        capture_output=True,
+        text=True,
+    )
+    return _RealVenv(venv_dir, python_bin, pip_bin, Path(site_out.stdout.strip()))
+
+
+def _record_line(rel_path: str, root: Path) -> str:
+    data = (root / rel_path).read_bytes()
+    digest = hashlib.sha256(data).digest()
+    b64 = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return f"{rel_path},sha256={b64},{len(data)}"
+
+
+def _write_dist_info(site_packages: Path, dist_name: str, module_name: str, version: str, requires: tuple = ()) -> None:
+    """Hand-build a real, pip-uninstallable dist-info directory.
+
+    Same on-disk shape `pip install` itself produces (METADATA + RECORD),
+    without needing a build backend or network access — a single-file module
+    plus its dist-info is enough for `importlib.metadata` to discover it and
+    for `pip uninstall` to remove it, and both are exercised for real here.
+
+    The dist-info directory name MUST be derived from *dist_name* (pip's own
+    uninstall matches on the directory name, not the METADATA ``Name:``
+    field) — *module_name* only names the importable ``.py`` stand-in, kept
+    separate so several fixture packages can share a venv's site-packages
+    without colliding on their module file.
+    """
+    dist_info_stem = dist_name.replace("-", "_")
+    dist_info = site_packages / f"{dist_info_stem}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    (site_packages / f"{module_name}.py").write_text(f'"""fake package {dist_name}"""\n', encoding="utf-8")
+    metadata_lines = ["Metadata-Version: 2.1", f"Name: {dist_name}", f"Version: {version}"]
+    metadata_lines += [f"Requires-Dist: {req}" for req in requires]
+    (dist_info / "METADATA").write_text("\n".join(metadata_lines) + "\n", encoding="utf-8")
+    (dist_info / "INSTALLER").write_text("test-fixture\n", encoding="utf-8")
+    record_lines = [
+        _record_line(f"{module_name}.py", site_packages),
+        _record_line(f"{dist_info_stem}-{version}.dist-info/METADATA", site_packages),
+        _record_line(f"{dist_info_stem}-{version}.dist-info/INSTALLER", site_packages),
+        f"{dist_info_stem}-{version}.dist-info/RECORD,,",
+    ]
+    (dist_info / "RECORD").write_text("\n".join(record_lines) + "\n", encoding="utf-8")
+
+
+def _installed_names(real_venv: _RealVenv) -> set:
+    raw = subprocess.run(  # noqa: S603
+        [
+            str(real_venv.python_bin),
+            "-c",
+            "import importlib.metadata as m, json\n"
+            "print(json.dumps([d.metadata['Name'] for d in m.distributions() if d.metadata.get('Name')]))",
+        ],
+        check=True,
+        timeout=30,
+        capture_output=True,
+        text=True,
+    )
+    return {vr.normalize_name(n) for n in json.loads(raw.stdout)}
+
+
+# ---------------------------------------------------------------------------
+# The real update path — #15063 AC: drive it for real, assert removed AND kept
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_real_venv_removes_orphan_keeps_declared_and_transitive(
+    real_venv: _RealVenv, tmp_path: Path
+) -> None:
+    """A package removed from requirements.txt is gone; a still-declared
+    package and a transitive dependency of it are untouched (#15063)."""
+    site = real_venv.site_packages
+    _write_dist_info(site, "pkg-root", "pkg_root_15063", "1.0", requires=("pkg-trans",))
+    _write_dist_info(site, "pkg-trans", "pkg_trans_15063", "1.0")
+    _write_dist_info(site, "pkg-orphan", "pkg_orphan_15063", "1.0")
+
+    req = tmp_path / "requirements.txt"
+    req.write_text("pkg-root>=1.0\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    lock_path = real_venv.venv_dir / vr._DECLARED_LOCK_FILENAME
+    # pkg-trans was previously declared DIRECTLY (like a pin later dropped in
+    # favour of letting pkg-root pull it in transitively) — the reconcile must
+    # keep it via the transitive-closure check, not because it is still declared.
+    lock_path.write_text(  # noqa: async_blocking_io
+        json.dumps({"declared": ["pkg-root", "pkg-trans", "pkg-orphan"]}), encoding="utf-8"
+    )
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp", str(req), str(real_venv.pip_bin), steps)
+
+    assert report.status == "ok"
+    assert report.removed == ("pkg-orphan",)  # exact package, never len() > 0
+    assert "pkg-trans" not in report.removed
+    assert "pkg-root" not in report.removed
+    assert "pkg-trans" in report.kept_transitive
+
+    installed = _installed_names(real_venv)
+    assert "pkg-orphan" not in installed
+    assert "pkg-root" in installed
+    assert "pkg-trans" in installed
+
+    # AC: the removal set is reported BEFORE it happens, in the job's own steps.
+    assert any("pkg-orphan" in s and "to remove" in s for s in steps)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_never_attempts_to_remove_a_package_that_is_not_installed(
+    real_venv: _RealVenv, tmp_path: Path
+) -> None:
+    """A previously-declared package that is already absent (removed by hand,
+    or never actually landed) must not appear in the removal set — there is
+    nothing to uninstall, and reporting it as removed would claim an action
+    that never happened."""
+    site = real_venv.site_packages
+    _write_dist_info(site, "pkg-still-declared", "pkg_still_declared_15063", "1.0")
+
+    req = tmp_path / "requirements.txt"
+    req.write_text("pkg-still-declared>=1.0\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    lock_path = real_venv.venv_dir / vr._DECLARED_LOCK_FILENAME
+    lock_path.write_text(  # noqa: async_blocking_io
+        json.dumps({"declared": ["pkg-still-declared", "pkg-phantom-never-installed"]}), encoding="utf-8"
+    )
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp-phantom", str(req), str(real_venv.pip_bin), steps)
+
+    assert report.status == "ok"
+    assert report.removed == ()
+    assert report.failed == ()
+    assert "pkg-phantom-never-installed" not in report.removed
+
+
+@pytest.mark.asyncio
+async def test_reconcile_first_run_records_baseline_and_removes_nothing(real_venv: _RealVenv, tmp_path: Path) -> None:
+    """No prior snapshot means "cannot reconcile yet" — never "nothing declared
+    means nothing to keep". Nothing is removed and a baseline is recorded."""
+    site = real_venv.site_packages
+    _write_dist_info(site, "pkg-baseline", "pkg_baseline_15063", "1.0")
+
+    req = tmp_path / "requirements.txt"
+    req.write_text("pkg-baseline>=1.0\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    lock_path = real_venv.venv_dir / vr._DECLARED_LOCK_FILENAME
+    lock_path.unlink(missing_ok=True)  # simulate "no history yet" regardless of test order
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp-baseline", str(req), str(real_venv.pip_bin), steps)
+
+    assert report.status == "baseline_recorded"
+    assert report.removed == ()
+    assert lock_path.exists()
+    recorded = json.loads(lock_path.read_text(encoding="utf-8"))  # noqa: async_blocking_io
+    assert "pkg-baseline" in recorded["declared"]
+    assert "pkg-baseline" in _installed_names(real_venv)
+
+
+# ---------------------------------------------------------------------------
+# Fail closed — uncertain reconciliation refuses, never approximates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_refuses_when_an_include_cannot_be_resolved(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-r missing-included.txt\npackage-a>=1.0\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp-refuse", str(req), "/nonexistent/venv/bin/pip", steps)
+
+    assert report.status == "refused"
+    assert "missing-included.txt" in report.reason
+    assert not any("to remove" in s for s in steps)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_refuses_when_venv_cannot_be_introspected(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("package-a>=1.0\n", encoding="utf-8")  # noqa: async_blocking_io
+
+    steps: list = []
+    report = await vr.reconcile_component("test-comp-noventv", str(req), "/nonexistent/venv/bin/pip", steps)
+
+    assert report.status == "refused"
+    assert "introspect" in report.reason
+
+
+def test_refuse_explicit_list_reports_not_silently_skips() -> None:
+    """The three ansible-package-list workers get a REPORTED refusal, not a
+    silent no-op (#15063 AC4)."""
+    steps: list = []
+    report = vr.refuse_explicit_list("autobot-npu-worker", steps)
+
+    assert report.status == "refused"
+    assert "autobot-npu-worker" in report.reason
+    assert "ansible role" in report.reason
+    assert steps and "autobot-npu-worker" in steps[0]
+
+
+def test_explicit_list_components_are_exactly_the_three_ansible_list_workers() -> None:
+    assert vr.EXPLICIT_LIST_COMPONENTS == frozenset(
+        {"autobot-npu-worker", "autobot-browser-worker", "autobot-slm-agent"}
+    )
+
+
+# ---------------------------------------------------------------------------
+# A failed removal is retried next run, not forgotten
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_removals_keeps_a_failed_uninstall_in_the_lock_for_retry(tmp_path: Path) -> None:
+    pip_bin = tmp_path / "venv" / "bin" / "pip"
+    pip_bin.parent.mkdir(parents=True)
+    lock_path = pip_bin.parents[1] / vr._DECLARED_LOCK_FILENAME
+
+    declared = {"pkg-a"}
+    previous = {"pkg-a", "pkg-b"}
+    graph = {"pkg-a": set(), "pkg-b": set()}
+
+    async def _fake_uninstall(pip, names):
+        return [], list(names)  # every removal attempt fails
+
+    orig = vr.uninstall_packages
+    vr.uninstall_packages = _fake_uninstall
+    try:
+        steps: list = []
+        report = await vr._apply_removals("test-comp-retry", declared, previous, graph, lock_path, pip_bin, steps)
+    finally:
+        vr.uninstall_packages = orig
+
+    assert report.failed == ("pkg-b",)
+    assert report.removed == ()
+    recorded = json.loads(lock_path.read_text(encoding="utf-8"))  # noqa: async_blocking_io
+    assert set(recorded["declared"]) == {"pkg-a", "pkg-b"}  # retried next run, not forgotten
+
+
+@pytest.mark.asyncio
+async def test_uninstall_packages_is_an_async_callee_usable_with_asyncmock(tmp_path: Path) -> None:
+    """Sanity check for the AsyncMock convention this suite relies on elsewhere."""
+    mock = AsyncMock(return_value=(["pkg-x"], []))
+    removed, failed = await mock(Path("/unused/pip"), ["pkg-x"])
+    assert removed == ["pkg-x"]
+    assert failed == []
+    mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Declared-set resolution: -r / -c / -e, mirroring the real repo layout
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_declared_names_follows_r_and_e_ignores_c(tmp_path: Path) -> None:
+    (tmp_path / "autobot_shared_pkg").mkdir()
+    (tmp_path / "autobot_shared_pkg" / "pyproject.toml").write_text(
+        '[project]\nname = "autobot_shared"\nversion = "0.1"\n', encoding="utf-8"
+    )
+    (tmp_path / "constraints").mkdir()
+    (tmp_path / "constraints" / "shared.txt").write_text("numpy>=2.0\n", encoding="utf-8")
+    (tmp_path / "requirements.txt").write_text("tenacity>=9.0\n", encoding="utf-8")
+
+    backend = tmp_path / "autobot-backend"
+    backend.mkdir()
+    (backend / "requirements.txt").write_text(
+        "-e ../autobot_shared_pkg\n"
+        "-c ../constraints/shared.txt  # pins transitive numpy\n"
+        "fastapi>=0.140.0\n"
+        "\n"
+        "-r ../requirements.txt\n",
+        encoding="utf-8",
+    )
+
+    declared, warnings = vr.resolve_declared_names(backend / "requirements.txt")
+
+    assert warnings == []
+    assert declared == {"autobot-shared", "fastapi", "tenacity"}
+    assert "numpy" not in declared  # a -c entry constrains a version, it never declares
+
+
+def test_resolve_declared_names_warns_on_missing_constraints_file(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-c missing_constraints.txt\npackage-a>=1.0\n", encoding="utf-8")
+
+    declared, warnings = vr.resolve_declared_names(req)
+
+    assert declared == {"package-a"}
+    assert any("missing_constraints.txt" in w for w in warnings)
+
+
+def test_resolve_declared_names_warns_on_missing_include(tmp_path: Path) -> None:
+    req = tmp_path / "requirements.txt"
+    req.write_text("-r nowhere.txt\n", encoding="utf-8")
+
+    declared, warnings = vr.resolve_declared_names(req)
+
+    assert declared == set()
+    assert any("nowhere.txt" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_transitive_closure_walks_multi_level_deps_and_stops_at_orphans() -> None:
+    graph = {"a": {"b"}, "b": {"c"}, "c": set(), "orphan": set()}
+    closure = vr.transitive_closure({"a"}, graph)
+    assert closure == {"a", "b", "c"}
+    assert "orphan" not in closure
+
+
+def test_normalize_name_is_pep503() -> None:
+    assert vr.normalize_name("Autobot_Shared") == "autobot-shared"
+    assert vr.normalize_name("Foo..Bar__Baz") == "foo-bar-baz"
+
+
+def test_extract_requirement_name_strips_specifiers_extras_markers() -> None:
+    assert vr.extract_requirement_name("FastAPI[all]>=0.140,<1.0 ; python_version>='3.10'") == "fastapi"
+    assert vr.extract_requirement_name("   ") is None
+
+
+def test_build_dependency_graph_normalizes_names_on_both_sides() -> None:
+    raw = {"Pkg-Root": ["Pkg_Trans>=1.0 ; extra == 'x'"], "Pkg_Trans": []}
+    graph = vr.build_dependency_graph(raw)
+    assert graph == {"pkg-root": {"pkg-trans"}, "pkg-trans": set()}

--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -1342,8 +1342,8 @@
 1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-backend/requirements.txt
 1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-backend/venv/bin/pip
 1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-frontend
-2|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-slm-backend/requirements.txt
-2|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-slm-backend/venv/bin/pip
+1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-slm-backend/requirements.txt
+1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-slm-backend/venv/bin/pip
 2|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/autobot-slm-frontend
 1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/{_CONSTRAINTS_SOURCE_SUBDIR}/
 1|other|autobot-slm-backend/api/code_sync.py|"/opt/autobot/{component}/
@@ -1351,7 +1351,7 @@
 1|other|autobot-slm-backend/api/code_sync.py|100
 6|other|autobot-slm-backend/api/code_sync.py|120
 3|other|autobot-slm-backend/api/code_sync.py|30
-6|other|autobot-slm-backend/api/code_sync.py|300
+4|other|autobot-slm-backend/api/code_sync.py|300
 2|other|autobot-slm-backend/api/code_sync.py|60
 1|ssot|autobot-slm-backend/api/code_sync.py|:8001
 1|other|autobot-slm-backend/api/errors.py|50

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -458,7 +458,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py": 2248,
     "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py": 739,
     "autobot-slm-backend/api/code_source.py": 720,
-    "autobot-slm-backend/api/code_sync.py": 6065,
+    "autobot-slm-backend/api/code_sync.py": 6032,
     "autobot-slm-backend/api/errors.py": 866,
     "autobot-slm-backend/api/infrastructure.py": 724,
     "autobot-slm-backend/api/monitoring.py": 1096,

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -458,7 +458,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py": 2248,
     "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py": 739,
     "autobot-slm-backend/api/code_source.py": 720,
-    "autobot-slm-backend/api/code_sync.py": 6032,
+    "autobot-slm-backend/api/code_sync.py": 6053,
     "autobot-slm-backend/api/errors.py": 866,
     "autobot-slm-backend/api/infrastructure.py": 724,
     "autobot-slm-backend/api/monitoring.py": 1096,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -453,7 +453,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py": 2248,
     "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py": 739,
     "autobot-slm-backend/api/code_source.py": 720,
-    "autobot-slm-backend/api/code_sync.py": 6065,
+    "autobot-slm-backend/api/code_sync.py": 6032,
     "autobot-slm-backend/api/errors.py": 866,
     "autobot-slm-backend/api/infrastructure.py": 724,
     "autobot-slm-backend/api/monitoring.py": 1096,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -453,7 +453,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py": 2248,
     "autobot-slm-backend/ansible/roles/slm_agent/files/slm/agent/agent.py": 739,
     "autobot-slm-backend/api/code_source.py": 720,
-    "autobot-slm-backend/api/code_sync.py": 6032,
+    "autobot-slm-backend/api/code_sync.py": 6053,
     "autobot-slm-backend/api/errors.py": 866,
     "autobot-slm-backend/api/infrastructure.py": 724,
     "autobot-slm-backend/api/monitoring.py": 1096,


### PR DESCRIPTION
Refs #15063 — one acceptance criterion is not met, by design, and is tracked separately (below); every other one is.

**Unmet: "Transitive dependencies and operator-installed packages are not removed as a side effect, and there is a test proving it."** The transitive half is met and tested. The operator half has one narrow, proven hole, not a bug in this delivery: a package an operator installs under a name this venv's history once declared — after that name left requirements, before the next reconcile — is indistinguishable from tool debris under the name-diff design this PR ships, and IS removed. `test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared` proves exactly that, on purpose, so it is a documented limitation rather than a surprise. Closing it needs an install-provenance marker, not a name diff — filed as #15067, cross-linked from the module docstring and from that test's own docstring. #15063 stays open until #15067 lands.

## Response to independent review (FIX-FIRST)

- **HIGH — overstated guarantee**: the module docstring claimed an operator-installed package "can never appear as a candidate". True only for a name this tool's history never declared. Softened to state that precisely, and added `test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared` — a real venv, real lock file, real removal — documenting the name-collision limitation instead of leaving it a surprise. Filed #15067 to actually close it (real install provenance, not a name diff — pip's own `INSTALLER` field is `pip` for both the tool's installs and an operator's, so it alone cannot discriminate), cross-linked from the module docstring and the test. Also documented the `& installed` filter's real reason in code: `pip uninstall -y <not-installed>` exits 0 with a warning, so without it a candidate that was never actually there would be reported as *falsely removed*, not merely waste a subprocess.
- **MEDIUM — AC2 unmet on the SLM self-sync path**: `reconcile_component(..., [])` was a throwaway list — the removal set reached only `logger.info`. `_sync_slm_from_code_source` now threads a real `steps` list and, before Phase 4's restart (the job row is marked complete beforehand, by design, because a self-restart can kill this process), persists it to the fleet-sync node's `message` field via `_update_node_state_db`.
- **LOW — `load_lock` crash on a malformed entry**: `{"declared": [1, 2, 3]}` or a non-object top level now returns `None` (refused/baseline) instead of raising inside `normalize_name`'s regex — same fail-closed contract as the existing truncated-JSON case. Two new tests, plus a mutation (dropping the per-entry `str` check) confirmed red before the fix and green after.
- **LOW — untested pip-failure guard**: added `test_backend_pip_failure_never_calls_reconcile` / `test_worker_pip_failure_never_calls_reconcile`, both mutated (removing the early return) to confirm red before restoring.
- **BLOCKING — CI red (SSOT compliance)**: `pipeline-scripts/hardcoded_values_baseline.txt` pruned via `./pipeline-scripts/detect-hardcoded-values.sh --prune-baseline` — the extraction had removed duplicate hardcoded requirements/pip-path and timeout literals, so several counts were stale highs. `detect-hardcoded-values.sh` now reports `new=0`.
- **Latent risk — shared-venv lock collision**: added a one-line assertion that `_COMPONENT_PIP_PATHS`/`_WORKER_COMPONENT_PIP` map every component to a distinct `pip_bin` — two components sharing a venv would otherwise silently corrupt each other's lock file.

Branch rebased to 0 behind `Dev_new_gui` (merge, not rebase — the prior push already carried a merge commit, so rewriting it would have required a force-push).

## Thinking Path

`code_sync.py` ran `pip install -r requirements.txt` and nothing else — the deployed venv was append-only. Verified: the true declared set is not one file (`-r`/`-c`/`-e` includes across `requirements.txt`, `constraints/shared.txt`, `autobot_shared`), and one worker component class (npu-worker, browser-worker, slm-agent) has no requirements file at all — its deps come from an explicit ansible package list. A naive `pip freeze` diff would catch transitive deps and operator-installed packages in its removal set, which is exactly the unsafe shortcut the issue warns against.

Chosen design: a persistent per-venv lock file recording the declared set from the *previous* successful reconcile. Only a package that was in that previous set and is **not** in the current declared set is even a removal candidate — this is what keeps a never-declared (operator-installed) package off the list, since the lock only ever contains names this tool itself resolved from a requirements file. Candidates still reachable from the current declared set's transitive closure (walked locally over each installed distribution's own `Requires-Dist`, via `importlib.metadata` inside the target venv — no network, no resolver call) are kept. No prior lock (first run, or a freshly recreated venv) is treated as "cannot reconcile yet" — it records a baseline and removes nothing, never "empty history means remove everything." A failed `pip uninstall` stays in the lock so the next run retries it rather than forgetting it.

`code_sync.py` is ratchet-grandfathered at its line-count ceiling (`scripts/python_file_size_known_large.py`), so the new logic and the two moved pip-install functions live in a new `api/venv_reconcile.py`, imported back in. Wiring `reconcile_component` into `_run_post_sync_steps` also tripped the (separately enforced, `stages: [pre-commit]`) function-length hook on `_run_post_sync_steps`, `_run_component_resolve_job` and `resolve_drift` — all three needed helper-extraction to get a clean local commit; two were already over the guard's block threshold before this PR touched anything (verified against `git show HEAD:...`).

## What Changed

- **`api/venv_reconcile.py` (new)**: `resolve_declared_names` (recursive `-r`/`-e` resolution, `-c` validated but never declares), `installed_state`/`build_dependency_graph` (local `importlib.metadata` introspection via subprocess), `transitive_closure`, `load_lock`/`write_lock` (the per-venv `.autobot_declared_lock.json`), `uninstall_packages` (one `pip uninstall -y` per package, for precise per-package success/failure), `reconcile_component` (orchestrator — refuses on any parse warning or introspection failure), `refuse_explicit_list` (explicit-list workers), plus `install_pip_deps_for_component` / `install_slm_pip_dependencies` relocated here from `code_sync.py` (same signatures/behavior, kept import-aliased so every existing `patch("api.code_sync._install_pip_deps_for_component", ...)` still resolves).
- **`api/code_sync.py`**: wires `reconcile_component` into `_run_post_sync_steps`'s backend and ai-stack-worker paths (after a successful install) and into `_sync_slm_from_code_source`'s self-update path; routes the three ansible-package-list workers to `refuse_explicit_list`. Extracted `_run_post_sync_backend_branch` / `_frontend_branch` / `_worker_branch` / `_shared_branch` out of `_run_post_sync_steps`, and job/response-building helpers out of `_run_component_resolve_job` and `resolve_drift` (function-length compliance; two pre-existing sync-I/O-in-async-def call sites fixed with `asyncio.to_thread` along the way).
- **`tests/test_venv_reconcile.py` (new)**: drives the real update path against a throwaway venv built with `python -m venv` (offline, no network) plus hand-built `dist-info` directories (same on-disk shape `pip install` itself produces) — real `pip uninstall`, real `importlib.metadata` introspection, real subprocess calls, all confined to `tmp_path`. Also covers `-r`/`-c`/`-e` parsing, missing-include refusal, first-run baseline, failed-uninstall retry, and the explicit-list refusal.
- **`tests/api/test_venv_reconcile_wiring_15063.py` (new)**: asserts `_run_post_sync_steps` calls `reconcile_component` with the exact `_COMPONENT_PIP_PATHS`/`_WORKER_COMPONENT_PIP` pair for a backend and for ai-stack, and calls `refuse_explicit_list` (not `reconcile_component`) for npu-worker.
- **`tests/api/conftest.py`**: the existing live-subprocess guard (#13312) now also stubs `api.code_sync.reconcile_component` by default (this host carries a real `/opt/autobot` tree, so an un-stubbed call would reach a real requirements file and a real subprocess) — same "inner patch wins" contract as the existing httpx/asyncio guards, so no unrelated grandfathered test file needed new lines.
- **`scripts/python_file_size_known_large.py` / `repo_tests/python_file_size_ratchet_baseline.py`**: `code_sync.py`'s ceiling lowered 6065 → 6032 (net shrink after extraction, despite the new helper functions).

## Verification

- `autobot-slm-backend/tests/test_venv_reconcile.py` — 16/16 pass, including the real-update-path test (removes an undeclared orphan, keeps a still-declared package and a transitive dependency, all asserted by exact package name).
- `autobot-slm-backend/tests/api` (full directory, 578 tests incl. the new wiring file) — pass.
- `repo_tests/python_file_size_ratchet_test.py` — 31/31 pass.
- Local commit went through every configured pre-commit hook cleanly (black/isort/flake8/bandit/function-length/file-size/canonical-check/no-blocking-io-in-async all green), hooks were not bypassed.
- **Mutation evidence** (manual, reverted, never pushed): flipped `kept = candidates & closure` to `kept = set()` → red (transitive dep wrongly removed); dropped the `& installed` filter from `removable` → **survived** against the original suite, so a new test (`test_reconcile_never_attempts_to_remove_a_package_that_is_not_installed`) was added, which does catch it; forced each of the three `refused`/`baseline_recorded` guard conditions (`if warnings`, `if raw_state is None`, `if previous is None`) to `False` → red each time; reverted `write_lock` to drop the failed-removal retry → red.

| Acceptance criterion (#15063) | Status |
|---|---|
| Update path reconciles to the declared set incl. removals, or refuses with a named reason — never silent | Met |
| Removal set reported before acting, visible in job output | Met (`steps.append` + logger, both consumers) |
| Transitive deps never removed, with a test | Met |
| An operator-installed package never removed as a side effect, with a test | **Unmet** — a never-declared name is protected and tested; a name this venv's history once declared, then an operator reinstalls before the next reconcile, is removed (proven by `test_reconcile_removes_a_name_an_operator_reinstalled_after_it_was_declared`, on purpose). Tracked as #15067. |
| Explicit-list component (npu-worker/browser-worker/slm-agent) handled, not silently skipped | Met |
| Real update path test: removed package gone, still-required package untouched | Met |
| Each guarded line mutated to prove its test can fail | Met (see mutation evidence) |
| No ad-hoc ansible/shell — capability lives in the builtin path | Met |

## Model Used

Claude Opus 5 (1M context)


