### PR TITLE
fix(terminal): tell a failed command apart from a failed post-processing step (#15073)

### DIFF
--- a/autobot-backend/services/agent_terminal/errors.py
+++ b/autobot-backend/services/agent_terminal/errors.py
@@ -1,0 +1,94 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Execution outcomes for agent terminal commands (#15073).
+
+"The command never ran" and "the command ran and a step after it raised" are
+two different events with two different fixes, and they used to close the same
+way: one `except Exception` around execution *and* post-processing turned both
+into ``{"status": "error", "error": "Command execution failed"}``. A signature
+mismatch in a logging helper was reported to the user as a failed command, and
+the stdout/stderr/return_code the command really produced were dropped on the
+floor.
+
+So the two outcomes are built here, once, and they are not interchangeable:
+
+* ``execution_failed_response`` -- the command did not produce a result.
+* ``post_execution_failed_response`` -- it did; the result travels with the
+  failure, and ``error_code`` says which of the two happened.
+
+``error_code`` is an identifier, never prose: the frontend maps it to a
+translated string (``ui.commandPermission.*``), so no user-facing English is
+minted in the backend. ``error`` stays English on purpose -- it is what the
+agent-facing tool layer and the log read, neither of which is localised.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator
+
+if TYPE_CHECKING:
+    from type_defs.common import Metadata
+
+# Wire values. Kept as module constants so callers and tests cannot drift.
+EXECUTION_FAILED_CODE = "executionFailed"
+POST_EXECUTION_FAILED_CODE = "postExecutionFailed"
+POST_EXECUTION_FAILED_STATUS = "completed_with_errors"
+
+
+class PostExecutionError(Exception):
+    """A command ran to completion and a step after it raised.
+
+    Carries the executor's real result so the caller can still return the
+    output the command actually produced.
+    """
+
+    def __init__(self, result: "Metadata", cause: BaseException) -> None:
+        super().__init__(f"{type(cause).__name__}: {cause}")
+        self.result = result
+        self.cause = cause
+
+
+@contextmanager
+def post_execution_guard(result: "Metadata") -> Iterator[None]:
+    """Mark every failure raised inside the block as post-execution.
+
+    The guard opens *after* the executor returned, so anything it catches is by
+    construction a defect in what happens after the command ran -- including
+    the `TypeError` / `AttributeError` a broad catch upstream would otherwise
+    have relabelled as an execution failure.
+    """
+    try:
+        yield
+    except PostExecutionError:
+        raise
+    except Exception as exc:
+        raise PostExecutionError(result, exc) from exc
+
+
+def execution_failed_response(command: str) -> "Metadata":
+    """The command produced no result: there is nothing to report but the failure."""
+    return {
+        "status": "error",
+        "error": "Command execution failed",
+        "error_code": EXECUTION_FAILED_CODE,
+        "command": command,
+    }
+
+
+def post_execution_failed_response(command: str, exc: PostExecutionError) -> "Metadata":
+    """The command ran; a step after it failed. The real result is preserved."""
+    response = dict(exc.result)
+    response.update(
+        {
+            "status": POST_EXECUTION_FAILED_STATUS,
+            "command_status": exc.result.get("status"),
+            "command": command,
+            "error": f"Command ran; a post-execution step failed: {exc}",
+            "error_code": POST_EXECUTION_FAILED_CODE,
+            "post_execution_error": str(exc),
+        }
+    )
+    return response

--- a/autobot-backend/services/agent_terminal/post_execution_failure_15073_test.py
+++ b/autobot-backend/services/agent_terminal/post_execution_failure_15073_test.py
@@ -1,0 +1,210 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A command that ran must never be reported as one that failed to run (#15073).
+
+One `except Exception` wrapped the executor call *and* the four post-processing
+awaits after it. A `TypeError` in a logging helper — exactly the class of defect
+#13281 stopped swallowing one layer down — came back as
+``{"status": "error", "error": "Command execution failed"}``: the wrong
+diagnosis (the operator is sent to the PTY and the shell, where nothing is
+broken) and, worse, the command's real stdout/stderr/return_code discarded.
+
+What is asserted here is the *distinction*, not the mere presence of an error.
+A fix that reported both outcomes as some error would satisfy "an error is
+returned" and still leave the user unable to tell "your command failed" from
+"your command worked, our bookkeeping did not". So every test below pins which
+of the two happened, and one compares the two responses head to head.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from autobot_shared.status_enums import CommandRisk
+from services.agent_terminal.errors import (
+    EXECUTION_FAILED_CODE,
+    POST_EXECUTION_FAILED_CODE,
+    POST_EXECUTION_FAILED_STATUS,
+)
+from services.agent_terminal.models import AgentTerminalSession
+from services.agent_terminal.service import AgentTerminalService
+from services.command_approval_manager import AgentRole
+
+pytestmark = pytest.mark.asyncio
+
+# The defect #13281 surfaced and this layer relabelled: a keyword the callee
+# does not accept. It is a programming error, not a failed command.
+SIGNATURE_MISMATCH = TypeError("add_message() got an unexpected keyword argument 'role'")
+
+SUCCESSFUL_RUN = {
+    "status": "success",
+    "stdout": "hello from the pty\n",
+    "stderr": "",
+    "return_code": 0,
+}
+
+
+def _session() -> AgentTerminalSession:
+    return AgentTerminalSession(
+        session_id="term-15073",
+        agent_id="agent-15073",
+        agent_role=AgentRole.CHAT_AGENT,
+        conversation_id="conv-15073",
+    )
+
+
+def _service(*, executor_result=None, executor_error: BaseException | None = None) -> AgentTerminalService:
+    """A service whose collaborators are all doubles except the code under test."""
+    svc = AgentTerminalService.__new__(AgentTerminalService)
+    svc.command_executor = AsyncMock()
+    if executor_error is not None:
+        svc.command_executor.execute_in_pty = AsyncMock(side_effect=executor_error)
+    else:
+        svc.command_executor.execute_in_pty = AsyncMock(return_value=dict(executor_result or SUCCESSFUL_RUN))
+    svc.approval_handler = AsyncMock()
+    svc.terminal_logger = AsyncMock()
+    svc.prometheus_metrics = MagicMock()  # record_task_execution is sync
+    svc.chat_workflow_manager = None
+    svc.session_manager = AsyncMock()
+    svc.redis_client = None
+    return svc
+
+
+async def _approve(svc: AgentTerminalService):
+    return await svc._execute_approved_command(
+        session=_session(),
+        command="echo hello",
+        command_id="cmd-1",
+        risk_level="LOW",
+        user_id="user-1",
+        comment=None,
+        auto_approve_future=False,
+    )
+
+
+async def _auto_execute(svc: AgentTerminalService, *, post_execution_error: BaseException | None = None):
+    """Drive the real ``execute_command`` boundary, stubbing only the gates before it.
+
+    ``post_execution_error`` is raised from the chat-history write, one of the
+    steps that runs after the command has already produced its output.
+    """
+    svc.get_session = AsyncMock(return_value=_session())
+    svc._assess_command = lambda command: (None, CommandRisk.SAFE, [], False, [])
+    svc._check_agent_permission = lambda *_a, **_k: None
+    svc._check_auto_approval_or_queue = AsyncMock(return_value=(True, None))
+    svc._save_command_to_chat = AsyncMock(side_effect=post_execution_error)
+    return await svc.execute_command(session_id="term-15073", command="echo hello")
+
+
+# --------------------------------------------------------------------------
+# Approved path (service.py::_execute_approved_command)
+# --------------------------------------------------------------------------
+
+
+async def test_post_processing_failure_keeps_the_output_the_command_produced():
+    """The exact bug: the command ran, so its result must survive the failure."""
+    svc = _service()
+    svc._post_execution_updates = AsyncMock(side_effect=SIGNATURE_MISMATCH)
+
+    response = await _approve(svc)
+
+    assert response["status"] == POST_EXECUTION_FAILED_STATUS
+    assert response["error_code"] == POST_EXECUTION_FAILED_CODE
+    assert response["stdout"] == SUCCESSFUL_RUN["stdout"]
+    assert response["return_code"] == 0
+    assert response["command_status"] == "success"
+    assert "add_message()" in response["post_execution_error"]
+    assert "Command execution failed" not in str(response)
+
+
+async def test_a_command_that_never_ran_is_reported_as_an_execution_failure():
+    """The other outcome, so the fix cannot pass by relabelling everything."""
+    svc = _service(executor_error=OSError("pty spawn failed"))
+
+    response = await _approve(svc)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == EXECUTION_FAILED_CODE
+    assert "stdout" not in response
+
+
+async def test_the_two_failures_are_told_apart_by_the_caller():
+    """Head to head: same call, two outcomes, nothing a caller could confuse."""
+    ran = _service()
+    ran._post_execution_updates = AsyncMock(side_effect=SIGNATURE_MISMATCH)
+    never_ran = _service(executor_error=OSError("pty spawn failed"))
+
+    ran_response = await _approve(ran)
+    never_ran_response = await _approve(never_ran)
+
+    assert ran_response["status"] != never_ran_response["status"]
+    assert ran_response["error_code"] != never_ran_response["error_code"]
+    # Only one of the two can show the user what the command printed.
+    assert ran_response.get("stdout") and not never_ran_response.get("stdout")
+
+
+async def test_a_programming_error_in_execution_itself_reaches_the_caller():
+    """#13281's split, held one layer up: a signature mismatch is not a verdict."""
+    svc = _service(executor_error=SIGNATURE_MISMATCH)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await _approve(svc)
+
+
+async def test_the_post_processing_failure_is_logged_with_its_traceback(caplog):
+    """`logger.error("...: %s", e)` loses the only line that names the real defect."""
+    svc = _service()
+    svc._post_execution_updates = AsyncMock(side_effect=SIGNATURE_MISMATCH)
+
+    with caplog.at_level(logging.ERROR):
+        await _approve(svc)
+
+    failures = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert failures, "the post-execution failure was not logged at all"
+    assert any(r.exc_info for r in failures), "logged without exc_info: no traceback to follow"
+
+
+# --------------------------------------------------------------------------
+# Auto-approved path (service.py::execute_command)
+# --------------------------------------------------------------------------
+
+
+async def test_auto_approved_run_reports_success_when_nothing_after_it_breaks():
+    """Baseline: the intact path is untouched, so the next test measures the fix."""
+    response = await _auto_execute(_service())
+
+    assert response["status"] == "success"
+    assert response["stdout"] == SUCCESSFUL_RUN["stdout"]
+
+
+async def test_auto_approved_post_processing_failure_keeps_the_output():
+    """The second site: fixing only one leaves the other free to misreport."""
+    response = await _auto_execute(_service(), post_execution_error=SIGNATURE_MISMATCH)
+
+    assert response["status"] == POST_EXECUTION_FAILED_STATUS
+    assert response["error_code"] == POST_EXECUTION_FAILED_CODE
+    assert response["stdout"] == SUCCESSFUL_RUN["stdout"]
+    assert response["command_status"] == "success"
+    assert "Command execution failed" not in str(response)
+
+
+async def test_auto_approved_execution_failure_stays_an_execution_failure():
+    svc = _service(executor_error=OSError("pty spawn failed"))
+
+    response = await _auto_execute(svc)
+
+    assert response["status"] == "error"
+    assert response["error_code"] == EXECUTION_FAILED_CODE
+    assert "stdout" not in response
+
+
+async def test_auto_approved_programming_error_in_execution_reaches_the_caller():
+    svc = _service(executor_error=SIGNATURE_MISMATCH)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        await _auto_execute(svc)

--- a/autobot-backend/services/agent_terminal/service.py
+++ b/autobot-backend/services/agent_terminal/service.py
@@ -21,9 +21,16 @@ from type_defs.common import Metadata
 
 from .approval_handler import ApprovalHandler
 from .command_executor import CommandExecutor
+from .errors import PostExecutionError, execution_failed_response, post_execution_failed_response, post_execution_guard
 from .models import AgentSessionState, AgentTerminalSession
 from .session_manager import SessionManager
-from .utils import create_command_execution, is_interactive_command, log_command_approval, log_command_result
+from .utils import (
+    create_command_execution,
+    is_interactive_command,
+    log_autobot_command,
+    log_command_approval,
+    log_command_result,
+)
 
 logger = get_logger(__name__)
 
@@ -267,46 +274,30 @@ class AgentTerminalService:
         command: str,
         risk,
     ) -> Metadata:
-        """Execute an auto-approved command (Issue #281: extracted)."""
-        task_start_time = time.time()
+        """Execute an auto-approved command (Issue #281: extracted).
 
-        if session.has_conversation():
-            await self.terminal_logger.log_command(
-                session_id=session.conversation_id,
-                command=command,
-                run_type="autobot",
-                status="executing",
-                user_id=None,
-            )
+        #15073: the guard opens the moment the executor has returned. Metrics,
+        transcript, chat, interpretation and broadcast are all post-processing
+        — a defect in any of them is reported as such, never as a command that
+        failed to run, and never at the cost of the result already in hand.
+        """
+        task_start_time = time.time()
+        await log_autobot_command(self.terminal_logger, session, command, "executing")
 
         result = await self.command_executor.execute_in_pty(session, command)
 
-        task_duration = time.time() - task_start_time
-        status = "success" if result.get("status") == "success" else "error"
-        self.prometheus_metrics.record_task_execution(
-            task_type="command_execution",
-            agent_type=session.agent_role.value,
-            status=status,
-            duration=task_duration,
-        )
-
-        if session.has_conversation():
-            await self.terminal_logger.log_command(
-                session_id=session.conversation_id,
-                command=command,
-                run_type="autobot",
+        with post_execution_guard(result):
+            status = "success" if result.get("status") == "success" else "error"
+            self.prometheus_metrics.record_task_execution(
+                task_type="command_execution",
+                agent_type=session.agent_role.value,
                 status=status,
-                result=result,
-                user_id=None,
+                duration=time.time() - task_start_time,
             )
-
-        await self._save_command_to_chat(session.conversation_id, command, result, command_type="agent")
-
-        # Interpret result if chat workflow manager available
-        await self._interpret_command_result(session, command, result)
-
-        # Update session history and broadcast status (Issue #665: extracted helper)
-        await self._finalize_auto_approved_execution(session, command, risk, result)
+            await log_autobot_command(self.terminal_logger, session, command, status, result)
+            await self._save_command_to_chat(session.conversation_id, command, result, command_type="agent")
+            await self._interpret_command_result(session, command, result)
+            await self._finalize_auto_approved_execution(session, command, risk, result)
 
         return result
 
@@ -456,24 +447,24 @@ class AgentTerminalService:
 
         result = await self.command_executor.execute_in_pty(session, command)
 
-        await self.approval_handler.update_command_queue_status(
-            command_id=command_id,
-            approved=True,
-            output=result.get("stdout", ""),
-            stderr=result.get("stderr", ""),
-            return_code=result.get("return_code", 0),
-        )
-
-        await log_command_result(self.terminal_logger, session, command, result, user_id)
-        await self._post_execution_updates(
-            session,
-            command,
-            result,
-            risk_level,
-            user_id,
-            comment,
-            auto_approve_future,
-        )
+        with post_execution_guard(result):
+            await self.approval_handler.update_command_queue_status(
+                command_id=command_id,
+                approved=True,
+                output=result.get("stdout", ""),
+                stderr=result.get("stderr", ""),
+                return_code=result.get("return_code", 0),
+            )
+            await log_command_result(self.terminal_logger, session, command, result, user_id)
+            await self._post_execution_updates(
+                session,
+                command,
+                result,
+                risk_level,
+                user_id,
+                comment,
+                auto_approve_future,
+            )
 
         return {
             "status": "approved",
@@ -529,13 +520,14 @@ class AgentTerminalService:
                 comment=comment,
                 auto_approve_future=auto_approve_future,
             )
-        except Exception as e:
-            logger.error("Approved command execution error: %s", e)
-            return {
-                "status": "error",
-                "error": "Command execution failed",
-                "command": command,
-            }
+        except PostExecutionError as exc:
+            logger.error("Approved command post-execution failure: %s", exc, exc_info=True)
+            return post_execution_failed_response(command, exc)
+        except (TypeError, AttributeError):
+            raise
+        except Exception:
+            logger.error("Approved command execution error", exc_info=True)
+            return execution_failed_response(command)
 
     async def _handle_denied_command(
         self,
@@ -769,13 +761,14 @@ class AgentTerminalService:
         # Execute auto-approved command
         try:
             return await self._execute_auto_approved_command(session, command, risk)
-        except Exception as e:
-            logger.error("Command execution error: %s", e)
-            return {
-                "status": "error",
-                "error": "Command execution failed",
-                "command": command,
-            }
+        except PostExecutionError as exc:
+            logger.error("Auto-approved command post-execution failure: %s", exc, exc_info=True)
+            return post_execution_failed_response(command, exc)
+        except (TypeError, AttributeError):
+            raise
+        except Exception:
+            logger.error("Command execution error", exc_info=True)
+            return execution_failed_response(command)
 
     async def _save_command_to_chat(
         self,

--- a/autobot-backend/services/agent_terminal/utils.py
+++ b/autobot-backend/services/agent_terminal/utils.py
@@ -253,3 +253,31 @@ async def log_command_result(
             result=result,
             user_id=user_id,
         )
+
+
+async def log_autobot_command(
+    terminal_logger: "TerminalLogger",
+    session: "AgentTerminalSession",
+    command: str,
+    status: str,
+    result: "Metadata | None" = None,
+) -> None:
+    """Record an auto-approved (``autobot`` run type) command against the transcript.
+
+    The same six-argument call was spelled out twice in
+    ``_execute_auto_approved_command`` — once before the command ran, once with
+    its result — inside a service already at its recorded size ceiling. Same
+    reason ``log_command_approval`` moved here in #14959; kept together with it
+    so the two run types stay one edit apart (#15073).
+
+    A session with no conversation has nowhere to write, and logs nothing.
+    """
+    if session.has_conversation():
+        await terminal_logger.log_command(
+            session_id=session.conversation_id,
+            command=command,
+            run_type="autobot",
+            status=status,
+            result=result,
+            user_id=None,
+        )

--- a/autobot-frontend/src/composables/__tests__/useCommandApproval.postExecution.spec.ts
+++ b/autobot-frontend/src/composables/__tests__/useCommandApproval.postExecution.spec.ts
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 mrveiss
+// SPDX-License-Identifier: Apache-2.0
+// AutoBot - AI-Powered Automation Platform
+// Author: mrveiss
+/**
+ * The toast tells the user WHICH failure happened (#15073).
+ *
+ * The backend used to answer both "the command never ran" and "the command ran
+ * and a step after it raised" with the same `{status: 'error', error:
+ * 'Command execution failed'}`, and this composable rendered that prose
+ * straight into a toast — untranslated, and wrong half the time.
+ *
+ * These tests assert the distinction at the surface the user actually reads:
+ * two backend outcomes, two different translated messages. Asserting only
+ * "a toast appeared" would pass against the bug itself.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+
+import { ApiClient } from '@/utils/ApiClient'
+import i18n, { loadLocaleMessages } from '@/i18n'
+import { useToast } from '@/composables/useToast'
+import { useCommandApproval } from '@/composables/useCommandApproval'
+
+const EXECUTION_FAILED_KEY = 'ui.commandPermission.executionFailed'
+const POST_EXECUTION_FAILED_KEY = 'ui.commandPermission.postExecutionFailed'
+
+/** The composable reads pinia stores, so it has to run inside a component. */
+function mountApproval() {
+  let api!: ReturnType<typeof useCommandApproval>
+  mount(
+    defineComponent({
+      setup() {
+        api = useCommandApproval()
+        return () => h('span')
+      }
+    })
+  )
+  return api
+}
+
+function toastMessages(): string[] {
+  return useToast().toasts.value.map(toast => toast.message)
+}
+
+describe('useCommandApproval — execution vs post-execution failure', () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    await loadLocaleMessages('en')
+    i18n.global.locale.value = 'en'
+    useToast().clearAllToasts()
+    vi.restoreAllMocks()
+  })
+
+  it('warns that the command RAN when post-processing is what failed', async () => {
+    vi.spyOn(ApiClient.prototype, 'post').mockResolvedValue({
+      status: 'completed_with_errors',
+      error_code: 'postExecutionFailed',
+      command_status: 'success',
+      stdout: 'hello from the pty\n',
+      return_code: 0,
+      post_execution_error: "TypeError: add_message() got an unexpected keyword argument 'role'"
+    } as never)
+
+    await mountApproval().approveCommand('term-1', true, undefined, 'cmd-1')
+
+    expect(toastMessages()).toContain(i18n.global.t(POST_EXECUTION_FAILED_KEY))
+    expect(toastMessages()).not.toContain(i18n.global.t(EXECUTION_FAILED_KEY))
+  })
+
+  it('reports an execution failure when the command never produced a result', async () => {
+    vi.spyOn(ApiClient.prototype, 'post').mockResolvedValue({
+      status: 'error',
+      error_code: 'executionFailed',
+      error: 'Command execution failed'
+    } as never)
+
+    await mountApproval().approveCommand('term-1', true, undefined, 'cmd-1')
+
+    expect(toastMessages()).toContain(i18n.global.t(EXECUTION_FAILED_KEY))
+    expect(toastMessages()).not.toContain(i18n.global.t(POST_EXECUTION_FAILED_KEY))
+  })
+
+  it('gives the two outcomes different words, in the user’s language', () => {
+    const executionFailed = i18n.global.t(EXECUTION_FAILED_KEY)
+    const postExecutionFailed = i18n.global.t(POST_EXECUTION_FAILED_KEY)
+
+    // A translation that resolved to its own key path would make the two
+    // assertions above pass while showing the user `ui.commandPermission.…`.
+    expect(executionFailed).not.toContain('ui.commandPermission')
+    expect(postExecutionFailed).not.toContain('ui.commandPermission')
+    expect(executionFailed).not.toBe(postExecutionFailed)
+  })
+
+  it('falls back to the backend detail for an outcome it has no translation for', async () => {
+    vi.spyOn(ApiClient.prototype, 'post').mockResolvedValue({
+      status: 'error',
+      error: 'No pending approval'
+    } as never)
+
+    await mountApproval().approveCommand('term-1', true, undefined, 'cmd-1')
+
+    expect(toastMessages()).toContain('No pending approval')
+  })
+})

--- a/autobot-frontend/src/composables/useCommandApproval.ts
+++ b/autobot-frontend/src/composables/useCommandApproval.ts
@@ -26,6 +26,7 @@ import { useChatStore } from '@/stores/useChatStore'
 import { usePermissionStore } from '@/stores/usePermissionStore'
 import { getApiBase } from '@/config/ssot-config'
 import { getRiskSeverity, type RiskSeverity } from '@/utils/riskLevel'
+import i18n from '@/i18n'
 
 const logger = createLogger('useCommandApproval')
 
@@ -50,9 +51,35 @@ export interface CommandResult {
 }
 
 export interface ApprovalResponse {
-  status: 'approved' | 'denied' | 'error' | string
+  /** `completed_with_errors` (#15073): the command ran, a step after it failed. */
+  status: 'approved' | 'denied' | 'error' | 'completed_with_errors' | string
   comment?: string
+  /** Developer-facing detail. English, untranslated — for the log, not the toast. */
   error?: string
+  /** Stable identifier for the outcome; the only thing safe to translate on. */
+  error_code?: string
+  /** Set with `completed_with_errors`: which post-execution step raised. */
+  post_execution_error?: string
+  result?: Record<string, unknown>
+}
+
+/**
+ * Backend `error_code` -> translation key (#15073).
+ *
+ * Explicit, not interpolated: an unknown code must fall back to the prose the
+ * backend sent, never render a raw `ui.commandPermission.<code>` path at a
+ * user.
+ */
+const APPROVAL_ERROR_CODE_KEYS: Record<string, string> = {
+  executionFailed: 'ui.commandPermission.executionFailed',
+  postExecutionFailed: 'ui.commandPermission.postExecutionFailed'
+}
+
+/** Translate a backend outcome, falling back to its untranslated detail. */
+export function translateApprovalOutcome(code?: string, detail?: string): string {
+  const key = code ? APPROVAL_ERROR_CODE_KEYS[code] : undefined
+  if (key) return i18n.global.t(key)
+  return detail || i18n.global.t('ui.commandPermission.executionFailed')
 }
 
 export function useCommandApproval() {
@@ -263,7 +290,7 @@ export function useCommandApproval() {
               // The output will appear naturally through the WebSocket/streaming flow
             } else if (pollResult.state === 'failed') {
               logger.error('Command failed:', pollResult.stderr)
-              notify('Command execution failed', 'error')
+              notify(i18n.global.t('ui.commandPermission.executionFailed'), 'error')
             } else if (pollResult.state === 'timeout') {
               logger.warn('Polling timed out')
               notify('Command execution timed out', 'warning')
@@ -303,9 +330,19 @@ export function useCommandApproval() {
         rememberForProject.value = false
         // Issue #680: Clear pending approval flag to allow polling to resume
         chatStore.setPendingApproval(false)
+      } else if (result.status === 'completed_with_errors') {
+        // #15073: the command RAN. Its output is real and already in `result`;
+        // only the bookkeeping after it is incomplete, so there is nothing to
+        // poll for and this is a warning, not an execution failure.
+        logger.error('Post-execution failure:', result.post_execution_error)
+        notify(translateApprovalOutcome(result.error_code, result.error), 'warning')
+        if (onMessageUpdate) {
+          onMessageUpdate(terminal_session_id, 'approved', comment || result.comment)
+        }
+        chatStore.setPendingApproval(false)
       } else if (result.status === 'error') {
         logger.error('Approval error:', result.error)
-        notify(`Approval failed: ${result.error}`, 'error')
+        notify(translateApprovalOutcome(result.error_code, result.error), 'error')
         // Issue #680: Clear pending approval flag on error too
         chatStore.setPendingApproval(false)
       }

--- a/autobot-frontend/src/i18n/locales/ar.json
+++ b/autobot-frontend/src/i18n/locales/ar.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "فشل تنفيذ الأمر",
+      "postExecutionFailed": "تم تنفيذ الأمر، لكن فشلت خطوة لاحقة. يتم عرض المخرجات؛ قد تكون بعض التحديثات مفقودة.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/de.json
+++ b/autobot-frontend/src/i18n/locales/de.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Befehlsausführung fehlgeschlagen",
+      "postExecutionFailed": "Der Befehl wurde ausgeführt, aber ein Folgeschritt ist fehlgeschlagen. Die Ausgabe wird angezeigt; einige Aktualisierungen fehlen möglicherweise.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/en.json
+++ b/autobot-frontend/src/i18n/locales/en.json
@@ -5626,6 +5626,7 @@
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
       "executionFailed": "Command execution failed",
+      "postExecutionFailed": "The command ran, but a follow-up step failed. Its output is shown; some updates may be missing.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/es.json
+++ b/autobot-frontend/src/i18n/locales/es.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Error al ejecutar el comando",
+      "postExecutionFailed": "El comando se ejecutó, pero falló un paso posterior. Se muestra su salida; puede que falten algunas actualizaciones.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/fa.json
+++ b/autobot-frontend/src/i18n/locales/fa.json
@@ -4753,7 +4753,8 @@
       "theme": "Theme"
     },
     "commandPermission": {
-      "executionFailed": "Command execution failed",
+      "executionFailed": "اجرای دستور ناموفق بود",
+      "postExecutionFailed": "دستور اجرا شد، اما یک مرحله پس از آن ناموفق بود. خروجی آن نمایش داده می‌شود؛ ممکن است برخی به‌روزرسانی‌ها انجام نشده باشند.",
       "allow": "Allow",
       "purposeLabel": "Purpose",
       "defaultPurpose": "System operation requested",

--- a/autobot-frontend/src/i18n/locales/fr.json
+++ b/autobot-frontend/src/i18n/locales/fr.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Échec de l'exécution de la commande",
+      "postExecutionFailed": "La commande s'est exécutée, mais une étape ultérieure a échoué. Sa sortie est affichée ; certaines mises à jour peuvent manquer.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/he.json
+++ b/autobot-frontend/src/i18n/locales/he.json
@@ -4753,7 +4753,8 @@
       "theme": "Theme"
     },
     "commandPermission": {
-      "executionFailed": "Command execution failed",
+      "executionFailed": "הרצת הפקודה נכשלה",
+      "postExecutionFailed": "הפקודה רצה, אך שלב המשך נכשל. הפלט שלה מוצג; ייתכן שחלק מהעדכונים חסרים.",
       "allow": "Allow",
       "purposeLabel": "Purpose",
       "defaultPurpose": "System operation requested",

--- a/autobot-frontend/src/i18n/locales/lv.json
+++ b/autobot-frontend/src/i18n/locales/lv.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Komandas izpilde neizdevās",
+      "postExecutionFailed": "Komanda tika izpildīta, taču nākamais solis neizdevās. Tās izvade tiek rādīta; daži atjauninājumi var trūkt.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/pl.json
+++ b/autobot-frontend/src/i18n/locales/pl.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Wykonanie polecenia nie powiodło się",
+      "postExecutionFailed": "Polecenie zostało wykonane, ale kolejny krok się nie powiódł. Wynik jest wyświetlany; niektóre aktualizacje mogą być niekompletne.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/pt.json
+++ b/autobot-frontend/src/i18n/locales/pt.json
@@ -5618,7 +5618,8 @@
       "executing": "Executing...",
       "securityNote": "Commands are executed in a sandboxed environment with limited permissions.",
       "missingSessionId": "Missing session ID for command execution",
-      "executionFailed": "Command execution failed",
+      "executionFailed": "Falha na execução do comando",
+      "postExecutionFailed": "O comando foi executado, mas uma etapa posterior falhou. A saída é exibida; algumas atualizações podem estar faltando.",
       "enterComment": "Please enter a comment before submitting"
     },
     "darkModeToggle": {

--- a/autobot-frontend/src/i18n/locales/ur.json
+++ b/autobot-frontend/src/i18n/locales/ur.json
@@ -4753,7 +4753,8 @@
       "theme": "Theme"
     },
     "commandPermission": {
-      "executionFailed": "Command execution failed",
+      "executionFailed": "کمانڈ کا نفاذ ناکام ہو گیا",
+      "postExecutionFailed": "کمانڈ چل گئی، لیکن اس کے بعد کا ایک مرحلہ ناکام ہو گیا۔ اس کا آؤٹ پٹ دکھایا جا رہا ہے؛ کچھ اپ ڈیٹس غائب ہو سکتی ہیں۔",
       "allow": "Allow",
       "purposeLabel": "Purpose",
       "defaultPurpose": "System operation requested",

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -333,7 +333,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,
     "autobot-backend/services/agent_analytics.py": 686,
-    "autobot-backend/services/agent_terminal/service.py": 969,
+    "autobot-backend/services/agent_terminal/service.py": 962,
     "autobot-backend/services/ai_stack_client.py": 790,
     "autobot-backend/services/analytics_service.py": 838,
     "autobot-backend/services/audit_logger.py": 1022,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -328,7 +328,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,
     "autobot-backend/services/agent_analytics.py": 686,
-    "autobot-backend/services/agent_terminal/service.py": 969,
+    "autobot-backend/services/agent_terminal/service.py": 962,
     "autobot-backend/services/ai_stack_client.py": 790,
     "autobot-backend/services/analytics_service.py": 838,
     "autobot-backend/services/audit_logger.py": 1022,


### PR DESCRIPTION
Closes #15073

## Thinking Path

The bug is not "the catch is too broad", it is that **two different events were given one name**.
"The command never ran" and "the command ran and a step after it raised" have different causes,
different fixes and different consequences for the user — and one `try` around the executor call
*plus* the four post-processing awaits collapsed them into
`{"status": "error", "error": "Command execution failed"}`. The operator is sent to the executor,
the PTY and the shell, none of which are broken; the user is told their command failed when it
succeeded; and the `result` already in hand — stdout, stderr, return code — is dropped on the
floor, which is the data-loss half of the bug.

So the fix keeps the two apart rather than catching narrower and moving on:

* `post_execution_guard(result)` opens the moment the executor has returned. Anything raised
  inside it is *by construction* a defect in what happens after the command ran, and it is
  re-raised as `PostExecutionError` carrying the real result.
* That comes back as `status: "completed_with_errors"` with the true `stdout` / `stderr` /
  `return_code`, `command_status` (what the command itself did), and `post_execution_error` naming
  the failing step. A command that never produced a result still comes back as `status: "error"`.
  Nothing can confuse the two: different status, different `error_code`, and only one of them can
  show the user what the command printed.
* `TypeError` / `AttributeError` from **execution itself** are re-raised, consistent with the
  transient-only split #13281 established one layer down. Post-processing ones are not re-raised —
  AC6 requires the caller to receive the successful output *and* a distinct error indication, which
  is impossible if the exception propagates; they are logged with `exc_info=True` and named in the
  response instead. That is the reading in which AC3 and AC6 are both satisfiable.
* Both handlers log with `exc_info=True`. `logger.error("...: %s", e)` lost the traceback, which
  was the only thing that pointed at the real line.

**The user-visible message goes through i18n, not a literal.** The backend emits an `error_code`
identifier and never prose for these outcomes; the composable maps it to
`ui.commandPermission.executionFailed` / `.postExecutionFailed`. Both keys are now translated in
all 11 locales — `executionFailed` existed but held the English string in every one of them, and
the toast call hardcoded the same English literal besides, so the "distinct message" this issue
asks for would have been English-only in 10 locales. `error` stays English on purpose: it is read
by the agent-facing tool layer and the log, neither of which is localised.

**Why `utils.py` moved:** `service.py` sat at exactly its recorded ceiling (969/969). Rather than
raise it, the duplicated six-argument `log_command` call in `_execute_auto_approved_command`
became `log_autobot_command` in `utils.py`, next to `log_command_approval` which moved there for
the same reason in #14959. The file lands at 962 and the ceiling is **lowered** to 962 in both
carriers.

**Found, not fixed here:** `tools/terminal_tool.py:228-232` is the same shape a third time, and it
would relabel the `TypeError` this PR deliberately re-raises. It cannot be fixed in this PR without
first splitting the file (it is at 608/608, ratchet is down-only), so it is filed as #15110 with
its own acceptance criteria.

## What Changed

| File | Change |
|---|---|
| `services/agent_terminal/errors.py` | **New.** `PostExecutionError`, `post_execution_guard`, and the two response builders. Error codes are identifiers, never prose |
| `services/agent_terminal/service.py` | Both sites: guard around post-processing, `PostExecutionError` → distinguished response, `TypeError`/`AttributeError` re-raised, `exc_info=True`. 969 → 962 lines |
| `services/agent_terminal/utils.py` | `log_autobot_command` — the twice-written `autobot` run-type transcript call |
| `services/agent_terminal/post_execution_failure_15073_test.py` | **New.** 9 tests, both paths |
| `scripts/python_file_size_known_large.py`, `repo_tests/python_file_size_ratchet_baseline.py` | ceiling lowered 969 → 962 in both carriers |
| `composables/useCommandApproval.ts` | `completed_with_errors` branch (warning, no polling — the command already finished); `translateApprovalOutcome` maps `error_code` → i18n key with a prose fallback; the hardcoded English toast is gone |
| `composables/__tests__/useCommandApproval.postExecution.spec.ts` | **New.** 4 tests at the toast surface |
| `i18n/locales/*.json` (11) | `postExecutionFailed` added and `executionFailed` translated — both, in all 11 |

Wire compatibility: the approve route's response model is `extra: "allow"`, and
`terminal_tool._format_execution_result` routes `completed_with_errors` to its success branch,
which already carries `stdout` / `stderr` / `return_code` through (#14141) — so the real output
reaches the model rather than the old generic string. What it does not yet carry is the
post-execution note; that gap is #15110.

## Verification

Kinds: **unit** (service boundary, both paths) · **component/DOM** (the toast the user reads) ·
**static** (size ratchet, locale parity, lint, typecheck). No host evidence — this is a
process-internal control-flow change with no deployed surface to observe; the route boundary is
covered by the response model being `extra: "allow"` and by the unit tests on the service method
the route calls.

```
$ python3 -m pytest services/agent_terminal/ api/terminal_tools_test.py tools/ -q
117 passed in 7.88s
```
including the 9 new ones, and #13281's `approval_handler_error_surfacing_test.py` unchanged.

```
$ vitest run src/composables/__tests__/ src/i18n/__tests__/locale-parity.test.ts
Test Files  85 passed (85)     Tests  1259 passed | 1 skipped (1260)
$ vue-tsc --noEmit -p tsconfig.app.json     # exit 0
$ eslint / oxlint on both changed TS files  # clean
$ python3 -m flake8 services/agent_terminal/  # clean
$ python3 scripts/check_python_file_size.py services/agent_terminal/service.py  # under ceiling
$ python3 -m pytest repo_tests/python_file_size_ratchet_test.py -q  → 31 passed
```

**Contrast mutation A — restore the original catch-all** on `_execute_approved_command`
(`except Exception` → generic dict), at this head:

```
5 failed, 4 passed
E   AssertionError: assert 'error' == 'completed_with_errors'
E   KeyError: 'error_code'
E   AssertionError: assert 'error' != 'error'          <- the two failures become one outcome
E   Failed: DID NOT RAISE <class 'TypeError'>
E   AssertionError: logged without exc_info: no traceback to follow
```

The third line is the point of the exercise: with the catch-all back, the head-to-head test finds
the two outcomes identical — which is exactly what a user saw.

**Contrast mutation B — collapse the two messages in the UI** (`translateApprovalOutcome(result.error_code, …)`
→ hardcoded `'executionFailed'`):

```
1 failed | 3 passed
AssertionError: expected [ 'Command execution failed' ] to include 'The command ran, but a follow-up step…'
```

Both mutations reverted; everything green at this head.

Shard: the new backend test module `services/agent_terminal/post_execution_failure_15073_test.py`
→ **shard 11 of 12** (`repo_tests/stable_shard.py` against `.test_durations`). The frontend spec is
not sharded by that plugin.

Per-criterion:

| AC | Evidence | Kind |
|---|---|---|
| No longer `"Command execution failed"`; the two are distinguished | `test_post_processing_failure_keeps_the_output_the_command_produced`, `test_the_two_failures_are_told_apart_by_the_caller` | unit |
| Real stdout/stderr/return_code survive | same two, plus the auto-approved twin | unit |
| `TypeError`/`AttributeError` not flattened | `test_a_programming_error_in_execution_itself_reaches_the_caller` (both paths) | unit |
| Both sites fixed | approved path + `execute_command` path each have their own tests | unit |
| `exc_info=True` on both handlers | `test_the_post_processing_failure_is_logged_with_its_traceback` (asserts `record.exc_info`) | unit |
| A test raises `TypeError` from a post-execution step and asserts output + distinct indication | the first test, verbatim | unit |

Not proven: this box runs fastapi 0.135.2 against CI's pinned 0.141.1 (#15091), so a local pass is
not a CI pass; and `shellcheck`-style host verification does not apply here.

## Model Used

Claude Opus 5 (1M context) — model id `claude-opus-5[1m]`
