### PR TITLE
test(terminal): drive the unknown-session rejection through the real route (#14961)

### DIFF
--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -1,0 +1,264 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Structural proof of the terminal router's dependency wiring (#14998).
+
+Split out of ``terminal_websocket_route_test.py`` (#14961): that file had
+grown past the 600-line guard, and the seam its own docstring already
+described is the one taken here. Two questions lived in one module -- *which
+dependencies does the mounted router attach to which routes* (answered by
+importing ``api.terminal`` in a clean subprocess and enumerating the mounted
+app), and *what does a real client experience on the wire* (answered by
+``TestClient`` handshakes). The first needs no fixtures, no fakeredis and no
+auth stubbing; the second needs all three. They are now separate modules.
+
+This module holds the first: the router-level ``Depends(check_admin_permission)``
+must be absent from both ``@router.websocket`` routes (the #14998 fix itself)
+and present on the HTTP routes. The subprocess entrypoint ``_dump_routes_main``
+lives here too, so the isolation the assertions depend on travels with them.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# --- clean-interpreter route/dependency enumeration (#14998, shard-12 pollution) ---
+#
+# Every structural gate assertion below reads from this, never from the
+# in-process ``terminal_router`` bound at collection time: that name observed
+# zero routes under python-suite shard 12/12 (CI job 98074498060) even though
+# this file passes in isolation -- some earlier-collected test in the same
+# xdist worker leaves shared state (import machinery or the router object
+# itself) in a way this file's own module-level import inherits. Filed as
+# #15087, unidentified polluter. A subprocess that imports ``api.terminal``
+# fresh sidesteps the mechanism entirely rather than needing to name it.
+
+_ADMIN_DEP = "auth_middleware.check_admin_permission"
+
+
+class _TerminalRouteDumpError(RuntimeError):
+    """The subprocess dump did not return a trustworthy answer.
+
+    Carries every diagnostic available -- interpreter/framework versions and
+    the subprocess's full stdout/stderr -- so a CI failure names the cause
+    instead of a downstream assertion naming only its symptom (#14998 job
+    98083466678: the terse "'/terminal/check-tool' missing" message hid that
+    the dump had only returned 3 of 26 routes, one with no identifiable path,
+    with nothing said about why).
+    """
+
+
+def _run_terminal_route_dump() -> list:
+    """Import api.terminal in a fresh subprocess and return its route list.
+
+    Bootstraps via ``-c`` and a dotted import (``api.terminal_router_dependency_wiring_test``)
+    rather than executing this file's own path directly: running a script
+    prepends *its own directory* (``api/``) to ``sys.path[0]``, and that
+    directory holds ``api/secrets.py`` -- which then shadows the stdlib
+    ``secrets`` module the very first thing FastAPI imports needs, crashing
+    with a circular-import ``ImportError`` before ``api.terminal`` is ever
+    reached. ``-c`` sets ``sys.path[0]`` to ``""`` (cwd) instead, which does
+    not collide.
+
+    Never returns a partial answer quietly: a non-zero exit, unparsable
+    stdout, a missing/malformed ``routes`` list, an empty result, or any
+    route entry the dump could not attach a path to, all raise
+    ``_TerminalRouteDumpError`` with the interpreter/framework versions and
+    the subprocess's raw stdout/stderr attached.
+    """
+    backend_root = Path(__file__).resolve().parents[1]
+    repo_root = backend_root.parent
+    # autobot_shared/ is a sibling of autobot-backend/, not nested under it
+    # (mirrors pytest.ini's `pythonpath = . autobot-backend autobot_shared ...`).
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join([str(repo_root), str(backend_root)]))
+    bootstrap = "import api.terminal_router_dependency_wiring_test as m; m._dump_routes_main()"
+    result = subprocess.run(
+        [sys.executable, "-c", bootstrap],
+        capture_output=True,
+        text=True,
+        cwd=str(backend_root),
+        env=env,
+        timeout=60,
+    )
+
+    def _fail(reason: str, spec_repr: str = "") -> None:
+        raise _TerminalRouteDumpError(
+            f"{reason}\n"
+            f"subprocess exit code: {result.returncode}\n"
+            f"{spec_repr}"
+            f"--- subprocess stdout ---\n{result.stdout}\n"
+            f"--- subprocess stderr ---\n{result.stderr}"
+        )
+
+    if result.returncode != 0:
+        _fail("terminal route dump subprocess exited non-zero")
+
+    # get_logger's default handler writes startup noise (e.g. the error-catalog
+    # load line) to stdout ahead of the JSON -- take the last line so that
+    # incidental logging can't break the parse.
+    stdout_lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+    if not stdout_lines:
+        _fail("terminal route dump subprocess produced no stdout at all")
+
+    try:
+        spec = json.loads(stdout_lines[-1])
+    except json.JSONDecodeError as exc:
+        _fail(f"terminal route dump subprocess stdout was not parseable JSON: {exc}")
+
+    routes = spec.get("routes") if isinstance(spec, dict) else None
+    versions = (
+        f"python: {spec.get('python', '<unreported>')!r}\n"
+        f"fastapi: {spec.get('fastapi', '<unreported>')!r}\n"
+        f"starlette: {spec.get('starlette', '<unreported>')!r}\n"
+        if isinstance(spec, dict)
+        else ""
+    )
+    if not isinstance(routes, list):
+        _fail(f"terminal route dump returned no usable 'routes' list: {spec!r}", versions)
+
+    unidentified = [r for r in routes if not isinstance(r, dict) or r.get("path") is None]
+    if unidentified:
+        _fail(
+            f"terminal route dump returned {len(routes)} route(s), of which "
+            f"{len(unidentified)} had no identifiable path -- a route the dump "
+            "cannot name is a parse failure, not a route, and is never folded "
+            "into the path->dependencies mapping.\n"
+            f"raw routes: {json.dumps(routes, indent=2)}\n" + versions,
+        )
+
+    if not routes:
+        _fail("terminal route dump subprocess returned zero routes", versions)
+
+    return routes
+
+
+@pytest.fixture(scope="session")
+def terminal_route_spec() -> dict:
+    """path -> sorted list of fully-qualified dependency names, from a clean
+    subprocess import. Non-vacuity (and every other partial-answer shape) is
+    enforced inside ``_run_terminal_route_dump`` -- every test consuming this
+    fixture fails loudly, with the raw dump attached, never silently passing
+    on a truncated or unparsable result.
+    """
+    routes = _run_terminal_route_dump()
+    return {r["path"]: r["dependencies"] for r in routes}
+
+
+class TestTerminalRouterDependencyWiring:
+    """Structural proof of the fix: the admin dependency moved off the WS
+    routes and stayed on the HTTP ones. This is the assertion #14998 itself
+    is about.
+    """
+
+    def test_websocket_routes_carry_no_admin_dependency(self, terminal_route_spec):
+        for path in ("/ws/{session_id}", "/ws/ssh/{host_id}"):
+            assert path in terminal_route_spec, f"route {path} missing from a clean import"
+            assert _ADMIN_DEP not in terminal_route_spec[path], f"{path} must not carry the router-level admin Depends"
+
+    def test_http_routes_keep_the_admin_dependency(self, terminal_route_spec):
+        assert "/" in terminal_route_spec, "route / missing from a clean import"
+        assert _ADMIN_DEP in terminal_route_spec["/"], "HTTP routes must keep check_admin_permission"
+
+
+def _dump_routes_main() -> None:
+    """Subprocess entrypoint (see ``_run_terminal_route_dump`` above): import
+    ``api.terminal`` in a fresh interpreter and print its routes as JSON.
+
+    Kept in this module, like ``core_test.py``'s ``_main``, so the isolation
+    the tests need travels with them rather than living in a separate script.
+
+    Reports each route's concrete type name alongside its path/dependencies,
+    and the resolved fastapi/starlette/python versions, so a truncated result
+    carries enough evidence in one subprocess call to diagnose without a
+    second round-trip. That is how the defect below was found.
+
+    Enumerates a **mounted app**, not the bare ``APIRouter``. Under fastapi
+    0.141.1 / starlette 1.6.0 (what CI resolves), ``include_router`` no longer
+    flattens the child's routes into ``parent.routes`` eagerly -- it appends a
+    single deferred ``_IncludedRouter`` entry with no ``path``, and the child's
+    routes materialise only when an app mounts it. Reading ``router.routes``
+    there returned 3 entries instead of 26 (job 98088603289) while every route
+    was perfectly fine at runtime. Mounting first is correct on both versions,
+    and asks the question the guard actually cares about: what does the
+    application serve, and with which dependencies.
+    """
+    import sys as _sys
+
+    import fastapi as _fastapi
+    import starlette as _starlette
+
+    import api.terminal as terminal_module
+
+    def _dep_names(route) -> list:
+        """Every dependency callable on a leaf route, fully merged.
+
+        ``route.dependant.dependencies`` is the set FastAPI actually resolves,
+        already including anything inherited from the routers the route was
+        included through -- which is exactly the question a gate check asks.
+        ``route.dependencies`` is the un-merged declaration and is the fallback.
+        """
+        dependant = getattr(route, "dependant", None)
+        if dependant is not None:
+            return sorted(
+                f"{dep.call.__module__}.{dep.call.__qualname__}"
+                for dep in getattr(dependant, "dependencies", [])
+                if getattr(dep, "call", None) is not None
+            )
+        return sorted(
+            f"{dep.dependency.__module__}.{dep.dependency.__qualname__}"
+            for dep in getattr(route, "dependencies", [])
+            if getattr(dep, "dependency", None) is not None
+        )
+
+    def _walk(container, prefix: str) -> list:
+        """Flatten deferred ``_IncludedRouter`` wrappers into real routes.
+
+        Under fastapi 0.141.1 neither ``include_router`` nor mounting an app
+        flattens eagerly: both leave a wrapper whose ``.original_router`` holds
+        the real routes, and whose own path is ``None``. Same idiom the repo
+        already uses in ``llc/tests/test_roles_routes_registered.py``,
+        ``api/codebase_analytics/endpoints/impact_endpoint_test.py`` and
+        ``api/self_capabilities_integration_test.py`` -- copied here rather than
+        invented, though the fact that four files now carry it by hand is its
+        own problem.
+        """
+        found = []
+        for route in getattr(container, "routes", []) or []:
+            original = getattr(route, "original_router", None)
+            if original is not None:
+                sub_prefix = getattr(route, "prefix", "") or getattr(original, "prefix", "") or ""
+                found.extend(_walk(original, prefix + sub_prefix))
+                continue
+            path = getattr(route, "path", None)
+            found.append(
+                {
+                    "path": None if path is None else prefix + path,
+                    "type": type(route).__name__,
+                    "dependencies": _dep_names(route),
+                }
+            )
+        return found
+
+    app = _fastapi.FastAPI()
+    app.include_router(terminal_module.router)
+
+    routes = [r for r in _walk(app, "") if not (r["path"] or "").startswith(("/openapi.json", "/docs", "/redoc"))]
+    print(
+        json.dumps(
+            {
+                "routes": routes,
+                "python": _sys.version,
+                "fastapi": getattr(_fastapi, "__version__", "unknown"),
+                "starlette": getattr(_starlette, "__version__", "unknown"),
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    _dump_routes_main()

--- a/autobot-backend/api/terminal_websocket_route_test.py
+++ b/autobot-backend/api/terminal_websocket_route_test.py
@@ -15,37 +15,29 @@ real client does, through ``starlette.testclient.TestClient``, which runs the
 actual ASGI app including route matching and dependency resolution.
 
 Covers:
-- Structural proof the merged router puts ``check_admin_permission`` on the
-  HTTP routes (including the tool-execution routes, #15084) and NOT on either
-  ``@router.websocket`` route (the fix itself). Sourced from a clean
-  subprocess import (see ``_dump_routes_main`` below) rather than an
-  in-process one: under ``python-suite`` shard 12/12, an in-process
-  ``api.terminal.router`` was observed with zero routes (CI job 98074498060),
-  something earlier in the same pytest-xdist worker having left ``sys.modules``
-  in a state this module's own collection-time import inherited. A fresh
-  interpreter is immune to that regardless of its cause (mirrors the
-  subprocess-per-class pattern in
-  ``autobot_shared/user_management/models/core_test.py``).
-- A real handshake on ``/ws/{session_id}``: authenticated owner connects,
-  unauthenticated caller is refused before ``accept()``.
+- A real handshake on ``/ws/{session_id}``: authenticated owner connects;
+  unauthenticated caller, non-owner and unknown ``session_id`` are each
+  refused ``1008`` before ``accept()``, with ``caplog`` separating the two
+  rejection branches that share one ``close()`` call site.
 - A real handshake on ``/ws/ssh/{host_id}``: authenticated admin connects,
   unauthenticated caller is refused before ``accept()``.
 - The HTTP routes on the same router still reject a non-admin caller
   (dependency_overrides, in-process -- this needs object identity with the
-  live app/router, so it cannot move to a subprocess).
+  live app/router, so it cannot move to a subprocess), including the
+  tool-execution routes (#15084).
 - Contrast mutation: an isolated router shaped exactly like the reported bug
   (router-level ``Depends`` of a ``Request``-typed callable, owning a
   ``@router.websocket`` route) fails the handshake with the same ``TypeError``
   ``solve_dependencies`` raises; the split-router shape this fix uses does not.
+
+The structural half -- which dependency is attached to which route, read from
+a clean subprocess import -- lives in ``terminal_router_dependency_wiring_test.py``
+(split out under #14961; it needs none of this module's fixtures).
 """
 
-import json
 import logging
-import os
-import subprocess
-import sys
+import uuid
 from contextlib import contextmanager
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import fakeredis
@@ -110,144 +102,6 @@ def terminal_app():
 @pytest.fixture
 def terminal_client(terminal_app):
     return TestClient(terminal_app, raise_server_exceptions=False)
-
-
-# --- clean-interpreter route/dependency enumeration (#14998, shard-12 pollution) ---
-#
-# Every structural gate assertion below reads from this, never from the
-# in-process ``terminal_router`` bound at collection time: that name observed
-# zero routes under python-suite shard 12/12 (CI job 98074498060) even though
-# this file passes in isolation -- some earlier-collected test in the same
-# xdist worker leaves shared state (import machinery or the router object
-# itself) in a way this file's own module-level import inherits. Filed as
-# #15087, unidentified polluter. A subprocess that imports ``api.terminal``
-# fresh sidesteps the mechanism entirely rather than needing to name it.
-
-_ADMIN_DEP = "auth_middleware.check_admin_permission"
-
-
-class _TerminalRouteDumpError(RuntimeError):
-    """The subprocess dump did not return a trustworthy answer.
-
-    Carries every diagnostic available -- interpreter/framework versions and
-    the subprocess's full stdout/stderr -- so a CI failure names the cause
-    instead of a downstream assertion naming only its symptom (#14998 job
-    98083466678: the terse "'/terminal/check-tool' missing" message hid that
-    the dump had only returned 3 of 26 routes, one with no identifiable path,
-    with nothing said about why).
-    """
-
-
-def _run_terminal_route_dump() -> list:
-    """Import api.terminal in a fresh subprocess and return its route list.
-
-    Bootstraps via ``-c`` and a dotted import (``api.terminal_websocket_route_test``)
-    rather than executing this file's own path directly: running a script
-    prepends *its own directory* (``api/``) to ``sys.path[0]``, and that
-    directory holds ``api/secrets.py`` -- which then shadows the stdlib
-    ``secrets`` module the very first thing FastAPI imports needs, crashing
-    with a circular-import ``ImportError`` before ``api.terminal`` is ever
-    reached. ``-c`` sets ``sys.path[0]`` to ``""`` (cwd) instead, which does
-    not collide.
-
-    Never returns a partial answer quietly: a non-zero exit, unparsable
-    stdout, a missing/malformed ``routes`` list, an empty result, or any
-    route entry the dump could not attach a path to, all raise
-    ``_TerminalRouteDumpError`` with the interpreter/framework versions and
-    the subprocess's raw stdout/stderr attached.
-    """
-    backend_root = Path(__file__).resolve().parents[1]
-    repo_root = backend_root.parent
-    # autobot_shared/ is a sibling of autobot-backend/, not nested under it
-    # (mirrors pytest.ini's `pythonpath = . autobot-backend autobot_shared ...`).
-    env = dict(os.environ, PYTHONPATH=os.pathsep.join([str(repo_root), str(backend_root)]))
-    bootstrap = "import api.terminal_websocket_route_test as m; m._dump_routes_main()"
-    result = subprocess.run(
-        [sys.executable, "-c", bootstrap],
-        capture_output=True,
-        text=True,
-        cwd=str(backend_root),
-        env=env,
-        timeout=60,
-    )
-
-    def _fail(reason: str, spec_repr: str = "") -> None:
-        raise _TerminalRouteDumpError(
-            f"{reason}\n"
-            f"subprocess exit code: {result.returncode}\n"
-            f"{spec_repr}"
-            f"--- subprocess stdout ---\n{result.stdout}\n"
-            f"--- subprocess stderr ---\n{result.stderr}"
-        )
-
-    if result.returncode != 0:
-        _fail("terminal route dump subprocess exited non-zero")
-
-    # get_logger's default handler writes startup noise (e.g. the error-catalog
-    # load line) to stdout ahead of the JSON -- take the last line so that
-    # incidental logging can't break the parse.
-    stdout_lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
-    if not stdout_lines:
-        _fail("terminal route dump subprocess produced no stdout at all")
-
-    try:
-        spec = json.loads(stdout_lines[-1])
-    except json.JSONDecodeError as exc:
-        _fail(f"terminal route dump subprocess stdout was not parseable JSON: {exc}")
-
-    routes = spec.get("routes") if isinstance(spec, dict) else None
-    versions = (
-        f"python: {spec.get('python', '<unreported>')!r}\n"
-        f"fastapi: {spec.get('fastapi', '<unreported>')!r}\n"
-        f"starlette: {spec.get('starlette', '<unreported>')!r}\n"
-        if isinstance(spec, dict)
-        else ""
-    )
-    if not isinstance(routes, list):
-        _fail(f"terminal route dump returned no usable 'routes' list: {spec!r}", versions)
-
-    unidentified = [r for r in routes if not isinstance(r, dict) or r.get("path") is None]
-    if unidentified:
-        _fail(
-            f"terminal route dump returned {len(routes)} route(s), of which "
-            f"{len(unidentified)} had no identifiable path -- a route the dump "
-            "cannot name is a parse failure, not a route, and is never folded "
-            "into the path->dependencies mapping.\n"
-            f"raw routes: {json.dumps(routes, indent=2)}\n" + versions,
-        )
-
-    if not routes:
-        _fail("terminal route dump subprocess returned zero routes", versions)
-
-    return routes
-
-
-@pytest.fixture(scope="session")
-def terminal_route_spec() -> dict:
-    """path -> sorted list of fully-qualified dependency names, from a clean
-    subprocess import. Non-vacuity (and every other partial-answer shape) is
-    enforced inside ``_run_terminal_route_dump`` -- every test consuming this
-    fixture fails loudly, with the raw dump attached, never silently passing
-    on a truncated or unparsable result.
-    """
-    routes = _run_terminal_route_dump()
-    return {r["path"]: r["dependencies"] for r in routes}
-
-
-class TestTerminalRouterDependencyWiring:
-    """Structural proof of the fix: the admin dependency moved off the WS
-    routes and stayed on the HTTP ones. This is the assertion #14998 itself
-    is about.
-    """
-
-    def test_websocket_routes_carry_no_admin_dependency(self, terminal_route_spec):
-        for path in ("/ws/{session_id}", "/ws/ssh/{host_id}"):
-            assert path in terminal_route_spec, f"route {path} missing from a clean import"
-            assert _ADMIN_DEP not in terminal_route_spec[path], f"{path} must not carry the router-level admin Depends"
-
-    def test_http_routes_keep_the_admin_dependency(self, terminal_route_spec):
-        assert "/" in terminal_route_spec, "route / missing from a clean import"
-        assert _ADMIN_DEP in terminal_route_spec["/"], "HTTP routes must keep check_admin_permission"
 
 
 def _request(client, method: str, path: str):
@@ -334,8 +188,6 @@ class TestTerminalWebsocketRouteHandshake:
 
     @pytest.fixture
     def owned_session_id(self):
-        import uuid
-
         session_id = str(uuid.uuid4())
         session_manager.session_configs[session_id] = {
             "session_id": session_id,
@@ -390,6 +242,52 @@ class TestTerminalWebsocketRouteHandshake:
         assert len(calls) == 0
         assert any("is not the owner" in r.message for r in caplog.records)
         assert not any("unknown session_id" in r.message for r in caplog.records)
+
+    def test_unknown_session_is_refused(self, terminal_client, owned_session_id, caplog):
+        """#14961 AC4: the unknown-session rejection, driven through the real route.
+
+        The sibling case in ``terminal_websocket_auth_test.py`` calls the
+        decorated handler directly, which cannot observe a routing or
+        dependency-resolution failure -- exactly how #14998 stayed invisible
+        while this route 500'd for every caller and the handler-level guard
+        tests stayed green. A criterion about what a client experiences has to
+        go through the ASGI stack.
+
+        ``owned_session_id`` is requested purely as a non-vacuity witness. The
+        config store is Redis-backed (``services/terminal_session_store.py``)
+        and **fails closed**, so an unreachable store answers every lookup with
+        ``None`` and would produce this same ``1008`` for entirely the wrong
+        reason. Reading that session back proves the fakeredis-backed store is
+        live and round-trips, which makes the miss below a genuine absence.
+
+        The ``caplog`` pair is the load-bearing part: the unknown-session and
+        ownership branches both exit through the one ``close(code=1008)`` in
+        ``terminal_websocket``, so the close code alone cannot tell them apart,
+        and a regression that turned "unknown" into "not the owner" would pass
+        silently. The non-owner test above pins the mirror direction.
+        """
+        unknown_session_id = str(uuid.uuid4())
+        assert session_manager.session_configs.get(owned_session_id) is not None, (
+            "the session store is not round-tripping -- a fail-closed store makes "
+            "every session look unknown and this test would pass vacuously"
+        )
+        assert session_manager.session_configs.get(unknown_session_id) is None
+
+        with (
+            patch("auth_middleware.authenticate_websocket", new=AsyncMock(return_value={"username": "alice"})),
+            patch("api.terminal._init_terminal_handler", new=AsyncMock()) as init_handler,
+            caplog.at_level(logging.WARNING, logger="api.terminal"),
+            _accept_spy() as calls,
+        ):
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with terminal_client.websocket_connect(f"/ws/{unknown_session_id}"):
+                    pass
+
+        assert exc_info.value.code == 1008
+        assert len(calls) == 0, "the handshake must be refused before accept()"
+        init_handler.assert_not_awaited()
+        assert any("unknown session_id" in r.message for r in caplog.records)
+        assert not any("is not the owner" in r.message for r in caplog.records)
 
 
 class TestSshTerminalWebsocketRouteHandshake:
@@ -512,102 +410,3 @@ class TestRouterLevelDependsBreaksWebSocketScope:
 
         with client.websocket_connect("/ws/fixed"):
             pass
-
-
-def _dump_routes_main() -> None:
-    """Subprocess entrypoint (see ``_run_terminal_route_dump`` above): import
-    ``api.terminal`` in a fresh interpreter and print its routes as JSON.
-
-    Kept in this module, like ``core_test.py``'s ``_main``, so the isolation
-    the tests need travels with them rather than living in a separate script.
-
-    Reports each route's concrete type name alongside its path/dependencies,
-    and the resolved fastapi/starlette/python versions, so a truncated result
-    carries enough evidence in one subprocess call to diagnose without a
-    second round-trip. That is how the defect below was found.
-
-    Enumerates a **mounted app**, not the bare ``APIRouter``. Under fastapi
-    0.141.1 / starlette 1.6.0 (what CI resolves), ``include_router`` no longer
-    flattens the child's routes into ``parent.routes`` eagerly -- it appends a
-    single deferred ``_IncludedRouter`` entry with no ``path``, and the child's
-    routes materialise only when an app mounts it. Reading ``router.routes``
-    there returned 3 entries instead of 26 (job 98088603289) while every route
-    was perfectly fine at runtime. Mounting first is correct on both versions,
-    and asks the question the guard actually cares about: what does the
-    application serve, and with which dependencies.
-    """
-    import sys as _sys
-
-    import fastapi as _fastapi
-    import starlette as _starlette
-
-    import api.terminal as terminal_module
-
-    def _dep_names(route) -> list:
-        """Every dependency callable on a leaf route, fully merged.
-
-        ``route.dependant.dependencies`` is the set FastAPI actually resolves,
-        already including anything inherited from the routers the route was
-        included through -- which is exactly the question a gate check asks.
-        ``route.dependencies`` is the un-merged declaration and is the fallback.
-        """
-        dependant = getattr(route, "dependant", None)
-        if dependant is not None:
-            return sorted(
-                f"{dep.call.__module__}.{dep.call.__qualname__}"
-                for dep in getattr(dependant, "dependencies", [])
-                if getattr(dep, "call", None) is not None
-            )
-        return sorted(
-            f"{dep.dependency.__module__}.{dep.dependency.__qualname__}"
-            for dep in getattr(route, "dependencies", [])
-            if getattr(dep, "dependency", None) is not None
-        )
-
-    def _walk(container, prefix: str) -> list:
-        """Flatten deferred ``_IncludedRouter`` wrappers into real routes.
-
-        Under fastapi 0.141.1 neither ``include_router`` nor mounting an app
-        flattens eagerly: both leave a wrapper whose ``.original_router`` holds
-        the real routes, and whose own path is ``None``. Same idiom the repo
-        already uses in ``llc/tests/test_roles_routes_registered.py``,
-        ``api/codebase_analytics/endpoints/impact_endpoint_test.py`` and
-        ``api/self_capabilities_integration_test.py`` -- copied here rather than
-        invented, though the fact that four files now carry it by hand is its
-        own problem.
-        """
-        found = []
-        for route in getattr(container, "routes", []) or []:
-            original = getattr(route, "original_router", None)
-            if original is not None:
-                sub_prefix = getattr(route, "prefix", "") or getattr(original, "prefix", "") or ""
-                found.extend(_walk(original, prefix + sub_prefix))
-                continue
-            path = getattr(route, "path", None)
-            found.append(
-                {
-                    "path": None if path is None else prefix + path,
-                    "type": type(route).__name__,
-                    "dependencies": _dep_names(route),
-                }
-            )
-        return found
-
-    app = _fastapi.FastAPI()
-    app.include_router(terminal_module.router)
-
-    routes = [r for r in _walk(app, "") if not (r["path"] or "").startswith(("/openapi.json", "/docs", "/redoc"))]
-    print(
-        json.dumps(
-            {
-                "routes": routes,
-                "python": _sys.version,
-                "fastapi": getattr(_fastapi, "__version__", "unknown"),
-                "starlette": getattr(_starlette, "__version__", "unknown"),
-            }
-        )
-    )
-
-
-if __name__ == "__main__":
-    _dump_routes_main()


### PR DESCRIPTION
## Thinking Path

The closure audit on #14961 left exactly one criterion short. AC4 asks for a test that
asserts the unknown-session case is rejected **driving the real route** — and no route-level
unknown-session handshake existed anywhere in the repo. `terminal_websocket_route_test.py`
drove the real route for the owner, unauthenticated and non-owner cases only; the
unknown-session case was covered handler-level, by `await terminal_websocket(ws, id)`.

That distinction is not a formality. A test that calls the handler bypasses routing and
dependency resolution, which is exactly how #14998 stayed invisible: the terminal WebSocket
route `500`'d for every caller inside `solve_dependencies` for the entire period its
handler-level guard tests stayed green. A criterion about what a client experiences needs a
test that goes through the ASGI stack.

Two things then had to be right for the new test to mean anything.

**Distinguishing the two rejection branches.** The unknown-session branch and the ownership
branch both exit through the one `close(code=1008)` in `terminal_websocket`. The close code
alone therefore cannot tell them apart, and a regression that turned "unknown" into "not the
owner" would pass silently. The `caplog` pair — the unknown-session message present, the
ownership message absent — is what makes the test discriminating. The existing non-owner case
already pins the mirror direction, so the two together bracket the shared exit.

**Distinguishing "unknown" from "store unreachable".** The session config store is Redis-backed
and **fails closed**: when Redis is unavailable every lookup answers `None`, so every session
looks unknown and the route closes `1008` for entirely the wrong reason — the test would pass
vacuously. The fix is a non-vacuity witness: the test requests the `owned_session_id` fixture
and reads that session back out of the fakeredis-backed store before connecting. A store that
round-trips a real session is demonstrably live, which makes the subsequent miss on a fresh
UUID a genuine absence rather than an outage.

**On the file split.** `terminal_websocket_route_test.py` was already **613 lines against the
600-line guard** on the merged base, with no ceiling entry — `check_python_file_size.py
--audit-ceilings` exits 1 on `Dev_new_gui` today for this one file. Adding to it was not an
option, and neither was a grandfather entry. The seam taken is the one the file's own docstring
already described: it answered two unrelated questions. *Which dependency is attached to which
route* needs no fixtures, no fakeredis and no auth stubbing, and reads from a clean subprocess
import. *What a real client experiences on the wire* needs all three. Those are now separate
modules, both well inside the limit, and the audit is green again.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/api/terminal_websocket_route_test.py` | Adds `TestTerminalWebsocketRouteHandshake::test_unknown_session_is_refused` (AC4). Structural half moved out; 613 → 412 lines |
| `autobot-backend/api/terminal_router_dependency_wiring_test.py` | New. The router/dependency-wiring assertions and the subprocess route dump, moved verbatim; 264 lines |

The new test asserts, through `TestClient`, against a `session_id` never written to the store:

- `WebSocketDisconnect` with code **`1008`** on the wire;
- accept-spy count of **0** — refused before `accept()`;
- `_init_terminal_handler` **never awaited** — no `TerminalWebSocket` constructed, no shell started;
- via `caplog`, the **unknown-session** branch fired and the **ownership** branch did not.

No production code changed. `api/terminal.py` is untouched and stays at exactly 1299 lines.
No `KNOWN_LARGE` entry added and no ceiling raised; no file that carries a ceiling changed size,
so neither ratchet list needed an edit.

## Verification

| Check | Result |
|---|---|
| `pytest` — both route modules + `terminal_websocket_auth_test.py` | **24 passed** |
| Existing route tests (owner / unauthenticated / non-owner / tool gates / contrast mutation) | all still pass |
| `check_python_file_size.py --audit-ceilings` | **rc 0** — 4871 files scanned, 509 grandfathered, all at size (was **rc 1** on the base, on this very file) |
| `bandit -c .bandit -q` | rc 0 |
| `py_compile` | clean |
| `black --check --line-length 120` | 2 files unchanged |
| `isort --check-only` | clean |
| `flake8 --max-line-length 120` | clean |
| Branch behind base | **0** |

**Contrast mutation 1 — make the unknown-session path permissive** (return `{}` instead of
`None`, so absence stops being a terminal condition):

```
E   Failed: DID NOT RAISE <class 'starlette.websockets.WebSocketDisconnect'>
FAILED ...::test_unknown_session_is_refused
1 failed, 17 deselected
```

The handshake succeeds instead of being refused — the test fails at the disconnect assertion,
before it ever reaches the log checks. Restored.

**Contrast mutation 2 — invert the log branch** so the unknown-session path emits the ownership
message:

```
E   assert any("unknown session_id" in r.message for r in caplog.records)
E   assert False
------------------------------ Captured log call -------------------------------
WARNING  api.terminal:terminal.py:727 Terminal WebSocket rejected: alice is not the owner of session 0b2683d0-...
FAILED ...::test_unknown_session_is_refused
1 failed, 17 deselected
```

This is the one that matters. The `1008`, the accept-spy count and `assert_not_awaited` all
still pass — the failure is the `caplog` assertion alone. The distinguishability check is
load-bearing, not decorative: without it this mutation would ship green. Restored.

**AC1–AC3 still met on the merged base** (`16c104be5`, unchanged by this PR):

| # | Criterion | Evidence |
|---|---|---|
| 1 | Unknown `session_id` rejected; no `TerminalWebSocket`, no shell | `api/terminal.py:725-727` — `.get(session_id)` with no default; `None` logs and returns, route closes `1008` before `accept()`. Now proven route-level by this PR |
| 2 | No default `SecurityLevel` for an unknown session | The single `SecurityLevel(config.get(...))` at `api/terminal.py:761` sits inside `_init_terminal_handler`, which is unreachable without an existence- and ownership-validated config |
| 3 | Cross-worker lookup fixed, not deferred | `services/terminal_session_store.py` wired at `api/terminal_handlers.py:1303` — `SessionConfigStore()` replaces the process-local dict |

## Model Used

Claude Opus 5 (1M context)

Closes #14961
