### PR TITLE
fix(terminal): gate terminal_tools router by declaration (#15084)

### DIFF
--- a/autobot-backend/api/terminal_tools.py
+++ b/autobot-backend/api/terminal_tools.py
@@ -15,21 +15,33 @@ Endpoints:
 - POST /validate-command - Validate command safety
 - GET /package-managers - Get available package managers
 
-These endpoints are imported into terminal.py via router inclusion.
+These endpoints are imported into terminal.py via router inclusion, and are
+also registered as a standalone top-level router
+(``initialization/router_registry/terminal_routers.py``). Gating must not
+depend on which parent mounts this router (#15084): install/check/validate
+run system commands and package installs, so the dependency lives here,
+on the router itself.
 """
 
 from typing import Any, Dict
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
 from api.schemas_terminal import PackageManagersResponse, ToolInstallRequest
+from auth_middleware import check_admin_permission
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 
 logger = get_logger(__name__)
 
-# Create router for tool management endpoints
-router = APIRouter(tags=["terminal-tools"])
+# Create router for tool management endpoints. Carries its own admin gate
+# (#15084) so every mount point is protected by declaration, not by whichever
+# parent router happens to include it -- terminal.py's admin router also
+# carries this dependency, and FastAPI's dependency cache (same callable, same
+# security scopes, default use_cache=True) resolves it once per request even
+# when it appears on both routers, so declaring it here costs nothing extra
+# on that path while closing the direct, dependency-free top-level mount.
+router = APIRouter(tags=["terminal-tools"], dependencies=[Depends(check_admin_permission)])
 
 
 # Tool Management endpoints

--- a/autobot-backend/api/terminal_tools_test.py
+++ b/autobot-backend/api/terminal_tools_test.py
@@ -1,0 +1,137 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Route-level admin gate tests for api/terminal_tools.py (#15084).
+
+Before this fix, ``api.terminal_tools.router`` declared no dependency of its
+own. It is mounted at two independent points:
+
+- ``api/terminal.py`` includes it onto ``admin_router``
+  (``Depends(check_admin_permission)`` at construction), so requests routed
+  through ``/terminal/...`` were gated -- but only because of *where*
+  ``terminal.py`` happened to include it, proved by
+  ``terminal_websocket_route_test.py::TestTerminalToolRoutesKeepTheirGate``.
+- ``initialization/router_registry/terminal_routers.py`` separately registers
+  the same router object as its own top-level entry with an empty prefix,
+  mounted by ``app_factory.py`` via a bare ``app.include_router(router,
+  prefix=f"/api{prefix}", tags=tags)`` -- no ``dependencies=`` passed. That
+  mount had no gate at all: install-tool, check-tool, validate-command and
+  package-managers were reachable anonymously.
+
+This file drives that second, previously-unauthenticated mount directly --
+``api.terminal_tools.router`` included alone into a fresh app, the same shape
+``terminal_routers.py`` uses -- through a real ``TestClient`` request, not by
+introspecting the route object (empty under fastapi 0.141.1 for genuinely
+gated routes; see the module docstring in ``terminal_websocket_route_test.py``
+for why introspection cannot answer this question on that version).
+"""
+
+import pytest
+from fastapi import APIRouter, FastAPI, HTTPException
+from starlette.testclient import TestClient
+
+from api.terminal_tools import check_admin_permission
+from api.terminal_tools import router as tools_router
+
+#: Paths as api.terminal_tools.router serves them on its own, unprefixed.
+_TOOL_ROUTES = (
+    ("post", "/install-tool"),
+    ("post", "/check-tool"),
+    ("post", "/validate-command"),
+    ("get", "/package-managers"),
+)
+
+
+def _request(client, method: str, path: str):
+    """Issue *method* at *path*, sending a body only where one is accepted.
+
+    ``TestClient.get()`` takes no ``json=`` -- passing one raises ``TypeError``
+    rather than returning a status, which would read as a routing failure.
+    """
+    if method == "get":
+        return client.get(path)
+    return getattr(client, method)(path, json={})
+
+
+@pytest.fixture
+def tools_app():
+    """Mount ``api.terminal_tools.router`` exactly as
+    ``initialization/router_registry/terminal_routers.py`` +
+    ``app_factory.py`` do at the top level: no ``dependencies=`` passed to
+    ``include_router``, nothing else on the app. This is the mount point that
+    had no gate at all before #15084.
+    """
+    app = FastAPI()
+    app.include_router(tools_router)
+    return app
+
+
+@pytest.fixture
+def tools_client(tools_app):
+    return TestClient(tools_app, raise_server_exceptions=False)
+
+
+class TestTerminalToolsStandaloneMountIsGated:
+    """#15084: the router now carries its own admin dependency, so it stays
+    gated no matter which parent includes it -- proved here against the
+    router mounted completely alone, which is the shape that was previously
+    reachable anonymously.
+    """
+
+    @pytest.mark.parametrize("method,path", _TOOL_ROUTES)
+    def test_route_refuses_a_non_admin(self, tools_app, tools_client, method, path):
+        def _deny():
+            raise HTTPException(status_code=403, detail="Admin permission required for this operation")
+
+        tools_app.dependency_overrides[check_admin_permission] = _deny
+        try:
+            response = _request(tools_client, method, path)
+        finally:
+            tools_app.dependency_overrides.pop(check_admin_permission, None)
+
+        assert response.status_code == 403, (
+            f"{path} installs packages / runs system commands and must stay gated on its own "
+            f"router regardless of mount point, got {response.status_code}"
+        )
+
+    @pytest.mark.parametrize("method,path", _TOOL_ROUTES)
+    def test_route_is_actually_served(self, tools_app, tools_client, method, path):
+        """Non-vacuity: a 404 would make the refusal above pass for the wrong
+        reason -- an unrouted path never reaches a dependency."""
+        tools_app.dependency_overrides[check_admin_permission] = lambda: True
+        try:
+            response = _request(tools_client, method, path)
+        finally:
+            tools_app.dependency_overrides.pop(check_admin_permission, None)
+
+        assert response.status_code != 404, f"{path} is not served at all -- the gate test above proves nothing"
+
+
+class TestDependencyFreeRouterDoesNotRefuseAnyone:
+    """Contrast, kept in-suite as a permanent regression guard: a router
+    shaped exactly like ``terminal_tools.py`` before #15084 -- same route,
+    but constructed with no ``dependencies=`` of its own -- reaches the
+    handler for anyone. Proves the assertions above are actually sensitive to
+    the fix rather than passing for an unrelated reason. The full contrast
+    (mutating ``terminal_tools.py`` itself and re-running the named tests
+    above) is exercised manually per #15084's testing requirements and is not
+    checked in, since it requires editing production source.
+    """
+
+    def test_bare_router_serves_a_non_admin(self):
+        bare_router = APIRouter(tags=["terminal-tools"])
+
+        @bare_router.get("/package-managers")
+        def _package_managers():
+            return {"detected": None, "available": [], "package_managers": {}}
+
+        app = FastAPI()
+        app.include_router(bare_router)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        response = client.get("/package-managers")
+        assert response.status_code == 200, (
+            "a router with no dependency of its own must reach the handler for anyone -- "
+            "this is the exact pre-fix shape #15084 reports"
+        )


### PR DESCRIPTION
## Thinking Path

`api/terminal_tools.py` declared no dependency of its own, so its four
routes (install-tool, check-tool, validate-command, package-managers) were
gated only by whichever parent router happened to include them. That router
object is mounted at **two independent points**:

- `api/terminal.py:197` -- `admin_router.include_router(tools_router,
  prefix="/terminal")`. `admin_router` carries
  `Depends(check_admin_permission)` at construction, so requests through
  this path (`/api/terminal/terminal/...`) were gated -- but only because of
  where `terminal.py` happened to include the router.
- `initialization/router_registry/terminal_routers.py:19` -- the same router
  object registered again as its own top-level entry, `("api.terminal_tools",
  "", ...)`, mounted by `app_factory.py` via a bare
  `app.include_router(router, prefix="/api", tags=tags)` with no
  `dependencies=` passed. **This mount had no gate at all**: `/api/install-tool`,
  `/api/check-tool`, `/api/validate-command` and `/api/package-managers` were
  reachable anonymously, install_tool included -- arbitrary package
  installation/system commands, no auth.

Both mount points are live in the current router registry, so both are
reachable from outside the process today; the second one is the one that
was actually unauthenticated.

**Double-resolution check:** adding `dependencies=[Depends(check_admin_permission)]`
to `terminal_tools.py`'s own router means the `terminal.py` mount now carries
the dependency twice (once from `admin_router`, once baked into each route
via `tools_router`'s own `self.dependencies` at `add_api_route` time -- see
`fastapi.routing.APIRouter.add_api_route`/`include_router` source). I verified
empirically (isolated FastAPI app, parent + child router each declaring the
same dependency, a call counter inside it) that **FastAPI resolves it once
per request**: `Depends()` defaults to `use_cache=True`, and the cache key is
`(callable, security_scopes)` -- identical for both declarations of
`check_admin_permission`, so the second occurrence is served from
`solve_dependencies`'s cache rather than re-invoked.

**Decision:** since double declaration costs nothing extra on the request
path that already had it, I left `admin_router`'s own dependency in
`terminal.py` in place rather than removing it, for defence in depth --
`terminal_tools.py`'s new dependency is what actually closes the
previously-unauthenticated top-level mount; `admin_router`'s existing one
stays as a second, independent gate on the other mount rather than being
pulled for a saving that doesn't exist.

## What Changed

- `autobot-backend/api/terminal_tools.py`: `router = APIRouter(tags=[...])`
  → `router = APIRouter(tags=[...], dependencies=[Depends(check_admin_permission)])`,
  plus a docstring/comment explaining why and the cache finding above.
- `autobot-backend/api/terminal_tools_test.py` (new): mounts
  `api.terminal_tools.router` alone, exactly as the previously-unauthenticated
  top-level registration does, and asserts through a real `TestClient` +
  `dependency_overrides`:
  - `test_route_refuses_a_non_admin` (one per route) -- a forced-deny override
    returns 403.
  - `test_route_is_actually_served` (non-vacuity partner) -- with the override
    forced to allow, the route is not 404, so the refusal test isn't passing
    because the path is unrouted.
  - `TestDependencyFreeRouterDoesNotRefuseAnyone` -- a permanent, in-suite
    contrast: a router shaped like the pre-fix `terminal_tools.py` (same
    route, no `dependencies=`) reaches the handler for anyone (200).
- No changes to `api/terminal.py` (grandfathered at 1299 lines, unchanged) or
  `api/terminal_websocket_route_test.py` (584/600, unchanged) -- its existing
  `TestTerminalToolRoutesKeepTheirGate` already covers the `terminal.py` mount
  point behaviourally and continues to pass.

## Verification

- `python3 -m pytest autobot-backend/api/terminal_tools_test.py
  autobot-backend/api/terminal_websocket_route_test.py -q` → 27 passed.
- Contrast mutation (manual, as required -- not checked in, since it edits
  production source): removed `dependencies=[Depends(check_admin_permission)]`
  from `terminal_tools.py`'s router **and** reparented `terminal.py`'s include
  site from `admin_router.include_router(tools_router, ...)` onto the
  dependency-free `router.include_router(tools_router, ...)` (mirroring the
  reported near-miss). Re-ran the named tests:
  ```
  autobot-backend/api/terminal_tools_test.py::TestTerminalToolsStandaloneMountIsGated FFFF....
  autobot-backend/api/terminal_websocket_route_test.py::TestTerminalToolRoutesKeepTheirGate FFFF....
  8 failed, 8 passed in 2.11s
  ```
  All 8 `test_..._refuses_a_non_admin` cases failed (422/200 instead of 403,
  i.e. the request reached the handler). The 8 `test_..._is_actually_served`
  non-vacuity partners still passed, confirming the failures were the gate
  disappearing, not the routes disappearing. Reverted both files; `git
  status`/`git diff` clean before commit.
- `python3 scripts/check_python_file_size.py --audit-ceilings` → rc 0, "4863
  files scanned, 509 grandfathered, all live and at size."
- `python3 -m bandit -c .bandit -q` on the changed files → clean.
- `python3 -m py_compile` on the changed files → clean.
- `python3 -m black --check --line-length 120` / `python3 -m isort
  --check-only` on the changed files → clean.
- Branch is 0 behind `origin/Dev_new_gui`.

## Model Used

Claude Sonnet 5

Closes #15084