### PR TITLE
fix(config): register the provision staleness TTL, split env_registry.py's ai group to make room (#14856)

### DIFF
--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -162,6 +162,44 @@ register_env_var(
     )
 )
 
+# --- ai ---------------------------------------------------------------------
+#
+# Kept here rather than moved to env_registry_ai.py (#14856): these three
+# carry hardcoded-value baseline entries keyed to this file's path in
+# pipeline-scripts/hardcoded_values_baseline.txt, and check_baseline_no_growth.sh
+# has no route to repoint an entry onto a file that did not exist at the base
+# ref. See env_registry_ai.py's module docstring and #13131.
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CLASSIFICATION_MODEL",
+        type=str,
+        default="gemma2:2b",
+        description="Ollama model name used for intent classification.",
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OLLAMA_BASE_URL",
+        type=str,
+        default=None,
+        description="Base URL of the local Ollama API (e.g. http://localhost:11434).",
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_ORCHESTRATOR_MODEL",
+        type=str,
+        default="llama3.2:1b",
+        description="Ollama model name used for the main orchestrator/routing loop.",
+        component="ai",
+    )
+)
+
 # --- system -----------------------------------------------------------------
 
 register_env_var(

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -925,6 +925,23 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
+        name="AUTOBOT_PROVISION_STALE_SECONDS",
+        type=int,
+        default=1800,
+        description=(
+            "How long a provision run may report no progress before the setup "
+            "wizard treats it as abandoned and lets a new run supersede it "
+            "(#14856). Keyed on observed progress, not on time since start, so "
+            "a slow-but-live run is never superseded; the floor keeps a value "
+            "too small to distinguish the two from wedging the wizard the other way."
+        ),
+        component="provisioning",
+        range=(60, 86400),
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
         name="AUTOBOT_CONFIG_REGISTRY_REDIS_RETRY_SECONDS",
         type=float,
         default=30.0,

--- a/autobot_shared/env_registry.py
+++ b/autobot_shared/env_registry.py
@@ -62,6 +62,13 @@ def env(name: str, default: Any = None) -> Any:
 # Registered variables — grouped by component
 # ---------------------------------------------------------------------------
 
+# The "ai" component (LLM/model config, delegation, chat trajectories) lives in
+# a sibling module, split out to keep this file under its file-size ceiling
+# (#14236, #14856). Importing it here — after EnvVarSpec/register_env_var/REGISTRY
+# are defined above, and before anything below can observe the registry — is a
+# side effect that fully populates the "ai" entries. See env_registry_ai.py.
+from autobot_shared import env_registry_ai  # noqa: E402,F401
+
 # --- events (#14817, #14818) -------------------------------------------------
 
 register_env_var(
@@ -152,38 +159,6 @@ register_env_var(
         default="data/chats",
         description="Filesystem path where chat session files are stored.",
         component="chat",
-    )
-)
-
-# --- ai ---------------------------------------------------------------------
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CLASSIFICATION_MODEL",
-        type=str,
-        default="gemma2:2b",
-        description="Ollama model name used for intent classification.",
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_OLLAMA_BASE_URL",
-        type=str,
-        default=None,
-        description="Base URL of the local Ollama API (e.g. http://localhost:11434).",
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_ORCHESTRATOR_MODEL",
-        type=str,
-        default="llama3.2:1b",
-        description="Ollama model name used for the main orchestrator/routing loop.",
-        component="ai",
     )
 )
 
@@ -997,20 +972,6 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
-        name="AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS",
-        type=float,
-        default=30.0,
-        description=(
-            "Cap applied to a provider's `Retry-After`. Without it a provider "
-            "advertising a long back-off would stall a request for that whole "
-            "period (services/llm_service.py)."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
         name="AUTOBOT_SUMMARY_FAILURE_BACKOFF_SECONDS",
         type=int,
         default=300,
@@ -1130,19 +1091,6 @@ register_env_var(
 
 
 # --- storage paths and toolsets (#14223) -------------------------------------
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_OPENVINO_CACHE_DIR",
-        type=str,
-        default="data/openvino_cache",
-        description=(
-            "Directory for compiled OpenVINO model artefacts. Relative to the "
-            "working directory unless given as an absolute path."
-        ),
-        component="ai",
-    )
-)
 
 register_env_var(
     EnvVarSpec(
@@ -1276,52 +1224,6 @@ register_env_var(
             "what reaches the prompt (#11537)."
         ),
         component="backend",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
-        type=int,
-        default=2,
-        description=("Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede " "the LLM."),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CHAT_TRAJECTORY_CONTEXT",
-        type=bool,
-        default=True,
-        description=(
-            "Search past trajectories before answering. Defaults on because the search is "
-            "one vector query; capture is gated separately since it spends a judge call."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S",
-        type=float,
-        default=0.15,
-        description=(
-            "Seconds the pre-answer trajectory search may take. It rides the response hot "
-            "path, so a cold or slow collection must never delay first token."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CHAT_TRAJECTORY_TOP_K",
-        type=int,
-        default=3,
-        description=("How many past trajectories the pre-answer search retrieves."),
-        component="ai",
     )
 )
 
@@ -1470,28 +1372,6 @@ register_env_var(
 
 register_env_var(
     EnvVarSpec(
-        name="AUTOBOT_DELEGATION_ENABLED",
-        type=bool,
-        default=False,
-        description=(
-            "Master switch for the delegate tool. Off, it records the delegation request " "and does not dispatch it."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_FACT_FORCING",
-        type=bool,
-        default=False,
-        description=("Enable the fact-forcing gate, which requires an answer to cite retrieved " "facts."),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
         name="AUTOBOT_INJECTION_HARDBLOCK_ENABLED",
         type=bool,
         default=False,
@@ -1513,52 +1393,6 @@ register_env_var(
             "hard-blocked. 0.75 maps to HIGH; 1.0 would block only CRITICAL."
         ),
         component="auth",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN",
-        type=int,
-        default=0,
-        description=(
-            "Cumulative token ceiling (input plus output) for one run. Zero disables the "
-            "gate, which is the shipped default (#11541)."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS",
-        type=int,
-        default=86400,
-        description=(
-            "Seconds a run's cumulative token counter survives in Redis, bounding memory "
-            "for abandoned sessions. Refreshed on every increment."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_MAX_DELEGATIONS_PER_TURN",
-        type=int,
-        default=5,
-        description=("Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality " "setting."),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_MAX_DELEGATION_DEPTH",
-        type=int,
-        default=2,
-        description=("How deep delegation may nest before it is refused, bounding runaway recursive " "delegation."),
-        component="ai",
     )
 )
 
@@ -1598,31 +1432,6 @@ register_env_var(
             "(#13602)."
         ),
         component="backend",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_PLAN_BEST_OF_N_COUNT",
-        type=int,
-        default=3,
-        description=(
-            "How many candidate plans best-of-N generates before selection. Clamped to a "
-            "minimum of 2, since best-of-1 is not a selection."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS",
-        type=int,
-        default=300,
-        description=(
-            "Seconds a provider stays marked degraded after a failure before traffic is " "offered to it again."
-        ),
-        component="ai",
     )
 )
 
@@ -1700,78 +1509,6 @@ register_env_var(
             "the whole buffer averages a short reply into silence (#13104)."
         ),
         component="voice",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
-        type=int,
-        default=50000,
-        description=("Rows a consolidation pass may scan, keeping the pass bounded on a large " "trajectory store."),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN",
-        type=float,
-        default=0.4,
-        description=(
-            "Reward at or above which a trajectory outcome is 'partial'. Below it the " "outcome is a failure (#11280)."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN",
-        type=float,
-        default=0.7,
-        description=(
-            "Reward at or above which a trajectory outcome is 'success'. The canonical "
-            "threshold, so callers stop re-deriving it inline (#11280)."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
-        type=int,
-        default=30,
-        description=("Age in days beyond which a low-reward trajectory is eligible for pruning " "(#11263)."),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR",
-        type=float,
-        default=0.4,
-        description=(
-            "Reward below which an aged trajectory is pruned. Stale low-reward failures are "
-            "noise that costs retrieval precision (#11263)."
-        ),
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_TRAJECTORY_USER_SCOPED",
-        type=bool,
-        default=True,
-        description=(
-            "Scope trajectory retrieval by user as well as tenant. tenant_id alone is "
-            "insufficient in single-company deployments where org_id is empty or identical "
-            "for everyone (#11089)."
-        ),
-        component="ai",
     )
 )
 

--- a/autobot_shared/env_registry_ai.py
+++ b/autobot_shared/env_registry_ai.py
@@ -4,11 +4,24 @@
 
 Split out of ``env_registry.py`` to keep that file under its grandfathered
 file-size ceiling (#14236) — the module was already at its ceiling, and this
-is the "ai" component's registrations: model selection, provider back-off
-and degradation, delegation, plan generation, and trajectory
-capture/retrieval/pruning. All genuinely one cohesive area (LLM-facing
-behaviour), so it moves as a unit rather than being split arbitrarily
-(#14856).
+is the "ai" component's registrations: provider back-off and degradation,
+delegation, plan generation, and trajectory capture/retrieval/pruning. All
+genuinely one cohesive area (LLM-facing behaviour), so it moves as a unit
+rather than being split arbitrarily (#14856).
+
+Three "ai" vars — ``AUTOBOT_CLASSIFICATION_MODEL``, ``AUTOBOT_OLLAMA_BASE_URL``,
+``AUTOBOT_ORCHESTRATOR_MODEL`` — stay behind in ``env_registry.py`` rather than
+moving here, deliberately: each carries a hardcoded default or description
+value already recorded in ``pipeline-scripts/hardcoded_values_baseline.txt``
+keyed to ``autobot_shared/env_registry.py``, and ``check_baseline_no_growth.sh``
+has no route to repoint a baseline entry onto a file that did not exist at the
+PR's base ref — by its own documented design, a moved file's new path is
+always "this change created it, so the value in it is new, not pre-existing"
+(#14856). Moving those three would either strand the old baseline entries
+(failing ``--audit-baseline``) or add new ones the growth guard refuses
+outright. Leaving them in place sidesteps a real gap in that guard rather than
+working around it. See #13131 for the same shape in a different tool
+(Semgrep).
 
 Importing this module registers every variable below into
 ``autobot_shared.env_registry.REGISTRY`` as a side effect, exactly like the
@@ -22,36 +35,6 @@ Closes GH#7081.
 from __future__ import annotations
 
 from autobot_shared.env_registry import EnvVarSpec, register_env_var
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_CLASSIFICATION_MODEL",
-        type=str,
-        default="gemma2:2b",
-        description="Ollama model name used for intent classification.",
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_OLLAMA_BASE_URL",
-        type=str,
-        default=None,
-        description="Base URL of the local Ollama API (e.g. http://localhost:11434).",
-        component="ai",
-    )
-)
-
-register_env_var(
-    EnvVarSpec(
-        name="AUTOBOT_ORCHESTRATOR_MODEL",
-        type=str,
-        default="llama3.2:1b",
-        description="Ollama model name used for the main orchestrator/routing loop.",
-        component="ai",
-    )
-)
 
 register_env_var(
     EnvVarSpec(

--- a/autobot_shared/env_registry_ai.py
+++ b/autobot_shared/env_registry_ai.py
@@ -1,0 +1,292 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""AI/LLM AUTOBOT_* environment variable registrations.
+
+Split out of ``env_registry.py`` to keep that file under its grandfathered
+file-size ceiling (#14236) — the module was already at its ceiling, and this
+is the "ai" component's registrations: model selection, provider back-off
+and degradation, delegation, plan generation, and trajectory
+capture/retrieval/pruning. All genuinely one cohesive area (LLM-facing
+behaviour), so it moves as a unit rather than being split arbitrarily
+(#14856).
+
+Importing this module registers every variable below into
+``autobot_shared.env_registry.REGISTRY`` as a side effect, exactly like the
+``register_env_var(...)`` calls in ``env_registry.py`` itself. It is imported
+from there, after ``EnvVarSpec``/``register_env_var``/``REGISTRY`` are
+defined, so nothing ever observes a partially-populated registry.
+
+Closes GH#7081.
+"""
+
+from __future__ import annotations
+
+from autobot_shared.env_registry import EnvVarSpec, register_env_var
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CLASSIFICATION_MODEL",
+        type=str,
+        default="gemma2:2b",
+        description="Ollama model name used for intent classification.",
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OLLAMA_BASE_URL",
+        type=str,
+        default=None,
+        description="Base URL of the local Ollama API (e.g. http://localhost:11434).",
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_ORCHESTRATOR_MODEL",
+        type=str,
+        default="llama3.2:1b",
+        description="Ollama model name used for the main orchestrator/routing loop.",
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LLM_MAX_RETRY_AFTER_SECONDS",
+        type=float,
+        default=30.0,
+        description=(
+            "Cap applied to a provider's `Retry-After`. Without it a provider "
+            "advertising a long back-off would stall a request for that whole "
+            "period (services/llm_service.py)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_OPENVINO_CACHE_DIR",
+        type=str,
+        default="data/openvino_cache",
+        description=(
+            "Directory for compiled OpenVINO model artefacts. Relative to the "
+            "working directory unless given as an absolute path."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_CAPTURE_CONCURRENCY",
+        type=int,
+        default=2,
+        description=("Concurrent trajectory judge calls. Bounded so a burst of turns cannot stampede " "the LLM."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_CONTEXT",
+        type=bool,
+        default=True,
+        description=(
+            "Search past trajectories before answering. Defaults on because the search is "
+            "one vector query; capture is gated separately since it spends a judge call."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_TIMEOUT_S",
+        type=float,
+        default=0.15,
+        description=(
+            "Seconds the pre-answer trajectory search may take. It rides the response hot "
+            "path, so a cold or slow collection must never delay first token."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_CHAT_TRAJECTORY_TOP_K",
+        type=int,
+        default=3,
+        description=("How many past trajectories the pre-answer search retrieves."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_DELEGATION_ENABLED",
+        type=bool,
+        default=False,
+        description=(
+            "Master switch for the delegate tool. Off, it records the delegation request " "and does not dispatch it."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_FACT_FORCING",
+        type=bool,
+        default=False,
+        description=("Enable the fact-forcing gate, which requires an answer to cite retrieved " "facts."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LLM_TOKEN_BUDGET_PER_RUN",
+        type=int,
+        default=0,
+        description=(
+            "Cumulative token ceiling (input plus output) for one run. Zero disables the "
+            "gate, which is the shipped default (#11541)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_LLM_TOKEN_BUDGET_TTL_SECONDS",
+        type=int,
+        default=86400,
+        description=(
+            "Seconds a run's cumulative token counter survives in Redis, bounding memory "
+            "for abandoned sessions. Refreshed on every increment."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MAX_DELEGATIONS_PER_TURN",
+        type=int,
+        default=5,
+        description=("Delegate calls allowed in a single LLM turn — a fan-out bound, not a quality " "setting."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_MAX_DELEGATION_DEPTH",
+        type=int,
+        default=2,
+        description=("How deep delegation may nest before it is refused, bounding runaway recursive " "delegation."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_PLAN_BEST_OF_N_COUNT",
+        type=int,
+        default=3,
+        description=(
+            "How many candidate plans best-of-N generates before selection. Clamped to a "
+            "minimum of 2, since best-of-1 is not a selection."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS",
+        type=int,
+        default=300,
+        description=(
+            "Seconds a provider stays marked degraded after a failure before traffic is " "offered to it again."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_CONSOLIDATE_SCAN_LIMIT",
+        type=int,
+        default=50000,
+        description=("Rows a consolidation pass may scan, keeping the pass bounded on a large " "trajectory store."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_OUTCOME_PARTIAL_MIN",
+        type=float,
+        default=0.4,
+        description=(
+            "Reward at or above which a trajectory outcome is 'partial'. Below it the " "outcome is a failure (#11280)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_OUTCOME_SUCCESS_MIN",
+        type=float,
+        default=0.7,
+        description=(
+            "Reward at or above which a trajectory outcome is 'success'. The canonical "
+            "threshold, so callers stop re-deriving it inline (#11280)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_PRUNE_MAX_AGE_DAYS",
+        type=int,
+        default=30,
+        description=("Age in days beyond which a low-reward trajectory is eligible for pruning " "(#11263)."),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_PRUNE_REWARD_FLOOR",
+        type=float,
+        default=0.4,
+        description=(
+            "Reward below which an aged trajectory is pruned. Stale low-reward failures are "
+            "noise that costs retrieval precision (#11263)."
+        ),
+        component="ai",
+    )
+)
+
+register_env_var(
+    EnvVarSpec(
+        name="AUTOBOT_TRAJECTORY_USER_SCOPED",
+        type=bool,
+        default=True,
+        description=(
+            "Scope trajectory retrieval by user as well as tenant. tenant_id alone is "
+            "insufficient in single-company deployments where org_id is empty or identical "
+            "for everyone (#11089)."
+        ),
+        component="ai",
+    )
+)

--- a/docs/developer/CLAUDE_RULES.md
+++ b/docs/developer/CLAUDE_RULES.md
@@ -535,6 +535,7 @@ To add a new variable:
 | `AUTOBOT_PROMETHEUS_URL` | monitoring | str | `'http://10.0.0.4:9090'` | Base URL of the Prometheus metrics server. |
 | `AUTOBOT_PROVIDER_DEGRADATION_TTL_SECONDS` | ai | int | `300` | Seconds a provider stays marked degraded after a failure before traffic is offered to it again. |
 | `AUTOBOT_PROVIDER_OAUTH_STATE_TTL_SECONDS` | auth | int | `600` | Lifetime of a pending OAuth `state` value. A provider authorisation that is not completed within this window is rejected as expired (api/provider_auth.py). |
+| `AUTOBOT_PROVISION_STALE_SECONDS` | provisioning | int | `1800` | How long a provision run may report no progress before the setup wizard treats it as abandoned and lets a new run supersede it (#14856). Keyed on observed progress, not on time since start, so a slow-but-live run is never superseded; the floor keeps a value too small to distinguish the two from wedging the wizard the other way. Range: 60–86400. |
 | `AUTOBOT_REDIS_DB_ANALYTICS` | redis | int | `11` | Redis logical database number for analytics data. Range: 0–15. |
 | `AUTOBOT_REDIS_DB_KNOWLEDGE` | redis | int | `1` | Redis logical database number for knowledge-base vectors. Range: 0–15. |
 | `AUTOBOT_REDIS_DB_MAIN` | redis | int | `0` | Redis logical database number for primary application data. Range: 0–15. |
@@ -586,5 +587,5 @@ To add a new variable:
 | `AUTOBOT_USERS_DATABASE_URL` | postgres | str | *(none)* | Full SQLAlchemy connection URL for the users database. Overrides AUTOBOT_POSTGRES_* individual vars when set. |
 | `AUTOBOT_VOICE_TOOLSETS` | voice | str | `'voice_safe'` | Comma-separated toolset bundles a voice session may call. Defaults to the restricted `voice_safe` bundle — voice input is harder to confirm than typed input, so the surface is narrowed by default. |
 
-*148 variables registered as of last generation.*
+*149 variables registered as of last generation.*
 <!-- END_AUTOGEN_ENV_DOCS -->

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -514,7 +514,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-slm-backend/user_management/services/sso_service.py": 778,
     "autobot-slm-backend/user_management/services/user_service.py": 863,
     "autobot_shared/auth/permissions.py": 631,
-    "autobot_shared/env_registry.py": 1716,
+    "autobot_shared/env_registry.py": 1754,
     "autobot_shared/http_client.py": 685,
     "autobot_shared/monitoring/prometheus_metrics.py": 954,
     "autobot_shared/network_constants.py": 618,

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -514,7 +514,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-slm-backend/user_management/services/sso_service.py": 778,
     "autobot-slm-backend/user_management/services/user_service.py": 863,
     "autobot_shared/auth/permissions.py": 631,
-    "autobot_shared/env_registry.py": 1962,
+    "autobot_shared/env_registry.py": 1716,
     "autobot_shared/http_client.py": 685,
     "autobot_shared/monitoring/prometheus_metrics.py": 954,
     "autobot_shared/network_constants.py": 618,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -509,7 +509,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-slm-backend/user_management/services/sso_service.py": 778,
     "autobot-slm-backend/user_management/services/user_service.py": 863,
     "autobot_shared/auth/permissions.py": 631,
-    "autobot_shared/env_registry.py": 1962,
+    "autobot_shared/env_registry.py": 1716,
     "autobot_shared/http_client.py": 685,
     "autobot_shared/monitoring/prometheus_metrics.py": 954,
     "autobot_shared/network_constants.py": 618,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -509,7 +509,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-slm-backend/user_management/services/sso_service.py": 778,
     "autobot-slm-backend/user_management/services/user_service.py": 863,
     "autobot_shared/auth/permissions.py": 631,
-    "autobot_shared/env_registry.py": 1716,
+    "autobot_shared/env_registry.py": 1754,
     "autobot_shared/http_client.py": 685,
     "autobot_shared/monitoring/prometheus_metrics.py": 954,
     "autobot_shared/network_constants.py": 618,


### PR DESCRIPTION
## Thinking Path

`python-suite shard 10/12` was red on `Dev_new_gui`: `check_env_var_registry.py`
failed with `neither registered nor baselined: ['AUTOBOT_PROVISION_STALE_SECONDS']`.
That variable was introduced by #15090 (issue #14856) at
`autobot-slm-backend/services/provision_progress.py:43` via `env_int_clamped(...)`,
but was never registered in `autobot_shared/env_registry.py`. The registry's
`_UNREGISTERED_BASELINE` is an empty `frozenset` by design — baselining it
would be the wrong fix, not just a discouraged one.

The obstacle: `env_registry.py` was already sitting exactly at its
grandfathered file-size ceiling (1962 lines, later found to already be 1979
with the pending registration added — 17 over). Registering the new variable
without making room first would either violate the ceiling or force raising
it, both of which the ratchet forbids. So this PR is a forced extraction, not
a chosen refactor for its own sake.

I picked the `component="ai"` group (23 variables: model selection, provider
back-off/degradation, delegation, plan generation, chat-trajectory
capture/retrieval/pruning) over the numerically larger `component="backend"`
group (35 variables) because `"ai"` is genuinely one cohesive area — every
entry is LLM-facing behaviour — whereas `"backend"` is a grab-bag spanning
audit filing, code-analysis pools, git co-change mining, ownership blame,
skill distillation, and remediation playbooks, none of which share a home.
Cohesion, not size, was the criterion.

### A second obstacle found during review: path-keyed exemption tooling

Moving the "ai" group's `register_env_var(...)` calls verbatim into a new
sibling module relocates three already-baselined hardcoded values (two Ollama
model names, one loopback URL) to a new file path. That broke two checks the
same way #13131 already documents for Semgrep — **exemptions keyed by path
don't survive the path moving**:

- `detect-hardcoded-values.sh --audit-baseline` correctly flags the old-path
  baseline entries as stale the moment the values move.
- Repointing those three entries to the new path fixes that step, but then
  `check_baseline_no_growth.sh` refuses the repoint outright — verified by
  running it directly. Its only addition route requires the entry's file to
  already exist, byte-identical, at the PR's base ref, and a brand-new
  sibling module never does. The guard's own comments acknowledge this is
  deliberate and has no override: *"What this route deliberately does NOT
  cover: a rename... it is not a regression."*

Rather than weaken either guard to accommodate this PR, the three vars that
carry a baseline entry (`AUTOBOT_CLASSIFICATION_MODEL`, `AUTOBOT_OLLAMA_BASE_URL`,
`AUTOBOT_ORCHESTRATOR_MODEL`) stay in `env_registry.py`. The other 20 "ai"
vars, none of which carry a baseline entry, still move — the extraction still
lands, just without dragging pre-existing hardcoded-value exemptions into a
guard with no route to follow them. Left a comment on #13131 noting this is
not Semgrep-specific: two independent path-keyed exemption mechanisms hit the
same failure mode in this one PR.

## What Changed

- Added `AUTOBOT_PROVISION_STALE_SECONDS` to `autobot_shared/env_registry.py`
  (`component="provisioning"`, `default=1800`, `range=(60, 86400)`), matching
  the default and floor already hard-coded via `env_int_clamped(...)` in
  `provision_progress.py`.
- Extracted 20 of the 23 `component="ai"` registrations out of
  `env_registry.py` into a new sibling module, `autobot_shared/env_registry_ai.py`
  (275 lines, well under the 600-line grandfathering threshold — no
  `KNOWN_LARGE` entry needed for it). The remaining 3 — the ones carrying a
  hardcoded-values baseline entry — stay in `env_registry.py`; see above.
- `env_registry.py` imports the sibling module as a registration side effect,
  placed immediately after `EnvVarSpec`/`register_env_var`/`REGISTRY` are
  defined and before any `register_env_var(...)` call runs, so nothing ever
  observes a partially-populated registry. `env_registry.py` drops from 1979
  to 1754 lines.
- Lowered both recorded ceilings for `autobot_shared/env_registry.py` from
  1962 to 1754 in `scripts/python_file_size_known_large.py` and
  `repo_tests/python_file_size_ratchet_baseline.py` — the ratchet only turns
  down, never up.
- Regenerated the autogenerated env-var table in
  `docs/developer/CLAUDE_RULES.md` (149 rows now, was 148); #15090 registered
  nothing there since it never registered the variable at all, so the table
  was already stale independent of this extraction.
- No changes to `pipeline-scripts/hardcoded_values_baseline.txt` — the three
  vars that carry an entry there never leave the file that entry names, so
  nothing needed repointing after all.

No behaviour change: every variable registered before this PR is still
registered after it, with an identical spec (verified by diff, see below).

## Verification

- `python3 pipeline-scripts/check_env_var_registry.py` → rc 0.
- `python3 pipeline-scripts/check_env_var_registry.py autobot_shared/env_registry.py autobot_shared/env_registry_ai.py autobot-slm-backend/services/provision_progress.py` (exercises the docs-freshness path pre-commit actually runs) → rc 0.
- `python3 -m pytest pipeline-scripts/check_env_var_registry_helpers_test.py -q` → 20 passed.
- `python3 scripts/check_python_file_size.py --audit-ceilings` → `4863 files scanned, 509 grandfathered, all live and at size.` rc 0.
- `bash autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values autobot_shared/env_registry.py autobot_shared/env_registry_ai.py` → `No new violations found!` rc 0.
- `./pipeline-scripts/detect-hardcoded-values.sh --json` (full tree scan) → `{"status": "pass", "total_violations": 0, ...}`, rc 0.
- `./pipeline-scripts/detect-hardcoded-values.sh --audit-baseline` → `every baseline entry still matches something`, rc 0.
- `./pipeline-scripts/check_baseline_no_growth.sh` (run directly against the base SHA) → `no key added and no count increased`, suppressed findings 1970 -> 1970, rc 0.
- Registry diff, before (`git show <base>:autobot_shared/env_registry.py`, imported standalone) vs after (current tree, `autobot_shared.env_registry.REGISTRY` after the sibling import runs): 149 names before, 149 after, `missing after: []`, `new in after: []`, `changed specs: 0` — every `EnvVarSpec` field-for-field identical. Re-verified after the second commit that kept the 3 baselined vars in place.
- `python3 -m py_compile` on every edited/added `.py` file → clean.
- `python3 -m black --check --line-length 120` on every edited/added `.py` file → clean.
- `python3 -m isort --check-only` on every edited/added `.py` file → clean.
- `import autobot_shared.env_registry` and a standalone exec of `pipeline-scripts/generate_env_docs.py` both import cleanly with the module split in place.

This repairs a base-branch failure introduced by #15090; the extraction was
forced by the pre-existing file-size ceiling, not chosen for its own sake.

## Model Used

Claude Sonnet 5

Refs #14856, #13131

## Ratchet movement, stated explicitly

`autobot_shared/env_registry.py`'s ceiling goes **1962 → 1754** in both copies, measured against the committed baseline on `Dev_new_gui`. The sibling `env_registry_ai.py` lands at 275 lines and gets **no `KNOWN_LARGE` entry** — a new file under 600 is not grandfathered.

Worth recording because the intermediate numbers look alarming in isolation: an earlier draft of this branch moved all 23 `component="ai"` vars and reached 1716, and keeping three of them back to avoid the baseline problem then took it to 1754. Relative to that draft the number went up; relative to what is committed it went down by 208 lines, which is the only comparison the ratchet makes.