### PR TITLE
fix(setup-wizard): bound the provision-fleet 409 lock by staleness (#14856)

### DIFF
--- a/autobot-slm-backend/api/setup_wizard.py
+++ b/autobot-slm-backend/api/setup_wizard.py
@@ -19,8 +19,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated
 
-_PROVISION_LOG = Path("/var/log/autobot/provision-wizard.log")
-
 import yaml
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
@@ -28,11 +26,17 @@ from pydantic import BaseModel
 from api.websocket import ws_manager
 from config import settings
 from services.ansible_secrets import fetch_deploy_secrets
-from services.ansible_utils import _extract_failure_summary
 from services.auth import get_current_user
 from services.database import db_service
 from services.inventory_builder import _DECLARED_ONLY_GROUPS, _declared_roles, groups_for_role_tokens
 from services.playbook_executor import ANSIBLE_LOCAL_TMP, get_playbook_executor, link_group_vars
+from services.provision_progress import (
+    PROVISION_STALE_SECONDS,
+    handle_provision_result,
+)
+from services.provision_progress import is_stale as _provision_is_stale
+from services.provision_progress import mark_progress as _mark_provision_progress
+from services.provision_progress import write_provision_log as _write_provision_log
 from services.role_registry import ROLE_ANSIBLE_GROUPS
 
 logger = logging.getLogger(__name__)
@@ -841,45 +845,17 @@ async def _activate_provisioned_roles(
         logger.warning("Failed to activate provisioned roles: %s", exc)
 
 
+# #14856: last_progress_at is the sign-of-life timestamp checked by
+# services.provision_progress.is_stale() -- see provision_fleet()'s 409 branch.
 _provision_state: dict = {
     "status": "idle",  # idle | running | completed | failed
     "started_at": None,
     "finished_at": None,
+    "last_progress_at": None,
     "output_lines": [],
     "error": None,
 }
 _provision_lock = asyncio.Lock()
-
-
-def _write_provision_log(line: str) -> None:
-    """Append a line to the persistent provision log (#1455)."""
-    try:
-        _PROVISION_LOG.parent.mkdir(parents=True, exist_ok=True)
-        with open(_PROVISION_LOG, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
-    except OSError:
-        pass
-
-
-def _handle_provision_result(result: dict) -> None:
-    """Record provisioning result to state and log (#1455)."""
-    raw_output = result.get("output", "")
-    if raw_output:
-        for line in raw_output.splitlines():
-            _provision_state["output_lines"].append(line)
-            _write_provision_log(line)
-
-    if result.get("success"):
-        _provision_state["status"] = "completed"
-        _write_provision_log("SUCCESS: Fleet provisioning completed")
-        logger.info("Fleet provisioning completed successfully")
-    else:
-        rc = result.get("returncode", -1)
-        _provision_state["status"] = "failed"
-        summary = _extract_failure_summary(raw_output)
-        _provision_state["error"] = summary or f"Ansible exited with code {rc}"
-        _write_provision_log(f"FAILED: {_provision_state['error']}")
-        logger.error("Fleet provisioning failed (rc=%s): %s", rc, _provision_state["error"])
 
 
 async def _create_wizard_deployments(
@@ -1067,6 +1043,7 @@ async def _run_provisioning_task(
             if msg:
                 _provision_state["output_lines"].append(msg)
                 _write_provision_log(msg)
+                _mark_provision_progress(_provision_state)  # #14856
                 # Broadcast via WebSocket (#2754)
                 log_type = "task"
                 if stage == "heartbeat":
@@ -1091,7 +1068,7 @@ async def _run_provisioning_task(
             inventory_path=temp_inventory_path,
             progress_callback=log_callback,
         )
-        _handle_provision_result(result)
+        handle_provision_result(_provision_state, result)
 
         # Update Deployment records with playbook outcome (#3032)
         await _complete_wizard_deployments(
@@ -1241,15 +1218,34 @@ async def provision_fleet(
 
     async with _provision_lock:
         if _provision_state["status"] == "running":
-            raise HTTPException(
-                status_code=409,
-                detail="Provisioning is already running",
+            if not _provision_is_stale(_provision_state):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Provisioning is already running",
+                )
+            # #14856: the prior run stopped reporting progress (no output line
+            # and no completion) for longer than PROVISION_STALE_SECONDS, so it
+            # is treated as abandoned rather than blocking every future run
+            # forever. Its last known state is not silently discarded: the
+            # persistent provision log already has every line it produced
+            # on disk (_write_provision_log runs on every callback), and this
+            # adds the terminal marker before the in-memory record below is
+            # superseded, so anyone reading the log sees why it stopped.
+            logger.warning(
+                "Fleet provisioning: prior run has made no progress since %s -- "
+                "treating it as abandoned and starting a new run",
+                _provision_state.get("last_progress_at") or _provision_state.get("started_at"),
+            )
+            _write_provision_log(
+                f"RETIRED: no progress for over {PROVISION_STALE_SECONDS}s -- "
+                "superseded by a new provisioning run (#14856)"
             )
 
         _provision_state = {
             "status": "running",
             "started_at": time.time(),
             "finished_at": None,
+            "last_progress_at": None,
             "output_lines": [],
             "error": None,
         }

--- a/autobot-slm-backend/conftest.py
+++ b/autobot-slm-backend/conftest.py
@@ -236,8 +236,15 @@ for _m in ("services", *sorted(_CODE_SYNC_SERVICE_MODULES | set(_EXTRA_SERVICE_M
 #   hf_token_validator #14307 — ditto.
 #   service_extra_data #14307 — ditto; pure data, so the emptiness failure mode
 #                      is deploy_artifacts' verbatim.
+#   provision_progress #14856 — ``is_stale()`` is a guard, and a MagicMock is
+#                      truthy: under a stub, every "running" provision state
+#                      would look stale, silently turning "override an
+#                      abandoned run" into "always override", which is
+#                      exactly the regression the counterweight test exists
+#                      to catch. Needs ``ansible_utils`` (also real-loaded,
+#                      above) for ``_extract_failure_summary``.
 #
-# All six are dependency-light (stdlib plus at most yaml/httpx/autobot_shared),
+# All seven are dependency-light (stdlib plus at most yaml/httpx/autobot_shared),
 # which is the bar for being loadable here at all.
 import importlib.util as _importlib_util  # noqa: E402
 
@@ -249,6 +256,7 @@ _REAL_SERVICE_MODULES = (
     "hf_token_validator",
     "service_extra_data",
     "ansible_utils",
+    "provision_progress",
 )
 
 for _name in _REAL_SERVICE_MODULES:

--- a/autobot-slm-backend/services/provision_progress.py
+++ b/autobot-slm-backend/services/provision_progress.py
@@ -22,12 +22,25 @@ import asyncio
 import logging
 import re
 import time
+from pathlib import Path
 from typing import Callable
+
+from autobot_shared.env_utils import env_int_clamped
+from services.ansible_utils import _extract_failure_summary
 
 logger = logging.getLogger(__name__)
 
 # How often (in seconds) to emit a heartbeat for a silent task.
 HEARTBEAT_INTERVAL_SECONDS: int = 5
+
+# Persistent log of fleet provisioning runs (#1455).
+PROVISION_LOG_PATH = Path("/var/log/autobot/provision-wizard.log")
+
+# #14856: how long a provision run may show no progress before a caller may
+# treat its "running" status as abandoned and start a new one. Generous on
+# purpose -- every log line from the playbook stamps progress, so this bounds
+# the gap between two signs of life, not the run's total duration.
+PROVISION_STALE_SECONDS = env_int_clamped("AUTOBOT_PROVISION_STALE_SECONDS", 1800, min_v=60)
 
 # Known slow task patterns mapped to human-readable duration estimates.
 # Patterns are matched (case-insensitively) against the Ansible task name.
@@ -187,3 +200,55 @@ class TaskProgressTracker:
                     logger.debug("TaskProgressTracker: progress_callback error: %s", exc)
         except asyncio.CancelledError:
             pass
+
+
+def write_provision_log(line: str) -> None:
+    """Append a line to the persistent provision log (#1455)."""
+    try:
+        PROVISION_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(PROVISION_LOG_PATH, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except OSError:
+        pass
+
+
+def mark_progress(state: dict) -> None:
+    """Stamp that *state* is still doing something (#14856)."""
+    state["last_progress_at"] = time.time()
+
+
+def is_stale(state: dict) -> bool:
+    """True when *state* claims ``"running"`` but has shown no sign of life.
+
+    Judged on progress, not age: a legitimate fleet provision across many
+    slow nodes can run far longer than any fixed bound, and reaping one that
+    is still working would be worse than the lockout this override exists to
+    cure. Falls back to ``started_at`` for a run that never stamped progress.
+    A state with neither marker is NOT treated as stale -- a genuinely
+    running provision must never be reaped on missing data.
+    """
+    marker = state.get("last_progress_at") or state.get("started_at")
+    if not marker:
+        return False
+    return (time.time() - marker) > PROVISION_STALE_SECONDS
+
+
+def handle_provision_result(state: dict, result: dict) -> None:
+    """Record a finished provisioning run's outcome into *state* and the log (#1455)."""
+    raw_output = result.get("output", "")
+    if raw_output:
+        for line in raw_output.splitlines():
+            state["output_lines"].append(line)
+            write_provision_log(line)
+
+    if result.get("success"):
+        state["status"] = "completed"
+        write_provision_log("SUCCESS: Fleet provisioning completed")
+        logger.info("Fleet provisioning completed successfully")
+    else:
+        rc = result.get("returncode", -1)
+        state["status"] = "failed"
+        summary = _extract_failure_summary(raw_output)
+        state["error"] = summary or f"Ansible exited with code {rc}"
+        write_provision_log(f"FAILED: {state['error']}")
+        logger.error("Fleet provisioning failed (rc=%s): %s", rc, state["error"])

--- a/autobot-slm-backend/tests/api/test_setup_wizard_stale_provision_14856.py
+++ b/autobot-slm-backend/tests/api/test_setup_wizard_stale_provision_14856.py
@@ -1,0 +1,123 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Tests for the stale-provision-state 409 override (#14856, AC4).
+
+The defect: ``POST /setup/provision-fleet`` 409ed whenever
+``_provision_state["status"] == "running"`` with no staleness bound. A run
+that crashed, was killed, or simply never reported completion left the wizard
+wedged forever -- there was no recovery short of restarting the process.
+
+These tests assert the guard, not the happy path: a state frozen at
+``running`` past the TTL must NOT 409 (the fix), and a state at ``running``
+with recent progress MUST still 409 (the counterweight -- without it "always
+override" would pass the first test too).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from api import setup_wizard as sw
+from services.provision_progress import PROVISION_STALE_SECONDS, is_stale
+
+
+def _reset_state(**overrides) -> None:
+    """Reset ``sw._provision_state`` in place (it is a module-level global).
+
+    ``provision_fleet`` REBINDS ``sw._provision_state`` to a brand new dict
+    on every successful start (see its ``global _provision_state`` block) --
+    so assertions after calling it must re-read ``sw._provision_state``
+    itself, never a name captured before the call, or they would silently
+    keep checking the old, now-orphaned dict.
+    """
+    sw._provision_state.clear()
+    sw._provision_state.update(
+        {
+            "status": "idle",
+            "started_at": None,
+            "finished_at": None,
+            "last_progress_at": None,
+            "output_lines": [],
+            "error": None,
+        }
+    )
+    sw._provision_state.update(overrides)
+
+
+# ---------------------------------------------------------------------------
+# Unit level: services.provision_progress.is_stale
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_that_stopped_advancing_is_stale() -> None:
+    """The defect: this state used to 409 every future provision-fleet call forever."""
+    long_ago = time.time() - PROVISION_STALE_SECONDS - 60
+    state = {"status": "running", "started_at": long_ago, "last_progress_at": long_ago}
+    assert is_stale(state) is True
+
+
+def test_a_run_still_making_progress_is_not_stale() -> None:
+    """The counterweight: reaping live work is worse than the lockout it cures."""
+    just_now = time.time()
+    state = {"status": "running", "started_at": just_now - 5000, "last_progress_at": just_now}
+    assert is_stale(state) is False
+
+
+def test_falls_back_to_started_at_when_nothing_stamped_yet() -> None:
+    """A run that has not produced a single output line yet is judged on start time."""
+    long_ago = time.time() - PROVISION_STALE_SECONDS - 60
+    state = {"status": "running", "started_at": long_ago, "last_progress_at": None}
+    assert is_stale(state) is True
+
+    just_started = time.time()
+    fresh_state = {"status": "running", "started_at": just_started, "last_progress_at": None}
+    assert is_stale(fresh_state) is False
+
+
+def test_a_state_with_no_markers_at_all_is_never_stale() -> None:
+    """Missing timestamps must never read as abandonment of a genuinely running run."""
+    assert is_stale({"status": "running", "started_at": None, "last_progress_at": None}) is False
+
+
+# ---------------------------------------------------------------------------
+# Endpoint level: POST /setup/provision-fleet's 409 branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provision_fleet_overrides_a_stale_running_state() -> None:
+    """AC4: a wedged run (running, no progress past the TTL) must not 409."""
+    long_ago = time.time() - PROVISION_STALE_SECONDS - 60
+    _reset_state(status="running", started_at=long_ago, last_progress_at=long_ago)
+
+    with patch("api.setup_wizard._run_provisioning_task", new=AsyncMock()):
+        result = await sw.provision_fleet(sw.ProvisionRequest(node_ids=None), _={})
+
+    assert result["status"] == "started"
+    # Re-read the module attribute: provision_fleet rebinds it to a fresh dict.
+    assert sw._provision_state["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_provision_fleet_still_409s_a_genuinely_running_run() -> None:
+    """The counterweight: a run showing recent progress must still 409.
+
+    Without this, "always override" would also pass the test above -- the
+    whole value of the fix is distinguishing "in flight" from "abandoned".
+    """
+    just_now = time.time()
+    _reset_state(status="running", started_at=just_now - 5, last_progress_at=just_now)
+
+    with patch("api.setup_wizard._run_provisioning_task", new=AsyncMock()):
+        with pytest.raises(HTTPException) as exc_info:
+            await sw.provision_fleet(sw.ProvisionRequest(node_ids=None), _={})
+
+    assert exc_info.value.status_code == 409
+    # The genuinely-running state must be left untouched by the failed attempt.
+    assert sw._provision_state["status"] == "running"

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -470,7 +470,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-slm-backend/api/roles.py": 691,
     "autobot-slm-backend/api/security.py": 962,
     "autobot-slm-backend/api/services.py": 1398,
-    "autobot-slm-backend/api/setup_wizard.py": 1358,
+    "autobot-slm-backend/api/setup_wizard.py": 1354,
     "autobot-slm-backend/api/stateful.py": 693,
     "autobot-slm-backend/api/tls.py": 994,
     "autobot-slm-backend/api/updates.py": 1129,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -465,7 +465,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-slm-backend/api/roles.py": 691,
     "autobot-slm-backend/api/security.py": 962,
     "autobot-slm-backend/api/services.py": 1398,
-    "autobot-slm-backend/api/setup_wizard.py": 1358,
+    "autobot-slm-backend/api/setup_wizard.py": 1354,
     "autobot-slm-backend/api/stateful.py": 693,
     "autobot-slm-backend/api/tls.py": 994,
     "autobot-slm-backend/api/updates.py": 1129,


### PR DESCRIPTION
## Thinking Path

`POST /setup/provision-fleet` 409ed whenever `_provision_state["status"] == "running"`, with no staleness bound. A run that crashed, was killed, or never reported completion left the wizard wedged forever — no recovery short of restarting the process (defect confirmed at `autobot-slm-backend/api/setup_wizard.py`'s `provision_fleet` 409 branch).

#14703 fixed the identical shape for `update-all`: judge staleness on *observed progress*, not wall-clock since start, so a genuinely running job never gets reaped mid-run. This PR mirrors that shape for the provisioning wizard.

`setup_wizard.py` was already sitting exactly at its file-size ratchet ceiling, so the provision-state helpers (`_write_provision_log`, `_handle_provision_result`, plus the new staleness logic) were extracted into `services/provision_progress.py` — an existing, thematically-fitting module — rather than grown in place. The file shrank from 1358 to 1354 lines; both ratchet ceilings are lowered to match.

## What Changed

- `services/provision_progress.py`: new `PROVISION_STALE_SECONDS` (env-var-backed, `AUTOBOT_PROVISION_STALE_SECONDS`, default 1800s, floor 60s), `mark_progress()`, `is_stale()`, and the relocated `write_provision_log()` / `handle_provision_result()`.
- `api/setup_wizard.py`: `_provision_state` gains `last_progress_at`, stamped on every playbook output line (the same sign-of-life every stage transition already produces). The `provision_fleet` 409 branch now overrides a `running` status only when `is_stale()` says so; a genuinely active run still 409s. The abandoned run's last state is not silently discarded — its output is already durable in the persistent provision log (written on every callback), and a `RETIRED` marker plus a `logger.warning` are added before the in-memory record is superseded.
- `conftest.py`: `provision_progress` added to the dev-host `_REAL_SERVICE_MODULES` real-load list — a MagicMock stub is truthy, so `is_stale()` under a stub would make every "running" state look stale and silently turn "override an abandoned run" into "always override" (the exact regression the counterweight test below exists to catch).
- New test file asserts the guard, not the happy path.

**Out of scope, explicitly:** this file also carries #14856's AC3 (idempotent re-run). That is unproven and unaddressed here — it needs host-level verification, not a diff, and is tracked separately.

## Verification

- `pytest tests/api/test_setup_wizard_stale_provision_14856.py` — 6/6 pass (unit-level `is_stale()` cases plus endpoint-level `provision_fleet()` 409 behavior).
- Regression: `test_setup_wizard_node_roles.py`, `test_setup_wizard_ai_stack_injection.py`, `test_wizard_inventory_parity_14286.py`, `test_provision_progress.py` — 51/51 pass, unaffected.
- Contrast mutation 1 (remove the staleness check, always 409): `test_provision_fleet_overrides_a_stale_running_state` fails as expected — `409: Provisioning is already running`. Restored.
- Contrast mutation 2 (make the override unconditional): `test_provision_fleet_still_409s_a_genuinely_running_run` fails as expected — `DID NOT RAISE HTTPException`. Restored.
- `scripts/check_python_file_size.py --audit-ceilings` — rc 0 (4859 files scanned, 509 grandfathered, all live and at size).
- `bandit -c .bandit -q` — clean.
- `py_compile`, `black --check --line-length 120`, `isort --check-only` — clean.
- Branch is 0 behind `origin/Dev_new_gui` at push time.

## Model Used

Claude Opus 5 (1M context)

Refs #14856, refs #14889 (AC3 — "the provision 409 guard cannot wedge indefinitely" — is delivered here; #14889's other three ACs, re-provisioning idempotency, gated destructive cleanup, and the reset endpoint's naming, remain open and need host verification, not addressed by this PR)