### PR TITLE
fix(security): wire per-endpoint enforcement overrides into the ownership decision (#15086)

### DIFF
--- a/autobot-backend/security/endpoint_enforcement.py
+++ b/autobot-backend/security/endpoint_enforcement.py
@@ -1,0 +1,66 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Wire a per-endpoint enforcement override into an authorization decision (#15086).
+
+`FeatureFlags.get_endpoint_enforcement` (`services/feature_flags.py`) read its
+key correctly -- it was never part of the `_redis` bug fixed for #15089. Its
+defect was narrower: nothing called it. `set_endpoint_enforcement` and
+`remove_endpoint_enforcement` (`api/feature_flags.py`) accept and audit-log a
+per-endpoint override; `SessionOwnershipValidator` read only the global mode.
+An operator could set an endpoint to `enforced`, see it accepted, audit-logged,
+and read back -- and it never reached an authorization decision.
+
+Split into its own module rather than added to `session_ownership.py`: that
+file is grandfathered at its current size (#14236) and may not grow.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from autobot_shared.logging_manager import get_logger
+from services.feature_flags import EnforcementMode, combine_enforcement_modes
+
+logger = get_logger(__name__)
+
+
+def route_pattern(request: Request) -> str:
+    """The endpoint identity used to look up a per-endpoint override.
+
+    Uses the route's path *template* (e.g. ``/api/chat/sessions/{session_id}``)
+    when FastAPI has resolved one -- matching what an operator is told to write
+    by ``set_endpoint_enforcement``'s docstring (`api/feature_flags.py`). Falls
+    back to the concrete request path when routing has not attached a route, so
+    a lookup never raises for want of one; that fallback simply matches no
+    stored override.
+    """
+    route = getattr(request, "scope", {}).get("route") if hasattr(request, "scope") else None
+    route_path = getattr(route, "path", None)
+    return route_path if isinstance(route_path, str) and route_path else str(request.url.path)
+
+
+async def effective_enforcement_mode(feature_flags, global_mode: str, request: Request) -> str:
+    """Combine *global_mode* with any per-endpoint override for *request*'s route.
+
+    The stricter of the two always wins -- see :func:`combine_enforcement_modes`
+    for the precedence rule and its justification. A failed or absent override
+    degrades to *global_mode* unchanged; it can never make the result weaker.
+    """
+    if feature_flags is None:
+        return global_mode
+
+    endpoint = route_pattern(request)
+    try:
+        override = await feature_flags.get_endpoint_enforcement(endpoint)
+    except Exception as exc:
+        logger.warning(
+            "Could not read per-endpoint enforcement override for %s (%s); using global mode %s.",
+            endpoint,
+            exc,
+            global_mode,
+        )
+        return global_mode
+
+    return combine_enforcement_modes(EnforcementMode(global_mode), override).value

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException, Request
 from auth_middleware import get_auth_middleware
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_30_DAYS
+from security.endpoint_enforcement import effective_enforcement_mode
 from services.feature_flags import EnforcementModeUnavailable
 
 logger = get_logger(__name__)
@@ -282,6 +283,10 @@ class SessionOwnershipValidator:
             )
             return DEGRADED_ENFORCEMENT_MODE
 
+    async def _get_enforcement_mode_for_request(self, request: Request) -> str:
+        """Global mode, tightened by any stricter per-endpoint override (#15086)."""
+        return await effective_enforcement_mode(self.feature_flags, await self._get_enforcement_mode(), request)
+
     def _audit_log_violation(
         self,
         username: str,
@@ -498,16 +503,12 @@ class SessionOwnershipValidator:
                 detail="You do not have permission to access this conversation",
             )
 
-    async def _resolve_fast_paths(
-        self,
-        session_id: str,
-        user_data: Dict,
-    ) -> Dict | None:
+    async def _resolve_fast_paths(self, session_id: str, user_data: Dict, enforcement_mode: str) -> Dict | None:
         """Helper for validate_ownership. Ref: #1088.
 
         Checks the two early-exit conditions that bypass ownership lookup:
         1. Auth is disabled globally (development mode).
-        2. Enforcement mode is "disabled".
+        2. Enforcement mode is "disabled" (resolved by the caller, incl. #15086 overrides).
 
         Returns the result dict when a fast path applies, or None to signal
         that the caller should proceed to the full ownership check.
@@ -519,8 +520,6 @@ class SessionOwnershipValidator:
                 "user_data": user_data,
                 "reason": "auth_disabled",
             }
-
-        enforcement_mode = await self._get_enforcement_mode()
 
         if enforcement_mode == "disabled":
             logger.debug(f"[DISABLED MODE] Skipping ownership validation for session {session_id[:8]}...")
@@ -659,12 +658,12 @@ class SessionOwnershipValidator:
         """
         user_data = self._get_authenticated_user(session_id, request)
         username = user_data["username"]
+        enforcement_mode = await self._get_enforcement_mode_for_request(request)
 
-        fast_path_result = await self._resolve_fast_paths(session_id, user_data)
+        fast_path_result = await self._resolve_fast_paths(session_id, user_data, enforcement_mode)
         if fast_path_result is not None:
             return fast_path_result
 
-        enforcement_mode = await self._get_enforcement_mode()
         return await self._resolve_ownership(session_id, username, user_data, request, enforcement_mode)
 
     async def get_user_sessions(self, username: str) -> list[str]:

--- a/autobot-backend/security/session_ownership_endpoint_enforcement_test.py
+++ b/autobot-backend/security/session_ownership_endpoint_enforcement_test.py
@@ -1,0 +1,252 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Wire a per-endpoint enforcement override into the authorization decision (#15086).
+
+`get_endpoint_enforcement` (`services/feature_flags.py`) read its key correctly
+-- it was never part of the `_redis` bug fixed for #15089. Its defect was
+narrower and worse: nothing called it. `set_endpoint_enforcement` and
+`remove_endpoint_enforcement` (`api/feature_flags.py`) accept and audit-log a
+per-endpoint override; `SessionOwnershipValidator._get_enforcement_mode` read
+only the global mode. An operator could set an endpoint to `enforced`, see it
+accepted, audit-logged, and read back -- and it never reached an authorization
+decision. A control that reports being on while being off.
+
+These tests drive `validate_ownership` end-to-end (not just the getter) so a
+correct resolver whose *consumer* still ignores it would still be caught here,
+one level up -- the same shape #14010's `TestTheDegradedModeStillRunsAndRecordsTheCheck`
+pins for the global-mode case.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from security.session_ownership import SessionOwnershipValidator
+from services.feature_flags import EnforcementMode
+
+BACKEND_ROOT = pathlib.Path(__file__).parent.parent
+
+SKIP_DIR_PARTS = {
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "archive",
+    "migrations",
+}
+
+
+def _validator(global_mode: EnforcementMode, endpoint_override: EnforcementMode | None):
+    flags = MagicMock()
+    flags.get_enforcement_mode = AsyncMock(return_value=global_mode)
+    flags.get_endpoint_enforcement = AsyncMock(return_value=endpoint_override)
+
+    validator = SessionOwnershipValidator.__new__(SessionOwnershipValidator)
+    validator.redis = MagicMock()
+    validator.feature_flags = flags
+    validator.metrics_service = None
+    validator.get_session_owner = AsyncMock(return_value="alice")
+    validator._is_org_admin_access = AsyncMock(return_value=False)
+    validator._get_authenticated_user = MagicMock(
+        return_value={"username": "bob", "user_id": "bob-id", "auth_disabled": False}
+    )
+    return validator
+
+
+def _request(route_path: str = "/api/chat/sessions/{session_id}"):
+    request = MagicMock()
+    request.scope = {"route": MagicMock(path=route_path)}
+    request.url.path = "/api/chat/sessions/abc123"
+    request.client.host = "198.51.100.7"
+    return request
+
+
+def _auth_enabled():
+    auth = MagicMock()
+    auth.enable_auth = True
+    return patch("security.session_ownership.get_auth_middleware", return_value=auth)
+
+
+class TestAPerEndpointOverrideChangesTheDecision:
+    """The defect: a written override that never reached authorization."""
+
+    @pytest.mark.asyncio
+    async def test_enforced_override_refuses_a_non_owner_the_global_mode_alone_would_allow(self):
+        """The exact scenario in #15086: global is `disabled` (would allow
+        everyone through the `_resolve_fast_paths` short-circuit), but this
+        endpoint has an `enforced` override. The non-owner must be refused --
+        asserting the raised 403, not merely that the getter was called.
+        """
+        validator = _validator(EnforcementMode.DISABLED, EnforcementMode.ENFORCED)
+
+        with _auth_enabled():
+            with pytest.raises(HTTPException) as exc_info:
+                await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert exc_info.value.status_code == 403
+        validator.get_session_owner.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_contrast_global_disabled_alone_allows(self):
+        """Same global mode, no override -- the pre-#15086 behaviour, so the
+        test above cannot be passing because `disabled` always refuses."""
+        validator = _validator(EnforcementMode.DISABLED, None)
+
+        with _auth_enabled():
+            result = await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert result["authorized"] is True
+        assert result["reason"] == "enforcement_disabled"
+        assert validator.get_session_owner.await_count == 0, "disabled must still skip the ownership lookup"
+
+
+class TestAnEndpointWithNoOverrideIsUnchanged:
+    """The half that must NOT move: no override stored anywhere for this route."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "global_mode,expected_reason",
+        [
+            (EnforcementMode.DISABLED, "enforcement_disabled"),
+            (EnforcementMode.LOG_ONLY, "log_only_mode"),
+        ],
+    )
+    async def test_behaviour_matches_the_pre_wiring_outcome(self, global_mode, expected_reason):
+        validator = _validator(global_mode, None)
+
+        with _auth_enabled():
+            result = await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert result["authorized"] is True
+        assert result["reason"] == expected_reason
+
+    @pytest.mark.asyncio
+    async def test_enforced_global_with_no_override_still_refuses(self):
+        validator = _validator(EnforcementMode.ENFORCED, None)
+
+        with _auth_enabled():
+            with pytest.raises(HTTPException) as exc_info:
+                await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_no_request_and_a_no_override_request_resolve_identically(self):
+        """A caller with no request object (existing call sites, if any) and one
+        whose route has no stored override must reach the same mode -- looking
+        an override up must never itself be a behaviour change."""
+        validator = _validator(EnforcementMode.LOG_ONLY, None)
+
+        without_request = await validator._get_enforcement_mode()
+        with_request = await validator._get_enforcement_mode_for_request(_request())
+
+        assert without_request == with_request == "log_only"
+
+
+class TestPrecedenceInTheDisagreementCase:
+    """Stricter side wins -- pinned against the specific case #15086 calls out:
+    an endpoint override must not loosen enforcement below the global mode.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_disabled_override_cannot_exempt_an_endpoint_the_global_mode_enforces(self):
+        """#15086's own words: 'Setting an endpoint to disabled while the global
+        mode is enforced reads as an exemption. It is not.' This is that case,
+        driven through the real decision path.
+        """
+        validator = _validator(EnforcementMode.ENFORCED, EnforcementMode.DISABLED)
+
+        with _auth_enabled():
+            with pytest.raises(HTTPException) as exc_info:
+                await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_an_enforced_override_does_win_over_a_log_only_global(self):
+        """The tightening direction, contrasted against the loosening one above
+        so the precedence rule cannot be mistaken for "override always wins" by
+        accident -- both directions must be exercised for it to be pinned.
+        """
+        validator = _validator(EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED)
+
+        with _auth_enabled():
+            with pytest.raises(HTTPException) as exc_info:
+                await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert exc_info.value.status_code == 403
+
+
+class TestAnUnreadableOverrideDegradesNoMorePermissivelyThanGlobal:
+    @pytest.mark.asyncio
+    async def test_a_failing_override_lookup_falls_back_to_the_global_mode(self):
+        validator = _validator(EnforcementMode.ENFORCED, None)
+        validator.feature_flags.get_endpoint_enforcement = AsyncMock(side_effect=RuntimeError("redis down"))
+
+        with _auth_enabled():
+            with pytest.raises(HTTPException) as exc_info:
+                await validator.validate_ownership("sess-1234abcd", _request())
+
+        assert exc_info.value.status_code == 403, "an unreadable override must not weaken an enforced global mode"
+
+
+def _endpoint_enforcement_references() -> tuple[str, ...]:
+    """``path:line`` for every textual reference to ``get_endpoint_enforcement``
+    across the backend -- the definition, its callers, and its tests alike.
+    """
+    hits: list[str] = []
+    for path in BACKEND_ROOT.rglob("*.py"):
+        if SKIP_DIR_PARTS & set(path.parts):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if "get_endpoint_enforcement" not in source:
+            continue
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if "get_endpoint_enforcement" in line:
+                hits.append(f"{path.relative_to(BACKEND_ROOT).as_posix()}:{lineno}")
+    return tuple(hits)
+
+
+def test_get_endpoint_enforcement_has_a_non_test_caller():
+    """The regression this issue exists to prevent: a getter that only its own
+    definition (and, now, its tests) ever mention is write-only again.
+    """
+    references = _endpoint_enforcement_references()
+
+    # Non-vacuity: the sweep must at least find the definition it is named
+    # after, or it swept nothing and every assertion below passes for free.
+    assert references, "the sweep found zero references to get_endpoint_enforcement -- the sweep itself is broken"
+
+    def _defines_it(path_part: str) -> bool:
+        """Whether *path_part* (a ``path:line`` reference's file) is the
+        ``async def get_endpoint_enforcement`` declaration itself, as opposed
+        to a call site. Checked by AST rather than string-matching ``def`` so a
+        comment or docstring mentioning the name is not mistaken for a caller.
+        """
+        file_path = BACKEND_ROOT / path_part
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"))
+        except (SyntaxError, OSError):
+            return False
+        return any(
+            isinstance(node, ast.AsyncFunctionDef) and node.name == "get_endpoint_enforcement"
+            for node in ast.walk(tree)
+        )
+
+    non_definition_refs = [ref for ref in references if not _defines_it(ref.split(":")[0])]
+    non_test_refs = [ref for ref in non_definition_refs if "_test.py" not in ref and "/tests/" not in ref]
+
+    assert non_test_refs, (
+        "get_endpoint_enforcement has no non-test, non-definition caller -- it is "
+        f"write-only again (#15086). All references: {sorted(references)}"
+    )

--- a/autobot-backend/services/feature_flags.py
+++ b/autobot-backend/services/feature_flags.py
@@ -63,6 +63,40 @@ class EnforcementModeUnavailable(RuntimeError):
     """
 
 
+# How strictly each mode gates access, from most to least permissive. Used only
+# to compare a global mode against a per-endpoint override (#15086) -- never to
+# order modes for any other purpose.
+_ENFORCEMENT_STRICTNESS: dict[EnforcementMode, int] = {
+    EnforcementMode.DISABLED: 0,
+    EnforcementMode.LOG_ONLY: 1,
+    EnforcementMode.ENFORCED: 2,
+}
+
+
+def combine_enforcement_modes(global_mode: EnforcementMode, override: EnforcementMode | None) -> EnforcementMode:
+    """Combine the global enforcement mode with a per-endpoint override (#15086).
+
+    Precedence: the **stricter** of the two wins. An override can tighten
+    enforcement above the global mode -- an operator turning ``enforced`` on for
+    one endpoint while the fleet is still ``log_only`` -- but it can never
+    loosen enforcement below the global mode. Letting an override relax below
+    the platform-wide posture would make it a per-endpoint fail-open: the same
+    class of defect as #14010 and #14866, a control that reads as protection
+    while doing the opposite.
+
+    ``override=None`` means no override is stored, or reading one failed and
+    degraded to "no opinion" rather than to a value (see
+    :meth:`FeatureFlags.get_endpoint_enforcement`) -- either way the global mode
+    applies unchanged. This is also why a failed override read cannot yield a
+    weaker mode than the global one: it never contributes a mode at all.
+    """
+    if override is None:
+        return global_mode
+    if _ENFORCEMENT_STRICTNESS[override] > _ENFORCEMENT_STRICTNESS[global_mode]:
+        return override
+    return global_mode
+
+
 # The single Redis key the platform's whole access-control posture is read from.
 # It was a literal repeated at each reader and writer; provisioning has to name
 # the same key, and a fourth copy of a string is how the fourth copy drifts.

--- a/autobot-backend/services/feature_flags_endpoint_precedence_test.py
+++ b/autobot-backend/services/feature_flags_endpoint_precedence_test.py
@@ -1,0 +1,85 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``combine_enforcement_modes`` pins the precedence decision for #15086.
+
+`get_endpoint_enforcement` (`services/feature_flags.py`) had exactly one caller
+before this issue: its own definition. An operator could write a per-endpoint
+override, see it accepted and audit-logged, read it back -- and it never
+reached an authorization decision.
+
+The precedence chosen here: the **stricter** side wins. A per-endpoint
+override may tighten enforcement above the global mode; it may never loosen it
+below. Allowing a per-endpoint override to relax below the global mode would be
+a per-endpoint fail-open -- the same class of defect as #14010 and #14866,
+just with a narrower blast radius.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.feature_flags import EnforcementMode, combine_enforcement_modes
+
+#: Every ordered pair of modes, used for the exhaustive precedence sweep below.
+_ALL_MODE_PAIRS: tuple[tuple[EnforcementMode, EnforcementMode], ...] = tuple(
+    (g, o) for g in EnforcementMode for o in EnforcementMode
+)
+
+
+def _stricter(a: EnforcementMode, b: EnforcementMode) -> EnforcementMode:
+    """Independent re-derivation of "stricter", so the test does not just
+    reimplement the function it is pinning."""
+    order = [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED]
+    return a if order.index(a) >= order.index(b) else b
+
+
+class TestNoOverrideLeavesTheGlobalModeUntouched:
+    """The half that must NOT change: an endpoint with no override stored."""
+
+    @pytest.mark.parametrize("global_mode", list(EnforcementMode))
+    def test_no_override_is_the_global_mode_verbatim(self, global_mode):
+        assert combine_enforcement_modes(global_mode, None) == global_mode
+
+    def test_the_sweep_itself_is_not_empty(self):
+        """Non-vacuity: a parametrize list that silently became empty must fail
+        loudly, not pass by skipping every case."""
+        assert list(EnforcementMode), "EnforcementMode has no members -- the sweep above tested nothing"
+
+
+class TestAnOverrideCanTightenButNeverLoosen:
+    """The wiring this issue exists for."""
+
+    def test_enforced_override_wins_over_disabled_global(self):
+        """The exact scenario #15086 reports: an endpoint set to enforced while
+        the fleet is disabled must actually become enforced."""
+        assert combine_enforcement_modes(EnforcementMode.DISABLED, EnforcementMode.ENFORCED) == EnforcementMode.ENFORCED
+
+    def test_disabled_override_cannot_loosen_an_enforced_global(self):
+        """The exact scenario #15086 reports as the opposite-direction defect:
+        an endpoint "exempted" while the fleet enforces must keep enforcing."""
+        assert combine_enforcement_modes(EnforcementMode.ENFORCED, EnforcementMode.DISABLED) == EnforcementMode.ENFORCED
+
+    def test_log_only_override_cannot_loosen_an_enforced_global(self):
+        assert combine_enforcement_modes(EnforcementMode.ENFORCED, EnforcementMode.LOG_ONLY) == EnforcementMode.ENFORCED
+
+    def test_log_only_override_tightens_a_disabled_global(self):
+        assert combine_enforcement_modes(EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY) == EnforcementMode.LOG_ONLY
+
+
+class TestTheExhaustiveSweepMatchesStricterWinsForEveryPair:
+    """Every (global, override) combination independently re-derived.
+
+    A hand-picked set of examples can pass by accident if the implementation
+    is subtly wrong for a pair no one thought to write down. This sweeps the
+    full 3x3 space.
+    """
+
+    @pytest.mark.parametrize("global_mode,override", _ALL_MODE_PAIRS)
+    def test_matches_the_independent_stricter_of_the_two(self, global_mode, override):
+        assert combine_enforcement_modes(global_mode, override) == _stricter(global_mode, override)
+
+    def test_the_pair_sweep_is_not_empty(self):
+        """Non-vacuity: nine pairs are expected; fewer means the generator broke."""
+        assert len(_ALL_MODE_PAIRS) == 9, f"expected all 3x3 mode pairs, got {len(_ALL_MODE_PAIRS)}: {_ALL_MODE_PAIRS}"

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -328,7 +328,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/security/input_validator.py": 607,
     "autobot-backend/security/prompt_injection_detector.py": 747,
     "autobot-backend/security/security_edge_cases_test.py": 638,
-    "autobot-backend/security/session_ownership.py": 859,
+    "autobot-backend/security/session_ownership.py": 858,
     "autobot-backend/security/threat_detection_refactor_test.py": 880,
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -323,7 +323,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/security/input_validator.py": 607,
     "autobot-backend/security/prompt_injection_detector.py": 747,
     "autobot-backend/security/security_edge_cases_test.py": 638,
-    "autobot-backend/security/session_ownership.py": 859,
+    "autobot-backend/security/session_ownership.py": 858,
     "autobot-backend/security/threat_detection_refactor_test.py": 880,
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,


### PR DESCRIPTION
## Thinking Path

`get_endpoint_enforcement` (`services/feature_flags.py`) reads its key correctly via `await redis.get(...)` -- confirmed separate from the `_redis` bug fixed for #15089. Its defect: `git grep get_endpoint_enforcement` on `Dev_new_gui` returns exactly one hit, its own definition. `set_endpoint_enforcement` / `remove_endpoint_enforcement` (`api/feature_flags.py`) accept and audit-log a per-endpoint override; `SessionOwnershipValidator._get_enforcement_mode` (`security/session_ownership.py`) and its two call sites (`_resolve_fast_paths`, `validate_ownership`) consulted only the global mode. An operator could set an endpoint to `enforced`, see it accepted, audit-logged, and read back -- and it never reached an authorization decision.

**Precedence decision: the stricter side wins.** An override may tighten enforcement above the global mode (the exact scenario reported: endpoint `enforced` while global is `disabled`) but may never loosen it below (the opposite-direction case the issue also calls out: endpoint `disabled` while global is `enforced` must keep enforcing). This matches the codebase's standing rule that where two paths disagree about what is permitted, the stricter one wins. Implemented as `combine_enforcement_modes(global_mode, override)` in `services/feature_flags.py`, ranking `DISABLED < LOG_ONLY < ENFORCED`.

**Endpoints with no override are unaffected.** `override=None` (no key stored, or a failed read -- `get_endpoint_enforcement` already degrades failures to `None` rather than a value) returns `global_mode` unchanged; verified by `TestAnEndpointWithNoOverrideIsUnchanged` and `TestNoOverrideLeavesTheGlobalModeUntouched`, and by an exhaustive 3x3 sweep of every (global, override) pair against an independently re-derived "stricter" function.

**Undetermined-override path:** a failing/misbehaving override lookup is caught in `effective_enforcement_mode` and falls back to `global_mode` -- never weaker, matching the `#14010` degrade discipline `_get_enforcement_mode`'s own global-mode resolution already follows.

`session_ownership.py` is grandfathered at its current line count (#14236) and may not grow, so the combining logic and route-pattern lookup live in a new `security/endpoint_enforcement.py` module; `session_ownership.py` only gained a thin `_get_enforcement_mode_for_request` delegator and a threaded `enforcement_mode` parameter on `_resolve_fast_paths`. The file's net change is -1 line, so its ceiling is lowered from 859 to 858 in both `scripts/python_file_size_known_large.py` and `repo_tests/python_file_size_ratchet_baseline.py`.

## What Changed

- `autobot-backend/services/feature_flags.py`: added `combine_enforcement_modes(global_mode, override)` -- the pure precedence function ("stricter wins"), plus `_ENFORCEMENT_STRICTNESS` ranking.
- `autobot-backend/security/endpoint_enforcement.py` (new): `route_pattern(request)` resolves the FastAPI route template (matching what `set_endpoint_enforcement`'s docstring tells operators to write) with a safe fallback to the concrete path; `effective_enforcement_mode(feature_flags, global_mode, request)` looks up the per-endpoint override and combines it, degrading to `global_mode` on any lookup failure.
- `autobot-backend/security/session_ownership.py`: `validate_ownership` now resolves the enforcement mode once per request via the new `_get_enforcement_mode_for_request`, and threads it into `_resolve_fast_paths` (previously the `disabled` fast-path check only ever saw the global mode -- now it sees the combined one, so a stricter per-endpoint override is not bypassed by that shortcut) and `_resolve_ownership`. `_get_enforcement_mode` (global-only) is unchanged and still used directly by existing tests/callers with no request.
- `scripts/python_file_size_known_large.py`, `repo_tests/python_file_size_ratchet_baseline.py`: `session_ownership.py` ceiling 859 -> 858 (file shrank by one line net).
- Tests: `autobot-backend/services/feature_flags_endpoint_precedence_test.py` (pure-function precedence, exhaustive 3x3 sweep, non-vacuity assertions), `autobot-backend/security/session_ownership_endpoint_enforcement_test.py` (decision-path wiring through `validate_ownership`, precedence in the disagreement case, unreadable-override degrade, and a guard asserting `get_endpoint_enforcement` has a non-test, non-definition caller so it cannot silently go orphaned again).

## Verification

- Targeted suite (118 tests across the new files plus every existing session-ownership/feature-flags/chat-session-ownership test): all pass.
- `scripts/check_python_file_size.py --audit-ceilings`: clean for every file this PR touches. One pre-existing, unrelated failure (`autobot-backend/api/terminal_websocket_route_test.py`, 613 > 600) predates this branch (introduced by 16c104be5 / #15100) and is filed separately as #15103 rather than folded into this PR's scope.
- `black --check --line-length 120`, `isort --check-only`, `bandit -c .bandit -q`, `python3 -m py_compile`: all clean on every changed/new file.
- **Contrast mutation 1** (unwire the call -- `effective_enforcement_mode` returns `global_mode` unconditionally, ignoring the override): `test_enforced_override_refuses_a_non_owner_the_global_mode_alone_would_allow` fails (`DID NOT RAISE HTTPException`). Reverted; suite green again.
- **Contrast mutation 2** (invert precedence -- `combine_enforcement_modes` returns `override` unconditionally instead of the stricter of the two): `test_a_disabled_override_cannot_exempt_an_endpoint_the_global_mode_enforces` fails (`DID NOT RAISE HTTPException`), along with 5 of the pure-function precedence tests. Reverted; suite green again.
- Branch is 0 behind `origin/Dev_new_gui` (`git fetch` + `git diff HEAD origin/Dev_new_gui` run and read as their own step before this push).
- No live Redis touched: every test drives `FeatureFlags`/`SessionOwnershipValidator` through `AsyncMock`, matching the existing test style in this module.

## Model Used

Claude Sonnet 5

Closes #15086