### PR TITLE
fix(llm): restore Bedrock AWS credential shape validation (#15080)

### DIFF
--- a/autobot-backend/llm_shared/providers/bedrock.py
+++ b/autobot-backend/llm_shared/providers/bedrock.py
@@ -28,7 +28,7 @@ from llm_shared.models import LLMRequest, LLMResponse, ToolCall
 from llm_shared.types import ProviderType
 
 from ..base_provider import BaseProvider
-from .bedrock_credentials import _AWS_REGION_PATTERN, load_credentials_from_vault
+from .bedrock_credentials import _AWS_REGION_PATTERN, load_credentials_from_vault, validate_credential_pair
 
 logger = get_logger(__name__)
 
@@ -97,6 +97,12 @@ class BedrockProvider(BaseProvider):
         Returns:
             Tuple of (access_key_id, secret_access_key, region).
             Any value can be None to use boto3's default credential chain.
+
+        Raises:
+            ValueError: If the resolved access-key/secret-key pair is malformed --
+                see validate_credential_pair(). Raised here rather than only at
+                client construction so every caller of this method gets the same
+                guarantee: a returned pair is either well-formed or both-absent.
         """
         access_key, secret_key, region = self._load_credentials_from_vault()
 
@@ -110,6 +116,7 @@ class BedrockProvider(BaseProvider):
                 )
 
         region = region or self._get_setting("region") or os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+        validate_credential_pair(access_key, secret_key)
         return access_key, secret_key, region
 
     def _ensure_runtime_client(self):

--- a/autobot-backend/llm_shared/providers/bedrock_credentials.py
+++ b/autobot-backend/llm_shared/providers/bedrock_credentials.py
@@ -44,6 +44,65 @@ BEDROCK_VAULT_ENTRY_TYPE = "aws_bedrock_credentials"
 #: partitions.
 _AWS_REGION_PATTERN = re.compile(r"^[a-z]{2}(-[a-z]+)+-\d{1,2}$")
 
+#: AWS access-key shape: AKIA (long-lived IAM user) or ASIA (temporary STS) followed
+#: by 16 uppercase-alphanumeric characters -- 20 characters total. Restores the check
+#: dropped alongside the vault lookup in d470c47c09 (#15080); see validate_credential_pair.
+_AWS_ACCESS_KEY_PATTERN = re.compile(r"^(AKIA|ASIA)[0-9A-Z]{16}$")
+
+#: AWS secret-access-key shape: exactly 40 base64 characters (A-Za-z0-9+/).
+_AWS_SECRET_KEY_PATTERN = re.compile(r"^[A-Za-z0-9+/]{40}$")
+
+
+def validate_credential_pair(access_key: object, secret_key: object) -> None:
+    """Validate the shape of a resolved AWS access-key/secret-key pair.
+
+    Applies regardless of source (SecretsService vault, settings, or environment) --
+    a vault entry is a trust boundary, not a format guarantee, the same reasoning
+    already applied to the region via ``_AWS_REGION_PATTERN``. Restores the check
+    dropped alongside the vault lookup in the formatting auto-fix ``d470c47c09``,
+    which #15062 never re-added (#15080).
+
+    An empty string is treated the same as ``None`` (no explicit credentials,
+    IAM role authentication applies). A non-string value -- reachable now that
+    a vault entry travels through ``json.loads`` rather than only ``os.getenv``
+    -- is rejected the same as a malformed string, never inspected further.
+
+    Raises:
+        ValueError: Naming the malformed field only -- never any part of its
+            value or its length, which is itself derived from the value.
+            Deliberately louder than a silent pass-through: a malformed vault
+            row means active misconfiguration, and falling through to the
+            boto3 default (IAM role) chain would substitute an unintended
+            identity rather than surface the bad entry.
+    """
+    if not access_key:
+        access_key = None
+    if not secret_key:
+        secret_key = None
+
+    if access_key is None and secret_key is None:
+        logger.info("Using IAM role authentication (no explicit Bedrock credentials)")
+        return
+
+    if (access_key is None) != (secret_key is None):
+        raise ValueError(
+            "Bedrock: resolved AWS credentials are incomplete -- both the access key and "
+            "the secret key must be present, or both absent for IAM role authentication"
+        )
+
+    if not isinstance(access_key, str) or not _AWS_ACCESS_KEY_PATTERN.match(access_key):
+        raise ValueError("Bedrock: resolved AWS access key has an unexpected format, refusing to initialize client")
+    if access_key.startswith("AKIA"):
+        logger.warning(
+            "Bedrock: using long-lived IAM user credentials (AKIA prefix); consider STS "
+            "temporary credentials (ASIA prefix) or IAM role authentication instead"
+        )
+    else:
+        logger.info("Bedrock: using STS temporary credentials (ASIA prefix)")
+
+    if not isinstance(secret_key, str) or not _AWS_SECRET_KEY_PATTERN.match(secret_key):
+        raise ValueError("Bedrock: resolved AWS secret key has an unexpected format, refusing to initialize client")
+
 
 def load_credentials_from_vault() -> tuple[str | None, str | None, str | None]:
     """Look up the Bedrock AWS credential pair in SecretsService.

--- a/autobot-backend/llm_shared/providers/bedrock_test.py
+++ b/autobot-backend/llm_shared/providers/bedrock_test.py
@@ -30,6 +30,7 @@ from llm_shared.providers.bedrock_credentials import (
     _AWS_REGION_PATTERN,
     BEDROCK_VAULT_ENTRY_NAME,
     BEDROCK_VAULT_ENTRY_TYPE,
+    validate_credential_pair,
 )
 
 #: Credential resolution spans two modules since #15023: the vault lookup lives in
@@ -37,6 +38,16 @@ from llm_shared.providers.bedrock_credentials import (
 #: through the bound functions keeps the patch targets correct if either moves again.
 _VAULT_GLOBALS = BedrockProvider._load_credentials_from_vault.__globals__
 _PROVIDER_GLOBALS = BedrockProvider._resolve_credentials.__globals__
+
+#: Format-valid stand-ins for the vault/env credential pairs below -- shaped to pass
+#: validate_credential_pair() (AKIA/ASIA + 16 alnum access key, 40-char base64 secret)
+#: so these fixtures exercise credential *resolution* without tripping the *format*
+#: validation restored by #15080. Distinct per source so priority-order assertions
+#: still tell vault and env values apart.
+_WELL_FORMED_VAULT_ACCESS_KEY_ID = "AKIA" + "V" * 16
+_WELL_FORMED_VAULT_SECRET_ACCESS_KEY = "V" * 40
+_WELL_FORMED_ENV_ACCESS_KEY_ID = "ASIA" + "E" * 16  # STS prefix avoids the AKIA warning below
+_WELL_FORMED_ENV_SECRET_ACCESS_KEY = "E" * 40
 
 
 def _vault_returning(value_json: str | None, secret_type: str = BEDROCK_VAULT_ENTRY_TYPE) -> MagicMock:
@@ -76,19 +87,24 @@ def _patch_warning(monkeypatch) -> MagicMock:
 def test_resolve_credentials_consults_secrets_service_first(monkeypatch):
     """SecretsService is consulted, with the exact call the vault reader must make."""
     vault = _vault_returning(
-        '{"aws_access_key_id": "AKIAVAULTVAULTVAULT", '
-        '"aws_secret_access_key": "vault-secret", "region": "eu-west-1"}'
+        '{"aws_access_key_id": "%s", '
+        '"aws_secret_access_key": "%s", "region": "eu-west-1"}'
+        % (_WELL_FORMED_VAULT_ACCESS_KEY_ID, _WELL_FORMED_VAULT_SECRET_ACCESS_KEY)
     )
     _patch_vault(monkeypatch, vault)
     # Set env vars too, to prove the vault wins priority rather than merely
     # being the only source available.
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENVENVENVENVENV")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _WELL_FORMED_ENV_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
 
     provider = BedrockProvider(settings={})
     access_key, secret_key, region = provider._resolve_credentials()
 
-    assert (access_key, secret_key, region) == ("AKIAVAULTVAULTVAULT", "vault-secret", "eu-west-1")
+    assert (access_key, secret_key, region) == (
+        _WELL_FORMED_VAULT_ACCESS_KEY_ID,
+        _WELL_FORMED_VAULT_SECRET_ACCESS_KEY,
+        "eu-west-1",
+    )
     vault.get_secret.assert_called_once_with(
         name=BEDROCK_VAULT_ENTRY_NAME,
         scope="general",
@@ -100,14 +116,14 @@ def test_resolve_credentials_consults_secrets_service_first(monkeypatch):
 def test_resolve_credentials_falls_back_to_env_and_logs_warning(monkeypatch):
     """Vault not configured -> env fallback is used AND a warning names the source."""
     _patch_vault(monkeypatch, _vault_returning(None))
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENVENVENVENVENV")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _WELL_FORMED_ENV_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
     warning_mock = _patch_warning(monkeypatch)
 
     provider = BedrockProvider(settings={})
     access_key, secret_key, _region = provider._resolve_credentials()
 
-    assert (access_key, secret_key) == ("AKIAENVENVENVENVENV", "env-secret")
+    assert (access_key, secret_key) == (_WELL_FORMED_ENV_ACCESS_KEY_ID, _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
     assert warning_mock.call_count == 1
     logged_message = warning_mock.call_args[0][0]
     assert "SecretsService" in logged_message
@@ -131,14 +147,14 @@ def test_vault_lookup_failure_is_logged_and_falls_back(monkeypatch):
     vault = MagicMock()
     vault.get_secret.side_effect = RuntimeError("db locked")
     _patch_vault(monkeypatch, vault)
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENVENVENVENVENV")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-secret")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _WELL_FORMED_ENV_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
     warning_mock = _patch_warning(monkeypatch)
 
     provider = BedrockProvider(settings={})
     access_key, secret_key, _region = provider._resolve_credentials()
 
-    assert (access_key, secret_key) == ("AKIAENVENVENVENVENV", "env-secret")
+    assert (access_key, secret_key) == (_WELL_FORMED_ENV_ACCESS_KEY_ID, _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
     # Two warnings: the vault-lookup failure, then the plain-text-fallback notice.
     assert warning_mock.call_count == 2
     assert "SecretsService lookup failed" in warning_mock.call_args_list[0][0][0]
@@ -200,3 +216,70 @@ def test_every_real_aws_partition_is_accepted(region):
 )
 def test_non_region_values_are_refused(value):
     assert not _AWS_REGION_PATTERN.match(value), f"{value!r} is not a region and must not reach boto3"
+
+
+# --- validate_credential_pair() (#15080) --------------------------------------------
+#
+# The AWS key pair reaches boto3 through the same vault-is-a-trust-boundary path as
+# the region above, but travelled unvalidated after the formatting auto-fix d470c47c09
+# dropped `_validate_credentials()` and #15062 restored only the vault lookup, not the
+# validator. These tests exercise `validate_credential_pair()` directly (the well-formed
+# and malformed shapes) and `_resolve_credentials()` end-to-end (a malformed vault entry
+# is refused before it can reach `client_kwargs`).
+
+
+@pytest.mark.parametrize(
+    "access_key, secret_key",
+    [
+        ("AKIA" + "A" * 16, "A" * 40),  # long-lived IAM user credentials
+        ("ASIA" + "0" * 16, "B" * 40),  # temporary STS credentials
+        (None, None),  # IAM role authentication -- both absent is well-formed too
+    ],
+)
+def test_well_formed_credential_pair_is_accepted(access_key, secret_key):
+    """Counterweight: a validator that rejected everything would fail this too."""
+    validate_credential_pair(access_key, secret_key)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "access_key, secret_key",
+    [
+        ("AKIA" + "A" * 16, None),  # secret key missing
+        (None, "A" * 40),  # access key missing
+        ("not-shaped-like-an-access-key", "A" * 40),  # wrong prefix/length
+        ("AKIA" + "a" * 16, "A" * 40),  # lowercase suffix, not the AWS charset
+        ("AKIA" + "A" * 15, "A" * 40),  # one character short
+        ("AKIA" + "A" * 16, "A" * 39),  # secret key one character short
+        ("AKIA" + "A" * 16, "A" * 41),  # secret key one character long
+        ("AKIA" + "A" * 16, "not base64 at all!!"),  # secret key outside the charset
+        ("AKIA" + "A" * 16, 12345),  # non-string secret key (malformed vault JSON)
+        (["AKIA" + "A" * 16], "A" * 40),  # non-string access key (malformed vault JSON)
+    ],
+)
+def test_malformed_credential_pair_is_rejected(access_key, secret_key):
+    with pytest.raises(ValueError):
+        validate_credential_pair(access_key, secret_key)
+
+
+def test_rejection_never_echoes_the_credential_value():
+    """The whole point of #15080: a malformed value must never reach the exception text."""
+    telltale = "TELLTALE-MARKER-VALUE-THAT-MUST-NEVER-APPEAR"
+    with pytest.raises(ValueError) as excinfo:
+        validate_credential_pair("AKIA" + telltale[:16], "A" * 40)
+    assert telltale not in str(excinfo.value)
+    assert "TELLTALE" not in str(excinfo.value)
+
+
+def test_resolve_credentials_rejects_a_malformed_vault_pair(monkeypatch):
+    """A malformed vault entry is refused inside `_resolve_credentials()` itself,
+    before it can reach `client_kwargs` -- not left for boto3 to fail on later."""
+    vault = _vault_returning(
+        '{"aws_access_key_id": "not-an-aws-access-key", '
+        '"aws_secret_access_key": "%s", "region": "eu-west-1"}' % _WELL_FORMED_VAULT_SECRET_ACCESS_KEY
+    )
+    _patch_vault(monkeypatch, vault)
+
+    provider = BedrockProvider(settings={})
+    with pytest.raises(ValueError) as excinfo:
+        provider._resolve_credentials()
+    assert "not-an-aws-access-key" not in str(excinfo.value)


### PR DESCRIPTION
## Thinking Path

Traced the gap first: `_resolve_credentials()` in `bedrock.py` pulls `access_key`/`secret_key` from
`load_credentials_from_vault()` (`bedrock_credentials.py:71-76`, bare `.get()` on a JSON blob) with a
settings/env fallback, and returns the pair unchecked. It reaches `client_kwargs` at `bedrock.py:136-138`
and on to `boto3.client()` with no shape check anywhere in between -- only the region got a guard from
#15062 (`_AWS_REGION_PATTERN`). Confirmed with `grep -n "_validate_credentials"` against
`origin/Dev_new_gui`: no hits.

Recovered the original validator with `git show d470c47c09 -- '*bedrock.py'`: a method
`_validate_credentials(access_key, secret_key)` that treated empty strings as `None`, required both
present or both absent, checked the access key against `^(AKIA|ASIA)[0-9A-Z]{16}$`, the secret key
against 40 base64 characters, and warned on long-lived `AKIA` credentials. One thing in that original
does exactly what this issue says a fix must never do: on a malformed access key it raised
`f"Invalid AWS access key format: {access_key[:8]}... "`, and on a malformed secret key it echoed
`len(secret_key)` -- both derived from the credential value. Restoring that verbatim would still be the
regression this issue is about, just relocated. Dropped both echoes; the rejection now names only which
field was malformed.

## What Changed

- `autobot-backend/llm_shared/providers/bedrock_credentials.py`: added `validate_credential_pair()` plus
  `_AWS_ACCESS_KEY_PATTERN` / `_AWS_SECRET_KEY_PATTERN`, alongside the existing `_AWS_REGION_PATTERN`.
  Placed here rather than in `bedrock.py` because `bedrock.py` is at 576/600 lines against a ceiling
  that is not grandfathered (582 lines after the one-line call site addition would already be close;
  the validator itself is ~50 lines) -- `bedrock_credentials.py` is the seam #15023 already cut for
  exactly this kind of vault-adjacent validation.
- `autobot-backend/llm_shared/providers/bedrock.py`: `_resolve_credentials()` now calls
  `validate_credential_pair(access_key, secret_key)` before returning, covering every source (vault,
  settings, environment) and both call sites (`_ensure_runtime_client()`, `is_available()`).
- `autobot-backend/llm_shared/providers/bedrock_test.py`: existing vault/env fixtures used credential
  literals (e.g. `"AKIAVAULTVAULTVAULT"`, `"vault-secret"`) that don't match AWS's real shape and would
  now be rejected by the restored validator, so they're replaced with format-valid fake pairs
  (`_WELL_FORMED_VAULT_ACCESS_KEY_ID` etc.) that keep the same resolution-priority assertions passing.
  Added: a well-formed-pair counterweight (`test_well_formed_credential_pair_is_accepted`, parametrized
  over AKIA/ASIA/both-absent), a malformed-shape table covering missing-half, bad prefix/length, wrong
  charset, and non-string values from a tampered vault blob (`test_malformed_credential_pair_is_rejected`),
  a value-non-echo test (`test_rejection_never_echoes_the_credential_value`), and an end-to-end test that
  a malformed vault entry is refused inside `_resolve_credentials()` itself
  (`test_resolve_credentials_rejects_a_malformed_vault_pair`).

**Deviation from the original, deliberate:** dropped the `access_key[:8]` and `len(secret_key)` echoes
from the rejection messages -- the issue's non-negotiable constraint is that a rejection never echoes
any part of the credential value, and both were value-derived. Everything else (the format patterns,
the both-present-or-both-absent rule, the AKIA/ASIA distinction) is restored as it was. Also added a
non-string check (`isinstance(access_key, str)` / `isinstance(secret_key, str)`) that the original never
needed, because its only input path was `os.getenv()` (always `str | None`); a vault entry now arrives
via `json.loads()`, so a tampered or malformed vault row can hand back a non-string value the original
code would have crashed on with an unhandled `TypeError` from `re.match`.

**Raise vs. fall-through:** raises `ValueError`, restoring the original's behavior and matching the
region check immediately below it in `_ensure_runtime_client()` (`bedrock.py:126-131`), which already
raises rather than falling through. A malformed vault/settings/env entry is active misconfiguration, not
absence of configuration -- falling through to the boto3 default (IAM role) chain would silently
substitute an unintended identity instead of surfacing the bad entry. `is_available()` already wraps
`_resolve_credentials()` in a broad `try/except` returning `False`, so this doesn't turn a health check
into a crash; it turns it into a correctly-reported "unavailable".

## Verification

- `python3 -m pytest autobot-backend/llm_shared/providers/bedrock_test.py -q` -> 37 passed (22 baseline +
  15 new/parametrized cases for `validate_credential_pair`).
- Contrast mutation: temporarily replaced the `validate_credential_pair(...)` call in `_resolve_credentials()`
  with `pass`; `test_resolve_credentials_rejects_a_malformed_vault_pair` failed with
  `Failed: DID NOT RAISE <class 'ValueError'>`, confirming the test actually exercises the restored guard.
  Reverted; full suite passes again (37/37).
- `python3 scripts/check_python_file_size.py --audit-ceilings` -> rc 0 (`bedrock.py` 583/600,
  `bedrock_credentials.py` 135 lines, neither grandfathered, no ceiling changes needed).
- `python3 -m bandit -c .bandit -q` on all three edited files -> rc 0, no findings.
- `py_compile`, `black --check --line-length 120`, `isort --check-only` on all three edited files -> clean.
- Branch was 0 behind `origin/Dev_new_gui` at push time (no rebase needed); #15082 (docstring-only change
  to `bedrock_credentials.py`) had not yet landed on `Dev_new_gui`, so no conflict materialized.

## Model Used

Claude Sonnet 5

Closes #15080
