### PR TITLE
ci(ratchet): assert the file-size ratchet on the base and make a red base heard (#15102)

### DIFF
--- a/.github/workflows/ratchet-base-guard.yml
+++ b/.github/workflows/ratchet-base-guard.yml
@@ -1,0 +1,195 @@
+# The down-only file-size ratchet, asserted on the INTEGRATION BRANCH ITSELF (#15102).
+#
+# Why this exists when `code-quality` already runs the same audit
+# ---------------------------------------------------------------
+# It does — and on 2026-08-26 it ran on `Dev_new_gui` and went RED (run
+# 32962821850, step "Audit the python-file-size ceilings for drift"), because
+# merging #15100 took `autobot-backend/api/terminal_websocket_route_test.py`
+# to 613 lines. Nobody was told. The violation was found days later by someone
+# running the audit by hand. A guard whose red result reaches no one is a guard
+# only in the sense that it produced a log line.
+#
+# So this workflow adds the two things the existing invocation does not have:
+#
+# 1. It CANNOT be skipped. `code-quality` filters both its `on.push.paths` and
+#    its `changes` job on the backend-Python set, so a push to `Dev_new_gui`
+#    that touches no Python leaves the base invariant unexamined that day. The
+#    ratchet is a property of the whole tree, not of one diff — a tree-wide
+#    invariant must not be gated on the diff that happened to arrive. There is
+#    deliberately no `paths:` filter here.
+# 2. A failure becomes a tracked ISSUE, opened or updated by title, and closed
+#    again by the first clean run. That is the artifact a human actually reads.
+#
+# The audit itself is NOT reimplemented here: this shells out to the same
+# `scripts/check_python_file_size.py --audit-ceilings` the pre-commit hook and
+# `code-quality` call, so there is one ratchet, invoked from three places.
+#
+# What this workflow is NOT
+# -------------------------
+# It is not a required status check and it cannot block a merge. Required
+# contexts are configured in branch protection and are evaluated on a pull
+# request's head; this runs on `push`, after the merge has already landed. It
+# shortens the time a red base goes unnoticed from "until someone runs the
+# audit locally" to "one workflow run" — it does not prevent the merge. The
+# pre-merge half is a branch-protection question, tracked separately in #15107:
+# #15100 merged with ZERO required contexts on the head it merged, which only
+# `enforce_admins: false` explains, and only the repo owner can change that.
+
+name: Ratchet Base Guard
+
+on:
+  push:
+    # No `paths:` filter, deliberately — see the header. `git ls-files` is what
+    # scopes this run, not the diff.
+    branches: [ Dev_new_gui, main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Never cancel: a cancelled base guard reports nothing, and "nothing" is what
+  # this workflow exists to stop the base being verified with (#13432).
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  audit-base:
+    name: base ratchet audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout the branch as it now stands
+        uses: actions/checkout@v7
+        # depth 1 is enough: the audit reads the working tree via
+        # `git ls-files`, it never diffs against a base.
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+
+      - name: Audit the python-file-size ceilings on this branch
+        id: audit
+        run: |
+          set -uo pipefail
+          # The script's own reach floor (MIN_TRACKED_PY_FILES) already fails a
+          # run whose tree walk came back empty, so an unreadable checkout
+          # cannot report clean here. rc is captured rather than allowed to
+          # abort the job, because the reporting steps below need to run on
+          # exactly the failing path.
+          python3 scripts/check_python_file_size.py --audit-ceilings >audit.log 2>&1
+          rc=$?
+          cat audit.log
+          echo "rc=${rc}" >>"$GITHUB_OUTPUT"
+          {
+            echo 'report<<RATCHET_EOF'
+            head -c 60000 audit.log
+            echo
+            echo RATCHET_EOF
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Open or update the base-violation issue
+        # `success() &&` is load-bearing: a custom `if:` REPLACES the implicit
+        # success() check, so without it a failed checkout would leave `rc`
+        # unset, compare unequal to '0', and file an issue about a violation
+        # that was never measured.
+        if: success() && steps.audit.outputs.rc != '0'
+        uses: actions/github-script@v9
+        env:
+          # Passed through the environment, never interpolated into the script
+          # body: the audit's own output would otherwise be parsed as
+          # JavaScript, and a filename containing a backtick or `${` would
+          # break the step that exists to report the failure.
+          RATCHET_REPORT: ${{ steps.audit.outputs.report }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = 'ci: the file-size ratchet is violated on ' + context.ref.replace('refs/heads/', '');
+            const body = [
+              '`scripts/check_python_file_size.py --audit-ceilings` fails on this branch as it now stands.',
+              '',
+              'Commit: `' + context.sha + '`',
+              'Run: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo +
+                '/actions/runs/' + context.runId,
+              '',
+              '```',
+              process.env.RATCHET_REPORT || '(the audit produced no output)',
+              '```',
+              '',
+              'The ratchet only turns down. A file over 600 lines with no `KNOWN_LARGE`',
+              'entry must be split; an entry whose file shrank must have its ceiling',
+              'lowered in **both** `scripts/python_file_size_known_large.py` and',
+              '`repo_tests/python_file_size_ratchet_baseline.py`; an entry that fell',
+              'under 600 must be removed, not lowered to 599.',
+              '',
+              'Filed automatically by `.github/workflows/ratchet-base-guard.yml` (#15102).',
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'automation',
+              per_page: 100,
+            });
+            const open = existing.find((issue) => issue.title === title && !issue.pull_request);
+
+            if (open) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.number,
+                body,
+              });
+              core.notice('Updated ratchet-violation issue #' + open.number);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug', 'infrastructure', 'automation'],
+              });
+              core.notice('Opened ratchet-violation issue #' + created.data.number);
+            }
+
+      - name: Close the base-violation issue once the branch is clean again
+        if: success() && steps.audit.outputs.rc == '0'
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = 'ci: the file-size ratchet is violated on ' + context.ref.replace('refs/heads/', '');
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'automation',
+              per_page: 100,
+            });
+            const open = existing.find((issue) => issue.title === title && !issue.pull_request);
+            if (!open) {
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: open.number,
+              body: 'The ceiling audit is clean again as of `' + context.sha + '`. Closing.',
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: open.number,
+              state: 'closed',
+            });
+
+      - name: Fail the run when the branch violates the ratchet
+        if: success() && steps.audit.outputs.rc != '0'
+        run: |
+          echo "::error::the file-size ratchet is violated on this branch — see the issue this run just filed"
+          exit 1

--- a/repo_tests/ratchet_base_guard_test.py
+++ b/repo_tests/ratchet_base_guard_test.py
@@ -1,0 +1,321 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15102 — the down-only ratchet must be asserted on the BASE, and be heard.
+
+The forensic record this file exists for
+----------------------------------------
+On 2026-08-26 ``autobot-backend/api/terminal_websocket_route_test.py`` reached
+613 lines on ``Dev_new_gui`` with no ``KNOWN_LARGE`` entry. Neither side of the
+merge that produced it was in violation:
+
+* the pull request's own head (``1eeaa912f01``) held it at **598** lines, and
+  ``code-quality`` ran there at 10:47:33Z and passed — truthfully;
+* the base (``e1bf21cf4``) held it at **599**;
+* the "Update branch" merge commit (``5646344859f``, 11:20:16Z) combined the
+  two disjoint additions and reached **613**; the pull request was merged five
+  seconds later, before any workflow could be dispatched against that head.
+
+So the violation was *born in a merge*, in a tree that had never existed before
+and against which no check had ever run. A ratchet evaluated only against a
+pull request cannot see that class of violation, by construction — however
+correctly it is gated.
+
+``code-quality`` did in fact catch it afterwards: its ``push`` run on
+``Dev_new_gui@16c104be5`` failed at the step "Audit the python-file-size
+ceilings for drift". Nobody was told. The failure was found days later by
+someone running the audit by hand, which is the actual defect — a red base that
+reaches no reader is indistinguishable from a green one.
+
+What this module pins
+---------------------
+``.github/workflows/ratchet-base-guard.yml``, the guard that closes the two
+gaps the existing invocation leaves open:
+
+* it is **unskippable** — ``code-quality`` filters both its ``on.push.paths``
+  and its ``changes`` job on the backend-Python set, so a push touching no
+  Python leaves the tree-wide invariant unexamined; a whole-tree invariant must
+  not be gated on the diff that happened to arrive;
+* a failure becomes a **tracked issue**, and the run goes red.
+
+Every assertion below is phrased so that an absent result fails. The lookups
+are helper functions, not inline expressions, precisely so the same helpers can
+be driven over a *mutated* copy of the workflow: a checker that never proves it
+can reject a broken input has not been shown to check anything.
+
+This guard is not, and cannot be, a required status check — see the workflow's
+own header. The pre-merge half (all ten required contexts were green on
+``1eeaa912f01`` and *none at all* reported on ``5646344859f``, the head that
+merged) is a branch-protection setting only the repo owner can change, tracked
+in #15107.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml", reason="PyYAML needed to parse the workflow")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ratchet-base-guard.yml"
+AUDIT_SCRIPT = "scripts/check_python_file_size.py"
+AUDIT_FLAG = "--audit-ceilings"
+
+#: The branch the whole project merges into. The guard is worthless on any
+#: other one.
+INTEGRATION_BRANCH = "Dev_new_gui"
+
+
+# ---------------------------------------------------------------------------
+# Lookups. Each proves its target exists rather than returning a falsy default,
+# because "absent" reading as "fine" is the failure mode this family repeats.
+# ---------------------------------------------------------------------------
+
+
+def load_workflow(path: Path = WORKFLOW) -> dict[str, Any]:
+    """Parse the workflow, or fail. A file that will not parse is not a pass."""
+    assert path.is_file(), f"{path} does not exist — the base guard is not wired at all"
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict), f"{path} did not parse to a mapping"
+    return doc
+
+
+def triggers(doc: dict[str, Any]) -> dict[str, Any]:
+    """The ``on:`` block.
+
+    YAML 1.1 resolves the bare key ``on`` to the boolean ``True``, so a plain
+    ``doc["on"]`` returns nothing and every check downstream would pass over an
+    unread file.
+    """
+    block = doc.get(True, doc.get("on"))
+    assert isinstance(block, dict), "the workflow declares no usable `on:` mapping"
+    return block
+
+
+def steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every step of every job, flattened."""
+    found: list[dict[str, Any]] = []
+    for job in (doc.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps") or []:
+            if isinstance(step, dict):
+                found.append(step)
+    return found
+
+
+def audit_invocations(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Steps that actually run the shared ceiling audit."""
+    return [step for step in steps(doc) if AUDIT_FLAG in str(step.get("run", ""))]
+
+
+def failing_steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Steps that end the run non-zero when the audit reported a violation."""
+    return [
+        step
+        for step in steps(doc)
+        if "exit 1" in str(step.get("run", "")) and "rc != '0'" in str(step.get("if", ""))
+    ]
+
+
+def issue_filing_steps(doc: dict[str, Any]) -> list[dict[str, Any]]:
+    """Steps that turn a violation into a tracked issue somebody will read."""
+    return [
+        step
+        for step in steps(doc)
+        if "github-script" in str(step.get("uses", ""))
+        # `issues.create({`, not `issues.create` — the latter is also a prefix of
+        # `issues.createComment`, which the *closing* step uses on the clean path.
+        and "issues.create({" in str(step.get("with", {}).get("script", ""))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity. These come first: every sweep below is a list comprehension over
+# `steps()`, and a comprehension over an empty list agrees with everything.
+# ---------------------------------------------------------------------------
+
+
+def test_the_step_enumeration_is_not_empty():
+    """An empty sweep would make every assertion in this module vacuously true.
+
+    This is the same rule the audit script applies to itself with
+    ``MIN_TRACKED_PY_FILES``: a walk that reached nothing has not earned a
+    verdict. Asserting the enumeration before asserting *over* it is what stops
+    a restructured workflow from silently exempting itself.
+    """
+    found = steps(load_workflow())
+    assert len(found) >= 4, f"the base guard flattened to {len(found)} step(s) — the sweep below would assert nothing"
+
+
+def test_every_step_the_sweep_returns_was_actually_read():
+    """The flattener must return real step mappings, not placeholders."""
+    found = steps(load_workflow())
+    assert all(step.get("name") or step.get("uses") or step.get("run") for step in found), (
+        "a step came back with no name, `uses` or `run` — the flattener is reading the wrong level of the document"
+    )
+
+
+def test_the_helpers_reject_a_workflow_that_lost_its_steps():
+    """Contrast for the two tests above: with no steps, the sweeps go empty.
+
+    Without this, "the enumeration is non-empty" is an assertion about today's
+    file rather than a property of the helper.
+    """
+    stripped = copy.deepcopy(load_workflow())
+    for job in stripped["jobs"].values():
+        job["steps"] = []
+
+    assert steps(stripped) == []
+    assert audit_invocations(stripped) == []
+    assert failing_steps(stripped) == []
+    assert issue_filing_steps(stripped) == []
+
+
+# ---------------------------------------------------------------------------
+# The guard runs the audit, on the base, on every push
+# ---------------------------------------------------------------------------
+
+
+def test_the_guard_runs_on_a_push_to_the_integration_branch():
+    branches = (triggers(load_workflow()).get("push") or {}).get("branches")
+    assert isinstance(branches, list) and INTEGRATION_BRANCH in branches, (
+        f"the base guard does not trigger on a push to {INTEGRATION_BRANCH}, which is the "
+        "only branch a merge lands on — it would never see the tree it exists to check"
+    )
+
+
+def test_the_guard_invokes_the_shared_audit_rather_than_reimplementing_it():
+    """One ratchet, called from three places — not three ratchets.
+
+    ``.pre-commit-config.yaml``, ``code-quality`` and this guard must all reach
+    the same script, or lowering a ceiling in the one source of truth stops
+    being enough.
+    """
+    invocations = audit_invocations(load_workflow())
+    assert len(invocations) == 1, f"expected exactly one ceiling-audit invocation, found {len(invocations)}"
+    assert AUDIT_SCRIPT in str(invocations[0].get("run", "")), (
+        f"the audit step does not call {AUDIT_SCRIPT} — a second copy of the ratchet "
+        "would drift from the one the pre-commit hook enforces"
+    )
+
+
+def test_the_guard_carries_no_paths_filter():
+    """A tree-wide invariant may not be gated on the diff that happened to arrive.
+
+    This is the concrete gap over ``code-quality``, which filters its push
+    trigger *and* its ``changes`` job on the backend-Python set: a merge that
+    touches no Python leaves a violation already sitting on the base entirely
+    unexamined. #14550/#14551 is the same lesson from the other direction — a
+    skipped required check reads to branch protection as a satisfied one.
+    """
+    push = triggers(load_workflow()).get("push") or {}
+    assert "paths" not in push and "paths-ignore" not in push, (
+        "the base guard declares a path filter, so a push that touches no matching "
+        "file skips it — and a skipped guard reports nothing, which is exactly what "
+        "a red base already looked like (#15102)"
+    )
+
+
+def test_the_paths_filter_check_rejects_a_workflow_that_grows_one():
+    """Contrast: prove the absence check can actually see a filter."""
+    mutated = copy.deepcopy(load_workflow())
+    push = mutated.get(True, mutated.get("on"))["push"]
+    push["paths"] = ["**/*.py"]
+
+    assert "paths" in (triggers(mutated).get("push") or {})
+
+
+# ---------------------------------------------------------------------------
+# A violation is heard: the run goes red AND an issue is filed
+# ---------------------------------------------------------------------------
+
+
+def test_a_violation_ends_the_run_non_zero():
+    failing = failing_steps(load_workflow())
+    assert failing, (
+        "no step ends the run non-zero on a failing audit. The audit's own exit code is "
+        "captured rather than allowed to abort the job, so without this the guard would "
+        "report success while holding a violation in its log"
+    )
+
+
+def test_a_violation_is_filed_as_an_issue():
+    """The part that is genuinely new.
+
+    ``code-quality`` already failed on the base for this exact violation
+    (``Dev_new_gui@16c104be5``, step "Audit the python-file-size ceilings for
+    drift"). Its redness reached no reader, so the violation stood until
+    someone ran the audit locally. A log line is not a report.
+    """
+    filing = issue_filing_steps(load_workflow())
+    assert filing, "a failing audit files no issue — the failure would again reach nobody"
+    guards = {str(step.get("if", "")) for step in filing}
+    assert all("rc != '0'" in guard for guard in guards), (
+        f"the issue-filing step(s) are not gated on the audit's exit code: {sorted(guards)}"
+    )
+
+
+def test_the_filing_step_is_granted_the_permission_it_needs():
+    """A step that cannot write an issue fails at the moment it is needed."""
+    doc = load_workflow()
+    jobs = [job for job in doc["jobs"].values() if isinstance(job, dict) and job.get("steps")]
+    assert jobs, "the workflow declares no job with steps"
+    for job in jobs:
+        perms = job.get("permissions") or doc.get("permissions") or {}
+        assert perms.get("issues") == "write", (
+            "the base guard's job cannot write issues, so the filing step would fail "
+            "precisely on the run where it matters"
+        )
+
+
+def test_the_audit_output_is_passed_through_the_environment():
+    """A filename is not JavaScript.
+
+    The report is injected with ``env:`` rather than interpolated into the
+    ``script:`` body, so a path containing a backtick or ``${`` cannot break the
+    step whose whole job is to report the failure.
+    """
+    filing = issue_filing_steps(load_workflow())
+    assert filing
+    for step in filing:
+        script = str(step.get("with", {}).get("script", ""))
+        assert "steps.audit.outputs.report" not in script, (
+            "the audit report is interpolated straight into the github-script body; "
+            "pass it through `env:` and read `process.env` instead"
+        )
+        assert "process.env" in script
+
+
+# ---------------------------------------------------------------------------
+# The guard must survive its own scheduling
+# ---------------------------------------------------------------------------
+
+
+def test_the_guard_does_not_cancel_superseded_base_runs():
+    """Two merges in quick succession is the case this guard was born from.
+
+    ``5646344859f`` and the merge five seconds later are exactly that shape.
+    With ``cancel-in-progress: true`` the second push would cancel the first
+    run, and a cancelled guard reports nothing (#13432).
+    """
+    concurrency = load_workflow().get("concurrency") or {}
+    assert concurrency.get("cancel-in-progress") is not True, (
+        "the base guard cancels superseded runs, so a rapid second merge would "
+        "discard the verification of the first"
+    )
+
+
+def test_the_workflow_declares_no_pull_request_trigger():
+    """It is a *base* guard, and saying so is part of not overclaiming.
+
+    A ``pull_request`` trigger here would publish a context that looks like a
+    merge gate and is not one — the required contexts are configured in branch
+    protection, and this workflow is not among them.
+    """
+    assert "pull_request" not in triggers(load_workflow())


### PR DESCRIPTION
Refs #15102. Refs #15107.

## Thinking Path

The issue's hypothesis was that `code-quality` reported green for a head other than the one merged. The workflow-run history says something sharper, and it changes what the fix has to be.

**AC1 — which head did the green belong to?** `16c104be5` is the *merge commit on the integration branch*, not the head that merged. PR #15100's head was `5646344859f`. By SHA:

| SHA | what it is | time (UTC) | the file | required contexts present |
|---|---|---|---|---|
| `43ac98f4898` | merge-base of branch and base | — | 584 | — |
| `1eeaa912f01` | branch head when the checks ran | 10:46:23Z | **598** | **all ten green** (`code-quality` at 10:47:33Z, run `32960027518`) |
| `3b32f7b9e` (#15095) | lands on the base | 11:19:46Z | 599 | — |
| `e1bf21cf4` (#15099) | lands on the base | 11:20:03Z | 599 | — |
| `5646344859f` | "Update branch" merge — **the head that merged** | 11:20:16Z | **613** | **none at all** |
| merged → `16c104be5` | | 11:20:21Z | 613 | `code-quality` on push: **failure** |

So the green was truthful. `code-quality` ran the ceiling audit on `1eeaa912f01`, where the file was 598 lines and the tree genuinely complied. It never ran on `5646344859f`, which was created five seconds before the merge. The ten greens a human read were the ten on the previous head.

**The violation was born in a merge.** 584 (merge-base) + 14 (the branch's fakeredis fixtures) + 15 (#15095's additions to the same file) = 613. Neither parent exceeded 600. This contradicts the issue's "the violation existed in that PR alone" — it is precisely a two-branches-combine case, and it matters, because a ratchet evaluated only against a pull request cannot see that class of violation however correctly it is gated. The violating tree did not exist until the merge produced it.

**AC2 — the mechanism.** No required context reported on `5646344859f` at all; its only check-runs (`Analyze (…)`, `CodeQL`, `notify-issues`, `semgrep`) started at or after 11:20:24Z, i.e. after the merge. With ten contexts required, a non-admin merge on that head is refused with "Expected — Waiting for status". `enforce_admins: false` on the integration branch is the only setting in the protection table consistent with the merge succeeding.

`required_status_checks.strict: false` is a **red herring for this incident**: strict forces the branch to be up to date, and the branch *was* brought up to date — that update is what created `5646344859f`. `enforce_admins: true` alone would have blocked it; `strict: true` alone would not have.

That remedy is a branch-protection setting only the repo owner can flip, so **AC2 is recorded and evidenced here but not closed here.** It is filed as #15107 with the full SHA table and the decision spelled out. This PR does not pretend to deliver it.

**AC3 — and here the issue's premise is also wrong, in a way that changes the deliverable.** "Nothing asserts the invariant on the base after a merge" is not true. Two things already do:

* `code-quality` runs on `push` to the integration branch and **did** fail on `16c104be5` — run `32962821850`, step 33, "Audit the python-file-size ceilings for drift";
* `python_file_size_ratchet_test.py::test_recorded_ceilings_match_the_files_today` already runs `audit_ceilings()` over the whole tree with a reach floor.

The base guard existed and fired. **Nobody was told.** The violation was found days later by someone running the audit by hand. So adding a third copy of the audit would have fixed nothing. What this PR adds are the two properties neither existing invocation has.

## What Changed

`.github/workflows/ratchet-base-guard.yml` — a `push`-triggered base guard on the integration branch. It **shells out to the same `scripts/check_python_file_size.py --audit-ceilings`**; the ratchet is not reimplemented, so there remains one source of truth invoked from three places (pre-commit, `code-quality`, this).

It adds exactly two things:

1. **It cannot be skipped.** `code-quality` filters both its `on.push.paths` and its `changes` job on the backend-Python set, so a push touching no Python leaves the tree-wide invariant unexamined that day. A whole-tree invariant must not be gated on the diff that happened to arrive. There is deliberately no `paths:` filter here — `git ls-files` is what scopes the run.
2. **A failure becomes a tracked issue**, opened or updated by title and closed again by the first clean run, and the run goes red. That is the artifact a human reads; a log line is not a report.

Hardening worth naming: the audit's exit code is captured rather than allowed to abort the job, so the reporting steps run on exactly the failing path; every downstream `if:` is written `success() && …` because a custom `if:` replaces the implicit success check, and without it a failed checkout would leave `rc` unset, compare unequal to `'0'`, and file an issue about a violation that was never measured; the audit output reaches the issue body through `env:` and `process.env`, never interpolated into the `script:` body, so a path containing a backtick cannot break the step whose whole job is to report the failure; `cancel-in-progress: false`, because two merges seconds apart is the exact shape this incident had and a cancelled guard reports nothing.

**This workflow is not a required status check and cannot block a merge**, and its header says so in those words. Required contexts are configured in branch protection and evaluated on a pull request's head; this runs on `push`, after the merge has landed. It shortens the time a red base goes unheard from "until someone runs the audit locally" to one workflow run. Stopping the merge is #15107.

`repo_tests/ratchet_base_guard_test.py` — 13 tests pinning that wiring, so it cannot quietly regress into the shape that failed. Lands in **shard 9 of 12** (`stable_shard.py`, verified by collection), alongside the existing repo-global ratchet guards, and all twelve shards run in the matrix. Every lookup is a helper function rather than an inline expression, so the same helpers can be driven over a mutated copy of the workflow.

## Verification

**Contrast mutation A — the guard fails when a real violation is present.** Appended 140 comment lines to `autobot-backend/api/terminal_websocket_route_test.py` (482 → 622) and ran the exact command the workflow runs:

```
$ python3 scripts/check_python_file_size.py --audit-ceilings
autobot-backend/api/terminal_websocket_route_test.py: 622 lines (max 600)
rc=1
```

Reverted; re-ran: `python-file-size ceilings: 4875 files scanned, 509 grandfathered, all live and at size.` `rc=0`. Working tree clean (`git status --porcelain` shows only the two new files).

**Contrast mutation B — the repo test fails when the workflow loses either new property.** Replaced the audit invocation with `echo` and added a `paths:` filter to the push trigger:

```
FAILED test_the_guard_invokes_the_shared_audit_rather_than_reimplementing_it
  AssertionError: expected exactly one ceiling-audit invocation, found 0
FAILED test_the_guard_carries_no_paths_filter
  AssertionError: the base guard declares a path filter, so a push that touches
  no matching file skips it — and a skipped guard reports nothing
2 failed, 11 passed
```

Reverted; 13 passed.

**Non-vacuity, both layers.**

*The workflow's file sweep.* Forced `tracked_python_files` to return `[]`:

```
sweep reached: 0 | problems from the sweep: []
reach check: the tree walk reached 0 files, under the 3000-file floor —
  it stopped covering most of the tree, so this run's verdict covers almost nothing.
run_audit() rc = 1
```

An empty sweep fails rather than passing quietly, and the workflow leans on that floor rather than restating it.

*The test's own enumeration.* Every assertion in the new module is a comprehension over `steps()`, and a comprehension over an empty list agrees with everything. `test_the_step_enumeration_is_not_empty` asserts the flattener returned ≥ 4 steps *before* anything asserts over them, and `test_the_helpers_reject_a_workflow_that_lost_its_steps` proves the helpers actually go empty on a workflow whose jobs have `steps: []` — so the non-emptiness is a property of the helper, not a fact about today's file.

**Neighbouring guards, unchanged and green.** `workflow_concurrency_guard_test.py`, `python_file_size_ratchet_test.py`, `code_quality_guard_reach_test.py`, `composite_action_step_keys_test.py`: 100 passed. `pipeline-scripts/check_workflow_path_filters.py`: `rc=0`, 6 inline path lists match the canonical set (the new workflow has no `paths:` and no dorny step, so it is outside that guard's table by construction). `tools/lint/check_spdx_header.py` on the new test: `rc=0`. New test file is 320 lines, well inside the 600-line limit it helps enforce.

**What I could not prove.** That the merge of #15100 was an admin bypass is an inference from the protection table plus the absence of any required context on the merged head — GitHub's bypass records are not readable through the API available here. The alternative explanation (a required context reporting on a stale head) is ruled out by the evidence: the merged head carried *no* required context at all, stale or otherwise.

**Not claimed.** This PR does not make a red base block anything, and does not change branch protection. AC1, AC3 and AC4 are delivered; AC2 is settled and evidenced but its remedy is owner-only and lives in #15107. `Refs`, not `Closes` — #15102 should close once #15107 is decided.

## Model Used

Claude Opus 5 (1M context).
