### PR TITLE
fix(verify): a skipped essential check is not a verified run (#14870)

### DIFF
--- a/autobot-infrastructure/shared/scripts/utilities/verify_backend_config.py
+++ b/autobot-infrastructure/shared/scripts/utilities/verify_backend_config.py
@@ -50,6 +50,12 @@ API_MOUNT_PREFIX = "/api"
 EXECUTE_PATH = "/execute"
 
 
+#: The check that actually exercises the claim this script's success message
+#: makes. The other checks read the registry statically and always pass, so a
+#: run where this one is skipped has verified nothing the message promises.
+ESSENTIAL_CHECK = "route registration"
+
+
 class CheckResults:
     """Tally of check outcomes; a check that could not run is never a pass."""
 
@@ -57,6 +63,7 @@ class CheckResults:
         self.passed = 0
         self.failed = 0
         self.skipped = 0
+        self.skipped_names: list[str] = []
 
     def record_pass(self, name: str, detail: str) -> None:
         self.passed += 1
@@ -68,14 +75,35 @@ class CheckResults:
 
     def record_skip(self, name: str, reason: str) -> None:
         self.skipped += 1
+        self.skipped_names.append(name)
         logger.warning("SKIPPED %s: %s", name, reason)
 
     def summary(self) -> int:
-        """Log the counts and return the process exit code."""
+        """Log the counts and return the process exit code.
+
+        Three outcomes, not two (#14870). A run where every check passed and a
+        run where the only check that exercises route registration was skipped
+        are not the same result, and reporting both as a green tick is how a
+        verifier comes to certify something it never looked at.
+        """
         logger.info("PASSED=%d FAILED=%d SKIPPED=%d", self.passed, self.failed, self.skipped)
         if self.failed or not self.passed:
             logger.error("❌ Workflow router registration NOT verified")
             return 1
+        if ESSENTIAL_CHECK in self.skipped_names:
+            logger.error(
+                "❌ Workflow router registration NOT verified — %r could not run, "
+                "and the remaining checks only read the registry statically",
+                ESSENTIAL_CHECK,
+            )
+            return 1
+        if self.skipped:
+            logger.warning(
+                "⚠️  Workflow router registration verified, but %d other check(s) could not run: %s",
+                self.skipped,
+                ", ".join(self.skipped_names),
+            )
+            return 0
         logger.info("✅ Workflow router registration verified")
         return 0
 

--- a/repo_tests/verify_backend_config_reporting_test.py
+++ b/repo_tests/verify_backend_config_reporting_test.py
@@ -1,0 +1,109 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A verifier must not report success for a check that never ran (#14870).
+
+``verify_backend_config.py`` has three checks. Two read the workflow registry
+statically and always pass; only ``route registration`` mounts the router and
+asserts the execute endpoint exists — the single claim the script's success
+message actually makes.
+
+Its ``summary()`` used to return 0 whenever nothing failed, so when backend
+imports were unavailable the essential check was skipped and the script still
+printed ``✅ Workflow router registration verified``. A verifier that certifies
+what it could not look at is worse than no verifier: the green tick is taken as
+evidence, and the thing it names goes unchecked.
+
+These tests pin the three outcomes apart. ``test_a_skipped_essential_check_is_not_success``
+is the one that fails if the fix is reverted.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts" / "utilities" / "verify_backend_config.py"
+
+
+def _load_by_path(path: pathlib.Path, module_name: str):
+    """Import a standalone script by path -- its directory is not a package.
+
+    Install and restore in the same ``try/finally``: leaving the key behind
+    trips the session-finish leak guard (#13361, #15076), which fails the run
+    after every test has passed.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.modules.get(module_name)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+
+
+@pytest.fixture(scope="module")
+def verifier():
+    assert _SCRIPT.is_file(), f"{_SCRIPT.relative_to(_REPO_ROOT)} moved -- this guard is looking at nothing"
+    return _load_by_path(_SCRIPT, "verify_backend_config_under_test")
+
+
+def test_the_essential_check_name_matches_a_real_call_site(verifier):
+    """Non-vacuity: the constant must name a check the script actually records.
+
+    If ``ESSENTIAL_CHECK`` drifted from the name passed to ``record_skip``, every
+    assertion below would still pass while guarding nothing.
+    """
+    source = _SCRIPT.read_text(encoding="utf-8")
+    assert (
+        f'name = "{verifier.ESSENTIAL_CHECK}"' in source
+    ), f"ESSENTIAL_CHECK is {verifier.ESSENTIAL_CHECK!r} but no check declares that name"
+
+
+def test_a_clean_run_reports_success(verifier):
+    results = verifier.CheckResults()
+    results.record_pass("registry entry", "found")
+    results.record_pass(verifier.ESSENTIAL_CHECK, "endpoint registered")
+    assert results.summary() == 0
+
+
+def test_a_skipped_essential_check_is_not_success(verifier):
+    """The regression this guard exists for: static checks passing is not verification."""
+    results = verifier.CheckResults()
+    results.record_pass("registry entry", "found")
+    results.record_pass("router module", "resolves")
+    results.record_skip(verifier.ESSENTIAL_CHECK, "backend imports unavailable")
+    assert results.summary() == 1, (
+        "the only check that exercises route registration was skipped, "
+        "so the run must not exit 0 -- the other two only read the registry as text"
+    )
+
+
+def test_a_skipped_non_essential_check_still_succeeds(verifier):
+    """The counterweight: not every skip is fatal, or the rule would be 'any skip fails'."""
+    results = verifier.CheckResults()
+    results.record_pass(verifier.ESSENTIAL_CHECK, "endpoint registered")
+    results.record_skip("router module", "registry entry unavailable")
+    assert results.summary() == 0
+
+
+def test_a_failure_still_fails(verifier):
+    results = verifier.CheckResults()
+    results.record_pass(verifier.ESSENTIAL_CHECK, "endpoint registered")
+    results.record_fail("registry entry", "missing")
+    assert results.summary() == 1
+
+
+def test_no_checks_at_all_is_not_success(verifier):
+    """An empty run has verified nothing, whatever the counters say."""
+    assert verifier.CheckResults().summary() == 1


### PR DESCRIPTION
## Thinking Path

#14870's fourth criterion — *"No script reports success when its check could not run"* — was the one criterion of four that #15041 left unmet, which is why that issue stayed open while its five siblings closed.

`verify_backend_config.py` has three checks. Two read the workflow registry statically and always pass. Only `route registration` mounts the router and asserts the execute endpoint exists — it is the sole check that exercises the claim the script's success message makes.

`summary()` returned 0 whenever `failed == 0 and passed > 0`. So when backend imports were unavailable, `check_route_registration` recorded a skip at `:163`, the two static checks passed, and the script printed **`✅ Workflow router registration verified`** and exited 0 with the registration never exercised.

That is worse than having no verifier. A green tick gets taken as evidence, and the thing it names goes unchecked — the same failure shape as #13570 and the guard degradation found in #15041, where a check reported success while inspecting nothing.

The repo already implements the correct pattern twice — `verify_ssh_manager.py:224-229` and `test_phase5_cleanup.py:342-344` both separate "complete" from "incomplete". This is an omission, not a design disagreement.

## What Changed

`autobot-infrastructure/shared/scripts/utilities/verify_backend_config.py`

- `ESSENTIAL_CHECK = "route registration"` names the check that carries the headline claim, with a comment saying why the others do not.
- `record_skip()` now keeps the skipped check's **name**, not just a count.
- `summary()` has three outcomes instead of two: a skipped essential check is an explicit failure with a message saying the remaining checks only read the registry statically; other skips succeed but warn and name what did not run.

Deliberately keyed on the **named** check rather than on `skipped > 0`. "Any skip fails" would be a blunter rule that punishes legitimately optional checks, and the counterweight test below pins that distinction so nobody later collapses it.

`repo_tests/verify_backend_config_reporting_test.py` (new) — six tests holding the outcomes apart.

## Verification

- `pytest repo_tests/verify_backend_config_reporting_test.py` → **6 passed**.
- **Contrast mutation:** restore the old two-way `summary()` → `FAILED test_a_skipped_essential_check_is_not_success`. The guard is not vacuous.
- **Non-vacuity assertion:** `test_the_essential_check_name_matches_a_real_call_site` greps the script for `name = "route registration"`. If the constant ever drifts from the name actually recorded, every other assertion would still pass while guarding nothing — this fails instead.
- **Counterweight:** `test_a_skipped_non_essential_check_still_succeeds` fails if someone simplifies the rule to "any skip fails".
- `pytest repo_tests/collection_coverage_test.py repo_tests/tests_that_return_instead_of_asserting_test.py` → 15 passed, so the new file is collected and asserts rather than returns.
- `check_python_file_size.py --audit-ceilings` rc 0; `py_compile`, `black --check --line-length 120` clean on both files.

The module loader in the new test installs and restores `sys.modules` in the same `try/finally`, per #15076 — the leak guard fails a run *after* every test passes, and adding another leaker while that is being fixed would have been careless.

Not run: the whole suite. This machine is the self-hosted runner and it is saturated; CI owns that.

## Model Used

Claude Opus 5 (1M context)

Closes #14870
