### PR TITLE
fix(tests): restore sys.modules after loading a script by path (#15076)

### DIFF
--- a/repo_tests/run_code_analysis_channel_14587_test.py
+++ b/repo_tests/run_code_analysis_channel_14587_test.py
@@ -52,9 +52,20 @@ def _load_module():
     """Import run_code_analysis by path -- its directory is not a package."""
     spec = importlib.util.spec_from_file_location("run_code_analysis", _MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
+    # The ``sys.modules`` entry exists only so ``exec_module`` can resolve the
+    # script's self-references; it is removed again immediately (#15076). Leaving
+    # it installed trips the session-finish leak guard (#13361), which fails the
+    # run *after* every test passes -- a failure with no failing test in the log.
+    previous = sys.modules.get("run_code_analysis")
     sys.modules["run_code_analysis"] = module
-    spec.loader.exec_module(module)
-    return module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous is None:
+            sys.modules.pop("run_code_analysis", None)
+        else:
+            sys.modules["run_code_analysis"] = previous
 
 
 rca = _load_module()
@@ -209,9 +220,7 @@ def test_report_file_with_non_dict_top_level_reports_error(scripts_dir, target_d
 def test_valid_report_file_is_returned_verbatim(scripts_dir, target_dir):
     """#14587: the orchestrator reads the file the analyzer writes, not stdout."""
     payload = {"status": "success", "complexity": 3, "maintainability": "excellent"}
-    _write_report_writing_script(
-        scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", payload
-    )
+    _write_report_writing_script(scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", payload)
 
     result = rca.run_code_quality_analysis(str(target_dir))
 
@@ -264,9 +273,7 @@ def test_main_exits_zero_when_analysis_succeeds(scripts_dir, target_dir, capsys,
     # #14635: shaped like the real code_quality_dashboard.py report -- scores
     # nest under "quality_metrics", not at the top level.
     payload = {"status": "success", "quality_metrics": {"maintainability_index": 82.5, "test_coverage_score": 91.0}}
-    _write_report_writing_script(
-        scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", payload
-    )
+    _write_report_writing_script(scripts_dir, "analyze_code_quality.py", "comprehensive_quality_report.json", payload)
     argv = ["run_code_analysis.py", "--target", str(target_dir), "--analysis-type", "quality"]
     monkeypatch.setattr(sys, "argv", argv)
 
@@ -295,8 +302,7 @@ def test_output_file_map_matches_what_each_real_script_writes():
         match = _REPORT_PATH_RE.search(source)
         assert match is not None, f"{script_name} has no report_path = Path(...) assignment"
         assert match.group(1) == expected_output, (
-            f"{script_name} writes {match.group(1)!r} but the orchestrator reads "
-            f"{expected_output!r} back for it"
+            f"{script_name} writes {match.group(1)!r} but the orchestrator reads " f"{expected_output!r} back for it"
         )
 
 

--- a/repo_tests/run_code_analysis_metrics_14635_test.py
+++ b/repo_tests/run_code_analysis_metrics_14635_test.py
@@ -40,9 +40,20 @@ def _load_module():
     """Import run_code_analysis by path -- its directory is not a package."""
     spec = importlib.util.spec_from_file_location("run_code_analysis_14635", _MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
+    # The ``sys.modules`` entry exists only so ``exec_module`` can resolve the
+    # script's self-references; it is removed again immediately (#15076). Leaving
+    # it installed trips the session-finish leak guard (#13361), which fails the
+    # run *after* every test passes -- a failure with no failing test in the log.
+    previous = sys.modules.get("run_code_analysis_14635")
     sys.modules["run_code_analysis_14635"] = module
-    spec.loader.exec_module(module)
-    return module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous is None:
+            sys.modules.pop("run_code_analysis_14635", None)
+        else:
+            sys.modules["run_code_analysis_14635"] = previous
 
 
 def _real_quality_metrics_keys() -> set:

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -37,8 +37,8 @@ from pathlib import Path
 
 import httpx
 import pytest
-
 from autobot_sdk import API_PREFIX, AutoBot, api_path, default_base_url
+
 from autobot_shared.api_routing import router_prefixes as routing
 from autobot_shared.ssot_config import config
 
@@ -57,13 +57,28 @@ _BACKEND_API_ROOT = "/api"
 
 
 def _route_decorator_re():
-    """The decorator grammar the blocking ``api-wiring`` gate already parses."""
+    """The decorator grammar the blocking ``api-wiring`` gate already parses.
+
+    The ``sys.modules`` entry exists only so ``exec_module`` can resolve the
+    script's own self-references; it is removed again immediately. Leaving it
+    installed trips the session-finish leak guard (#13361) -- which fails the
+    run *after* pytest reports every test passed, so the job log carries no
+    failing test to find. Restore the previous value rather than popping
+    unconditionally: another module may legitimately own the name.
+    """
     script = _REPO / "scripts" / "audit_api_wiring.py"
     spec = importlib.util.spec_from_file_location("audit_api_wiring", script)
     module = importlib.util.module_from_spec(spec)
+    previous = sys.modules.get("audit_api_wiring")
     sys.modules["audit_api_wiring"] = module
-    spec.loader.exec_module(module)
-    return module.ROUTE_DECORATOR_RE
+    try:
+        spec.loader.exec_module(module)
+        return module.ROUTE_DECORATOR_RE
+    finally:
+        if previous is None:
+            sys.modules.pop("audit_api_wiring", None)
+        else:
+            sys.modules["audit_api_wiring"] = previous
 
 
 @pytest.fixture(scope="module")

--- a/repo_tests/zero_downtime_deploy_test.py
+++ b/repo_tests/zero_downtime_deploy_test.py
@@ -28,9 +28,7 @@ def test_no_undefined_self_references() -> None:
     tree = ast.parse(SCRIPT_PATH.read_text(encoding="utf-8"))
 
     cls = next(
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.ClassDef) and node.name == "ZeroDowntimeDeployer"
+        node for node in ast.walk(tree) if isinstance(node, ast.ClassDef) and node.name == "ZeroDowntimeDeployer"
     )
 
     defined = {n.name for n in cls.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
@@ -62,9 +60,20 @@ def _load_module():
 
     spec = importlib.util.spec_from_file_location("zero_downtime_deploy_under_test", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
+    # The ``sys.modules`` entry exists only so ``exec_module`` can resolve the
+    # script's self-references; it is removed again immediately (#15076). Leaving
+    # it installed trips the session-finish leak guard (#13361), which fails the
+    # run *after* every test passes -- a failure with no failing test in the log.
+    previous = sys.modules.get(spec.name)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous is None:
+            sys.modules.pop(spec.name, None)
+        else:
+            sys.modules[spec.name] = previous
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Thinking Path

`python-suite shard 4/12` has been failing on the base since `e49045bed` (#15061), and it is a nasty one to read: the step exits 1 **after** pytest reports `2631 passed, 20 skipped`. There is no failing test, no `short test summary` line, and no `FAILED` marker anywhere in the job log, so the usual way of reading a CI failure finds nothing at all.

The failing thing is `repo_tests/sys_modules_leak_guard.py` (#13361), a session-finish hook that overrides the exit status. `repo_tests/sdk_request_url_test.py:64` installed `audit_api_wiring` into `sys.modules` and never removed it, and that file is not on the leak baseline, so the guard failed the run by design.

It is deterministic, not a flake — it lands in shard 4 because that shard also holds a node outside `repo_tests/` (`pipeline-scripts/detect-hardcoded-values_test.py`), which is what the guard compares against. Shard assignment is a stable hash (`repo_tests/stable_shard.py`, #14111), so it keeps landing there. Observed byte-identically on two runs across two branches: `32890665674` job `97947379516` (#15061's own PR, `2630 passed` + exit 1) and `32896921308` job `97964680744` (#15020, `2631 passed` + exit 1).

**Three more tests have the identical shape and are also absent from the baseline.** They have not failed yet only because they have not been sharded alongside a node outside `repo_tests/`. Leaving them would mean waiting for the same hour-long diagnosis the next time sharding shifts, so they are fixed here too.

## What Changed

`sdk_request_url_test.py`, `run_code_analysis_metrics_14635_test.py`, `run_code_analysis_channel_14587_test.py`, `zero_downtime_deploy_test.py` — each installs its module into `sys.modules` inside a `try` and restores in `finally`.

Restoring the **previous value** rather than popping unconditionally: another module may legitimately own the name, and `run_code_analysis_channel_14587_test.py` registers the un-suffixed key `run_code_analysis`, which is exactly the kind of name a second owner could hold.

No entry was added to `repo_tests/sys_modules_leak_baseline.txt`. It is down-only and the guard's own message says so — "do not add a line to the baseline, it only shrinks". It stays at 79 lines.

Also corrected a pre-existing isort violation in `sdk_request_url_test.py` (the `autobot_sdk` import was grouped as third-party). It fails `isort --check-only` under the repo's own `pyproject.toml` config on the base today; CI's isort step does not cover `repo_tests/`, which is why nothing caught it.

## Verification

- Behavioural, against the real function rather than a copy: load the test module, call `_route_decorator_re()`, assert `"audit_api_wiring" not in sys.modules` afterwards. Passes.
- Previous-owner preservation: install a sentinel under the key, call the function, assert the sentinel is still there. Passes.
- **Contrast mutation:** delete the `finally` block and re-run the same probe → `mutated version leaks: True`. The check is not vacuous.
- `pytest repo_tests/sdk_request_url_test.py` → 41 passed. The other three touched suites → 30 passed.
- `py_compile`, `black --check --line-length 120`, `isort --check-only` (repo config, no CLI overrides) all clean on the four files.

Not run: the whole suite. This machine is the self-hosted runner and it is saturated; CI owns that.

## Model Used

Claude Opus 5 (1M context)

Closes #15076
