### PR TITLE
fix(feature-flags): the admin enforcement writer reported failure after succeeding (#15089)

### DIFF
--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -68,6 +68,12 @@ class EnforcementModeUnavailable(RuntimeError):
 # the same key, and a fourth copy of a string is how the fourth copy drifts.
 ENFORCEMENT_MODE_KEY = "feature_flag:access_control:enforcement_mode"
 
+# The audit list recording who moved the posture and when. Named here for the
+# same reason as the key above: the writer and the statistics reader both have
+# to mean the same list.
+ENFORCEMENT_HISTORY_KEY = "feature_flag:access_control:history"
+ENFORCEMENT_HISTORY_LENGTH = 100
+
 # Posture provisioning writes when an install has no value of its own (#14866).
 # ``log_only`` is the value both issues record: #14010's acceptance criterion 4
 # asks for "the ``log_only`` measurement before any flip to ``enforced``", and
@@ -193,38 +199,80 @@ class FeatureFlags(AsyncRedisClientMixin):
         logger.info("Access control enforcement mode already set to %s; left unchanged", existing.value)
         return False, existing
 
-    async def set_enforcement_mode(self, mode: EnforcementMode) -> bool:
-        """
-        Set access control enforcement mode
+    @staticmethod
+    def _enforcement_history_entry(mode: EnforcementMode) -> str:
+        """Serialise one posture change for the audit list."""
+        return json.dumps(
+            {
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+                "mode": mode.value,
+                "changed_by": "system",
+            }
+        )
 
-        Args:
-            mode: Enforcement mode to set
+    @staticmethod
+    def _report_enforcement_write(mode: EnforcementMode, results: list) -> bool:
+        """Say whether the posture changed, and name the half that did not.
+
+        ``True`` means one thing only: :data:`ENFORCEMENT_MODE_KEY` now holds
+        *mode*. Reporting a write that landed as a failure is the defect this
+        replaces (#15089), so a lost audit entry is logged loudly and does not
+        turn a change that happened into a reported failure.
+        """
+        if not results or isinstance(results[0], Exception):
+            reason = results[0] if results else "Redis returned no result for the mode write"
+            logger.error("Failed to set enforcement mode: %s", reason)
+            return False
+
+        history_errors = [result for result in results[1:] if isinstance(result, Exception)]
+        if history_errors:
+            # Redis applies the remainder of a MULTI when one command errors,
+            # so the posture did move even though its record did not.
+            logger.error(
+                "Enforcement mode set to %s, but its change history was not recorded: %s",
+                mode.value,
+                history_errors[0],
+            )
+            return True
+
+        logger.info("Enforcement mode set to: %s", mode.value)
+        return True
+
+    async def set_enforcement_mode(self, mode: EnforcementMode) -> bool:
+        """Set the access control enforcement mode, with its audit entry.
+
+        The posture and the record of who moved it are issued as one
+        ``MULTI``/``EXEC``. Before #15089 they were three awaits in a row and
+        the second reached for a ``_redis`` attribute the async client does not
+        have, so every call wrote the key, raised, and returned ``False`` -- the
+        admin API answered 500 for a change that had in fact happened, and the
+        audit trail was never written at all.
+
+        One dispatched operation is what removes that shape structurally: an
+        exception while the commands are being queued now happens before ``EXEC``
+        and therefore before anything is written, so ``False`` genuinely means
+        the posture is unchanged. It cannot be reintroduced by a later edit
+        moving a line between two writes, because there are no longer two.
 
         Returns:
-            True if successful
+            ``True`` when :data:`ENFORCEMENT_MODE_KEY` holds *mode* afterwards.
         """
         try:
             redis = await self._get_redis()
+            if redis is None:
+                logger.error("Failed to set enforcement mode: no Redis client available")
+                return False
 
-            # Set the mode
-            await redis.set(ENFORCEMENT_MODE_KEY, mode.value)
+            pipe = redis.pipeline(transaction=True)
+            pipe.set(ENFORCEMENT_MODE_KEY, mode.value)
+            pipe.lpush(ENFORCEMENT_HISTORY_KEY, self._enforcement_history_entry(mode))
+            pipe.ltrim(ENFORCEMENT_HISTORY_KEY, 0, ENFORCEMENT_HISTORY_LENGTH - 1)
+            results = await pipe.execute(raise_on_error=False)
 
-            # Record change in history
-            history_key = "feature_flag:access_control:history"
-            history_entry = json.dumps(
-                {
-                    "timestamp": datetime.now(tz=timezone.utc).isoformat(),
-                    "mode": mode.value,
-                    "changed_by": "system",
-                }
-            )
-            await redis._redis.lpush(history_key, history_entry)
-            await redis._redis.ltrim(history_key, 0, 99)  # Keep last 100 changes
-
-            logger.info("Enforcement mode set to: %s", mode.value)
-            return True
+            return self._report_enforcement_write(mode, results)
 
         except Exception as e:
+            # Nothing reached EXEC, so nothing was written: False is the truth.
             logger.error("Failed to set enforcement mode: %s", e)
             return False
 
@@ -430,16 +478,14 @@ class FeatureFlags(AsyncRedisClientMixin):
             mode = await self.get_enforcement_mode()
 
             # Get and parse change history (Issue #315 - uses helper)
-            history_raw = await redis._redis.lrange("feature_flag:access_control:history", 0, 9)
+            history_raw = await redis.lrange(ENFORCEMENT_HISTORY_KEY, 0, 9)
             history = self._parse_history_entries(history_raw)
 
             # Get endpoint overrides
             endpoint_keys = []
             cursor = 0
             while True:
-                cursor, keys = await redis._redis.scan(
-                    cursor, match="feature_flag:access_control:endpoint:*", count=100
-                )
+                cursor, keys = await redis.scan(cursor, match="feature_flag:access_control:endpoint:*", count=100)
                 endpoint_keys.extend(keys)
                 if cursor == 0:
                     break
@@ -482,7 +528,7 @@ class FeatureFlags(AsyncRedisClientMixin):
             cursor = 0
             deleted = 0
             while True:
-                cursor, keys = await redis._redis.scan(cursor, match="feature_flag:*", count=100)
+                cursor, keys = await redis.scan(cursor, match="feature_flag:*", count=100)
                 if keys:
                     deleted += await redis.delete(*keys)
                 if cursor == 0:

--- a/autobot-backend/services/feature_flags_enforcement_write_test.py
+++ b/autobot-backend/services/feature_flags_enforcement_write_test.py
@@ -1,0 +1,317 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The admin write path for the enforcement posture, and what its answer means (#15089).
+
+``set_enforcement_mode`` used to write the key, then reach for a ``_redis``
+attribute the async Redis client does not have, raise, and return ``False``. An
+operator moving the posture through the admin API therefore got a 500 for a
+change that had in fact landed, while the audit entry the same block was trying
+to record was never written at all -- reported state and real state disagreeing,
+on an authorization control.
+
+The tests below pin both halves of the repair: the happy path really writes, and
+a failure really does mean nothing changed. The fakes deliberately answer only
+what ``redis.asyncio.Redis`` answers, so the next wrong-surface call cannot be
+tested green.
+"""
+
+import json
+
+import pytest
+import redis.asyncio as async_redis
+
+from constants.threshold_constants import CategoryDefaults
+from services.feature_flags import (
+    ENFORCEMENT_HISTORY_KEY,
+    ENFORCEMENT_HISTORY_LENGTH,
+    ENFORCEMENT_MODE_KEY,
+    EnforcementMode,
+    FeatureFlags,
+)
+
+# Bookkeeping the fakes need to be observable at all. Everything outside this
+# set has to exist on the real client -- see the surface guards at the bottom.
+_TEST_ONLY_ATTRIBUTES = frozenset({"store", "lists", "dispatch_error", "command_error", "commands"})
+
+
+class _FakePipeline:
+    """A MULTI buffer: commands queue, and ``execute`` applies them or none."""
+
+    def __init__(self, client: "_FakeAsyncRedis") -> None:
+        self._client = client
+        self.commands: list[tuple] = []
+
+    def set(self, key, value, **kwargs):
+        self.commands.append(("set", key, value))
+        return self
+
+    def get(self, key):
+        self.commands.append(("get", key))
+        return self
+
+    def lpush(self, key, value):
+        self.commands.append(("lpush", key, value))
+        return self
+
+    def ltrim(self, key, start, stop):
+        self.commands.append(("ltrim", key, start, stop))
+        return self
+
+    async def execute(self, raise_on_error: bool = True):
+        """Apply the queued commands.
+
+        ``dispatch_error`` models the connection dying before ``EXEC``: nothing
+        is applied, which is what makes a ``False`` answer truthful.
+        ``command_error`` models one command erroring *inside* ``EXEC``, which
+        Redis does not roll back -- the rest of the transaction still applies.
+        """
+        if self._client.dispatch_error is not None:
+            raise self._client.dispatch_error
+
+        results = []
+        for command in self.commands:
+            error = self._client.command_error.get(command[0]) if self._client.command_error else None
+            if error is not None:
+                if raise_on_error:
+                    raise error
+                results.append(error)
+                continue
+            results.append(self._client.apply(command))
+        return results
+
+
+class _FakeAsyncRedis:
+    """Only the surface ``redis.asyncio.Redis`` actually offers."""
+
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        self.store: dict[str, str] = dict(initial or {})
+        self.lists: dict[str, list[str]] = {}
+        self.dispatch_error: Exception | None = None
+        self.command_error: dict[str, Exception] = {}
+
+    def apply(self, command: tuple):
+        name = command[0]
+        if name == "set":
+            self.store[command[1]] = command[2]
+            return True
+        if name == "get":
+            return self.store.get(command[1])
+        if name == "lpush":
+            self.lists.setdefault(command[1], []).insert(0, command[2])
+            return len(self.lists[command[1]])
+        if name == "ltrim":
+            # LTRIM on a key that does not exist is a no-op in Redis; it does
+            # not create an empty list, and the fake must not either.
+            if command[1] in self.lists:
+                self.lists[command[1]] = self.lists[command[1]][command[2] : command[3] + 1]
+            return True
+        raise AssertionError(f"unmodelled command {name}")
+
+    def pipeline(self, transaction: bool = True):
+        return _FakePipeline(self)
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, nx: bool = False):
+        if nx and key in self.store:
+            return None
+        self.store[key] = value
+        return True
+
+    async def lpush(self, key, value):
+        """Present so the pre-#15089 ordering can be run as a contrast mutation."""
+        if self.dispatch_error is not None:
+            raise self.dispatch_error
+        return self.apply(("lpush", key, value))
+
+    async def ltrim(self, key, start, stop):
+        if self.dispatch_error is not None:
+            raise self.dispatch_error
+        return self.apply(("ltrim", key, start, stop))
+
+    async def lrange(self, key, start, stop):
+        entries = self.lists.get(key, [])
+        return entries[start : stop + 1] if stop >= 0 else entries[start:]
+
+    async def scan(self, cursor, match=None, count=None):
+        return 0, [key for key in self.store if match is None or key.startswith(match.rstrip("*"))]
+
+    async def delete(self, *keys):
+        return sum(1 for key in keys if self.store.pop(key, None) is not None)
+
+
+def _flags(redis: _FakeAsyncRedis) -> FeatureFlags:
+    flags = FeatureFlags()
+
+    async def _get_redis():
+        return redis
+
+    flags._get_redis = _get_redis
+    return flags
+
+
+class TestTheAdminWritePathActuallyWrites:
+    """The regression: every admin write reported failure after succeeding."""
+
+    @pytest.mark.asyncio
+    async def test_setting_the_mode_returns_true_and_the_key_is_set(self):
+        redis = _FakeAsyncRedis()
+
+        assert await _flags(redis).set_enforcement_mode(EnforcementMode.ENFORCED) is True
+        assert redis.store[ENFORCEMENT_MODE_KEY] == EnforcementMode.ENFORCED.value
+
+    @pytest.mark.asyncio
+    async def test_the_change_is_recorded_in_the_history_the_stats_reader_reads(self):
+        """The audit trail was never written at all before this fix."""
+        redis = _FakeAsyncRedis()
+
+        await _flags(redis).set_enforcement_mode(EnforcementMode.LOG_ONLY)
+
+        entries = redis.lists[ENFORCEMENT_HISTORY_KEY]
+        assert len(entries) == 1
+        assert json.loads(entries[0])["mode"] == EnforcementMode.LOG_ONLY.value
+
+    @pytest.mark.asyncio
+    async def test_every_mode_an_operator_can_choose_is_written_back(self):
+        modes = list(EnforcementMode)
+        assert modes, "an empty enumeration would assert nothing at all"
+
+        for mode in modes:
+            redis = _FakeAsyncRedis()
+
+            assert await _flags(redis).set_enforcement_mode(mode) is True, f"{mode.value} was not written"
+            assert redis.store[ENFORCEMENT_MODE_KEY] == mode.value
+
+    @pytest.mark.asyncio
+    async def test_the_history_is_trimmed_to_its_documented_length(self):
+        redis = _FakeAsyncRedis()
+        redis.lists[ENFORCEMENT_HISTORY_KEY] = ["old"] * (ENFORCEMENT_HISTORY_LENGTH + 50)
+
+        await _flags(redis).set_enforcement_mode(EnforcementMode.ENFORCED)
+
+        assert len(redis.lists[ENFORCEMENT_HISTORY_KEY]) == ENFORCEMENT_HISTORY_LENGTH
+
+
+class TestAFailedWriteMeansNothingChanged:
+    """The chosen semantics: ``False`` is only ever returned for a posture that
+    did not move. Returning ``False`` for a write that landed is the shape that
+    kept this invisible, so it is pinned here rather than left to convention."""
+
+    @pytest.mark.asyncio
+    async def test_a_failure_before_exec_returns_false_and_leaves_the_key_unset(self):
+        redis = _FakeAsyncRedis()
+        redis.dispatch_error = ConnectionError("connection lost before EXEC")
+
+        result = await _flags(redis).set_enforcement_mode(EnforcementMode.ENFORCED)
+
+        assert result is False
+        assert ENFORCEMENT_MODE_KEY not in redis.store, "False must mean the posture did not move"
+        assert ENFORCEMENT_HISTORY_KEY not in redis.lists
+
+    @pytest.mark.asyncio
+    async def test_a_deliberate_posture_survives_a_failed_change(self):
+        """The half-write's real danger: an operator's existing choice replaced
+        by a value the API then reports as not applied."""
+        redis = _FakeAsyncRedis({ENFORCEMENT_MODE_KEY: EnforcementMode.LOG_ONLY.value})
+        redis.dispatch_error = ConnectionError("connection lost before EXEC")
+
+        assert await _flags(redis).set_enforcement_mode(EnforcementMode.DISABLED) is False
+        assert redis.store[ENFORCEMENT_MODE_KEY] == EnforcementMode.LOG_ONLY.value
+
+    @pytest.mark.asyncio
+    async def test_a_lost_audit_entry_does_not_report_a_change_that_happened_as_a_failure(self):
+        """Redis does not roll back a command that errors inside ``EXEC``, so the
+        posture really did move; saying otherwise would be the original defect
+        in a rarer form. The loss is logged, not converted into a false ``False``."""
+        redis = _FakeAsyncRedis()
+        redis.command_error = {"lpush": TypeError("WRONGTYPE against a key holding the wrong kind of value")}
+
+        result = await _flags(redis).set_enforcement_mode(EnforcementMode.ENFORCED)
+
+        assert result is True
+        assert redis.store[ENFORCEMENT_MODE_KEY] == EnforcementMode.ENFORCED.value
+        assert ENFORCEMENT_HISTORY_KEY not in redis.lists
+
+    @pytest.mark.asyncio
+    async def test_an_unreachable_flag_store_is_a_failure_not_a_silent_success(self):
+        flags = FeatureFlags()
+
+        async def _no_redis():
+            return None
+
+        flags._get_redis = _no_redis
+
+        assert await flags.set_enforcement_mode(EnforcementMode.ENFORCED) is False
+
+
+class TestRolloutStatisticsHasASuccessPath:
+    """``get_rollout_statistics`` reported ``unknown`` on every call, because the
+    ``_redis`` access raised before anything could be read. The error-path test
+    beside this one passed only because the error path was the only path."""
+
+    @pytest.mark.asyncio
+    async def test_statistics_report_the_real_mode_and_the_recorded_history(self):
+        redis = _FakeAsyncRedis()
+        flags = _flags(redis)
+        await flags.set_enforcement_mode(EnforcementMode.ENFORCED)
+
+        stats = await flags.get_rollout_statistics()
+
+        assert stats["current_mode"] == EnforcementMode.ENFORCED.value
+        assert stats["current_mode"] != CategoryDefaults.UNKNOWN
+        assert len(stats["history"]) == 1
+        assert stats["history"][0]["mode"] == EnforcementMode.ENFORCED.value
+
+    @pytest.mark.asyncio
+    async def test_endpoint_overrides_are_reported_from_the_scan(self):
+        redis = _FakeAsyncRedis({"feature_flag:access_control:endpoint:/api/chat": EnforcementMode.ENFORCED.value})
+        flags = _flags(redis)
+        await flags.set_enforcement_mode(EnforcementMode.LOG_ONLY)
+
+        stats = await flags.get_rollout_statistics()
+
+        assert stats["endpoint_overrides"] == {"/api/chat": EnforcementMode.ENFORCED.value}
+        assert stats["total_endpoints_configured"] == 1
+
+
+class TestTheFakesCannotAnswerWhatTheRealClientCannot:
+    """A fake that answers ``_redis`` would have kept every test above green
+    while production raised on every call. That is the whole reason this file
+    builds its own doubles instead of using ``MagicMock``."""
+
+    def test_the_real_async_client_has_no_redis_attribute(self):
+        assert not hasattr(async_redis.Redis, "_redis")
+
+    def test_the_fake_client_has_no_redis_attribute(self):
+        assert "_redis" not in _TEST_ONLY_ATTRIBUTES, "the allowlist must not be able to smuggle it back"
+        assert not hasattr(_FakeAsyncRedis(), "_redis")
+
+    def test_the_fake_client_exposes_nothing_the_real_client_lacks(self):
+        surface = {name for name in dir(_FakeAsyncRedis()) if not name.startswith("__")}
+        checked = sorted(surface - _TEST_ONLY_ATTRIBUTES - {"apply"})
+        assert checked, "an empty surface would assert nothing at all"
+
+        invented = [name for name in checked if not hasattr(async_redis.Redis, name)]
+        assert invented == [], f"the fake answers what the real client does not: {invented}"
+
+    def test_the_fake_pipeline_exposes_nothing_the_real_pipeline_lacks(self):
+        real = async_redis.client.Pipeline
+        surface = {name for name in dir(_FakePipeline(_FakeAsyncRedis())) if not name.startswith("_")}
+        checked = sorted(surface - _TEST_ONLY_ATTRIBUTES)
+        assert checked, "an empty surface would assert nothing at all"
+
+        invented = [name for name in checked if not hasattr(real, name)]
+        assert invented == [], f"the fake pipeline answers what the real one does not: {invented}"
+
+    def test_the_service_never_reaches_through_a_private_redis_attribute(self):
+        """The guard for the four call sites this issue names."""
+        import inspect
+
+        import services.feature_flags as module
+
+        source = inspect.getsource(module)
+        assert source, "an unreadable module would assert nothing at all"
+        assert "redis._redis." not in source


### PR DESCRIPTION
## Thinking Path

Verified the filed defect before touching anything.

**The attribute genuinely does not exist.** `FeatureFlags` extends `AsyncRedisClientMixin`, whose
`_get_redis()` returns `await get_async_redis_client(database="cache")`. That resolves through
`RedisConnectionManager.get_async_client`, which constructs a bare
`redis.asyncio.Redis(connection_pool=...)` and returns it — no wrapper anywhere on the path.
`redis.asyncio.Redis` declares `__slots__ = ()` and has no `_redis` member, so every one of these
accesses raised `AttributeError`.

**The write-then-raise ordering is real.** In `set_enforcement_mode` the key write came first and
the history append second, both inside one broad `except` that logged and returned `False`:

```
await redis.set(ENFORCEMENT_MODE_KEY, mode.value)   # lands
await redis._redis.lpush(history_key, entry)        # AttributeError
except Exception: ... return False                  # reports total failure
```

The admin endpoint turns that into an operator-visible lie: `api/feature_flags.py:139` does
`if not success: raise HTTPException(500, "Failed to update enforcement mode")`. So the operator
saw a 500 for a posture change that had in fact been written, and the audit entry recording who
moved an authorization control was never written at all.

**One correction to the filed count.** The issue names four call sites; there are five accesses
across three methods — `lpush` and `ltrim` in `set_enforcement_mode`, `lrange` and `scan` in
`get_rollout_statistics`, and a third `scan` in `clear_all_flags`. Only three are list operations;
two are `scan`. All five are fixed.

**Atomicity decision: one `MULTI`/`EXEC`, and a return value that never lies.** The posture and its
audit entry are now issued as a single transaction. The reason is structural rather than aesthetic:
with three sequential awaits, correctness depended on nothing ever raising between the first and the
second — which is exactly the assumption that broke here, and exactly the assumption a future edit
can quietly break again by moving a line. With one dispatched operation there is no "between".
An exception while the commands are queued now happens *before* `EXEC`, so nothing is written and
`False` is truthful. The audit trail of who moved an authorization posture is not decoration, so
binding it to the change is also the right coupling on its merits.

Redis does not roll back a command that errors *inside* `EXEC`, so one residual case remains: the
mode write applies and the `lpush` errors. Reporting `False` there would reproduce this very defect
in a rarer form, so the pipeline runs with `raise_on_error=False`, the results are inspected, and
that case returns `True` with a loud error naming the lost audit entry. `True` now means one thing
only: the enforcement key holds the requested mode.

**Not changed, deliberately:** `unset → DISABLED` and `log_only → allow` are untouched. This fixes a
broken writer, not the posture. The `#15088` seeder is likewise untouched — see the note below.

## What Changed

- `autobot-backend/services/feature_flags.py`
  - `set_enforcement_mode` issues `SET` + `LPUSH` + `LTRIM` as one transaction and reports the
    result through a new `_report_enforcement_write` helper; a `None` client is now an explicit
    failure rather than an `AttributeError`.
  - `_enforcement_history_entry` extracted so the writer and the format have one home.
  - `ENFORCEMENT_HISTORY_KEY` and `ENFORCEMENT_HISTORY_LENGTH` named next to `ENFORCEMENT_MODE_KEY`;
    the history key was a literal repeated in the writer and the statistics reader.
  - `get_rollout_statistics` (`lrange`, `scan`) and `clear_all_flags` (`scan`) call the client
    directly. No `redis._redis` access remains in the module.
- `autobot-backend/services/feature_flags_enforcement_write_test.py` — new. Hand-written async
  fakes rather than `MagicMock`, because a mock answers `_redis` and would have kept the broken
  code green.

## Verification

Targeted suites, 32 passed: the new file (15), the kept `feature_flags_rollout_stats_test.py`
error-path test (1), `feature_flags_enforcement_seed_test.py` (15), `api/feature_flags_test.py` (1).

**Contrast mutation 1 — restore `_redis`** (`redis.pipeline(` → `redis._redis.pipeline(`).
`TestTheAdminWritePathActuallyWrites::test_setting_the_mode_returns_true_and_the_key_is_set` fails:

```
E   assert False is True
ERROR services.feature_flags: Failed to set enforcement mode:
      '_FakeAsyncRedis' object has no attribute '_redis'
```

**Contrast mutation 2 — restore the old ordering** (pipeline replaced with sequential
`set` → `lpush` → `ltrim` awaits).
`TestAFailedWriteMeansNothingChanged::test_a_failure_before_exec_returns_false_and_leaves_the_key_unset`
fails, reproducing the half-write exactly:

```
E   AssertionError: False must mean the posture did not move
E   assert 'feature_flag:access_control:enforcement_mode' not in
        {'feature_flag:access_control:enforcement_mode': 'enforced'}
```

Both mutations restored; the suite is green again afterwards.

Non-vacuity assertions guard both enumerations (`list(EnforcementMode)`, the fake-surface sweeps) so
an empty enumeration fails rather than passing quietly. A surface guard asserts the fakes expose
nothing `redis.asyncio.Redis` / `redis.asyncio.client.Pipeline` lack, that neither fake answers
`_redis`, and that the allowlist cannot smuggle `_redis` back in — so the next wrong-surface call
cannot be tested green.

Gates: `black --check --line-length 120` clean · `isort --check-only` clean · `py_compile` clean ·
`bandit -c .bandit -q` rc 0 · `check_python_file_size.py --audit-ceilings` rc 0 (no ceiling raised,
no `KNOWN_LARGE` entry added). Branch 0 behind base. No new env vars, so no `env_registry` change.
No live Redis touched — the tests use their own in-process fakes.

## Related, not conflated

**#14866 / #15088.** The provisioning seeder writes the same key with `SET NX` and deliberately
avoided `set_enforcement_mode` because it was unreliable. **Recommendation: leave the seeder
independent.** It is not a workaround that this PR retires — `seed_enforcement_mode` and
`set_enforcement_mode` answer different questions. The seeder must never overwrite an operator's
deliberate choice, which is `SET NX`'s whole point, whereas the admin writer must always overwrite;
routing provisioning through the admin writer would reintroduce the clobbering that #14866 exists to
prevent. The seeder also has no business appending to the operator-change audit list. Noted on
#14866 rather than changed here.

**#15086.** Genuinely separate, not this root cause. `get_endpoint_enforcement`
(`services/feature_flags.py`) reads through `await redis.get(key)` correctly — it never touched
`_redis`, and this PR does not alter it. Its defect is that nothing calls it:
`SessionOwnershipValidator._get_enforcement_mode` reads only the global mode, so a per-endpoint
override is written, audited, and read back while never reaching an authorization decision. Same
*family* as #14010/#14866 — a control that reports being on while being off — but a different
mechanism, and fixing this writer does not move it.

## Model Used

Claude Opus 5 (1M context)

Closes #15089
