### PR TITLE
fix(access-control): provision the enforcement mode instead of inheriting an unset key (#14866)

### DIFF
--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -29,6 +29,7 @@ Usage:
 
 import asyncio
 import json
+import os
 from datetime import datetime, timezone
 from enum import Enum
 
@@ -62,6 +63,46 @@ class EnforcementModeUnavailable(RuntimeError):
     """
 
 
+# The single Redis key the platform's whole access-control posture is read from.
+# It was a literal repeated at each reader and writer; provisioning has to name
+# the same key, and a fourth copy of a string is how the fourth copy drifts.
+ENFORCEMENT_MODE_KEY = "feature_flag:access_control:enforcement_mode"
+
+# Posture provisioning writes when an install has no value of its own (#14866).
+# ``log_only`` is the value both issues record: #14010's acceptance criterion 4
+# asks for "the ``log_only`` measurement before any flip to ``enforced``", and
+# #14866 calls it "the safe first value" because every ownership check runs and
+# every violation is audited while nothing that succeeds today starts being
+# refused. Flipping to ``enforced`` is a separate, measured step and is
+# deliberately NOT made here. Neither is the meaning of an unset key or of
+# ``log_only`` changed: this makes *unset* stop being the production state, it
+# does not redefine it.
+PROVISIONED_ENFORCEMENT_MODE_ENV = "ACCESS_CONTROL_ENFORCEMENT_MODE"
+PROVISIONED_ENFORCEMENT_MODE_DEFAULT = EnforcementMode.LOG_ONLY
+
+
+def resolve_provisioned_enforcement_mode(raw: str | None = None) -> EnforcementMode:
+    """Resolve the posture provisioning should write.
+
+    Precedence: an explicit *raw* value (the provisioning entry point's
+    ``--mode``), then the ``ACCESS_CONTROL_ENFORCEMENT_MODE`` environment value,
+    then :data:`PROVISIONED_ENFORCEMENT_MODE_DEFAULT`.
+
+    An unrecognised value raises instead of falling back. Quietly defaulting a
+    misconfigured authorization posture is precisely the defect #14866 exists
+    for, and a provisioning run that cannot honour what it was asked for must
+    say so rather than write something else.
+    """
+    value = raw if raw is not None else os.environ.get(PROVISIONED_ENFORCEMENT_MODE_ENV, "")
+    if not value or not value.strip():
+        return PROVISIONED_ENFORCEMENT_MODE_DEFAULT
+    try:
+        return EnforcementMode(value.strip().lower())
+    except ValueError as exc:
+        valid = ", ".join(mode.value for mode in EnforcementMode)
+        raise ValueError(f"Unrecognised enforcement mode {value!r}; expected one of: {valid}") from exc
+
+
 class FeatureFlags(AsyncRedisClientMixin):
     """
     Redis-backed feature flags for access control rollout
@@ -88,7 +129,7 @@ class FeatureFlags(AsyncRedisClientMixin):
         """
         try:
             redis = await self._get_redis()
-            mode_str = await redis.get("feature_flag:access_control:enforcement_mode")
+            mode_str = await redis.get(ENFORCEMENT_MODE_KEY)
 
             if mode_str:
                 # Handle bytes response
@@ -112,6 +153,46 @@ class FeatureFlags(AsyncRedisClientMixin):
             logger.error("Could not read enforcement mode: %s", e)
             raise EnforcementModeUnavailable(str(e)) from e
 
+    @staticmethod
+    async def _read_enforcement_mode(redis) -> EnforcementMode | None:
+        """Return the mode currently stored, or ``None`` when the key is absent."""
+        raw = await redis.get(ENFORCEMENT_MODE_KEY)
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        return EnforcementMode(raw) if raw else None
+
+    async def seed_enforcement_mode(
+        self, mode: EnforcementMode | None = None, dry_run: bool = False
+    ) -> tuple[bool, EnforcementMode]:
+        """Give an install a deliberate enforcement posture without clobbering one.
+
+        Writes *mode* only when the key is absent, with ``SET NX`` so the check
+        and the write are one atomic Redis operation: two provisioning runs
+        racing cannot both write, and re-provisioning never overwrites a value an
+        operator set on purpose (#14866). That is the whole of the idempotency
+        guarantee -- it is Redis's, not a read-then-write of ours.
+
+        Returns ``(written, effective_mode)``.
+        """
+        target = mode or resolve_provisioned_enforcement_mode()
+        redis = await self._get_redis()
+        if redis is None:
+            raise EnforcementModeUnavailable("no Redis client available to provision the enforcement mode")
+
+        if dry_run:
+            existing = await self._read_enforcement_mode(redis)
+            return existing is None, existing or target
+
+        if await redis.set(ENFORCEMENT_MODE_KEY, target.value, nx=True):
+            logger.info("Provisioned access control enforcement mode: %s", target.value)
+            return True, target
+
+        existing = await self._read_enforcement_mode(redis)
+        if existing is None:
+            raise EnforcementModeUnavailable("enforcement mode was neither written nor readable")
+        logger.info("Access control enforcement mode already set to %s; left unchanged", existing.value)
+        return False, existing
+
     async def set_enforcement_mode(self, mode: EnforcementMode) -> bool:
         """
         Set access control enforcement mode
@@ -126,7 +207,7 @@ class FeatureFlags(AsyncRedisClientMixin):
             redis = await self._get_redis()
 
             # Set the mode
-            await redis.set("feature_flag:access_control:enforcement_mode", mode.value)
+            await redis.set(ENFORCEMENT_MODE_KEY, mode.value)
 
             # Record change in history
             history_key = "feature_flag:access_control:history"

--- a/autobot-backend/services/feature_flags_enforcement_seed_test.py
+++ b/autobot-backend/services/feature_flags_enforcement_seed_test.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Provisioning writes the enforcement posture, and never twice (#14866).
+
+``feature_flag:access_control:enforcement_mode`` existed in no Redis database on
+the deployed install, so ``get_enforcement_mode`` took its unset branch, returned
+``DISABLED``, and ``validate_ownership`` short-circuited before the ownership
+lookup on every gated call site. The fix is a provisioning writer, not a change
+of meaning: the tests below pin **both** halves of that -- the key gets written,
+and what an unset key or ``log_only`` mean is left exactly as it was.
+"""
+
+import pytest
+
+from services.feature_flags import (
+    ENFORCEMENT_MODE_KEY,
+    PROVISIONED_ENFORCEMENT_MODE_DEFAULT,
+    PROVISIONED_ENFORCEMENT_MODE_ENV,
+    EnforcementMode,
+    EnforcementModeUnavailable,
+    FeatureFlags,
+    resolve_provisioned_enforcement_mode,
+)
+
+
+class _FakeRedis:
+    """Enough of the async client to observe SET NX semantics faithfully."""
+
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        self.store: dict[str, str] = dict(initial or {})
+        self.set_calls: list[tuple[str, str, bool]] = []
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, nx: bool = False):
+        self.set_calls.append((key, value, nx))
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+
+def _flags(redis: _FakeRedis) -> FeatureFlags:
+    flags = FeatureFlags()
+
+    async def _get_redis():
+        return redis
+
+    flags._get_redis = _get_redis
+    return flags
+
+
+class TestProvisioningWritesThePostureWhenTheInstallHasNone:
+    """The unwritten key is the production state this issue exists to end."""
+
+    @pytest.mark.asyncio
+    async def test_the_key_is_written_when_it_is_absent(self):
+        redis = _FakeRedis()
+
+        written, effective = await _flags(redis).seed_enforcement_mode()
+
+        assert written is True
+        assert redis.store[ENFORCEMENT_MODE_KEY] == PROVISIONED_ENFORCEMENT_MODE_DEFAULT.value
+        assert effective is PROVISIONED_ENFORCEMENT_MODE_DEFAULT
+        assert redis.set_calls, "the seeder must actually reach the flag store"
+
+    @pytest.mark.asyncio
+    async def test_the_value_written_is_the_prescribed_posture(self):
+        """Asserted against the constant, so the posture has exactly one home."""
+        redis = _FakeRedis()
+
+        await _flags(redis).seed_enforcement_mode()
+
+        assert redis.store[ENFORCEMENT_MODE_KEY] == PROVISIONED_ENFORCEMENT_MODE_DEFAULT.value
+
+    def test_the_prescribed_posture_is_the_one_the_issues_record(self):
+        """#14010 AC4 asks for the ``log_only`` measurement before any flip to
+        ``enforced``; #14866 calls it "the safe first value". Neither issue
+        prescribes ``disabled``, which would provision an install into exactly
+        the posture that protects nothing."""
+        assert PROVISIONED_ENFORCEMENT_MODE_DEFAULT is EnforcementMode.LOG_ONLY
+        assert PROVISIONED_ENFORCEMENT_MODE_DEFAULT is not EnforcementMode.DISABLED
+
+    @pytest.mark.asyncio
+    async def test_the_write_is_guarded_by_set_nx_rather_than_a_read_first(self):
+        """Two provisioning runs racing must not both write. The guard is the
+        Redis operation, not a check we perform before it."""
+        redis = _FakeRedis()
+
+        await _flags(redis).seed_enforcement_mode()
+
+        assert redis.set_calls == [(ENFORCEMENT_MODE_KEY, PROVISIONED_ENFORCEMENT_MODE_DEFAULT.value, True)]
+
+
+class TestReprovisioningNeverOverwritesAnOperatorsChoice:
+    """Idempotency is the difference between provisioning and clobbering."""
+
+    @pytest.mark.asyncio
+    async def test_an_existing_value_is_left_untouched(self):
+        redis = _FakeRedis({ENFORCEMENT_MODE_KEY: EnforcementMode.ENFORCED.value})
+
+        written, effective = await _flags(redis).seed_enforcement_mode()
+
+        assert written is False
+        assert effective is EnforcementMode.ENFORCED
+        assert redis.store[ENFORCEMENT_MODE_KEY] == EnforcementMode.ENFORCED.value
+
+    @pytest.mark.asyncio
+    async def test_a_deliberate_disabled_survives_reprovisioning(self):
+        """An operator turning enforcement off on purpose is a decision, and a
+        deploy must not quietly undo it."""
+        redis = _FakeRedis({ENFORCEMENT_MODE_KEY: EnforcementMode.DISABLED.value})
+
+        written, effective = await _flags(redis).seed_enforcement_mode()
+
+        assert written is False
+        assert effective is EnforcementMode.DISABLED
+        assert redis.store[ENFORCEMENT_MODE_KEY] == EnforcementMode.DISABLED.value
+
+    @pytest.mark.asyncio
+    async def test_every_mode_an_operator_could_have_set_is_preserved(self):
+        modes = list(EnforcementMode)
+        assert modes, "an empty enumeration would assert nothing at all"
+
+        for mode in modes:
+            redis = _FakeRedis({ENFORCEMENT_MODE_KEY: mode.value})
+
+            written, effective = await _flags(redis).seed_enforcement_mode()
+
+            assert written is False, f"{mode.value} was overwritten by re-provisioning"
+            assert effective is mode
+
+    @pytest.mark.asyncio
+    async def test_a_dry_run_writes_nothing(self):
+        redis = _FakeRedis()
+
+        written, effective = await _flags(redis).seed_enforcement_mode(dry_run=True)
+
+        assert written is True, "a dry run still reports what it would do"
+        assert effective is PROVISIONED_ENFORCEMENT_MODE_DEFAULT
+        assert redis.set_calls == []
+        assert ENFORCEMENT_MODE_KEY not in redis.store
+
+
+class TestTheResolvedPostureIsNeverInvented:
+    """A misconfigured posture must fail provisioning, not silently become one."""
+
+    def test_an_explicit_mode_wins(self):
+        assert resolve_provisioned_enforcement_mode("enforced") is EnforcementMode.ENFORCED
+
+    def test_the_environment_selects_the_posture(self, monkeypatch):
+        monkeypatch.setenv(PROVISIONED_ENFORCEMENT_MODE_ENV, EnforcementMode.ENFORCED.value)
+
+        assert resolve_provisioned_enforcement_mode() is EnforcementMode.ENFORCED
+
+    def test_an_unset_environment_falls_back_to_the_recorded_default(self, monkeypatch):
+        monkeypatch.delenv(PROVISIONED_ENFORCEMENT_MODE_ENV, raising=False)
+
+        assert resolve_provisioned_enforcement_mode() is PROVISIONED_ENFORCEMENT_MODE_DEFAULT
+
+    def test_an_unrecognised_mode_is_refused_rather_than_defaulted(self):
+        with pytest.raises(ValueError) as excinfo:
+            resolve_provisioned_enforcement_mode("mostly_enforced")
+
+        assert "mostly_enforced" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_a_missing_flag_store_is_reported_not_assumed_provisioned(self):
+        flags = FeatureFlags()
+
+        async def _no_redis():
+            return None
+
+        flags._get_redis = _no_redis
+
+        with pytest.raises(EnforcementModeUnavailable):
+            await flags.seed_enforcement_mode()
+
+
+class TestTheSemanticsThisChangeDeliberatelyLeavesAlone:
+    """The decision was "write the flag, keep the semantics". These pin the
+    second half, so a later change cannot flip them by accident."""
+
+    @pytest.mark.asyncio
+    async def test_an_unset_flag_still_means_disabled(self):
+        redis = _FakeRedis()
+        flags = _flags(redis)
+        flags._enforcement_default_logged = False
+
+        assert await flags.get_enforcement_mode() is EnforcementMode.DISABLED
+
+    @pytest.mark.asyncio
+    async def test_a_provisioned_posture_is_what_the_reader_returns(self):
+        redis = _FakeRedis()
+        flags = _flags(redis)
+
+        await flags.seed_enforcement_mode()
+
+        assert await flags.get_enforcement_mode() is PROVISIONED_ENFORCEMENT_MODE_DEFAULT

--- a/autobot-infrastructure/shared/scripts/security/seed_enforcement_mode.py
+++ b/autobot-infrastructure/shared/scripts/security/seed_enforcement_mode.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Provision the access control enforcement mode (#14866).
+
+The enforcement posture is read from a single Redis key. Nothing that runs at
+install time has ever written it, so every install has been sitting at the
+*unset* default -- which resolves to ``disabled`` and short-circuits every
+gated ownership check before the lookup. This entry point is what makes the
+posture a value the install was **given** rather than one it fell back to.
+
+It does not change what an unset key or ``log_only`` mean: it stops *unset*
+from being the production state.
+
+Idempotent by construction: the write is ``SET NX``, so a re-provision leaves
+an operator's deliberate value exactly as it found it.
+
+Usage:
+    python scripts/security/seed_enforcement_mode.py [options]
+
+Options:
+    --mode MODE   Posture to seed: disabled, log_only or enforced.
+                  Defaults to ACCESS_CONTROL_ENFORCEMENT_MODE, then to the
+                  value recorded in services.feature_flags.
+    --dry-run     Report what would happen without writing anything.
+
+Exit codes (the provisioning role keys its ``changed`` state off these):
+    0  a value was already present and was left untouched
+    1  provisioning failed
+    2  the key was absent and this run seeded it
+"""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_BACKEND_DIR = _REPO_ROOT / "autobot-backend"
+for _entry in (str(_REPO_ROOT), str(_BACKEND_DIR)):
+    if _entry not in sys.path:
+        sys.path.insert(0, _entry)
+
+from autobot_shared.logging_manager import get_logger  # noqa: E402
+from services.feature_flags import (  # noqa: E402
+    EnforcementMode,
+    FeatureFlags,
+    resolve_provisioned_enforcement_mode,
+)
+
+logger = get_logger(__name__)
+
+EXIT_UNCHANGED = 0
+EXIT_FAILED = 1
+EXIT_SEEDED = 2
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse the operator arguments for this entry point."""
+    parser = argparse.ArgumentParser(description="Provision the access control enforcement mode")
+    parser.add_argument(
+        "--mode",
+        default=None,
+        help="Posture to seed: " + ", ".join(mode.value for mode in EnforcementMode),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the outcome without writing the flag",
+    )
+    return parser.parse_args(argv)
+
+
+async def _seed(target: EnforcementMode, dry_run: bool) -> tuple[bool, EnforcementMode]:
+    """Run the seeding call against the flag store."""
+    return await FeatureFlags().seed_enforcement_mode(target, dry_run=dry_run)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Seed the enforcement mode, reporting the outcome through the exit code."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        target = resolve_provisioned_enforcement_mode(args.mode)
+        written, effective = asyncio.run(_seed(target, args.dry_run))
+    except Exception as exc:  # noqa: BLE001 - an operator entry point reports, it does not raise
+        logger.error("Could not provision the access control enforcement mode: %s", exc)
+        return EXIT_FAILED
+
+    prefix = "dry run: would " if args.dry_run else ""
+    if written:
+        logger.info("%sseed access control enforcement mode as %s", prefix, effective.value)
+        return EXIT_SEEDED
+
+    logger.info("%sleave access control enforcement mode at %s (already provisioned)", prefix, effective.value)
+    return EXIT_UNCHANGED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/autobot-slm-backend/ansible/roles/access_control/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/defaults/main.yml
@@ -37,6 +37,16 @@ audit_backends:
   - file
   - redis
 
+# Enforcement posture written into the flag store at provisioning time (#14866).
+# Valid values: disabled, log_only, enforced. Must stay in step with
+# services.feature_flags.PROVISIONED_ENFORCEMENT_MODE_DEFAULT -- an install
+# provisioned by Ansible and one provisioned by running the seeder directly must
+# not end up with different postures. Pinned by
+# repo_tests/access_control_enforcement_provisioning_test.py.
+access_control_enforcement_mode: log_only
+access_control_enforcement_seeder: >-
+  {{ project_root }}/autobot-infrastructure/shared/scripts/security/seed_enforcement_mode.py
+
 # Session ownership
 session_ownership_backfill: true
 session_ownership_strict_mode: false  # Reject if owner missing

--- a/autobot-slm-backend/ansible/roles/access_control/tasks/enforcement_mode.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/tasks/enforcement_mode.yml
@@ -1,0 +1,45 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+---
+# Provision the access control enforcement mode (#14866)
+#
+# Until this ran, no install-time path wrote
+# feature_flag:access_control:enforcement_mode, so every install resolved the
+# unset key to "disabled" and skipped every gated ownership check. The seeder
+# writes with SET NX, so re-provisioning never overwrites a value an operator
+# set deliberately.
+
+- name: Verify the enforcement mode provisioner exists
+  ansible.builtin.stat:
+    path: "{{ access_control_enforcement_seeder }}"
+  register: enforcement_seeder_stat
+
+- name: Fail if the enforcement mode provisioner is missing
+  ansible.builtin.fail:
+    msg: >-
+      Enforcement mode provisioner not found at
+      {{ access_control_enforcement_seeder }}. Without it the install has no
+      access control posture of its own and falls back to disabled.
+  when: not enforcement_seeder_stat.stat.exists
+
+- name: Provision access control enforcement mode
+  ansible.builtin.command:
+    argv:
+      - "{{ project_root }}/venv/bin/python"
+      - "{{ access_control_enforcement_seeder }}"
+      - "--mode"
+      - "{{ access_control_enforcement_mode }}"
+  register: enforcement_mode_result
+  # 2 = the key was absent and this run seeded it; 0 = already provisioned,
+  # left untouched. Any other code is a real failure and must stop the run --
+  # an install silently continuing without a posture is the defect itself.
+  changed_when: enforcement_mode_result.rc == 2
+  failed_when: enforcement_mode_result.rc not in [0, 2]
+
+- name: Display the provisioned enforcement mode
+  ansible.builtin.debug:
+    msg: >-
+      Access control enforcement mode: {{ access_control_enforcement_mode }}
+      ({{ 'seeded by this run' if enforcement_mode_result.rc == 2 else 'already set, left unchanged' }})

--- a/autobot-slm-backend/ansible/roles/access_control/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/access_control/tasks/main.yml
@@ -32,6 +32,13 @@
     - access_control
     - sessions
 
+- name: Provision access control enforcement mode
+  include_tasks: enforcement_mode.yml
+  tags:
+    - access_control
+    - sessions
+    - enforcement
+
 - name: Execute rollout phase
   include_tasks: rollout.yml
   when: rollout_phase is defined and rollout_phase > 0

--- a/repo_tests/access_control_enforcement_provisioning_test.py
+++ b/repo_tests/access_control_enforcement_provisioning_test.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The provisioning role actually runs the enforcement-mode seeder (#14866).
+
+A writer nothing invokes is the defect this issue is about, one layer up: the
+only automated writer of ``feature_flag:access_control:enforcement_mode`` was a
+deployment script importing a package that does not exist, executed with its
+output discarded. So the seeder existing is not the deliverable -- the
+provisioning path reaching it is.
+
+These checks are structural on purpose. They run in CI, where no host, no Redis
+and no Ansible are available, and they assert the three things that can silently
+drift: the role includes the task, the task names a script that exists, and the
+two independent statements of the posture default (Ansible's and Python's) still
+agree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+from services.feature_flags import PROVISIONED_ENFORCEMENT_MODE_DEFAULT, EnforcementMode
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ROLE = _REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "access_control"
+_SEEDER = _REPO_ROOT / "autobot-infrastructure" / "shared" / "scripts" / "security" / "seed_enforcement_mode.py"
+_SEEDER_REPO_PATH = "autobot-infrastructure/shared/scripts/security/seed_enforcement_mode.py"
+
+
+def _load_yaml(path: Path):
+    assert path.exists(), f"{path.relative_to(_REPO_ROOT)} is missing"
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def role_defaults() -> dict:
+    return _load_yaml(_ROLE / "defaults" / "main.yml")
+
+
+@pytest.fixture(scope="module")
+def enforcement_tasks() -> list:
+    tasks = _load_yaml(_ROLE / "tasks" / "enforcement_mode.yml")
+    assert tasks, "the enforcement-mode task file must not be empty"
+    return tasks
+
+
+@pytest.fixture(scope="module")
+def seeder_module():
+    spec = importlib.util.spec_from_file_location("seed_enforcement_mode", _SEEDER)
+    assert spec and spec.loader, f"{_SEEDER_REPO_PATH} is not importable"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestTheRoleReachesTheSeeder:
+    """An install-time writer is only a writer if provisioning calls it."""
+
+    def test_the_role_includes_the_enforcement_mode_tasks(self):
+        main_tasks = _load_yaml(_ROLE / "tasks" / "main.yml")
+        assert main_tasks, "the role's task list must not be empty"
+
+        included = [task.get("include_tasks") for task in main_tasks if task.get("include_tasks")]
+        assert included, "no task file is included at all -- this check would pass vacuously"
+        assert "enforcement_mode.yml" in included
+
+    def test_the_task_runs_the_seeder_that_exists(self, enforcement_tasks, role_defaults):
+        commands = [task["ansible.builtin.command"] for task in enforcement_tasks if "ansible.builtin.command" in task]
+        assert commands, "the enforcement-mode task file runs no command at all"
+
+        argv = [str(item) for command in commands for item in command.get("argv", [])]
+        assert argv, "the command task passes no argv"
+        assert any("access_control_enforcement_seeder" in item for item in argv)
+
+        seeder_var = role_defaults["access_control_enforcement_seeder"]
+        assert _SEEDER_REPO_PATH in seeder_var, "the role points at a path this repository does not carry"
+        assert _SEEDER.exists()
+
+    def test_the_task_passes_the_configured_posture(self, enforcement_tasks):
+        commands = [task["ansible.builtin.command"] for task in enforcement_tasks if "ansible.builtin.command" in task]
+        argv = [str(item) for command in commands for item in command.get("argv", [])]
+
+        assert "--mode" in argv, "the role must state the posture rather than rely on the seeder's own default"
+        assert any("access_control_enforcement_mode" in item for item in argv)
+
+    def test_a_missing_seeder_stops_the_run(self, enforcement_tasks):
+        """Silently continuing without a posture is the defect itself."""
+        failures = [task for task in enforcement_tasks if "ansible.builtin.fail" in task]
+        assert failures, "nothing fails the run when the provisioner is absent"
+
+
+class TestTheTwoStatementsOfTheDefaultAgree:
+    """The same drift #13335 found in the service-auth block: an Ansible role and
+    a Pydantic/module default stating the same thing differently, so an install
+    provisioned by one route ends up in a different posture than the other."""
+
+    def test_the_role_default_matches_the_python_default(self, role_defaults):
+        assert role_defaults["access_control_enforcement_mode"] == PROVISIONED_ENFORCEMENT_MODE_DEFAULT.value
+
+    def test_the_role_default_is_a_mode_the_platform_recognises(self, role_defaults):
+        valid = {mode.value for mode in EnforcementMode}
+        assert valid, "an empty mode enumeration would make this assertion meaningless"
+        assert role_defaults["access_control_enforcement_mode"] in valid
+
+
+class TestTheExitCodeContractIsSharedNotRestated:
+    """The role decides ``changed`` from the seeder's exit code. If either side
+    renumbers, a seeding run reports 'ok' and nobody notices the flag moved."""
+
+    def test_the_seeder_publishes_distinct_outcomes(self, seeder_module):
+        codes = {
+            seeder_module.EXIT_UNCHANGED,
+            seeder_module.EXIT_FAILED,
+            seeder_module.EXIT_SEEDED,
+        }
+        assert len(codes) == 3, "the three provisioning outcomes must be distinguishable"
+
+    def test_the_role_reports_changed_on_the_seeded_code(self, enforcement_tasks, seeder_module):
+        changed_when = [task["changed_when"] for task in enforcement_tasks if "changed_when" in task]
+        assert changed_when, "no task states when provisioning counts as a change"
+        assert any(f"== {seeder_module.EXIT_SEEDED}" in str(expr) for expr in changed_when)
+
+    def test_the_role_treats_only_the_two_success_codes_as_success(self, enforcement_tasks, seeder_module):
+        failed_when = [task["failed_when"] for task in enforcement_tasks if "failed_when" in task]
+        assert failed_when, "no task states when provisioning has failed"
+
+        expression = " ".join(str(expr) for expr in failed_when)
+        assert f"[{seeder_module.EXIT_UNCHANGED}, {seeder_module.EXIT_SEEDED}]" in expression
+        assert str(seeder_module.EXIT_FAILED) not in expression.split("[", 1)[1]


### PR DESCRIPTION
Refs #14866

## Thinking Path

`feature_flag:access_control:enforcement_mode` exists in no Redis database on a
deployed install, so `get_enforcement_mode` takes its *unset* branch, returns
`DISABLED` with no exception, and `validate_ownership` short-circuits with
`authorized: True, reason: "enforcement_disabled"` before any ownership lookup.
The two prior patches do not cover this route: one closed the *unreadable*
path, which needs an outage; the unset path needs nothing at all, and it is the
one in effect.

The decision this implements is **write the flag, keep the semantics**. Nothing
here changes what an unset key or `log_only` mean — `unset -> DISABLED` and
`log_only -> allow` are kept deliberately. What changes is that *unset* stops
being the production state, because provisioning now gives the install a value
it was handed rather than one it fell back to.

**The value written is `log_only`,** which is what the issues prescribe, not a
choice made here:

- #14010 acceptance criterion 4 — "The intended default enforcement mode is
  decided and recorded, with the **`log_only` measurement before any flip to
  `enforced`**".
- #14866, closure audit of 2026-08-26, proposed plan step 1 — "Given the mode
  has never been on anywhere, `log_only` is strictly more information than
  exists today and refuses nothing. **That is the safe first value.**"

Under `log_only` every ownership check runs and every violation is audited and
metered, and no request that succeeds today starts being refused. The flip to
`enforced` is the separate, measured step both issues describe and is
deliberately not made here.

The writer goes on the provisioning path, not application startup: the
`access_control` role is what configures this subsystem on an install, and it
already runs an operator script from the shared scripts tree the same way.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/services/feature_flags.py` | `ENFORCEMENT_MODE_KEY` constant replaces the repeated key literal at the read and write sites; `PROVISIONED_ENFORCEMENT_MODE_DEFAULT` / `..._ENV` record the posture; `resolve_provisioned_enforcement_mode()` resolves explicit value -> env -> default and **raises** on an unrecognised value; `seed_enforcement_mode()` writes with `SET NX` and reports `(written, effective_mode)` |
| `autobot-infrastructure/shared/scripts/security/seed_enforcement_mode.py` | New provisioning entry point, patterned on the session-ownership backfill in the same directory: `--mode`, `--dry-run`, canonical logger, exit codes `0` unchanged / `1` failed / `2` seeded |
| `.../roles/access_control/tasks/enforcement_mode.yml` | New role task: asserts the provisioner exists, runs it, derives `changed` from the seeded exit code, fails the run on anything else |
| `.../roles/access_control/tasks/main.yml`, `defaults/main.yml` | Include the new task; `access_control_enforcement_mode: log_only` and the seeder path as role variables |
| `autobot-backend/services/feature_flags_enforcement_seed_test.py` | 15 tests over the seeding behaviour and the semantics deliberately left alone |
| `repo_tests/access_control_enforcement_provisioning_test.py` | 9 tests that provisioning actually reaches the seeder, and that the Ansible default and the Python default still agree |

**Idempotency** is Redis's, not ours: the write is `SET NX`, one atomic
operation, so the check and the write cannot be split by a concurrent run and
re-provisioning leaves an operator's deliberate value — including a deliberate
`disabled` — exactly as it found it. A test asserts the call is made with
`nx=True` rather than only asserting the outcome, since a read-then-write would
pass the outcome test and still race.

**No hardcoding:** the posture lives in one module constant, overridable by
`ACCESS_CONTROL_ENFORCEMENT_MODE` and by the role variable; the tests assert
against the constant, never a repeated literal. It is a module constant rather
than an SSOT field because `ssot_config.py` sits exactly at its file-size
ceiling and that ratchet is down-only.

## Verification

Both new suites, and the existing suites over the same code:

```
feature_flags_enforcement_seed_test.py + access_control_enforcement_provisioning_test.py   24 passed
session_ownership_enforcement_mode_test.py + feature_flags_rollout_stats_test.py
  + validate_access_control_reporting_test.py                                              20 passed
test_infra_scripts_import_14129.py + deployment_script_imports_resolve_test.py   252 passed, 1 skipped
```

Contrast mutations — each applied, the named test run, then restored:

| Mutation | Named test | Result |
|---|---|---|
| A: the writer reports success but writes nothing | `test_the_key_is_written_when_it_is_absent` | **FAILED** — `KeyError` on the enforcement-mode key |
| B: `nx=True` dropped, so the write always lands | `test_an_existing_value_is_left_untouched` | **FAILED** — `assert True is False` |
| C: posture constant flipped to `disabled` | `test_the_prescribed_posture_is_the_one_the_issues_record` | **FAILED** — `assert DISABLED is LOG_ONLY` |
| C: same mutation, parity check | `test_the_role_default_matches_the_python_default` | **FAILED** — `- disabled / + log_only` |
| D: the role stops including the seeder task | `test_the_role_includes_the_enforcement_mode_tasks` | **FAILED** — `'enforcement_mode.yml' not in [...]` |
| E: the role includes nothing at all (vacuity) | `test_the_role_includes_the_enforcement_mode_tasks` | **FAILED** — "no task file is included at all — this check would pass vacuously" |

E is the non-vacuity control: an empty enumeration fails rather than passing
quietly, so a role whose task list stopped being parsed cannot report clean.
The mode enumeration in the "every operator value is preserved" test and in the
role-default validity test carries the same floor.

Tooling, on the four touched/added Python files:

```
py_compile                     OK
black --check --line-length 120  4 files would be left unchanged
isort --check-only               clean
flake8 --select=F                rc 0
bandit -c .bandit -q             rc 0
check_python_file_size.py --audit-ceilings   rc 0 (4859 scanned, 509 grandfathered, all at size)
```

Branch is 0 commits behind the base.

### Honest assessment against #14866's criteria — `Refs`, not `Closes`

| # | Criterion | After this PR |
|---|---|---|
| 1 | Live enforcement mode checked and recorded | Already met before this PR |
| 2 | The validator imports a module that exists and fails loudly | Already met before this PR |
| 3 | The mode has a deliberate, deployed value set by whatever provisions the install | **Met by this PR** — in code and pinned by tests. Host evidence needs a provisioning run, which this PR does not perform |
| 4 | A guard asserts the deployment scripts' imports resolve | Already met before this PR |
| 5 | An install cannot silently sit at `disabled` because a key was never written | **Not met.** The unset fallback still exists by decision. This PR makes it unreachable on a provisioned install, which is not the same as removing it |

Criterion 5 asks for the fallback itself to go, and removing it changes what an
unset key means — exactly the semantics this decision keeps. It stays open, now
with the mitigation in place rather than as an unmitigated exposure.

### Filed from this work

`FeatureFlags.set_enforcement_mode`, `get_rollout_statistics` and the endpoint
history reads call `redis._redis.<list op>` on a client that has no `_redis`
attribute, so those calls raise `AttributeError` into their own `except` and
report failure — the admin API's writer sets the key and then reports `False`.
Untouched here (a different path, and widening this change would widen its blast
radius); filed separately. The new seeder does not use that path.

## Model Used

Claude Opus 5 (1M context)
