### PR TITLE
fix(secrets): record failed credential access in secrets_audit (#15023)

### DIFF
--- a/autobot-backend/llm_shared/providers/bedrock_credentials.py
+++ b/autobot-backend/llm_shared/providers/bedrock_credentials.py
@@ -26,6 +26,11 @@ import json
 import re
 
 from autobot_shared.logging_manager import get_logger
+from services.secrets_audit_store import (
+    REASON_LOOKUP_ERROR,
+    REASON_MALFORMED_VALUE,
+    REASON_TYPE_MISMATCH,
+)
 from services.secrets_service import get_secrets_service
 
 logger = get_logger(__name__)
@@ -35,6 +40,11 @@ logger = get_logger(__name__)
 #: sole writer, migrate_bedrock_credentials.py.
 BEDROCK_VAULT_ENTRY_NAME = "bedrock_aws_credentials"
 BEDROCK_VAULT_ENTRY_TYPE = "aws_bedrock_credentials"
+
+#: Identity stamped on every audit row this provider causes -- the successful
+#: access and the failed ones alike, so both limbs of #15023 AC3 attribute to
+#: the same principal and a query for one finds the other.
+BEDROCK_ACCESSED_BY = "bedrock_provider"
 
 #: AWS region shape, e.g. "us-east-1", "eu-west-1", "us-gov-west-1". Used to
 #: validate a region resolved from SecretsService before it is used to build
@@ -111,32 +121,59 @@ def validate_credential_pair(access_key: object, secret_key: object) -> None:
         raise ValueError("Bedrock: resolved AWS secret key has an unexpected format, refusing to initialize client")
 
 
+def _audit_vault_rejection(reason: str, secret_id: str | None = None) -> None:
+    """Record a vault row *this module* rejected, after ``get_secret()`` returned it.
+
+    ``get_secret()`` audits the failures it can see itself -- no such entry, and
+    an expired one. The three below are only visible here, so without this they
+    would be a log line and nothing else, which is exactly the hole #15023's AC3
+    failure limb names. Auditing is best-effort by construction: a credential
+    path must not start failing because its audit sink did.
+    """
+    try:
+        get_secrets_service().record_access_failure(
+            reason,
+            name=BEDROCK_VAULT_ENTRY_NAME,
+            accessed_by=BEDROCK_ACCESSED_BY,
+            secret_id=secret_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - audit write must never break credential resolution
+        logger.warning("Bedrock: could not record the failed credential access: %s", type(exc).__name__)
+
+
 def load_credentials_from_vault() -> tuple[str | None, str | None, str | None]:
     """Look up the Bedrock AWS credential pair in SecretsService.
 
     Returns (access_key, secret_key, region), each None if not configured or
-    unusable -- never raises; any failure is logged (never the credential
-    value). A successful lookup is audited to ``secrets_audit`` by ``get_secret()``.
+    unusable -- never raises; any failure is logged (never the credential value)
+    and recorded in ``secrets_audit``. A successful lookup is audited by
+    ``get_secret()``; so are its own two failure modes, so the rejections
+    audited here are only the ones it cannot see (#15023 AC3).
     """
     try:
         secret = get_secrets_service().get_secret(
             name=BEDROCK_VAULT_ENTRY_NAME,
             scope="general",
             include_value=True,
-            accessed_by="bedrock_provider",
+            accessed_by=BEDROCK_ACCESSED_BY,
         )
     except Exception as exc:  # noqa: BLE001 - vault lookup is best-effort, fallback follows
         logger.warning("Bedrock SecretsService lookup failed, falling back: %s", type(exc).__name__)
+        _audit_vault_rejection(REASON_LOOKUP_ERROR)
         return None, None, None
+    # No row, or an expired one: get_secret() has already written the row that
+    # distinguishes those two, so auditing again here would double-count them.
     if not secret or "value" not in secret:
         return None, None, None
     if secret.get("secret_type") != BEDROCK_VAULT_ENTRY_TYPE:
         logger.warning("Bedrock secret '%s' has an unexpected secret_type, ignoring", BEDROCK_VAULT_ENTRY_NAME)
+        _audit_vault_rejection(REASON_TYPE_MISMATCH, secret.get("id"))
         return None, None, None
     try:
         creds = json.loads(secret["value"])
     except (TypeError, ValueError) as exc:
         logger.warning("Bedrock secret from SecretsService is not valid JSON: %s", type(exc).__name__)
+        _audit_vault_rejection(REASON_MALFORMED_VALUE, secret.get("id"))
         return None, None, None
     logger.info("Loaded Bedrock credentials from SecretsService (encrypted, access audited)")
     return creds.get("aws_access_key_id"), creds.get("aws_secret_access_key"), creds.get("region")

--- a/autobot-backend/llm_shared/providers/bedrock_test.py
+++ b/autobot-backend/llm_shared/providers/bedrock_test.py
@@ -28,9 +28,15 @@ import pytest
 from llm_shared.providers.bedrock import BedrockProvider
 from llm_shared.providers.bedrock_credentials import (
     _AWS_REGION_PATTERN,
+    BEDROCK_ACCESSED_BY,
     BEDROCK_VAULT_ENTRY_NAME,
     BEDROCK_VAULT_ENTRY_TYPE,
     validate_credential_pair,
+)
+from services.secrets_audit_store import (
+    REASON_LOOKUP_ERROR,
+    REASON_MALFORMED_VALUE,
+    REASON_TYPE_MISMATCH,
 )
 
 #: Credential resolution spans two modules since #15023: the vault lookup lives in
@@ -109,7 +115,7 @@ def test_resolve_credentials_consults_secrets_service_first(monkeypatch):
         name=BEDROCK_VAULT_ENTRY_NAME,
         scope="general",
         include_value=True,
-        accessed_by="bedrock_provider",
+        accessed_by=BEDROCK_ACCESSED_BY,
     )
 
 
@@ -283,3 +289,84 @@ def test_resolve_credentials_rejects_a_malformed_vault_pair(monkeypatch):
     with pytest.raises(ValueError) as excinfo:
         provider._resolve_credentials()
     assert "not-an-aws-access-key" not in str(excinfo.value)
+
+
+# --- failed-access auditing (#15023 AC3, failure limb) --------------------------------
+#
+# get_secret() audits the two failures it can see itself -- no such entry, and an
+# expired one. The three below are verdicts this module reaches *after* get_secret()
+# has returned, so nothing but the caller can record them; before #15023 they were a
+# logger.warning and a silent (None, None, None). The real row-writing is covered
+# against a real database in services/secrets_audit_store_test.py; what is pinned here
+# is that the provider reports each rejection, with the right reason, to the right
+# principal -- and that it does NOT report the two get_secret() already owns.
+
+
+def test_vault_lookup_exception_is_audited(monkeypatch):
+    vault = MagicMock()
+    vault.get_secret.side_effect = RuntimeError("db locked")
+    _patch_vault(monkeypatch, vault)
+    _patch_warning(monkeypatch)
+
+    BedrockProvider(settings={})._resolve_credentials()
+
+    vault.record_access_failure.assert_called_once_with(
+        REASON_LOOKUP_ERROR,
+        name=BEDROCK_VAULT_ENTRY_NAME,
+        accessed_by=BEDROCK_ACCESSED_BY,
+        secret_id=None,
+    )
+
+
+def test_secret_type_mismatch_is_audited_against_the_rejected_row(monkeypatch):
+    vault = _vault_returning('{"aws_access_key_id": "x"}', secret_type="some_other_secret_type")
+    _patch_vault(monkeypatch, vault)
+    _patch_warning(monkeypatch)
+
+    BedrockProvider(settings={})._resolve_credentials()
+
+    vault.record_access_failure.assert_called_once_with(
+        REASON_TYPE_MISMATCH,
+        name=BEDROCK_VAULT_ENTRY_NAME,
+        accessed_by=BEDROCK_ACCESSED_BY,
+        secret_id="sec-1",
+    )
+
+
+def test_unparseable_vault_value_is_audited(monkeypatch):
+    vault = _vault_returning("{not json at all")
+    _patch_vault(monkeypatch, vault)
+    _patch_warning(monkeypatch)
+
+    BedrockProvider(settings={})._resolve_credentials()
+
+    reason, kwargs = vault.record_access_failure.call_args[0][0], vault.record_access_failure.call_args[1]
+    assert reason == REASON_MALFORMED_VALUE
+    assert kwargs["secret_id"] == "sec-1"
+    # The malformed value must not travel to the audit sink in any argument.
+    assert "not json at all" not in str(vault.record_access_failure.call_args)
+
+
+def test_absent_vault_entry_is_not_double_audited(monkeypatch):
+    """get_secret() already wrote the not-found row; a second one here would double-count."""
+    vault = _vault_returning(None)
+    _patch_vault(monkeypatch, vault)
+
+    BedrockProvider(settings={})._resolve_credentials()
+
+    vault.record_access_failure.assert_not_called()
+
+
+def test_a_failing_audit_sink_never_breaks_credential_resolution(monkeypatch):
+    """Auditing is best-effort: a broken sink must not take the credential path down."""
+    vault = MagicMock()
+    vault.get_secret.side_effect = RuntimeError("db locked")
+    vault.record_access_failure.side_effect = RuntimeError("audit sink down")
+    _patch_vault(monkeypatch, vault)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", _WELL_FORMED_ENV_ACCESS_KEY_ID)
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", _WELL_FORMED_ENV_SECRET_ACCESS_KEY)
+    _patch_warning(monkeypatch)
+
+    access_key, secret_key, _region = BedrockProvider(settings={})._resolve_credentials()
+
+    assert (access_key, secret_key) == (_WELL_FORMED_ENV_ACCESS_KEY_ID, _WELL_FORMED_ENV_SECRET_ACCESS_KEY)

--- a/autobot-backend/services/secrets_audit_store.py
+++ b/autobot-backend/services/secrets_audit_store.py
@@ -1,0 +1,281 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The ``secrets_audit`` table: schema, writes and reads (#15023).
+
+Extracted from ``secrets_service.py`` because AC3 of #15023 needs the audit trail
+to record *failed* credential access, and a lookup that found nothing has no
+``secrets(id)`` to record against: the column was ``TEXT NOT NULL`` with a
+foreign key to a row that, for a miss, does not exist by definition.
+
+**Schema change.** ``secrets_audit.secret_id`` becomes nullable. The foreign key
+stays -- SQLite treats a NULL child column as satisfying it -- so a row that
+*does* name a secret is constrained exactly as before, and the rows already on
+disk are carried across verbatim by ``_relax_secret_id_not_null``.
+
+**Reversibility.** The widening is backward-compatible at the code level: every
+pre-#15023 write supplies a non-NULL ``secret_id`` and every read is a plain
+``SELECT``, so rolling the code back needs no schema revert and loses nothing.
+A schema revert is deliberately *not* offered -- restoring ``NOT NULL`` would
+mean deleting the failed-access rows, and destroying audit history to undo a
+widening is not a rollback.
+
+**Never record a credential value.** ``record_failed_access`` takes no value
+parameter and ``AuditLookup`` carries only lookup keys -- the name, id, scope and
+chat id a caller asked *for*, plus who asked -- so there is no argument through
+which a decrypted secret, or anything derived from one (a prefix, a length, a
+hash), can reach a row. That is structural rather than a convention: #15080 is
+the precedent for a helper that leaked key fragments through its own strings.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Dict, List
+from uuid import uuid4
+
+from autobot_shared.logging_manager import get_logger
+from autobot_shared.time_utils import now_utc
+
+logger = get_logger(__name__)
+
+#: Action recorded for an access that yielded a secret.
+ACTION_ACCESSED = "accessed"
+#: Action recorded when an attributable access yielded nothing usable (#15023 AC3).
+ACTION_ACCESS_FAILED = "access_failed"
+
+#: Why an access failed. Distinct values because "no such entry" and "the entry
+#: expired" are the same ``None`` to the caller and must not be the same row to
+#: an auditor -- telling them apart is the point of the failure limb.
+REASON_NOT_FOUND = "not_found"
+REASON_EXPIRED = "expired"
+REASON_TYPE_MISMATCH = "type_mismatch"
+REASON_MALFORMED_VALUE = "malformed_value"
+REASON_LOOKUP_ERROR = "lookup_error"
+
+#: Every accepted reason. ``build_failure_details`` rejects anything else rather
+#: than writing a row whose reason no reader knows how to interpret.
+FAILURE_REASONS = (
+    REASON_NOT_FOUND,
+    REASON_EXPIRED,
+    REASON_TYPE_MISMATCH,
+    REASON_MALFORMED_VALUE,
+    REASON_LOOKUP_ERROR,
+)
+
+_AUDIT_COLUMNS = "id, secret_id, action, performed_by, performed_at, details"
+
+_CREATE_AUDIT_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS secrets_audit (
+        id TEXT PRIMARY KEY,
+        secret_id TEXT,
+        action TEXT NOT NULL,
+        performed_by TEXT,
+        performed_at TEXT NOT NULL,
+        details TEXT,
+        FOREIGN KEY (secret_id) REFERENCES secrets(id)
+    )
+"""
+
+_INSERT_AUDIT_SQL = (
+    "INSERT INTO secrets_audit (id, secret_id, action, performed_by, performed_at, details) "
+    "VALUES (?, ?, ?, ?, ?, ?)"
+)
+
+_SELECT_AUDIT_SQL = (
+    "SELECT id, secret_id, action, performed_by, performed_at, details "
+    "FROM secrets_audit ORDER BY performed_at DESC LIMIT ?"
+)
+
+_SELECT_AUDIT_FOR_ID_SQL = (
+    "SELECT id, secret_id, action, performed_by, performed_at, details "
+    "FROM secrets_audit WHERE secret_id = ? ORDER BY performed_at DESC LIMIT ?"
+)
+
+#: Name the pre-#15023 table is parked under for the duration of the rebuild.
+_LEGACY_AUDIT_TABLE = "secrets_audit_pre_nullable_secret_id"
+
+
+@dataclass(frozen=True)
+class AuditLookup:
+    """What a caller asked for, and who asked -- never what came back.
+
+    Deliberately has no field for a secret's value. See the module docstring:
+    the absence is the guarantee.
+    """
+
+    name: str | None = None
+    secret_id: str | None = None
+    scope: str = "general"
+    chat_id: str | None = None
+    performed_by: str | None = None
+
+
+def _secret_id_is_not_null(cursor: sqlite3.Cursor) -> bool:
+    """True when this database still has the pre-#15023 ``NOT NULL`` column."""
+    cursor.execute("PRAGMA table_info(secrets_audit)")
+    for column in cursor.fetchall():
+        if column[1] == "secret_id":
+            return bool(column[3])
+    return False
+
+
+def _relax_secret_id_not_null(cursor: sqlite3.Cursor) -> None:
+    """Rebuild ``secrets_audit`` with a nullable ``secret_id``, carrying every row.
+
+    SQLite cannot drop ``NOT NULL`` in place, so this is the rename/copy/discard
+    rebuild. It runs inside one explicit transaction: Python's sqlite3 leaves DDL
+    in autocommit, and a rebuild whose rename autocommits would, if interrupted,
+    leave the history parked under another name with an empty table in its place.
+    The row count is compared before the parked table goes -- a copy that lost
+    rows aborts the transaction instead of completing.
+    """
+    conn = cursor.connection
+    own_transaction = not conn.in_transaction
+    if own_transaction:
+        cursor.execute("BEGIN IMMEDIATE")
+    try:
+        cursor.execute(f"ALTER TABLE secrets_audit RENAME TO {_LEGACY_AUDIT_TABLE}")
+        cursor.execute(_CREATE_AUDIT_TABLE_SQL)
+        # Both interpolations below are module constants -- no caller input reaches them.
+        cursor.execute(
+            f"INSERT INTO secrets_audit ({_AUDIT_COLUMNS}) SELECT {_AUDIT_COLUMNS} FROM {_LEGACY_AUDIT_TABLE}"  # nosec B608
+        )
+        cursor.execute(f"SELECT COUNT(*) FROM {_LEGACY_AUDIT_TABLE}")  # nosec B608
+        carried = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM secrets_audit")
+        if cursor.fetchone()[0] != carried:
+            raise sqlite3.IntegrityError("secrets_audit rebuild would lose audit rows; refusing to complete")
+        cursor.execute(f"DROP TABLE {_LEGACY_AUDIT_TABLE}")
+    except Exception:
+        if own_transaction:
+            conn.rollback()
+        raise
+    if own_transaction:
+        conn.commit()
+    logger.info("Migrated secrets_audit to a nullable secret_id (%d existing rows carried)", carried)
+
+
+def ensure_audit_schema(cursor: sqlite3.Cursor) -> None:
+    """Create the audit table, and widen a pre-#15023 one already on disk."""
+    cursor.execute(_CREATE_AUDIT_TABLE_SQL)
+    if _secret_id_is_not_null(cursor):
+        _relax_secret_id_not_null(cursor)
+
+
+def record_action(
+    cursor: sqlite3.Cursor,
+    secret_id: str | None,
+    action: str,
+    performed_by: str | None = None,
+    details: Dict | None = None,
+) -> None:
+    """Append one audit row. ``secret_id`` is None only for a failed access."""
+    cursor.execute(
+        _INSERT_AUDIT_SQL,
+        (
+            str(uuid4()),
+            secret_id,
+            action,
+            performed_by,
+            now_utc().isoformat(),
+            json.dumps(details) if details else None,
+        ),
+    )
+
+
+def build_failure_details(lookup: AuditLookup, reason: str) -> Dict:
+    """The context that makes a failed row useful: what was looked for, and why it failed.
+
+    Composed field by field from ``lookup``'s keys rather than by serialising an
+    object wholesale, so a field added to some future lookup type cannot become a
+    recorded field here without someone writing the line that records it.
+
+    Raises:
+        ValueError: for a reason outside ``FAILURE_REASONS``.
+    """
+    if reason not in FAILURE_REASONS:
+        raise ValueError(f"unknown failed-access reason: {reason}")
+    details: Dict = {"reason": reason, "scope": lookup.scope}
+    if lookup.name:
+        details["requested_name"] = lookup.name
+    if lookup.secret_id:
+        details["requested_secret_id"] = lookup.secret_id
+    if lookup.chat_id:
+        details["chat_id"] = lookup.chat_id
+    return details
+
+
+def record_failed_access(
+    cursor: sqlite3.Cursor,
+    lookup: AuditLookup,
+    reason: str,
+    secret_id: str | None = None,
+) -> None:
+    """Record a failed access on an open cursor, and commit it.
+
+    ``secret_id`` is the row the access resolved to when there was one -- an
+    expired entry, or one rejected for its type -- and None when the lookup
+    matched nothing at all.
+
+    A lookup with no ``performed_by`` is not recorded, for the same reason the
+    success limb only audits when a value is actually handed over: an access
+    that does not name its caller is not attributable, and a row that cannot say
+    who tried is not an audit record. The commit is here because a failed access
+    ends its caller's transaction -- there is no value to hand back after it.
+    """
+    if lookup.performed_by is None:
+        return
+    record_action(
+        cursor,
+        secret_id,
+        ACTION_ACCESS_FAILED,
+        lookup.performed_by,
+        build_failure_details(lookup, reason),
+    )
+    cursor.connection.commit()
+
+
+def record_standalone_failed_access(
+    db_path: str,
+    lookup: AuditLookup,
+    reason: str,
+    secret_id: str | None = None,
+) -> None:
+    """Record a failed access for a caller that holds no cursor of its own."""
+    conn = sqlite3.connect(db_path)
+    try:
+        record_failed_access(conn.cursor(), lookup, reason, secret_id)
+    finally:
+        conn.close()
+
+
+def fetch_audit_log(db_path: str, secret_id: str | None = None, limit: int = 100) -> List[Dict]:
+    """Read audit entries, newest first.
+
+    Filtering by secret id excludes failed rows that never resolved to one --
+    pass no id to see those.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        if secret_id:
+            cursor.execute(_SELECT_AUDIT_FOR_ID_SQL, (secret_id, limit))
+        else:
+            cursor.execute(_SELECT_AUDIT_SQL, (limit,))
+        return [
+            {
+                "id": row[0],
+                "secret_id": row[1],
+                "action": row[2],
+                "performed_by": row[3],
+                "performed_at": row[4],
+                "details": json.loads(row[5]) if row[5] else {},
+            }
+            for row in cursor.fetchall()
+        ]
+    finally:
+        conn.close()

--- a/autobot-backend/services/secrets_audit_store.py
+++ b/autobot-backend/services/secrets_audit_store.py
@@ -66,8 +66,6 @@ FAILURE_REASONS = (
     REASON_LOOKUP_ERROR,
 )
 
-_AUDIT_COLUMNS = "id, secret_id, action, performed_by, performed_at, details"
-
 _CREATE_AUDIT_TABLE_SQL = """
     CREATE TABLE IF NOT EXISTS secrets_audit (
         id TEXT PRIMARY KEY,
@@ -95,8 +93,32 @@ _SELECT_AUDIT_FOR_ID_SQL = (
     "FROM secrets_audit WHERE secret_id = ? ORDER BY performed_at DESC LIMIT ?"
 )
 
-#: Name the pre-#15023 table is parked under for the duration of the rebuild.
-_LEGACY_AUDIT_TABLE = "secrets_audit_pre_nullable_secret_id"
+#: The four statements of the rebuild in ``_relax_secret_id_not_null``, which
+#: parks the pre-#15023 table under ``secrets_audit_pre_nullable_secret_id``,
+#: recreates it widened, copies every row back, and discards the parked copy.
+#:
+#: Each is a complete literal, not composed from a table-name variable or a
+#: shared column list. SQLite cannot bind an *identifier* -- a table or column
+#: name is never a ``?`` parameter -- so "use a parameterised query" has no
+#: form to take for these four, and interpolating instead would leave SQL built
+#: by string formatting for a scanner to flag and a reader to have to prove
+#: safe. The table and its six columns are fixed and known at author time, so
+#: the honest shape is a literal with nothing to inject into. It also leaves the
+#: migration auditable by reading it, which matters more for a rebuild of the
+#: table holding audit history than for any other statement in this module.
+_MIGRATION_PARK_TABLE_SQL = "ALTER TABLE secrets_audit RENAME TO secrets_audit_pre_nullable_secret_id"
+
+_MIGRATION_COPY_ROWS_SQL = (
+    "INSERT INTO secrets_audit (id, secret_id, action, performed_by, performed_at, details) "
+    "SELECT id, secret_id, action, performed_by, performed_at, details "
+    "FROM secrets_audit_pre_nullable_secret_id"
+)
+
+_MIGRATION_COUNT_PARKED_SQL = "SELECT COUNT(*) FROM secrets_audit_pre_nullable_secret_id"
+
+_MIGRATION_COUNT_REBUILT_SQL = "SELECT COUNT(*) FROM secrets_audit"
+
+_MIGRATION_DISCARD_PARKED_SQL = "DROP TABLE secrets_audit_pre_nullable_secret_id"
 
 
 @dataclass(frozen=True)
@@ -138,18 +160,15 @@ def _relax_secret_id_not_null(cursor: sqlite3.Cursor) -> None:
     if own_transaction:
         cursor.execute("BEGIN IMMEDIATE")
     try:
-        cursor.execute(f"ALTER TABLE secrets_audit RENAME TO {_LEGACY_AUDIT_TABLE}")
+        cursor.execute(_MIGRATION_PARK_TABLE_SQL)
         cursor.execute(_CREATE_AUDIT_TABLE_SQL)
-        # Both interpolations below are module constants -- no caller input reaches them.
-        cursor.execute(
-            f"INSERT INTO secrets_audit ({_AUDIT_COLUMNS}) SELECT {_AUDIT_COLUMNS} FROM {_LEGACY_AUDIT_TABLE}"  # nosec B608
-        )
-        cursor.execute(f"SELECT COUNT(*) FROM {_LEGACY_AUDIT_TABLE}")  # nosec B608
+        cursor.execute(_MIGRATION_COPY_ROWS_SQL)
+        cursor.execute(_MIGRATION_COUNT_PARKED_SQL)
         carried = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM secrets_audit")
+        cursor.execute(_MIGRATION_COUNT_REBUILT_SQL)
         if cursor.fetchone()[0] != carried:
             raise sqlite3.IntegrityError("secrets_audit rebuild would lose audit rows; refusing to complete")
-        cursor.execute(f"DROP TABLE {_LEGACY_AUDIT_TABLE}")
+        cursor.execute(_MIGRATION_DISCARD_PARKED_SQL)
     except Exception:
         if own_transaction:
             conn.rollback()

--- a/autobot-backend/services/secrets_audit_store_test.py
+++ b/autobot-backend/services/secrets_audit_store_test.py
@@ -1,0 +1,329 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Failed-credential-access auditing (#15023 AC3, failure limb).
+
+Before this, ``INSERT INTO secrets_audit`` had exactly one reachable call site
+tree-wide and it required a secret that was *found*: ``secret_id`` was
+``TEXT NOT NULL`` with a foreign key to ``secrets(id)``, so a lookup that
+matched nothing had no id to record against and simply returned ``None``. A
+failed credential access left no trace at all.
+
+These tests drive the real ``SecretsService`` against a temporary database file
+-- no mock stands in for the audit write -- and assert on the *row*: that it
+exists, that it names the reason, that "no such entry" and "expired" are
+distinguishable when both hand the caller the same ``None``, that the success
+path still writes exactly what it wrote before, and that nothing derived from
+the credential value reaches any column. That last one follows #15080's
+telltale-marker pattern: plant a marker inside the value being looked up, then
+assert it is absent from everything written.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import timedelta
+
+import pytest
+from cryptography.fernet import Fernet
+
+from autobot_shared.time_utils import now_utc
+from services.secrets_audit_store import (
+    ACTION_ACCESS_FAILED,
+    ACTION_ACCESSED,
+    FAILURE_REASONS,
+    REASON_EXPIRED,
+    REASON_LOOKUP_ERROR,
+    REASON_NOT_FOUND,
+    REASON_TYPE_MISMATCH,
+    AuditLookup,
+    _secret_id_is_not_null,
+    build_failure_details,
+)
+from services.secrets_service import SecretsService
+
+_CALLER = "bedrock_provider"
+_ENTRY_NAME = "bedrock_aws_credentials"
+_SECRET_TYPE = "aws_bedrock_credentials"  # nosemgrep: autobot-hardcoded-secret-key
+
+#: Planted inside the *value* of the secret under lookup. It must never reach an
+#: audit row -- not whole, and not as a fragment (#15080's failure mode was an
+#: error message echoing the first characters of a key).
+_TELLTALE = "TELLTALE-MARKER-THAT-MUST-NEVER-BE-AUDITED"
+_PARKED_TABLE = "secrets_audit_pre_nullable_secret_id"
+
+
+@pytest.fixture()
+def service(tmp_path) -> SecretsService:
+    """A real service on a throwaway database, with an explicit key.
+
+    Both constructor arguments are supplied so the fixture never resolves the
+    canonical data directory or the deployment's encryption key -- this must not
+    touch a live store.
+    """
+    return SecretsService(
+        db_path=str(tmp_path / "secrets.db"),
+        encryption_key=Fernet.generate_key().decode(),
+    )
+
+
+def _credential_value(marker: str = _TELLTALE) -> str:
+    """A Bedrock-shaped credential payload carrying the telltale marker."""
+    return json.dumps({"aws_access_key_id": "AKIA" + "T" * 16, "aws_secret_access_key": marker})
+
+
+def _failed_rows(service: SecretsService) -> list[dict]:
+    return [entry for entry in service.get_audit_log() if entry["action"] == ACTION_ACCESS_FAILED]
+
+
+def _expired_yesterday() -> str:
+    return (now_utc() - timedelta(days=1)).isoformat()
+
+
+def _dump_every_audit_cell(db_path: str) -> list[str]:
+    """Every column of every audit row, as text -- the whole written surface."""
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM secrets_audit")
+        return [str(cell) for row in cursor.fetchall() for cell in row]
+    finally:
+        conn.close()
+
+
+def _table_names(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        return {row[0] for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+
+def test_lookup_that_finds_nothing_writes_a_failed_access_row(service):
+    """The gap #15023 AC3 names: a miss used to return None and record nothing."""
+    assert service.get_secret(name=_ENTRY_NAME, include_value=True, accessed_by=_CALLER) is None
+
+    rows = _failed_rows(service)
+    assert len(rows) == 1, "a failed credential lookup must write exactly one audit row"
+    row = rows[0]
+    assert row["secret_id"] is None, "a lookup that matched nothing has no secret to point at"
+    assert row["performed_by"] == _CALLER
+    assert row["details"]["reason"] == REASON_NOT_FOUND
+    assert row["details"]["requested_name"] == _ENTRY_NAME
+    assert row["details"]["scope"] == "general"
+
+
+def test_expired_secret_writes_a_distinct_reason(service):
+    """Expired and missing are the same None to the caller; they must not be the
+    same row to an auditor."""
+    created = service.create_secret(
+        name=_ENTRY_NAME,
+        secret_type=_SECRET_TYPE,
+        value=_credential_value(),
+        expires_at=_expired_yesterday(),
+    )
+
+    assert service.get_secret(name=_ENTRY_NAME, include_value=True, accessed_by=_CALLER) is None
+
+    rows = _failed_rows(service)
+    assert len(rows) == 1
+    assert rows[0]["details"]["reason"] == REASON_EXPIRED
+    assert rows[0]["details"]["reason"] != REASON_NOT_FOUND
+    # The expired row *does* resolve to a secret, so it records which one -- that
+    # is the whole reason the column stays a foreign key rather than being dropped.
+    assert rows[0]["secret_id"] == created["id"]
+
+
+def test_expired_and_missing_are_told_apart_from_the_same_none(service):
+    """Non-vacuity for the pair: both calls return None, and the rows still differ."""
+    service.create_secret(
+        name="expired-entry",
+        secret_type=_SECRET_TYPE,
+        value=_credential_value(),
+        expires_at=_expired_yesterday(),
+    )
+
+    assert service.get_secret(name="expired-entry", include_value=True, accessed_by=_CALLER) is None
+    assert service.get_secret(name="absent-entry", include_value=True, accessed_by=_CALLER) is None
+
+    by_name = {row["details"]["requested_name"]: row["details"]["reason"] for row in _failed_rows(service)}
+    assert by_name == {"expired-entry": REASON_EXPIRED, "absent-entry": REASON_NOT_FOUND}
+
+
+def test_unattributed_lookup_writes_no_row(service):
+    """No ``accessed_by`` means no principal to record, and no row -- the mirror of
+    the success limb, which only audits when a value is actually handed over."""
+    assert service.get_secret(name=_ENTRY_NAME, include_value=True) is None
+    assert _failed_rows(service) == []
+
+
+def test_successful_access_writes_exactly_what_it_wrote_before(service):
+    """Regression guard on the limb that already worked: one 'accessed' row beside
+    the 'created' row, unchanged in shape, and no failure row alongside it."""
+    created = service.create_secret(
+        name=_ENTRY_NAME,
+        secret_type=_SECRET_TYPE,
+        value=_credential_value(),
+        created_by="operator",
+    )
+
+    got = service.get_secret(name=_ENTRY_NAME, include_value=True, accessed_by=_CALLER)
+    assert got["value"] == _credential_value()
+
+    entries = service.get_audit_log()
+    assert sorted(entry["action"] for entry in entries) == ["accessed", "created"]
+    accessed = [entry for entry in entries if entry["action"] == ACTION_ACCESSED]
+    assert len(accessed) == 1, "the success path must not double-audit"
+    assert accessed[0]["secret_id"] == created["id"]
+    assert accessed[0]["performed_by"] == _CALLER
+    assert accessed[0]["details"] == {}, "the success row carried no details before and must not now"
+    assert _failed_rows(service) == []
+
+
+def test_failed_row_carries_no_part_of_the_credential_value(service):
+    """#15080's pattern: plant a marker in the value, assert it is nowhere written."""
+    service.create_secret(
+        name=_ENTRY_NAME,
+        secret_type=_SECRET_TYPE,
+        value=_credential_value(),
+        expires_at=_expired_yesterday(),
+    )
+    service.get_secret(name=_ENTRY_NAME, include_value=True, accessed_by=_CALLER)
+
+    assert _failed_rows(service), "no failed row was written -- the assertions below would be vacuous"
+    cells = _dump_every_audit_cell(service.db_path)
+    assert cells, "no audit cells to inspect"
+    written = " ".join(cells)
+    assert _TELLTALE not in written
+    for fragment in (_TELLTALE[:10], _TELLTALE[-10:]):
+        assert fragment not in written, "a fragment of the credential value reached an audit row"
+    assert str(len(_TELLTALE)) not in json.dumps(_failed_rows(service)[0]["details"])
+
+
+@pytest.mark.parametrize("reason", FAILURE_REASONS)
+def test_every_reason_round_trips_to_its_own_row(service, reason):
+    """Enumeration guard: each declared reason is writable and reads back as itself."""
+    service.record_access_failure(reason, name=_ENTRY_NAME, accessed_by=_CALLER)
+    rows = _failed_rows(service)
+    assert len(rows) == 1
+    assert rows[0]["details"]["reason"] == reason
+
+
+def test_the_reason_enumeration_is_not_empty():
+    """Non-vacuity for the parametrisation above: an empty tuple would pass it silently."""
+    assert len(FAILURE_REASONS) >= 5
+    assert REASON_NOT_FOUND in FAILURE_REASONS
+    assert REASON_EXPIRED in FAILURE_REASONS
+
+
+def test_an_unknown_reason_is_refused(service):
+    """A row whose reason no reader understands is worse than no row."""
+    with pytest.raises(ValueError):
+        build_failure_details(AuditLookup(performed_by=_CALLER), "reason_nobody_declared")
+
+
+def test_caller_side_rejection_records_the_secret_it_rejected(service):
+    """A found-but-unusable row -- wrong type, unparseable value -- is only visible to
+    the caller, so ``record_access_failure`` carries the resolved id through."""
+    created = service.create_secret(name=_ENTRY_NAME, secret_type="some_other_type", value=_credential_value())
+
+    service.record_access_failure(
+        REASON_TYPE_MISMATCH,
+        name=_ENTRY_NAME,
+        accessed_by=_CALLER,
+        secret_id=created["id"],
+    )
+
+    rows = _failed_rows(service)
+    assert len(rows) == 1
+    assert rows[0]["secret_id"] == created["id"]
+    assert rows[0]["details"]["reason"] == REASON_TYPE_MISMATCH
+
+
+# --- the schema migration -----------------------------------------------------------
+
+
+def _build_pre_15023_database(db_path) -> None:
+    """A database with the old ``secret_id TEXT NOT NULL`` audit table and history in it."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        "CREATE TABLE secrets (id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, "
+        "secret_type TEXT NOT NULL, encrypted_value TEXT NOT NULL, scope TEXT NOT NULL DEFAULT 'general', "
+        "chat_id TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, expires_at TEXT, created_by TEXT, "
+        "metadata TEXT, access_count INTEGER DEFAULT 0, last_accessed_at TEXT, is_active BOOLEAN DEFAULT 1, "
+        "UNIQUE(name, scope, chat_id))"
+    )
+    cursor.execute(
+        "CREATE TABLE secrets_audit (id TEXT PRIMARY KEY, secret_id TEXT NOT NULL, action TEXT NOT NULL, "
+        "performed_by TEXT, performed_at TEXT NOT NULL, details TEXT, "
+        "FOREIGN KEY (secret_id) REFERENCES secrets(id))"
+    )
+    stamp = now_utc().isoformat()
+    cursor.executemany(
+        "INSERT INTO secrets_audit (id, secret_id, action, performed_by, performed_at, details) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("audit-1", "secret-1", "created", "operator", stamp, None),
+            ("audit-2", "secret-1", "accessed", _CALLER, stamp, None),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_migration_carries_every_existing_row_across(tmp_path):
+    """The table holds audit history -- the rebuild must not lose a single row."""
+    db_path = tmp_path / "legacy.db"
+    _build_pre_15023_database(db_path)
+
+    service = SecretsService(db_path=str(db_path), encryption_key=Fernet.generate_key().decode())
+
+    entries = service.get_audit_log()
+    assert {entry["id"] for entry in entries} == {"audit-1", "audit-2"}
+    assert {entry["action"] for entry in entries} == {"created", "accessed"}
+    assert _PARKED_TABLE not in _table_names(str(db_path)), "the rebuild left its scratch table behind"
+
+
+def test_migration_relaxes_not_null_so_a_miss_can_be_recorded(tmp_path):
+    """The point of the migration: after it, an unresolvable access is writable."""
+    db_path = tmp_path / "legacy.db"
+    _build_pre_15023_database(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert _secret_id_is_not_null(conn.cursor()), "fixture is not the pre-#15023 schema"
+    finally:
+        conn.close()
+
+    service = SecretsService(db_path=str(db_path), encryption_key=Fernet.generate_key().decode())
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert not _secret_id_is_not_null(conn.cursor())
+    finally:
+        conn.close()
+
+    assert service.get_secret(name="absent-entry", include_value=True, accessed_by=_CALLER) is None
+    rows = _failed_rows(service)
+    assert len(rows) == 1
+    assert rows[0]["secret_id"] is None
+    assert rows[0]["details"]["reason"] == REASON_NOT_FOUND
+
+
+def test_migration_is_idempotent(tmp_path):
+    """Re-opening an already-migrated database must not rebuild it again."""
+    db_path = tmp_path / "legacy.db"
+    _build_pre_15023_database(db_path)
+
+    SecretsService(db_path=str(db_path), encryption_key=Fernet.generate_key().decode())
+    reopened = SecretsService(db_path=str(db_path), encryption_key=Fernet.generate_key().decode())
+
+    assert {entry["id"] for entry in reopened.get_audit_log()} == {"audit-1", "audit-2"}
+    assert _PARKED_TABLE not in _table_names(str(db_path))
+    reopened.record_access_failure(REASON_LOOKUP_ERROR, name=_ENTRY_NAME, accessed_by=_CALLER)
+    assert len(_failed_rows(reopened)) == 1

--- a/autobot-backend/services/secrets_audit_store_test.py
+++ b/autobot-backend/services/secrets_audit_store_test.py
@@ -30,6 +30,7 @@ import pytest
 from cryptography.fernet import Fernet
 
 from autobot_shared.time_utils import now_utc
+from services import secrets_audit_store
 from services.secrets_audit_store import (
     ACTION_ACCESS_FAILED,
     ACTION_ACCESSED,
@@ -327,3 +328,27 @@ def test_migration_is_idempotent(tmp_path):
     assert _PARKED_TABLE not in _table_names(str(db_path))
     reopened.record_access_failure(REASON_LOOKUP_ERROR, name=_ENTRY_NAME, accessed_by=_CALLER)
     assert len(_failed_rows(reopened)) == 1
+
+
+def test_a_lossy_rebuild_aborts_and_leaves_the_history_intact(tmp_path, monkeypatch):
+    """The transaction and the row-count compare exist so an interrupted or
+    incomplete rebuild cannot cost audit history -- it must abort and roll back,
+    not complete with fewer rows than it started with."""
+    db_path = tmp_path / "legacy.db"
+    _build_pre_15023_database(db_path)
+    # A copy step that carries nothing: the shape of any rebuild that silently
+    # loses rows, without needing to interrupt one mid-flight.
+    monkeypatch.setattr(secrets_audit_store, "_MIGRATION_COPY_ROWS_SQL", "SELECT 1")
+
+    with pytest.raises(sqlite3.IntegrityError):
+        SecretsService(db_path=str(db_path), encryption_key=Fernet.generate_key().decode())
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM secrets_audit")
+        assert {row[0] for row in cursor.fetchall()} == {"audit-1", "audit-2"}
+        assert _secret_id_is_not_null(conn.cursor()), "the aborted rebuild must leave the old schema in place"
+    finally:
+        conn.close()
+    assert _PARKED_TABLE not in _table_names(str(db_path)), "the rollback left the parked table behind"

--- a/autobot-backend/services/secrets_service.py
+++ b/autobot-backend/services/secrets_service.py
@@ -19,6 +19,17 @@ from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_config import config
 from autobot_shared.time_utils import now_utc, parse_utc_iso
 from config.manager import get_config_manager as _get_config_manager
+from services.secrets_audit_store import (
+    ACTION_ACCESSED,
+    REASON_EXPIRED,
+    REASON_NOT_FOUND,
+    AuditLookup,
+    ensure_audit_schema,
+    fetch_audit_log,
+    record_action,
+    record_failed_access,
+    record_standalone_failed_access,
+)
 from type_defs.common import Metadata
 from utils.secrets_store_migration import (
     ALL_SECRETS_STORE_FILES,
@@ -116,7 +127,7 @@ class SecretsService:
 
         self._create_secrets_table(cursor)
         self._create_secrets_indexes(cursor)
-        self._create_audit_table(cursor)
+        ensure_audit_schema(cursor)
 
         conn.commit()
         conn.close()
@@ -149,20 +160,6 @@ class SecretsService:
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_secrets_scope ON secrets(scope)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_secrets_chat_id ON secrets(chat_id)")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_secrets_name ON secrets(name)")
-
-    def _create_audit_table(self, cursor: sqlite3.Cursor) -> None:
-        """Create the audit log table if it doesn't exist"""
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS secrets_audit (
-                id TEXT PRIMARY KEY,
-                secret_id TEXT NOT NULL,
-                action TEXT NOT NULL,
-                performed_by TEXT,
-                performed_at TEXT NOT NULL,
-                details TEXT,
-                FOREIGN KEY (secret_id) REFERENCES secrets(id)
-            )
-        """)
 
     def _encrypt_value(self, value: str) -> str:
         """Encrypt a secret value"""
@@ -227,7 +224,7 @@ class SecretsService:
         """,
             (now_utc().isoformat(), secret_id),
         )
-        self._audit_action(cursor, secret_id, "accessed", accessed_by)
+        self._audit_action(cursor, secret_id, ACTION_ACCESSED, accessed_by)
 
     def _build_secret_result(
         self,
@@ -355,6 +352,8 @@ class SecretsService:
         if query is None:
             return None
 
+        lookup = AuditLookup(name=name, secret_id=secret_id, scope=scope, chat_id=chat_id, performed_by=accessed_by)
+
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
@@ -363,12 +362,14 @@ class SecretsService:
             row = cursor.fetchone()
 
             if not row:
+                record_failed_access(cursor, lookup, REASON_NOT_FOUND)
                 return None
 
             secret = self._row_to_secret_dict(row, include_encrypted=True)
 
             # Check expiration
             if self._is_secret_expired(secret["expires_at"]):
+                record_failed_access(cursor, lookup, REASON_EXPIRED, secret["id"])
                 return None
 
             # Handle value decryption and access tracking
@@ -382,6 +383,29 @@ class SecretsService:
             return secret
         finally:
             conn.close()
+
+    def record_access_failure(
+        self,
+        reason: str,
+        name: str | None = None,
+        scope: str = "general",
+        chat_id: str | None = None,
+        accessed_by: str | None = None,
+        secret_id: str | None = None,
+    ) -> None:
+        """Record a failed access that the *caller* rejected, not the lookup.
+
+        A row can be found, unexpired, and still unusable -- the wrong
+        ``secret_type``, a value that will not parse, or a lookup that raised.
+        Those verdicts are reached after ``get_secret()`` has returned, so only
+        the caller can report them (#15023 AC3).
+        """
+        record_standalone_failed_access(
+            self.db_path,
+            AuditLookup(name=name, scope=scope, chat_id=chat_id, performed_by=accessed_by),
+            reason,
+            secret_id,
+        )
 
     def _build_list_secrets_query(
         self,
@@ -627,52 +651,11 @@ class SecretsService:
         details: Dict | None = None,
     ) -> None:
         """Add an audit log entry"""
-        cursor.execute(
-            """
-            INSERT INTO secrets_audit (id, secret_id, action, performed_by, performed_at, details)
-            VALUES (?, ?, ?, ?, ?, ?)
-        """,
-            (
-                str(uuid4()),
-                secret_id,
-                action,
-                performed_by,
-                now_utc().isoformat(),
-                json.dumps(details) if details else None,
-            ),
-        )
+        record_action(cursor, secret_id, action, performed_by, details)
 
     def get_audit_log(self, secret_id: str | None = None, limit: int = 100) -> List[Metadata]:
         """Get audit log entries"""
-        conn = sqlite3.connect(self.db_path)
-        cursor = conn.cursor()
-
-        if secret_id:
-            cursor.execute(
-                "SELECT * FROM secrets_audit WHERE secret_id = ? ORDER BY performed_at DESC LIMIT ?",
-                (secret_id, limit),
-            )
-        else:
-            cursor.execute(
-                "SELECT * FROM secrets_audit ORDER BY performed_at DESC LIMIT ?",
-                (limit,),
-            )
-
-        audit_entries = []
-        for row in cursor.fetchall():
-            audit_entries.append(
-                {
-                    "id": row[0],
-                    "secret_id": row[1],
-                    "action": row[2],
-                    "performed_by": row[3],
-                    "performed_at": row[4],
-                    "details": json.loads(row[5]) if row[5] else {},
-                }
-            )
-
-        conn.close()
-        return audit_entries
+        return fetch_audit_log(self.db_path, secret_id, limit)
 
 
 # Singleton instance getter (thread-safe)

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -376,7 +376,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/services/redis_service_management_e2e_test.py": 613,
     "autobot-backend/services/redis_service_manager.py": 623,
     "autobot-backend/services/redis_service_manager_test.py": 839,
-    "autobot-backend/services/secrets_service.py": 705,
+    "autobot-backend/services/secrets_service.py": 688,
     "autobot-backend/services/security_memory_integration.py": 1033,
     "autobot-backend/services/security_tool_parsers.py": 865,
     "autobot-backend/services/security_workflow_manager.py": 1306,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -371,7 +371,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/services/redis_service_management_e2e_test.py": 613,
     "autobot-backend/services/redis_service_manager.py": 623,
     "autobot-backend/services/redis_service_manager_test.py": 839,
-    "autobot-backend/services/secrets_service.py": 705,
+    "autobot-backend/services/secrets_service.py": 688,
     "autobot-backend/services/security_memory_integration.py": 1033,
     "autobot-backend/services/security_tool_parsers.py": 865,
     "autobot-backend/services/security_workflow_manager.py": 1306,


### PR DESCRIPTION
## Thinking Path

AC3 of #15023 asks for credential access to be recorded in `secrets_audit` on success **and**
failure. The closure audit on the issue verified the success limb and found the failure limb
structurally impossible rather than merely missing: `secrets_audit.secret_id` was
`TEXT NOT NULL` with a foreign key to `secrets(id)`, so a lookup that matched nothing had no
id to record against. `INSERT INTO secrets_audit` had exactly one call site tree-wide and it
was reachable only with a secret that had been found; `get_secret()` returned early for both
the no-row and the expired case before any audit call, and the Bedrock reader's own three
rejections returned `(None, None, None)` after a `logger.warning`.

The prior art named in the issue body — the unlanded #14087 work — already had failed-access
rows, and its shape informed this one: a correlation between the failure and the caller, a
`failure_type` alongside the reason, and best-effort auditing that never breaks the credential
path. Its *mechanism* was not reusable. It opened a bare `sqlite3.connect` from inside the
provider, wrote raw SQL there, and satisfied the `NOT NULL` foreign key with the literal
sentinel `"bedrock_credentials_failed"` — a value that names no row in `secrets`, and works only
because SQLite leaves foreign keys unenforced by default. That is a fix that depends on the
constraint not being checked. So the constraint is widened properly instead, the write moves
behind the service that owns the table, and the provider keeps only the part it alone can see.

Two design points worth stating. The failure limb is gated on `accessed_by` for the same reason
the success limb is gated on `include_value`: an access that does not name its caller is not
attributable, and a row that cannot say who tried is not an audit record. And `not_found` and
`expired` are separate reasons because both hand the caller the same `None` — telling them apart
is the whole value of the failed row, so the tests assert the reason, never merely that a row
exists.

On recording no credential value, #15080 is the precedent: a validator was deliberately not
restored verbatim because it echoed key fragments into its error messages. Here the guarantee is
structural rather than a matter of care — `record_failed_access` has no value parameter and
`AuditLookup` has no value field, so there is no argument through which a decrypted secret or
anything derived from one can reach a row.

## What Changed

**Schema.** `secrets_audit.secret_id` becomes nullable; the foreign key stays, since SQLite
treats a NULL child column as satisfying it — a row that *does* name a secret is constrained
exactly as before. Databases already on disk are rebuilt by `_relax_secret_id_not_null` (SQLite
cannot drop `NOT NULL` in place): rename, recreate, copy, compare row counts, discard the parked
table — inside one explicit transaction, because Python's `sqlite3` leaves DDL in autocommit and
an interrupted rebuild would otherwise leave the history parked under another name with an empty
table in its place. A copy that lost rows aborts instead of completing. The step is idempotent,
gated on `PRAGMA table_info`.

**Reversibility.** The widening is backward-compatible at the code level: every pre-change write
supplies a non-NULL `secret_id` and every read is a plain `SELECT`, so rolling the code back needs
no schema revert and loses nothing. A schema revert is deliberately not offered — restoring
`NOT NULL` would mean deleting the failed-access rows, and destroying audit history to undo a
widening is not a rollback. Nothing outside the owning service touches the table (`secrets_audit`
appears in one module tree-wide), so the FK is not relied on elsewhere. The table is not
Alembic-managed and is not one of the `migration-matrix` gate's watched paths, so that required
context reports its explicit "nothing to verify" verdict rather than running the Postgres matrix.

**Emission.** `get_secret()` records `not_found` and `expired` as distinct reasons on the two
returns that were silent. The Bedrock vault reader records the three verdicts reached only after
`get_secret()` returns — a raising lookup, a `secret_type` mismatch, an unparseable value — and
deliberately does *not* re-record the two `get_secret()` already owns, which would double-count
them. A failing audit sink is caught and logged; it never takes the credential path down.

**Placement.** The audit-table concerns move out of `secrets_service.py` into
`services/secrets_audit_store.py` — that file sat at its ratchet ceiling of exactly 705 lines, so
adding a failure limb to it in place was not possible. It is now 688 and **both** ceilings
(`scripts/python_file_size_known_large.py`, `repo_tests/python_file_size_ratchet_baseline.py`)
are lowered to match, so the shrink is locked in rather than left as headroom.

No new environment variable, no new configuration, no bare connections outside the store module.

## Verification

Tests, ceilings, format and lint (rc from each command, not inferred):

| Check | Result |
|---|---|
| `pytest` on the two suites + the ratchet test | 90 passed |
| `check_python_file_size.py --audit-ceilings` | rc 0 — 4875 files scanned, 509 grandfathered, all live and at size |
| `bandit -c .bandit -q` (5 files) | rc 0 |
| `py_compile` (5 files) | rc 0 |
| `black --check --line-length 120` | rc 0 |
| `isort --check-only` | rc 0 |
| Branch vs base | 0 behind, rebased onto the base tip |

**Contrast mutations** — each applied alone, its named test run, then reverted. Every one failed
the test that claims to catch it; none passed:

| Mutation | Test | Result |
|---|---|---|
| M1 not-found audit call deleted | `test_lookup_that_finds_nothing_writes_a_failed_access_row` | 1 failed |
| M2 expired recorded as `not_found` | `test_expired_and_missing_are_told_apart_from_the_same_none` | 1 failed |
| M3 success path double-audits | `test_successful_access_writes_exactly_what_it_wrote_before` | 1 failed |
| M4 expired row leaks a fragment of the credential value | `test_failed_row_carries_no_part_of_the_credential_value` | 1 failed |
| M5 migration never runs | `test_migration_relaxes_not_null_so_a_miss_can_be_recorded` | 1 failed |
| M6 migration drops the row copy | `test_migration_carries_every_existing_row_across` | 1 failed |
| M7 provider stops auditing a `secret_type` mismatch | `test_secret_type_mismatch_is_audited_against_the_rejected_row` | 1 failed |
| M8 provider double-audits the not-found path | `test_absent_vault_entry_is_not_double_audited` | 1 failed |
| M9 attribution gate removed | `test_unattributed_lookup_writes_no_row` | 1 failed |

The tests drive a real `SecretsService` against a temporary database file — no mock stands in for
the audit write — and assert on the row, not on a call. The no-credential-value test follows
#15080's telltale-marker pattern: a marker is planted inside the value being looked up, then
every column of every audit row is dumped and asserted free of it, whole and in fragments, with a
non-vacuity assertion first so an empty dump cannot pass silently. The reason enumeration carries
its own non-vacuity check, since an empty tuple would satisfy the parametrised test.

Not verified here: behaviour on a live host. This is a code-level change with no deploy step in
this PR.

## Model Used

Claude Opus 5 (1M context)

---

### Follow-up: `code-quality` and `Semgrep OSS` / SAST (commit `84e7fea6c`)

The first revision composed the four rebuild statements from an interpolated table name and a
shared column list. flake8 rejected one at E501 (124 > 120) and `semgrep.autobot-sql-string-format`
raised four ERROR-severity code-scanning alerts on it.

SQLite cannot bind an *identifier* -- a table or column name is never a `?` parameter -- so the
rule's literal advice has no form to take for these four. The table and its six columns are fixed
at author time, so each statement is now a complete literal constant with nothing to interpolate
into, rather than a suppression over a composed string. No `# nosec` or `# nosemgrep` was added;
the two `# nosec B608` markers the first revision carried are gone with the f-strings that needed
them. Every `execute()` in the module now takes a plain literal or a named constant -- no f-string,
no `%`, no `+` -- so the rule has nothing left to match.

Added with it: `test_a_lossy_rebuild_aborts_and_leaves_the_history_intact`, which patches the copy
step to carry nothing and asserts the rebuild raises, rolls back, and leaves both the original rows
and the old schema in place. The row-count-compare abort was previously only shown by a mutation;
it is now asserted directly.

| Check on `84e7fea6c` | Result |
|---|---|
| `flake8` (repo `.flake8`) | rc 0 |
| `black --check --line-length 120` | rc 0 |
| `isort --check-only` | rc 0 |
| `bandit -c .bandit -q` | rc 0 |
| `py_compile` | rc 0 |
| `--audit-ceilings` | rc 0 |
| `pytest` (both suites + ratchet test) | 91 passed |

Mutations re-run against this head, since the code under M5/M6 changed:

| Mutation | Test | Result |
|---|---|---|
| M5 migration never runs | `test_migration_relaxes_not_null_so_a_miss_can_be_recorded` | 1 failed |
| M6 migration drops the row copy | `test_migration_carries_every_existing_row_across` | 1 failed |
| M10 row-count compare removed | `test_a_lossy_rebuild_aborts_and_leaves_the_history_intact` | 1 failed |

The three other alerts on this branch predate it and are untouched by it: #1050
(`autobot_shared/user_management/models/audit.py:201`) and #1026/#1027
(`autobot-backend/utils/sql_injection_hardening_test.py:92,94`) sit in files this branch does not
modify -- `git diff --name-only origin/Dev_new_gui...HEAD` lists neither.

Closes #15023
