### PR TITLE
docs(bedrock): the module documents a re-export it does not have (#15081)

### DIFF
--- a/autobot-backend/llm_shared/providers/bedrock_credentials.py
+++ b/autobot-backend/llm_shared/providers/bedrock_credentials.py
@@ -8,9 +8,16 @@ Split out of ``bedrock.py`` because that module reached its 600-line ceiling,
 and this is the one cohesive piece in it that owes nothing to provider state:
 the credential retrieval touches no ``self``, and the region pattern is data.
 
-``bedrock.py`` re-exports every name defined here, so
-``llm_shared.providers.bedrock.BEDROCK_VAULT_ENTRY_NAME`` and its siblings
-still resolve for existing importers and patch targets.
+These names live here and only here. ``bedrock.py`` imports the two it uses
+and deliberately re-exports nothing: an ``__all__`` whose only purpose is to
+satisfy F401 would be indirection existing to quiet a linter. Import the
+constants from this module, not through ``bedrock`` -- ``llm_shared.providers.
+bedrock.BEDROCK_VAULT_ENTRY_NAME`` raises ``AttributeError`` (#15081).
+
+The test patches ``get_secrets_service`` through
+``BedrockProvider._load_credentials_from_vault.__globals__``, which resolves to
+*this* module's globals -- where the call actually is -- so the patch target
+follows the function rather than a re-export.
 """
 
 from __future__ import annotations

--- a/autobot-backend/llm_shared/providers/bedrock_credentials.py
+++ b/autobot-backend/llm_shared/providers/bedrock_credentials.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""Vault lookup and region validation for the Bedrock provider (#15023).
+"""Vault lookup and credential validation for the Bedrock provider (#15023).
 
 Split out of ``bedrock.py`` because that module reached its 600-line ceiling,
 and this is the one cohesive piece in it that owes nothing to provider state:
 the credential retrieval touches no ``self``, and the region pattern is data.
 
-These names live here and only here. ``bedrock.py`` imports the two it uses
-and deliberately re-exports nothing: an ``__all__`` whose only purpose is to
+These names live here and only here. ``bedrock.py`` imports only what it
+calls and deliberately re-exports nothing: an ``__all__`` whose only purpose is to
 satisfy F401 would be indirection existing to quiet a linter. Import the
 constants from this module, not through ``bedrock`` -- ``llm_shared.providers.
 bedrock.BEDROCK_VAULT_ENTRY_NAME`` raises ``AttributeError`` (#15081).


### PR DESCRIPTION
## Thinking Path

I wrote this docstring, and it was wrong the moment I wrote it.

`bedrock_credentials.py:11-13` claimed:

> `bedrock.py` re-exports every name defined here, so `llm_shared.providers.bedrock.BEDROCK_VAULT_ENTRY_NAME` and its siblings still resolve for existing importers and patch targets.

`bedrock.py:31` imports exactly two names — `_AWS_REGION_PATTERN` and `load_credentials_from_vault`. The attribute the docstring promises raises `AttributeError`.

The contradiction came from changing my mind mid-change and not revisiting the prose. I first wrote the split with a re-export, then removed it deliberately — an `__all__` whose only purpose is to satisfy F401 is indirection that exists to quiet a linter — and pointed `bedrock_test.py` at the new module instead. The code is right; the paragraph describing it was left behind.

Nothing imports it that way today, so this breaks nothing. It is worth fixing anyway, because a docstring that names a working patch target is exactly what someone reaches for when writing the next test, and they would find out it is fiction only at runtime.

Doc-versus-reality conflicts resolve against reality — the same rule applied in #15037 and recorded in #15070 and #15075.

## What Changed

`autobot-backend/llm_shared/providers/bedrock_credentials.py` — the module docstring now says what is true:

- these names live here and only here; `bedrock.py` re-exports nothing, and why;
- import the constants from this module, and `llm_shared.providers.bedrock.BEDROCK_VAULT_ENTRY_NAME` raises;
- the patch target that *does* work: `BedrockProvider._load_credentials_from_vault.__globals__` resolves to this module's globals, where the `get_secrets_service()` call actually is, so it follows the function rather than depending on a re-export.

Documentation only. No behaviour change.

## Verification

- AST check on the merged-base `bedrock.py`, rather than reasoning about it: `imports from bedrock_credentials: ['_AWS_REGION_PATTERN', 'load_credentials_from_vault']`, `BEDROCK_VAULT_ENTRY_NAME reachable via bedrock: False`. That is the claim the new text makes, confirmed against the code.
- `pytest llm_shared/providers/bedrock_test.py` → 22 passed, so the `__globals__` patch route the docstring now documents is the one actually exercised.
- `py_compile` and `black --check --line-length 120` clean.

Not run: the whole suite. This machine is the self-hosted runner; CI owns that.

## Model Used

Claude Opus 5 (1M context)

Closes #15081
