### PR TITLE
fix(terminal): resolve SSH host_id against the infrastructure host registry (#14991)

### DIFF
--- a/autobot-backend/api/ssh_terminal_websocket_auth_test.py
+++ b/autobot-backend/api/ssh_terminal_websocket_auth_test.py
@@ -6,22 +6,29 @@
 (#14991).
 
 This deprecated infrastructure-SSH WebSocket had no authentication at all,
-reachable live from the primary chat UI (SSHTerminal.vue -> ChatTabContent.vue)
-with no per-host permission model anywhere in the codebase to scope a
-host_id against a caller. It must (1) authenticate before accept(), and (2)
-require admin role -- the strictest reading available without inventing a
-new capability model -- for every host_id, since no finer grain exists.
+reachable live from the primary chat UI (SSHTerminal.vue -> ChatTabContent.vue).
+It must (1) authenticate before accept(), (2) require admin role -- the
+strictest reading available without inventing a new capability model, since
+no per-admin-host ownership model exists anywhere in the codebase (#14964 is
+open and unimplemented, and is scoped to paired-device capabilities, not
+admin-host association) -- and (3) resolve host_id against the real
+infrastructure-host registry (``resolve_ssh_host_id``,
+``api/terminal_ssh.py``), refusing an unknown host_id distinctly from an
+admin-role refusal. Per-admin host scoping stays deferred to #14964; this is
+the decidable slice of AC2 only.
 
 Drives the real route object registered on the router. ``_setup_ssh_terminal``
 is patched with ``AsyncMock`` so a rejection test proves no SSH handler is
 ever constructed.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from api.terminal import ssh_terminal_websocket
+from api.terminal_ssh import resolve_ssh_host_id
 
 
 def _fake_websocket() -> MagicMock:
@@ -78,7 +85,8 @@ class TestSshTerminalWebsocketAuthorization:
 
     @pytest.mark.asyncio
     async def test_authenticated_admin_reaches_accept(self):
-        """#14991: an authenticated admin clears both gates and reaches accept()."""
+        """#14991: an authenticated admin, for a host_id the registry knows
+        about, clears both gates and reaches accept()."""
         ws = _fake_websocket()
         fake_terminal = MagicMock()
         fake_terminal.start = AsyncMock(return_value=False)  # stub always declines to start
@@ -88,6 +96,7 @@ class TestSshTerminalWebsocketAuthorization:
                 "auth_middleware.authenticate_websocket",
                 new=AsyncMock(return_value={"username": "admin-bob", "role": "admin"}),
             ),
+            patch("api.terminal.resolve_ssh_host_id", new=AsyncMock(return_value=True)),
             patch("api.terminal._setup_ssh_terminal", new=AsyncMock(return_value=fake_terminal)) as mock_setup,
             patch("api.terminal.ssh_terminal_manager.close_session", new=AsyncMock()),
         ):
@@ -96,3 +105,65 @@ class TestSshTerminalWebsocketAuthorization:
         ws.accept.assert_awaited_once()
         mock_setup.assert_awaited_once()
         ws.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_with_unknown_host_id_is_rejected(self, caplog):
+        """#14991 AC2: an admin is refused for a host_id the registry does not
+        know about -- refused before accept(), and never reaches
+        ``_setup_ssh_terminal``. ``caplog`` proves the rejection is logged as
+        an unknown-host refusal, not conflated with the admin-role refusal
+        exercised above -- the two share no text and must stay that way."""
+        ws = _fake_websocket()
+
+        with (
+            patch(
+                "auth_middleware.authenticate_websocket",
+                new=AsyncMock(return_value={"username": "admin-bob", "role": "admin"}),
+            ),
+            patch("api.terminal.resolve_ssh_host_id", new=AsyncMock(return_value=False)),
+            patch("api.terminal._setup_ssh_terminal", new=AsyncMock()) as mock_setup,
+            caplog.at_level(logging.WARNING, logger="api.terminal"),
+        ):
+            await ssh_terminal_websocket(ws, "no-such-host")
+
+        ws.close.assert_awaited_once()
+        assert ws.close.await_args.kwargs.get("code") == 1008
+        ws.accept.assert_not_awaited()
+        mock_setup.assert_not_awaited()
+        assert any("unknown host_id" in r.message for r in caplog.records)
+        assert not any("is not an admin" in r.message for r in caplog.records)
+
+
+class TestResolveSshHostId:
+    """Unit coverage for ``resolve_ssh_host_id`` itself (#14991 AC2) -- the
+    registry lookup the route-level tests above stub out."""
+
+    @pytest.mark.asyncio
+    async def test_known_host_id_resolves_true(self):
+        """Non-vacuity witness: a host_id the registry actually carries must
+        resolve positively before the absence case below means anything --
+        see ``terminal_websocket_route_test.py`` for why a fail-closed store
+        makes 'unknown' and 'unreachable' look identical otherwise."""
+        with patch(
+            "api.infrastructure._load_secrets_hosts",
+            return_value=[{"id": "prod-host-1", "name": "prod-host-1"}],
+        ):
+            assert await resolve_ssh_host_id("prod-host-1") is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_host_id_resolves_false(self):
+        with patch(
+            "api.infrastructure._load_secrets_hosts",
+            return_value=[{"id": "prod-host-1", "name": "prod-host-1"}],
+        ):
+            assert await resolve_ssh_host_id("no-such-host") is False
+
+    @pytest.mark.asyncio
+    async def test_unreachable_registry_fails_closed(self):
+        """#14991: the backing store being unavailable must deny, never pass.
+        ``_load_secrets_hosts`` already swallows its own read failures into
+        ``[]`` (api/infrastructure.py) -- this asserts the caller-visible
+        contract holds through that boundary, not just the implementation
+        detail of how it holds."""
+        with patch("api.infrastructure._load_secrets_hosts", return_value=[]):
+            assert await resolve_ssh_host_id("prod-host-1") is False

--- a/autobot-backend/api/terminal.py
+++ b/autobot-backend/api/terminal.py
@@ -187,6 +187,7 @@ from api.terminal_ssh import (  # noqa: E402
     _init_ssh_redis_client,
     _run_ssh_message_loop,
     _setup_ssh_terminal,
+    resolve_ssh_host_id,
     ssh_terminal_manager,
 )
 
@@ -878,26 +879,16 @@ async def ssh_terminal_websocket(
     """
     DEPRECATED: SSH terminal connections to infrastructure hosts.
 
-    Issue #729: This endpoint has been deprecated as part of layer separation.
-    Issue #620: Refactored to use helper functions.
+    Issue #729/#620: infra SSH now lives in slm-server; backward-compat
+    stub -- use slm-admin -> Tools -> Terminal, or /api/terminal/ssh/{host_id}.
 
-    SSH connections to infrastructure hosts are now handled by slm-server.
-
-    Use slm-admin → Tools → Terminal or the SLM API directly:
-        - SLM Terminal API: /api/terminal/ssh/{host_id}
-        - SLM Admin UI: slm-admin → Tools → Terminal
-
-    This endpoint remains for backward compatibility but returns a deprecation
-    message directing clients to use SLM for infrastructure connections.
-
-    Issue #14991: this had no authentication at all -- any caller who knew or
-    guessed a host_id reached SSHTerminalWebSocket (today an inert stub, but
-    the live shape of an interactive infrastructure shell). No per-host
-    permission model exists to scope host_id against a caller's permitted
-    set, and #14958 rules out inventing one here. The strictest reading
-    without a new capability model is admin role, checked explicitly here (a
-    router-level `Depends` cannot gate a WS route -- #14998), for every
-    host_id. Per-host granularity is out of scope (#14964).
+    Issue #14991: any caller who knew or guessed a host_id reached the inert
+    SSH stub with zero authentication. Fixed with two gates before accept():
+    admin role (#14958 rules out inventing a finer capability model; per-host
+    ownership is deferred to #14964, open and unimplemented) and host_id
+    resolved against the infrastructure-host registry (resolve_ssh_host_id,
+    api/terminal_ssh.py) -- an unknown host_id is refused and logged
+    distinctly from an admin-role refusal.
     """
     if not await enforce_ws_origin(websocket):
         return
@@ -913,6 +904,15 @@ async def ssh_terminal_websocket(
             host_id,
         )
         await websocket.close(code=1008, reason="Admin role required for infrastructure SSH access")
+        return
+
+    if not await resolve_ssh_host_id(host_id):
+        logger.warning(
+            "SSH terminal WebSocket rejected: unknown host_id %s (user %s)",
+            host_id,
+            user.get("username"),
+        )
+        await websocket.close(code=1008, reason="Unknown host_id")
         return
 
     await websocket.accept()

--- a/autobot-backend/api/terminal_ssh.py
+++ b/autobot-backend/api/terminal_ssh.py
@@ -164,6 +164,27 @@ ssh_terminal_manager = _SSHTerminalManager()
 # This endpoint now returns a deprecation message and redirects to SLM
 
 
+async def resolve_ssh_host_id(host_id: str) -> bool:
+    """Resolve host_id against the infrastructure host registry (#14991 AC2).
+
+    This is the decidable slice of AC2: whether host_id names a host that
+    exists at all. It is deliberately NOT the per-admin host-permission
+    question -- no ownership/RBAC model tying an admin to a subset of hosts
+    exists anywhere in the codebase (#14964 is open and unimplemented, and
+    is scoped to paired-device capabilities, not admin-host association;
+    #14958's audit explicitly rules out inventing a capability model here).
+    Inventing that policy is not this function's job.
+
+    Fails closed: ``_load_secrets_hosts`` already swallows its own read
+    failures into ``[]`` (api/infrastructure.py), so an unreachable registry
+    and a genuinely empty one both deny here -- never a pass.
+    """
+    from api.infrastructure import _load_secrets_hosts
+
+    known_hosts = _load_secrets_hosts()
+    return any(host.get("id") == host_id for host in known_hosts)
+
+
 async def _init_ssh_redis_client():
     """
     Initialize Redis client for SSH terminal logging.

--- a/autobot-backend/api/terminal_websocket_route_test.py
+++ b/autobot-backend/api/terminal_websocket_route_test.py
@@ -291,7 +291,20 @@ class TestTerminalWebsocketRouteHandshake:
 
 
 class TestSshTerminalWebsocketRouteHandshake:
-    """Real handshake on /ws/ssh/{host_id} via TestClient -- not a handler call."""
+    """Real handshake on /ws/ssh/{host_id} via TestClient -- not a handler call.
+
+    #14991 AC2: host_id is resolved against the real infrastructure-host
+    registry (``resolve_ssh_host_id``, api/terminal_ssh.py -- patched at its
+    source, ``api.infrastructure._load_secrets_hosts``, not mocked away, so
+    the route-level resolution path itself is exercised). Per-admin host
+    scoping is NOT covered here: no ownership model ties an admin to a
+    subset of hosts anywhere in the codebase (#14964, open, unimplemented),
+    and inventing one is out of scope for this route (#14958's audit).
+    """
+
+    @staticmethod
+    def _known_hosts():
+        return [{"id": "prod-host-1", "name": "prod-host-1"}]
 
     def test_authenticated_admin_connects(self, terminal_client):
         fake_terminal = MagicMock()
@@ -302,6 +315,7 @@ class TestSshTerminalWebsocketRouteHandshake:
                 "auth_middleware.authenticate_websocket",
                 new=AsyncMock(return_value={"username": "admin-bob", "role": "admin"}),
             ),
+            patch("api.infrastructure._load_secrets_hosts", return_value=self._known_hosts()),
             patch("api.terminal._setup_ssh_terminal", new=AsyncMock(return_value=fake_terminal)),
             patch.object(ssh_terminal_manager, "close_session", new=AsyncMock()),
             _accept_spy() as calls,
@@ -319,6 +333,62 @@ class TestSshTerminalWebsocketRouteHandshake:
 
         assert exc_info.value.code == 1008
         assert len(calls) == 0
+
+    def test_admin_with_unknown_host_id_is_refused(self, terminal_client, caplog):
+        """#14991 AC2: registry is live (positive witness on prod-host-1)
+        and admin is genuine -- only the host_id is unresolvable, and that
+        alone must refuse before accept(), logged distinctly from the
+        admin-role refusal exercised by the non-admin case below.
+        """
+        assert any(h["id"] == "prod-host-1" for h in self._known_hosts()), (
+            "the registry fixture itself must contain a resolvable host, or the "
+            "refusal below would pass vacuously with an always-empty registry"
+        )
+
+        with (
+            patch(
+                "auth_middleware.authenticate_websocket",
+                new=AsyncMock(return_value={"username": "admin-bob", "role": "admin"}),
+            ),
+            patch("api.infrastructure._load_secrets_hosts", return_value=self._known_hosts()),
+            patch("api.terminal._setup_ssh_terminal", new=AsyncMock()) as mock_setup,
+            caplog.at_level(logging.WARNING, logger="api.terminal"),
+            _accept_spy() as calls,
+        ):
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with terminal_client.websocket_connect("/ws/ssh/no-such-host"):
+                    pass
+
+        assert exc_info.value.code == 1008
+        assert len(calls) == 0
+        mock_setup.assert_not_awaited()
+        assert any("unknown host_id" in r.message for r in caplog.records)
+        assert not any("is not an admin" in r.message for r in caplog.records)
+
+    def test_non_admin_with_known_host_id_is_refused(self, terminal_client, caplog):
+        """Mirror of the unknown-host case above: a genuine, registry-known
+        host_id but a non-admin caller -- refused for role, not host, and the
+        two log lines must stay distinguishable in both directions.
+        """
+        with (
+            patch(
+                "auth_middleware.authenticate_websocket",
+                new=AsyncMock(return_value={"username": "alice", "role": "user"}),
+            ),
+            patch("api.infrastructure._load_secrets_hosts", return_value=self._known_hosts()),
+            patch("api.terminal._setup_ssh_terminal", new=AsyncMock()) as mock_setup,
+            caplog.at_level(logging.WARNING, logger="api.terminal"),
+            _accept_spy() as calls,
+        ):
+            with pytest.raises(WebSocketDisconnect) as exc_info:
+                with terminal_client.websocket_connect("/ws/ssh/prod-host-1"):
+                    pass
+
+        assert exc_info.value.code == 1008
+        assert len(calls) == 0
+        mock_setup.assert_not_awaited()
+        assert any("is not an admin" in r.message for r in caplog.records)
+        assert not any("unknown host_id" in r.message for r in caplog.records)
 
 
 class TestTerminalHttpRouteAdminGate:


### PR DESCRIPTION
## Thinking Path

#14991's closure audit found AC2 unmet: `ssh_terminal_websocket` accepted any
`host_id` string once the caller was an admin, with no resolution of whether
the host existed. The companion issue, #14964, is the designated model for
"which admin may reach which host" — but it is **open, unimplemented, and
scoped to paired-device capabilities (desktop/VNC), not admin-host
association**. No host-ownership, tenancy or RBAC-scope model tying a
specific admin to a specific host exists anywhere in the codebase, confirmed
by reading `models/`, `api/secrets.py` (dual-scoped by chat-id vs. general
pool, no per-user ownership field) and #14958's own audit, which explicitly
rules out inventing a capability model on this route.

That makes full per-admin host scoping **not decidable without inventing
authorization policy**, which is not this PR's call to make. What *is*
decidable: whether `host_id` names a host that exists at all. A real
inventory already exists — `api.infrastructure._load_secrets_hosts()`, the
same registry backing `GET /api/infrastructure/hosts` — so wiring an
existence check to it is enforcing against a real registry, not shipping a
placeholder. This is the scope-down the issue's own closure-audit comment
invited: land the unknown-host denial now, leave per-admin scoping to
#14964.

## What Changed

- `api/terminal_ssh.py`: new `resolve_ssh_host_id(host_id)` — checks
  `host_id` against `_load_secrets_hosts()`. Fails closed: that function
  already swallows its own read failures into `[]`, so an unreachable
  registry and a genuinely empty one both deny, never pass.
- `api/terminal.py`: `ssh_terminal_websocket` calls `resolve_ssh_host_id`
  after the existing admin-role check and before `accept()`. An unknown
  `host_id` closes `1008` and logs `"unknown host_id"` — text that never
  overlaps with the existing `"is not an admin"` refusal, so the two
  denial reasons stay distinguishable in logs even though both close the
  same way on the wire.
- `api/terminal.py` stays at its grandfathered 1299-line ceiling: the new
  gate (10 lines) is offset by trimming its own docstring (10 lines), not
  by growing the file. No `KNOWN_LARGE`/ratchet-baseline edit needed.
- Tests added at both layers: `ssh_terminal_websocket_auth_test.py`
  (handler-level: admin-role + host-registry gates, plus direct unit
  coverage of `resolve_ssh_host_id` including the fail-closed case) and
  `terminal_websocket_route_test.py` (route-level, via `TestClient` —
  admin+known-host connects, admin+unknown-host refused, non-admin+known-host
  refused, each with the log-distinction assertion).

**Not changed, deliberately**: no per-admin host-permission model. An admin
permitted for one host and denied another is not testable or enforceable
without inventing that policy — left to #14964.

## Verification

- `python3 -m pytest api/ssh_terminal_websocket_auth_test.py
  api/terminal_websocket_route_test.py -q` → **27 passed**.
- Contrast mutations (each applied, run, reverted):
  1. `resolve_ssh_host_id` body forced to `return True` unconditionally →
     3 named tests fail (`test_unknown_host_id_resolves_false`,
     `test_unreachable_registry_fails_closed`,
     `test_admin_with_unknown_host_id_is_refused`).
  2. Host-id gate removed entirely from `ssh_terminal_websocket` (accept()
     reached unconditionally after the admin check) → 2 named tests fail
     (`test_admin_with_unknown_host_id_is_rejected`,
     `test_admin_with_unknown_host_id_is_refused`).
  3. Unknown-host log message collapsed to the admin-role refusal's text →
     2 named tests fail on the log-distinction assertion in both files.
- `python3 scripts/check_python_file_size.py --audit-ceilings` → clean,
  4875 files scanned, 509 grandfathered, all at size.
- `black --check --line-length 120`, `isort --check-only`, `py_compile`,
  `bandit -c .bandit -q` → all clean.
- Branch 0 behind/ahead of `origin/Dev_new_gui` before push.

## Model Used

Claude Sonnet 5 (claude-sonnet-5), interactive session.

Refs #14991