### PR TITLE
test(terminal): prove the WS ownership refusal through the real route (#14960)

### DIFF
--- a/autobot-backend/api/terminal_websocket_route_test.py
+++ b/autobot-backend/api/terminal_websocket_route_test.py
@@ -41,6 +41,7 @@ Covers:
 
 import json
 import os
+import logging
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -50,6 +51,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, WebSocket
 from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from api.terminal import check_admin_permission
 from api.terminal import router as terminal_router
@@ -350,8 +352,6 @@ class TestTerminalWebsocketRouteHandshake:
         for EVERY caller, admin or not. After the fix, an unauthenticated
         caller reaches the explicit per-route guard and is refused cleanly.
         """
-        from starlette.websockets import WebSocketDisconnect
-
         with _no_ws_credentials(), _accept_spy() as calls:
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with terminal_client.websocket_connect(f"/ws/{owned_session_id}"):
@@ -359,6 +359,23 @@ class TestTerminalWebsocketRouteHandshake:
 
         assert exc_info.value.code == 1008
         assert len(calls) == 0
+
+    def test_authenticated_non_owner_is_refused(self, terminal_client, owned_session_id, caplog):
+        """#14960 AC2 at route level: a non-owner is refused 1008 before accept().
+        caplog pins the ownership branch; #14961's unknown-session branch also closes 1008."""
+        with (
+            patch("auth_middleware.authenticate_websocket", new=AsyncMock(return_value={"username": "mallory"})),
+            caplog.at_level(logging.WARNING, logger="api.terminal"),
+            _accept_spy() as calls,
+        ):
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with terminal_client.websocket_connect(f"/ws/{owned_session_id}"):
+                    pass
+
+        assert exc_info.value.code == 1008
+        assert len(calls) == 0
+        assert any("is not the owner" in r.message for r in caplog.records)
+        assert not any("unknown session_id" in r.message for r in caplog.records)
 
 
 class TestSshTerminalWebsocketRouteHandshake:
@@ -383,8 +400,6 @@ class TestSshTerminalWebsocketRouteHandshake:
         assert len(calls) == 1
 
     def test_unauthenticated_caller_is_refused_not_500(self, terminal_client):
-        from starlette.websockets import WebSocketDisconnect
-
         with _no_ws_credentials(), _accept_spy() as calls:
             with pytest.raises(WebSocketDisconnect) as exc_info:
                 with terminal_client.websocket_connect("/ws/ssh/prod-host-1"):

--- a/autobot-backend/api/terminal_websocket_route_test.py
+++ b/autobot-backend/api/terminal_websocket_route_test.py
@@ -40,8 +40,8 @@ Covers:
 """
 
 import json
-import os
 import logging
+import os
 import subprocess
 import sys
 from contextlib import contextmanager


### PR DESCRIPTION
## Thinking Path

Closure audit of #14960 found four of its five acceptance criteria discharged by merged code
with route-level evidence, and one — *"an authenticated user connecting to another user's
session id is rejected"* — covered **only at handler level**.

`api/terminal_websocket_auth_test.py::TestTerminalWebsocketOwnership::test_non_owner_is_rejected`
awaits `terminal_websocket(ws, session_id)` directly. That style of test cannot observe a
routing or dependency-resolution failure — which is precisely how #14998 hid: the same suite
stayed green for the entire period every real handshake 500'd inside `solve_dependencies`,
because a router-level `Request`-typed `Depends` cannot resolve in a WebSocket scope.

A rejection criterion is about what a **client** experiences, so it needs a test that reaches
the guard the way a client does. #15085 added exactly that shape for the authenticated and the
unauthenticated cases; the non-owner case was the one left behind. This adds it, and nothing
else — no production code changes, no change to authentication or authorization semantics.

## What Changed

`autobot-backend/api/terminal_websocket_route_test.py` only.

- New `TestTerminalWebsocketRouteHandshake::test_authenticated_non_owner_is_refused`: a real
  `TestClient` handshake on `/ws/{session_id}` as `mallory` against a session owned by `alice`.
  Asserts close code `1008` observed on the wire as a `WebSocketDisconnect`, that `accept()`
  never ran (so no terminal handler is constructed and no shell starts), and — via `caplog` —
  that the **ownership** branch fired, not the unknown-session branch of #14961. Both branches
  close `1008` from the same line, so without the log assertion the test would pass for the
  wrong reason.
- `WebSocketDisconnect` hoisted to module scope and the two existing function-local imports
  dropped in favour of it. This is what keeps the file inside the 600-line cap: **599 lines**,
  up from 584 minus the 4 lines the hoist recovers.

`api/terminal.py` is untouched and unchanged in size at its grandfathered 1299 lines.

## Verification

Targeted run, this file only:

```
api/terminal_websocket_route_test.py ...................  [100%]
19 passed in 4.71s
```

**Contrast mutation** — the point of the change. Replacing the ownership comparison in
`_lookup_terminal_session` with a never-taken branch:

```
    owner = config.get("owner")
-   if not owner or owner != user.get("username"):
+   if False:  # MUTATION: ownership check removed
```

```
1 failed, 18 passed
FAILED ...::TestTerminalWebsocketRouteHandshake::test_authenticated_non_owner_is_refused
E   Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>
------------------------------ Captured log call ----------------------------
ERROR    services.simple_pty: Error in PTY read loop: [Errno 9] Bad file descriptor
```

Exactly one test fails, the new one, and it fails for the right reason: with the check removed
the non-owner's handshake is accepted and a **real PTY is allocated** for them — the captured
`simple_pty` error is that shell being torn down. The other 18 route tests, including both
pre-existing handshake tests, pass throughout: they could not see this.

Mutation reverted before commit; `git diff --stat` on the branch shows one file, +19/-4.

Local `fastapi` is 0.135.2 against CI's 0.141.1 (#15091). The assertion here is behavioural —
a real handshake — so it is unaffected by the deferred-`include_router` differences that made
introspection unusable in #14998; the file's structural checks already run through a
clean-interpreter subprocess dump and are untouched.

## Model Used

Claude Opus 5 (1M context)

Refs #14960.
