### PR TITLE
test(api): guard the include_router deferral the repo knew about four times (#15093)

### DIFF
--- a/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
+++ b/autobot-backend/api/codebase_analytics/endpoints/impact_endpoint_test.py
@@ -155,13 +155,13 @@ def test_max_depth_override_reaches_the_engine(depth):
 def test_the_endpoint_is_registered_on_the_router():
     """#13506 is a wiring defect — an endpoint nothing includes repeats it."""
     from api.codebase_analytics.router import router
+    from autobot_shared.api_routing.router_routes import effective_routes
 
-    # This app wraps includes in `_IncludedRouter`, so the mounted paths live on
-    # `.original_router.routes`, not on the top-level route objects.
-    paths = {
-        p
-        for included in router.routes
-        for sub in getattr(included, "original_router", None).routes
-        if (p := getattr(sub, "path", None))
-    }
+    # The traversal handles both FastAPI shapes (#15093). What it replaces read
+    # `.original_router.routes` with no `None` fallback, so it was correct only
+    # on the deferred shape and raised `AttributeError: 'NoneType' object has no
+    # attribute 'routes'` on any checkout resolving a FastAPI below 0.139.
+    mounted = effective_routes(router)
+    assert mounted, "non-vacuity: the analytics router enumerated no routes at all"
+    paths = {m.path for m in mounted}
     assert "/impact" in paths, f"/impact not mounted; got {sorted(paths)[:8]}…"

--- a/autobot-backend/api/presence_ws_router_test.py
+++ b/autobot-backend/api/presence_ws_router_test.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import FastAPI
 
 from api.presence_ws import router
+from autobot_shared.api_routing.router_routes import effective_routes
 
 
 class TestPresenceWSRouter:
@@ -61,8 +62,12 @@ class TestPresenceWSRouter:
         except Exception as e:
             pytest.fail(f"Failed to mount router: {e}")
 
-        # Verify the router was mounted
-        assert len(app.routes) > 0
+        # A real mounted path, not `len(app.routes) > 0` (#15093): under
+        # fastapi>=0.139 a single deferred wrapper satisfies that count, so it
+        # was already true before `include_router` was called and asserted
+        # nothing about this router reaching the app.
+        mounted = {m.path for m in effective_routes(app)}
+        assert "/ws/sessions/{session_id}/presence" in mounted, f"router not mounted; app serves {sorted(mounted)}"
 
 
 class TestPresenceWSConfiguration:

--- a/autobot-backend/api/self_capabilities.py
+++ b/autobot-backend/api/self_capabilities.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, Request
 from fastapi.openapi.utils import get_openapi
 
 from api.schemas_agent import SelfCapabilitiesResponse
+from autobot_shared.api_routing.router_routes import effective_route_count
 from autobot_shared.error_boundaries import ErrorCategory, with_error_handling
 from autobot_shared.logging_manager import get_logger
 from constants.ttl_constants import TTL_5_MINUTES
@@ -42,10 +43,20 @@ _cache_schema_hash: str = ""
 _cache_lock = asyncio.Lock()
 
 
-def _schema_hash(app_routes_count: int) -> str:
-    """Cheap fingerprint: route count is enough to detect new registrations."""
+def _schema_hash(app: Any) -> str:
+    """Cheap fingerprint of the served route table.
+
+    Counted through ``effective_route_count`` rather than ``len(app.routes)``
+    (#15093). Under ``fastapi>=0.139`` — the declared floor — ``app.routes``
+    holds one deferred entry per ``include_router`` **call**, so its length moves
+    when a router is mounted and not when an endpoint is added inside one that
+    is already mounted. That is the common case, and it left the cache serving a
+    stale table for a full TTL while the docstring promised the opposite. The
+    traversal is a walk over route objects, not schema generation, so this stays
+    cheap enough to run on the fast path.
+    """
     # usedforsecurity=False: fingerprint only, not a security hash  # noqa: S324
-    return hashlib.md5(str(app_routes_count).encode(), usedforsecurity=False).hexdigest()  # noqa: S324
+    return hashlib.md5(str(effective_route_count(app)).encode(), usedforsecurity=False).hexdigest()  # noqa: S324
 
 
 def _cache_is_valid(current_hash: str) -> bool:
@@ -164,8 +175,10 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
     """
     Return live endpoint discovery data for the given FastAPI app.
 
-    Results are cached for TTL_5_MINUTES and invalidated automatically when
-    the number of registered routes changes (e.g., after optional routers load).
+    Results are cached for TTL_5_MINUTES and invalidated automatically when the
+    number of served routes changes — counted through the mount-aware traversal,
+    so an endpoint added inside an already-mounted router busts the cache too
+    (#15093).
 
     Args:
         app: The FastAPI application instance.
@@ -175,7 +188,7 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
     """
     global _cache, _cache_ts, _cache_schema_hash
 
-    current_hash = _schema_hash(len(app.routes))
+    current_hash = _schema_hash(app)
 
     # Fast path — no lock needed for read
     if _cache_is_valid(current_hash):
@@ -186,7 +199,7 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
         if _cache_is_valid(current_hash):
             return _cache  # type: ignore[return-value]
 
-        logger.info("endpoint-discovery: refreshing cache (routes=%d)", len(app.routes))
+        logger.info("endpoint-discovery: refreshing cache (routes=%d)", effective_route_count(app))
         paths = await asyncio.to_thread(_openapi_paths, app)
         endpoints = _collect_endpoints(paths)
         payload = _build_payload(endpoints)
@@ -215,7 +228,7 @@ async def discover_endpoints(app: Any) -> Dict[str, Any]:
         "Returns a dynamically derived list of all registered API endpoints, "
         "grouped by OpenAPI tag and operation type.  The result is derived from "
         "the live FastAPI OpenAPI schema (not hardcoded) and is cached with a "
-        f"{TTL_5_MINUTES // 60}-minute TTL that resets on route changes."
+        f"{TTL_5_MINUTES // 60}-minute TTL that resets when the served route table changes."
     ),
     tags=["self", "capabilities"],
     response_model=SelfCapabilitiesResponse,

--- a/autobot-backend/llc/tests/test_roles_routes_registered.py
+++ b/autobot-backend/llc/tests/test_roles_routes_registered.py
@@ -13,6 +13,7 @@ importing the module proves only that the file parses.
 
 from __future__ import annotations
 
+from autobot_shared.api_routing.router_routes import effective_routes
 from llc.api import router as llc_router
 
 #: The assembled router carries prefix="/llc", so mounted paths include it.
@@ -50,27 +51,14 @@ _EXPECTED = {
 def _mounted() -> set:
     """(method, path) pairs reachable through the assembled LLC router.
 
-    This FastAPI version defers inclusion: ``router.routes`` holds
-    ``_IncludedRouter`` wrappers with no ``.path``, and the real routes live on
-    ``.original_router.routes``. Walking the top level alone finds one route out
-    of thirty-eight and reads as "nothing is mounted".
-
-    Same idiom as ``api/codebase_analytics/endpoints/impact_endpoint_test.py``
-    and ``api/self_capabilities_integration_test.py``, which both document this.
-    The sub-router paths are relative to the parent, so the ``/llc`` prefix is
-    prepended here rather than expected on the route itself.
+    ``effective_routes`` is the one traversal (#15093). What it replaces here was
+    correct in CI and broken locally: it walked ``.original_router.routes`` with
+    no fallback for the eager shape, and it prepended ``llc_router.prefix`` by
+    hand — which doubles to ``/llc/llc/...`` on a FastAPI that folds the prefix
+    in at include time. Both halves of that are now the helper's job, so this
+    file no longer encodes a FastAPI version.
     """
-    found = set()
-    for included in llc_router.routes:
-        original = getattr(included, "original_router", None)
-        subroutes = original.routes if original is not None else [included]
-        for sub in subroutes:
-            path = getattr(sub, "path", None)
-            if not path:
-                continue
-            for method in getattr(sub, "methods", set()) or set():
-                found.add((method, f"{llc_router.prefix}{path}"))
-    return found
+    return {(method, mounted.path) for mounted in effective_routes(llc_router) for method in mounted.methods}
 
 
 def test_every_role_route_is_mounted_on_the_llc_router() -> None:
@@ -87,17 +75,14 @@ def test_role_routes_require_authentication() -> None:
     """
     unguarded = []
     checked = 0
-    for included in llc_router.routes:
-        original = getattr(included, "original_router", None)
-        for sub in original.routes if original is not None else []:
-            path = f"{llc_router.prefix}{getattr(sub, 'path', '')}"
-            if not path.startswith(_PREFIX):
-                continue
-            checked += 1
-            dependant = getattr(sub, "dependant", None)
-            names = {getattr(dep.call, "__name__", "") for dep in getattr(dependant, "dependencies", [])}
-            if "get_current_user" not in names or "require_org_context" not in names:
-                unguarded.append((sorted(getattr(sub, "methods", []) or []), path, sorted(names)))
+    for mounted in effective_routes(llc_router):
+        if not mounted.path.startswith(_PREFIX):
+            continue
+        checked += 1
+        dependant = getattr(mounted.route, "dependant", None)
+        names = {getattr(dep.call, "__name__", "") for dep in getattr(dependant, "dependencies", [])}
+        if "get_current_user" not in names or "require_org_context" not in names:
+            unguarded.append((sorted(mounted.methods), mounted.path, sorted(names)))
     # Presence check first: with a wrong prefix this loop matches nothing and
     # the assertion below passes while having verified nothing at all — an
     # empty result reading as a clean result, which is how the first draft of

--- a/autobot-frontend/src/types/generated/api.ts
+++ b/autobot-frontend/src/types/generated/api.ts
@@ -1590,7 +1590,7 @@ export interface paths {
         };
         /**
          * Dynamic endpoint capability discovery
-         * @description Returns a dynamically derived list of all registered API endpoints, grouped by OpenAPI tag and operation type.  The result is derived from the live FastAPI OpenAPI schema (not hardcoded) and is cached with a 5-minute TTL that resets on route changes.
+         * @description Returns a dynamically derived list of all registered API endpoints, grouped by OpenAPI tag and operation type.  The result is derived from the live FastAPI OpenAPI schema (not hardcoded) and is cached with a 5-minute TTL that resets when the served route table changes.
          */
         get: operations["get_capabilities_api_capabilities_get"];
         put?: never;

--- a/autobot-infrastructure/shared/scripts/test_real_startup.py
+++ b/autobot-infrastructure/shared/scripts/test_real_startup.py
@@ -17,9 +17,13 @@ from pathlib import Path
 # sys.path, so this script raised ModuleNotFoundError on its own import block
 # before doing any work. Add the directory the way the other operator entry
 # points in this tree do (#14129).
-_BACKEND_DIR = Path(__file__).resolve().parents[3] / "autobot-backend"
-if str(_BACKEND_DIR) not in sys.path:
-    sys.path.insert(0, str(_BACKEND_DIR))
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BACKEND_DIR = _REPO_ROOT / "autobot-backend"
+for _path in (_BACKEND_DIR, _REPO_ROOT):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from autobot_shared.api_routing.router_routes import effective_route_count  # noqa: E402
 
 
 def test_backend_import():
@@ -79,14 +83,17 @@ def test_uvicorn_startup():
     # 2. Access app attributes (this should trigger lazy creation)
     access_start = time.time()
     app_type = type(main.app)  # This might trigger app creation
-    routes = len(main.app.routes) if hasattr(main.app, "routes") else 0  # This definitely will
+    # Counted through the mount-aware traversal (#15093): `len(main.app.routes)`
+    # counts deferred include_router entries, not endpoints, so it under-reports
+    # by orders of magnitude on the declared fastapi floor.
+    routes = effective_route_count(main.app)  # accessing app.routes is what triggers creation
     access_time = time.time() - access_start
 
     total_time = time.time() - start_time
 
     print(f"✅ Module import      : {import_time:6.3f}s")
     print(f"✅ App access/creation: {access_time:6.3f}s")
-    print(f"📋 App has {routes} routes")
+    print(f"📋 App has {routes} routes ({app_type.__module__}.{app_type.__name__})")
     print(f"🎯 Total uvicorn-style: {total_time:6.3f}s")
 
     return total_time

--- a/autobot_shared/api_routing/mount_graph.py
+++ b/autobot_shared/api_routing/mount_graph.py
@@ -264,8 +264,43 @@ def _routes_subject(node: ast.AST) -> Optional[ast.AST]:
 
 
 def _is_apirouter(call: ast.Call) -> bool:
+    """Whether *call* constructs an ``APIRouter``, plain or dotted.
+
+    The ``None`` branch is explicit rather than folded into ``bool(rendered) and
+    rendered.split(...)``. That spelling never reached ``.split`` with ``None`` —
+    ``and`` short-circuits — so this is a narrowing the checker can follow, not a
+    bug fix, and the two forms select exactly the same calls. ``_dotted`` cannot
+    return ``""`` either: it always joins at least one identifier.
+    """
     rendered = _dotted(call.func)
-    return bool(rendered) and rendered.split(".")[-1] == "APIRouter"
+    if rendered is None:
+        return False
+    return rendered.split(".")[-1] == "APIRouter"
+
+
+@dataclass
+class _Buckets:
+    """The node kinds one ``ast.walk`` collects, each keeping its own type.
+
+    A ``Dict[type, List[ast.AST]]`` would be shorter and is what this was first
+    written as, but it erases the element type: every later pass then reads
+    ``.func`` / ``.module`` / ``.targets`` off a bare ``ast.AST``, which the type
+    checker cannot verify and a future edit could get wrong with nothing saying
+    so. Five named lists cost five lines and make each pass's assumption explicit.
+
+    ``isinstance`` rather than ``type(node) is ...`` when filling these: it is
+    what the passes used before they were merged into one walk, and it stays
+    correct if a node kind ever gains a subclass. None of these five has one
+    today — ``AsyncFor`` is a sibling of ``For``, not a subclass, and
+    ``AnnAssign``/``AugAssign`` are siblings of ``Assign`` — so the two spellings
+    select the same nodes now, and ``isinstance`` is the one that keeps doing so.
+    """
+
+    fors: List[ast.For] = field(default_factory=list)
+    imports: List[ast.ImportFrom] = field(default_factory=list)
+    assigns: List[ast.Assign] = field(default_factory=list)
+    calls: List[ast.Call] = field(default_factory=list)
+    attributes: List[ast.Attribute] = field(default_factory=list)
 
 
 class ModuleScan:
@@ -282,7 +317,7 @@ class ModuleScan:
         self.dynamic: List[str] = []
         self.loop_targets: Set[str] = set()
         self.routes_reads: List[RoutesRead] = []
-        self._nodes: Dict[type, List[ast.AST]] = {}
+        self._nodes = _Buckets()
 
     def run(self) -> None:
         """One ``ast.walk``, then five passes over what it bucketed.
@@ -293,17 +328,18 @@ class ModuleScan:
         module-local definitions then override an imported name of the same
         spelling, and only after both can a mount or a ``.routes`` read resolve.
         """
-        buckets: Dict[type, List[ast.AST]] = {
-            ast.For: [],
-            ast.ImportFrom: [],
-            ast.Assign: [],
-            ast.Call: [],
-            ast.Attribute: [],
-        }
+        buckets = _Buckets()
         for node in ast.walk(self.tree):
-            found = buckets.get(type(node))
-            if found is not None:
-                found.append(node)
+            if isinstance(node, ast.For):
+                buckets.fors.append(node)
+            elif isinstance(node, ast.ImportFrom):
+                buckets.imports.append(node)
+            elif isinstance(node, ast.Assign):
+                buckets.assigns.append(node)
+            elif isinstance(node, ast.Call):
+                buckets.calls.append(node)
+            elif isinstance(node, ast.Attribute):
+                buckets.attributes.append(node)
         self._nodes = buckets
         self._collect_loop_targets()
         self._collect_imports()
@@ -324,7 +360,8 @@ class ModuleScan:
         counted and reported; a dropped one cannot be told apart from a scan
         that matched nothing.
         """
-        for node in self._nodes[ast.Attribute] + self._nodes[ast.Call]:
+        reads: List[ast.expr] = [*self._nodes.attributes, *self._nodes.calls]
+        for node in reads:
             subject = _routes_subject(node)
             if subject is None:
                 continue
@@ -342,7 +379,7 @@ class ModuleScan:
         entries instead, so it must be recorded as *dynamic*, not as an
         unresolvable reference.
         """
-        for node in self._nodes[ast.For]:
+        for node in self._nodes.fors:
             targets = node.target.elts if isinstance(node.target, ast.Tuple) else [node.target]
             for target in targets:
                 if isinstance(target, ast.Name):
@@ -350,7 +387,7 @@ class ModuleScan:
 
     # imports first: `from api.x import router as y` binds y -> api.x:router.
     def _collect_imports(self) -> None:
-        for node in self._nodes[ast.ImportFrom]:
+        for node in self._nodes.imports:
             if node.module is None:
                 continue
             source = node.module
@@ -365,7 +402,7 @@ class ModuleScan:
     # definitions second, so a module-local `router = APIRouter()` wins over an
     # imported name of the same spelling.
     def _collect_definitions(self) -> None:
-        for node in self._nodes[ast.Assign]:
+        for node in self._nodes.assigns:
             if not isinstance(node.value, ast.Call):
                 continue
             if not _is_apirouter(node.value):
@@ -390,7 +427,7 @@ class ModuleScan:
         return None
 
     def _collect_include_calls(self) -> None:
-        for node in self._nodes[ast.Call]:
+        for node in self._nodes.calls:
             if not isinstance(node.func, ast.Attribute):
                 continue
             if node.func.attr != "include_router" or not node.args:

--- a/autobot_shared/api_routing/mount_graph.py
+++ b/autobot_shared/api_routing/mount_graph.py
@@ -1,0 +1,531 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The router mount graph, derived from source rather than from a running app.
+
+Two repo guards need the same three facts — which ``APIRouter`` objects exist,
+which ``include_router`` calls mount which of them, and what each hop carries:
+
+* ``repo_tests/router_mount_parity_test.py`` (#15098) — is a router reachable
+  through a mount that skips a gate its other mounts apply?
+* ``repo_tests/router_routes_traversal_test.py`` (#15093) — does anything read
+  ``<router>.routes`` on a router that has children?
+
+They were one file's private machinery until #15093. Two copies of an AST
+resolver drift the way the two ``include_router`` regexes in
+``router_prefixes.py`` drifted (#12985): one gets a resolution fix, the other
+does not, and the gate that decides whether a PR may merge disagrees with the
+report a human reads to judge it. This is the single copy.
+
+## Why static
+
+Under ``fastapi>=0.139`` ``include_router`` defers: neither the include-time
+``prefix=`` nor an include-time ``dependencies=`` list is recoverable from the
+route objects afterwards (#15093, and see
+``autobot_shared/api_routing/router_routes.py`` for the runtime half). A
+development checkout may resolve a lower FastAPI where some of it *is* readable
+(#15091), so a runtime-introspection guard would mean one thing locally and
+another in CI — worse than no guard. Parsing the registration sites is
+version-independent, which is the property both consumers need.
+
+## What it cannot see
+
+* A mount whose target is computed at runtime. ``app_factory`` iterates the
+  registry tuples and includes a loop variable; those are recorded as
+  ``dynamic`` and modelled from the registry entries instead. Any *other*
+  dynamic mount is recorded too, so it can be failed on rather than skipped.
+* An attribute chain rooted in a local variable — ``bridge.router.routes``
+  resolves no further than the literal text. Such reads are returned with
+  ``target=None`` rather than silently dropped.
+* A gate applied by anything other than a ``dependencies=`` argument:
+  middleware path matching, a decorator, an in-body ``Depends``.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
+
+__all__ = [
+    "APP_ROOT",
+    "Mount",
+    "MountGraph",
+    "ModuleScan",
+    "RouterDef",
+    "RoutesRead",
+    "build_graph",
+    "is_relevant",
+    "module_name",
+    "python_files",
+    "registry_dirname",
+]
+
+#: Directory name under ``initialization/`` whose tuples the app factory mounts.
+_REGISTRY_DIRNAME = "router_registry"
+
+#: Never walked: build output, vendored trees, virtualenvs.
+_SKIP_DIRS: FrozenSet[str] = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git"})
+
+# The synthetic parent for a mount performed by the application factory: every
+# registry entry is included by `app_factory` with `prefix=f"/api{prefix}"` and
+# no `dependencies=`, so the app root contributes no guard.
+APP_ROOT = "<app>"
+
+
+def registry_dirname() -> str:
+    """The registry directory name, so consumers do not re-spell it."""
+    return _REGISTRY_DIRNAME
+
+
+@dataclass(frozen=True)
+class RoutesRead:
+    """One ``<expr>.routes`` read found in source."""
+
+    site: str
+    expr: str
+    target: Optional[str]
+
+
+@dataclass(frozen=True)
+class RouterDef:
+    """A module-level ``X = APIRouter(...)`` binding."""
+
+    key: str
+    own_guards: FrozenSet[str]
+
+
+@dataclass(frozen=True)
+class Mount:
+    """One ``include_router`` (or registry entry) edge in the mount graph."""
+
+    parent: str
+    child: str
+    guards: FrozenSet[str]
+    site: str
+
+
+@dataclass
+class MountGraph:
+    routers: Dict[str, RouterDef] = field(default_factory=dict)
+    edges: List[Mount] = field(default_factory=list)
+    unresolved: List[str] = field(default_factory=list)
+    dynamic: List[str] = field(default_factory=list)
+    routes_reads: List[RoutesRead] = field(default_factory=list)
+
+    def paths_to(self, key: str) -> Set[FrozenSet[str]]:
+        """Every distinct guard set that reaches *key* from the app root.
+
+        A guard set is the union of the dependencies named at each hop: the
+        ``dependencies=`` of the ``include_router`` call plus those declared on
+        the parent's own ``APIRouter(...)`` constructor, all the way up --
+        **and the router's own constructor dependencies**, which apply at every
+        mount by construction.
+
+        That last term is the one that matters. A router protected on its own
+        constructor is protected everywhere, which is exactly how #15084 was
+        fixed and how every other gated router in this repo is written. Omitting
+        it made such a router read as ungated on every path, so the comparison
+        was empty-set against empty-set: agreement reached by seeing nothing
+        rather than by seeing a gate.
+        """
+        own = self._own_guards(key)
+        return {path | own for path in self._paths(key, frozenset())}
+
+    def _paths(self, key: str, seen: FrozenSet[str]) -> Set[FrozenSet[str]]:
+        if key in seen:  # a cycle contributes nothing new
+            return set()
+        seen = seen | {key}
+        incoming = [e for e in self.edges if e.child == key]
+        if not incoming:
+            return set()
+        out: Set[FrozenSet[str]] = set()
+        for edge in incoming:
+            hop = edge.guards | self._own_guards(edge.parent)
+            if edge.parent == APP_ROOT:
+                out.add(hop)
+                continue
+            for upstream in self._paths(edge.parent, seen):
+                out.add(hop | upstream)
+        return out
+
+    def _own_guards(self, key: str) -> FrozenSet[str]:
+        found = self.routers.get(key)
+        return found.own_guards if found else frozenset()
+
+    def mounted_keys(self) -> List[str]:
+        return sorted({e.child for e in self.edges})
+
+    def inconsistent(self, exempt: Iterable[str] = ()) -> Dict[str, Set[FrozenSet[str]]]:
+        """Routers whose reachable paths do not all carry the same guards.
+
+        A router mounted once, or mounted many times with identical guards, is
+        consistent. One reachable both behind ``check_admin_permission`` and
+        without it is the defect. *exempt* names keys to skip; the caller owns
+        that list because it also owns the reason each entry carries.
+        """
+        bad: Dict[str, Set[FrozenSet[str]]] = {}
+        exempt_keys = set(exempt)
+        for key in self.mounted_keys():
+            if key in exempt_keys:
+                continue
+            paths = self.paths_to(key)
+            if len(paths) < 2:
+                continue
+            weakest = frozenset.intersection(*paths)
+            strongest = frozenset.union(*paths)
+            if weakest != strongest:
+                bad[key] = paths
+        return bad
+
+    def routers_with_children(self) -> Set[str]:
+        """Keys of routers that receive at least one ``include_router`` call.
+
+        Reading ``.routes`` on one of these is the #15093 defect: under
+        ``fastapi>=0.139`` the list holds a deferred wrapper per included child
+        rather than the children's routes. Every other router's ``.routes`` is
+        built from decorators alone and is the same on both FastAPI shapes.
+        """
+        return {edge.parent for edge in self.edges if edge.parent != APP_ROOT}
+
+
+# --- source parsing ---------------------------------------------------------
+
+
+def module_name(path: Path, root: Path) -> str:
+    """Dotted import name for *path* relative to *root*.
+
+    ``__init__`` is stripped, so ``llc/api/__init__.py`` is ``llc.api`` — the
+    name every importer actually writes and the name a registry entry spells.
+    Leaving it in produced two spellings of one router: definitions landed under
+    ``llc.api.__init__:router`` while mounts and imports named ``llc.api:router``,
+    so a package router's own constructor guards were attached to a key nothing
+    else referenced and read as absent everywhere.
+    """
+    parts = path.relative_to(root).with_suffix("").as_posix().split("/")
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _guards_from_keyword(node: ast.AST) -> FrozenSet[str]:
+    """Dependency names inside a ``dependencies=[Depends(x), ...]`` argument."""
+    names: Set[str] = set()
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return frozenset()
+    for element in node.elts:
+        target = element
+        if isinstance(element, ast.Call):
+            args = element.args
+            target = args[0] if args else element.func
+        rendered = _dotted(target)
+        if rendered:
+            names.add(rendered)
+    return frozenset(names)
+
+
+def _dotted(node: ast.AST) -> str | None:
+    """Render ``a.b.c`` / ``a`` from an expression; None for anything else."""
+    parts: List[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if not isinstance(node, ast.Name):
+        return None
+    parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _call_kwarg(call: ast.Call, name: str) -> ast.AST | None:
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return keyword.value
+    return None
+
+
+def _routes_subject(node: ast.AST) -> Optional[ast.AST]:
+    """The expression whose ``routes`` *node* reads, or ``None``.
+
+    Both spellings count. ``x.routes`` is the obvious one; ``getattr(x, "routes", [])``
+    is the same read written so it cannot raise, which is the strictly more
+    dangerous form — on the deferred shape it turns "this router has children I
+    cannot see" into an empty list and an assertion over nothing (#15087).
+    """
+    if isinstance(node, ast.Attribute) and node.attr == "routes" and isinstance(node.ctx, ast.Load):
+        return node.value
+    if not isinstance(node, ast.Call) or _dotted(node.func) != "getattr" or len(node.args) < 2:
+        return None
+    name = node.args[1]
+    if isinstance(name, ast.Constant) and name.value == "routes":
+        return node.args[0]
+    return None
+
+
+def _is_apirouter(call: ast.Call) -> bool:
+    rendered = _dotted(call.func)
+    return bool(rendered) and rendered.split(".")[-1] == "APIRouter"
+
+
+class ModuleScan:
+    """Local-name -> router-key bindings and mounts within one module."""
+
+    def __init__(self, module: str, tree: ast.AST, backend: Path):
+        self.module = module
+        self.tree = tree
+        self.backend = backend
+        self.local: Dict[str, str] = {}
+        self.defs: List[RouterDef] = []
+        self.edges: List[Mount] = []
+        self.unresolved: List[str] = []
+        self.dynamic: List[str] = []
+        self.loop_targets: Set[str] = set()
+        self.routes_reads: List[RoutesRead] = []
+        self._nodes: Dict[type, List[ast.AST]] = {}
+
+    def run(self) -> None:
+        """One ``ast.walk``, then five passes over what it bucketed.
+
+        Walking the tree once per pass was five full traversals of every module
+        in the repo — around four minutes for the trees this scans. The passes
+        still run in order, because it is load-bearing: imports bind names first,
+        module-local definitions then override an imported name of the same
+        spelling, and only after both can a mount or a ``.routes`` read resolve.
+        """
+        buckets: Dict[type, List[ast.AST]] = {
+            ast.For: [],
+            ast.ImportFrom: [],
+            ast.Assign: [],
+            ast.Call: [],
+            ast.Attribute: [],
+        }
+        for node in ast.walk(self.tree):
+            found = buckets.get(type(node))
+            if found is not None:
+                found.append(node)
+        self._nodes = buckets
+        self._collect_loop_targets()
+        self._collect_imports()
+        self._collect_definitions()
+        self._collect_include_calls()
+        self._collect_routes_reads()
+
+    def _collect_routes_reads(self) -> None:
+        """Every ``<expr>.routes`` attribute read in this module.
+
+        The expression is resolved with the same bindings the mount graph uses,
+        so ``from llc.api import router as llc_router`` followed by
+        ``llc_router.routes`` yields ``llc.api:router`` — the key the graph knows
+        as a parent of thirty-eight inclusions.
+
+        An unresolvable expression is kept with ``target=None`` rather than
+        dropped. It is a blind spot either way, but a recorded one can be
+        counted and reported; a dropped one cannot be told apart from a scan
+        that matched nothing.
+        """
+        for node in self._nodes[ast.Attribute] + self._nodes[ast.Call]:
+            subject = _routes_subject(node)
+            if subject is None:
+                continue
+            expr = _dotted(subject) or "<expr>"
+            self.routes_reads.append(
+                RoutesRead(site=f"{self.module}:{node.lineno}", expr=expr, target=self._resolve(subject))
+            )
+
+    def _collect_loop_targets(self) -> None:
+        """Names bound by a ``for`` statement.
+
+        ``app_factory`` iterates the loaded registry tuples and calls
+        ``include_router`` on the loop variable. That mount is real but its
+        target is only known at runtime — it is modelled from the registry
+        entries instead, so it must be recorded as *dynamic*, not as an
+        unresolvable reference.
+        """
+        for node in self._nodes[ast.For]:
+            targets = node.target.elts if isinstance(node.target, ast.Tuple) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    self.loop_targets.add(target.id)
+
+    # imports first: `from api.x import router as y` binds y -> api.x:router.
+    def _collect_imports(self) -> None:
+        for node in self._nodes[ast.ImportFrom]:
+            if node.module is None:
+                continue
+            source = node.module
+            if node.level:  # relative import, resolve against this package
+                package = self.module.rsplit(".", node.level)[0]
+                source = f"{package}.{node.module}" if package else node.module
+            for alias in node.names:
+                if "router" not in alias.name.lower():
+                    continue
+                self.local[alias.asname or alias.name] = f"{source}:{alias.name}"
+
+    # definitions second, so a module-local `router = APIRouter()` wins over an
+    # imported name of the same spelling.
+    def _collect_definitions(self) -> None:
+        for node in self._nodes[ast.Assign]:
+            if not isinstance(node.value, ast.Call):
+                continue
+            if not _is_apirouter(node.value):
+                continue
+            guards = _guards_from_keyword(_call_kwarg(node.value, "dependencies") or ast.List(elts=[]))
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                key = f"{self.module}:{target.id}"
+                self.local[target.id] = key
+                self.defs.append(RouterDef(key=key, own_guards=guards))
+
+    def _resolve(self, node: ast.AST) -> str | None:
+        rendered = _dotted(node)
+        if rendered is None:
+            return None
+        if rendered in self.local:
+            return self.local[rendered]
+        if "." in rendered:  # `api.terminal.router` style reference
+            module, _, attr = rendered.rpartition(".")
+            return f"{module}:{attr}"
+        return None
+
+    def _collect_include_calls(self) -> None:
+        for node in self._nodes[ast.Call]:
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "include_router" or not node.args:
+                continue
+            site = f"{self.module}:{node.lineno}"
+            child_expr = _dotted(node.args[0])
+            if child_expr in self.loop_targets:
+                self.dynamic.append(site)
+                continue
+            child = self._resolve(node.args[0])
+            if child is None:
+                self.unresolved.append(f"{site} child={ast.dump(node.args[0])[:60]}")
+                continue
+            parent_expr = _dotted(node.func.value) or ""
+            parent = self._resolve(node.func.value)
+            if parent is None:
+                # `app.include_router(...)` and friends: an application object,
+                # not a router. Treat as an app-root mount.
+                parent = APP_ROOT
+                if parent_expr not in {"app", "application", "self.app"}:
+                    self.unresolved.append(f"{site} parent={parent_expr or '<expr>'}")
+            guards = _guards_from_keyword(_call_kwarg(node, "dependencies") or ast.List(elts=[]))
+            self.edges.append(Mount(parent=parent, child=child, guards=guards, site=site))
+
+
+# --- registry entries -------------------------------------------------------
+
+
+def _registry_entry(element: ast.AST, module: str, local: Dict[str, str]) -> str | None:
+    """Router key named by one ``(module, [attr,] prefix, tags, name)`` tuple.
+
+    Both registry shapes are handled: a 4-tuple whose first element is a module
+    path string (``("api.terminal_tools", "", [...], "terminal_tools")``), the
+    5-tuple monitoring form that names the attribute second, and the
+    ``core_routers`` form whose first element is an already-imported router.
+    """
+    if not isinstance(element, (ast.Tuple, ast.List)) or len(element.elts) < 4:
+        return None
+    head = element.elts[0]
+    if isinstance(head, ast.Constant) and isinstance(head.value, str):
+        attr = "router"
+        second = element.elts[1]
+        if len(element.elts) >= 5 and isinstance(second, ast.Constant) and isinstance(second.value, str):
+            # 5-tuple: (module, router_attr, prefix, tags, name)
+            attr = second.value or "router"
+        return f"{head.value}:{attr}"
+    rendered = _dotted(head)
+    if rendered and rendered in local:
+        return local[rendered]
+    if rendered:
+        return f"{module}:{rendered}"
+    return None
+
+
+def _scan_registry(path: Path, backend: Path, local: Dict[str, str]) -> List[Mount]:
+    """Registry entries become app-root mounts carrying no guards.
+
+    ``app_factory.register_routers`` includes each loaded tuple with
+    ``prefix=f"/api{prefix}"`` and no ``dependencies=`` argument, so nothing a
+    registry entry can express adds a gate.
+    """
+    module = module_name(path, backend)
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    mounts: List[Mount] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)):
+            continue
+        for element in node.elts:
+            key = _registry_entry(element, module, local)
+            if key is None:
+                continue
+            mounts.append(
+                Mount(
+                    parent=APP_ROOT,
+                    child=key,
+                    guards=frozenset(),
+                    site=f"{module}:{getattr(element, 'lineno', 0)}",
+                )
+            )
+    return mounts
+
+
+#: A file with none of these tokens defines no router, mounts none, and reads
+#: no ``routes`` attribute, so parsing it can only produce empty results. Kept
+#: as a whole-word-ish substring test rather than a regex: it runs once per file
+#: over thousands of files and is pure cost when it does not match.
+_RELEVANT_TOKENS = ("APIRouter", "include_router", ".routes", '"routes"', "'routes'")
+
+
+def is_relevant(source: str) -> bool:
+    """Whether *source* can contribute anything to a mount graph.
+
+    ``initialization/router_registry/*.py`` is exempted by its caller rather
+    than by a token here: those files are pure data — tuples of module paths the
+    app factory mounts — so a registry naming only modules contains none of
+    these tokens and dropping it silently loses every app-root mount it declares.
+    """
+    return any(token in source for token in _RELEVANT_TOKENS)
+
+
+def python_files(root: Path, skip: FrozenSet[str] = _SKIP_DIRS) -> Iterable[Path]:
+    for path in sorted(root.rglob("*.py")):
+        if set(path.parts) & skip:
+            continue
+        yield path
+
+
+def build_graph(backend: Path, skip: FrozenSet[str] = _SKIP_DIRS | frozenset({"tests"})) -> MountGraph:
+    """Derive the whole mount graph from source — nothing is handed in.
+
+    Three discovery sources, matching the three ways a router reaches the app:
+    ``APIRouter`` definitions, ``include_router`` call sites, and
+    ``initialization/router_registry/`` entries loaded by the app factory.
+    """
+    graph = MountGraph()
+    registry_files: List[Tuple[Path, Dict[str, str]]] = []
+    for path in python_files(backend, skip):
+        try:
+            source = path.read_text(encoding="utf-8")
+            if not is_relevant(source) and _REGISTRY_DIRNAME not in path.parts:
+                continue
+            tree = ast.parse(source)
+        except (SyntaxError, UnicodeDecodeError) as exc:  # pragma: no cover
+            graph.unresolved.append(f"{path}: {exc}")
+            continue
+        scan = ModuleScan(module_name(path, backend), tree, backend)
+        scan.run()
+        for definition in scan.defs:
+            graph.routers[definition.key] = definition
+        graph.edges.extend(scan.edges)
+        graph.unresolved.extend(scan.unresolved)
+        graph.dynamic.extend(scan.dynamic)
+        graph.routes_reads.extend(scan.routes_reads)
+        if _REGISTRY_DIRNAME in path.parts:
+            registry_files.append((path, dict(scan.local)))
+    for path, local in registry_files:
+        graph.edges.extend(_scan_registry(path, backend, local))
+    return graph

--- a/autobot_shared/api_routing/router_routes.py
+++ b/autobot_shared/api_routing/router_routes.py
@@ -1,0 +1,175 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The one way to read the routes an ``APIRouter`` actually carries (#15093).
+
+``fastapi>=0.139`` changed ``include_router`` from *copy the child's routes onto
+me* to *record that I include this child*. The parent's ``routes`` list then
+holds an opaque wrapper — its ``path`` is ``None``, it has no ``methods``, and
+the real routes live on ``wrapper.original_router.routes``. Below 0.139 the same
+call flattens eagerly and ``routes`` holds the real objects directly.
+
+Both shapes exist in this project at once: ``requirements-ci/framework.txt`` pins
+``fastapi==0.141.1`` (deferred) while a development checkout may resolve lower
+(#15091). Code written for either one alone is wrong on the other, and wrong in
+the worst possible direction: an ``hasattr``-guarded walk over the deferred shape
+does not raise, it silently finds **nothing**, and a test asserting over nothing
+passes.
+
+Four files had already worked this out privately, each with its own copy and its
+own gaps (``llc/tests/test_roles_routes_registered.py``,
+``api/codebase_analytics/endpoints/impact_endpoint_test.py``,
+``api/terminal_router_dependency_wiring_test.py``,
+``api/self_capabilities_integration_test.py``). This module replaces those copies;
+``repo_tests/router_routes_traversal_test.py`` fails when a fifth one appears.
+
+## What this can and cannot tell you
+
+**Can**, on every version: the set of real route objects a router carries,
+their handlers, their ``dependant``, their ``methods``, and their path *as the
+route itself declares it* — which already includes any prefix given to the
+child's own ``APIRouter(prefix=...)`` constructor, because FastAPI applies that
+at decoration time.
+
+**Cannot**, on the deferred shape: a prefix passed to the ``include_router``
+call itself, and dependencies passed the same way. Nothing on the wrapper is
+guaranteed to expose them. Rather than guess, every :class:`MountedRoute`
+carries :attr:`MountedRoute.prefix_complete`; when it is ``False`` at least one
+inclusion hop above that route hid its prefix and :attr:`MountedRoute.path` is
+short by an unknown amount. Callers that need the *served* path must go through
+``fastapi.openapi.utils.get_openapi(routes=app.routes)`` on a mounted app, which
+is FastAPI's own supported view, or assert a gate behaviourally (see
+``api/terminal_websocket_route_test.py``). An include-time ``dependencies=`` is
+invisible for the same reason, which is why gates belong on the child router's
+own constructor (``api/terminal_tools.py``) where they are readable everywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, FrozenSet, Iterator, List, Optional, Set, Tuple
+
+__all__ = [
+    "MountedRoute",
+    "effective_routes",
+    "effective_route_count",
+    "included_router",
+    "route_method_paths",
+]
+
+
+def included_router(route: Any) -> Optional[Any]:
+    """The child router behind a deferred-inclusion wrapper, else ``None``.
+
+    ``None`` is the answer for a real route object, which is what the eager
+    shape yields, so a caller can branch on this alone without knowing which
+    FastAPI is installed. The ``routes`` check keeps an unrelated attribute
+    named ``original_router`` from being walked as if it were a router.
+    """
+    original = getattr(route, "original_router", None)
+    if original is None or not hasattr(original, "routes"):
+        return None
+    return original
+
+
+def _hop_prefix(parent: Any, wrapper: Any) -> Tuple[str, bool]:
+    """``(prefix, known)`` to prepend when descending one inclusion hop.
+
+    Two terms, and they behave differently:
+
+    * **The including router's own prefix.** Eager inclusion rewrites it into
+      every child path at include time; deferred inclusion leaves it on the
+      parent and the child's paths are relative. Adding it exactly when we
+      descend into a wrapper is therefore right on both shapes — on the eager
+      shape there is no wrapper to descend into, so it is never added twice.
+      This is the term that made ``llc/tests/test_roles_routes_registered.py``
+      correct in CI and broken locally: it prepended ``llc_router.prefix`` by
+      hand, which doubles to ``/llc/llc/...`` the moment inclusion is eager.
+    * **The prefix given to the ``include_router`` call.** Readable only if the
+      wrapper exposes it. A wrapper that does not is reported as *unknown*
+      rather than as empty: the two are different answers, and collapsing them
+      is how a path silently loses a segment (#14356 is the same failure on the
+      source-parsing side).
+
+    The child router's own ``prefix`` is deliberately not a term here. FastAPI
+    applies it at decoration time, so it is already inside every ``route.path``
+    beneath the child and adding it would duplicate the segment rather than
+    recover anything.
+    """
+    own = getattr(parent, "prefix", "") or ""
+    hop = getattr(wrapper, "prefix", None)
+    if isinstance(hop, str):
+        return f"{own}{hop}", True
+    return own, False
+
+
+@dataclass(frozen=True)
+class MountedRoute:
+    """One real route, plus how much of its mount path could be recovered."""
+
+    route: Any
+    #: Include-time prefixes above this route that introspection could read.
+    known_prefix: str = ""
+    #: ``False`` when some inclusion hop above this route hid its prefix, so
+    #: :attr:`path` is short by an unknown amount. Always ``True`` on the eager
+    #: shape, where the prefix is already inside ``route.path``.
+    prefix_complete: bool = True
+
+    @property
+    def path(self) -> str:
+        """The route's path with every recovered prefix applied."""
+        return f"{self.known_prefix}{getattr(self.route, 'path', '') or ''}"
+
+    @property
+    def methods(self) -> FrozenSet[str]:
+        """HTTP methods, empty for a WebSocket route rather than ``None``."""
+        return frozenset(getattr(self.route, "methods", None) or ())
+
+
+def _walk(container: Any, prefix: str, complete: bool, seen: Set[int]) -> Iterator[MountedRoute]:
+    if id(container) in seen:  # a router included into its own subtree
+        return
+    seen = seen | {id(container)}
+    for route in getattr(container, "routes", None) or ():
+        child = included_router(route)
+        if child is None:
+            yield MountedRoute(route=route, known_prefix=prefix, prefix_complete=complete)
+            continue
+        hop, known = _hop_prefix(container, route)
+        yield from _walk(child, prefix + hop, complete and known, seen)
+
+
+def effective_routes(container: Any) -> List[MountedRoute]:
+    """Every real route reachable from *container*, on either FastAPI shape.
+
+    *container* may be an ``APIRouter`` or a ``FastAPI`` app; mounting an app
+    defers exactly the same way, so both are walked identically.
+    """
+    return list(_walk(container, "", True, set()))
+
+
+def effective_route_count(container: Any) -> int:
+    """How many real routes *container* serves.
+
+    ``len(container.routes)`` is not this number on the deferred shape: it
+    counts one entry per ``include_router`` **call**, so it does not move when
+    an endpoint is added inside an already-included router. Anything using a
+    route count as a change signal has to use this instead or it will not
+    notice the change it exists to notice.
+    """
+    return len(effective_routes(container))
+
+
+def route_method_paths(container: Any) -> Set[Tuple[str, str]]:
+    """``(method, path)`` for every reachable route; WebSockets use ``"WEBSOCKET"``.
+
+    Paths are subject to the prefix limit documented at module level. Use
+    :func:`effective_routes` when a caller needs to know whether a prefix was
+    recoverable.
+    """
+    found: Set[Tuple[str, str]] = set()
+    for mounted in effective_routes(container):
+        methods = mounted.methods or frozenset({"WEBSOCKET"})
+        found.update((method, mounted.path) for method in methods)
+    return found

--- a/autobot_shared/api_routing/router_routes_test.py
+++ b/autobot_shared/api_routing/router_routes_test.py
@@ -1,0 +1,287 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The traversal must give the same answer on both FastAPI shapes (#15093).
+
+Two halves, deliberately:
+
+* **Synthetic** — hand-built stand-ins for the eager and the deferred shape.
+  These run identically everywhere, so the helper's contract is pinned on a
+  checkout that resolves either FastAPI (#15091 — a development box resolves
+  0.135.2, CI pins 0.141.1, and a local pass therefore carries no information
+  about the deferred behaviour).
+* **Real FastAPI** — the same properties asserted against whatever version is
+  installed, phrased so that they hold on both. These are what make the
+  synthetic stand-ins evidence rather than a story: if the real wrapper ever
+  stops being named ``original_router`` the real half fails while the synthetic
+  half still passes.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, FastAPI
+
+from autobot_shared.api_routing.router_routes import (
+    MountedRoute,
+    effective_route_count,
+    effective_routes,
+    included_router,
+    route_method_paths,
+)
+
+# --- synthetic shapes -------------------------------------------------------
+
+
+class _Route:
+    """A real route object: what the eager shape leaves in ``routes``."""
+
+    def __init__(self, path: str, methods=("GET",)):
+        self.path = path
+        self.methods = set(methods)
+
+
+class _Deferred:
+    """The deferred wrapper: no usable ``path``, real routes one level down."""
+
+    path = None
+
+    def __init__(self, child, prefix=None):
+        self.original_router = child
+        if prefix is not None:
+            self.prefix = prefix
+
+
+class _Router:
+    def __init__(self, *routes):
+        self.routes: List[object] = list(routes)
+
+
+def test_eager_shape_is_returned_unchanged():
+    router = _Router(_Route("/a"), _Route("/b"))
+
+    assert [m.path for m in effective_routes(router)] == ["/a", "/b"]
+    assert all(m.prefix_complete for m in effective_routes(router))
+
+
+def test_deferred_shape_is_flattened():
+    child = _Router(_Route("/leaf"))
+    parent = _Router(_Route("/own"), _Deferred(child, prefix=""))
+
+    assert [m.path for m in effective_routes(parent)] == ["/own", "/leaf"]
+
+
+def test_deferred_nesting_recurses():
+    """Inclusion nests; a single-level unwrap is the bug this replaces."""
+    leaf = _Router(_Route("/leaf"))
+    middle = _Router(_Deferred(leaf, prefix="/mid"))
+    parent = _Router(_Deferred(middle, prefix="/top"))
+
+    assert [m.path for m in effective_routes(parent)] == ["/top/mid/leaf"]
+
+
+def test_an_unreadable_include_prefix_is_reported_not_invented():
+    """A wrapper with no ``prefix`` must not be read as *no prefix*.
+
+    Reporting an unknown prefix as ``""`` produces a path that looks served and
+    is not — the failure mode #14356 recorded for the source-parsing side of the
+    same grammar.
+    """
+    parent = _Router(_Deferred(_Router(_Route("/leaf"))))
+
+    (mounted,) = effective_routes(parent)
+    assert mounted.path == "/leaf"
+    assert mounted.prefix_complete is False
+
+
+def test_a_cycle_terminates():
+    router = _Router()
+    router.routes.append(_Deferred(router, prefix=""))
+    router.routes.append(_Route("/a"))
+
+    assert [m.path for m in effective_routes(router)] == ["/a"]
+
+
+def test_included_router_ignores_a_lookalike_attribute():
+    class _Decoy:
+        path = "/x"
+        methods = {"GET"}
+        original_router = "not a router"
+
+    assert included_router(_Decoy()) is None
+    assert [m.path for m in effective_routes(_Router(_Decoy()))] == ["/x"]
+
+
+def test_websocket_routes_report_a_method():
+    class _WS:
+        path = "/ws"
+        methods = None
+
+    assert route_method_paths(_Router(_WS())) == {("WEBSOCKET", "/ws")}
+    assert MountedRoute(route=_WS()).methods == frozenset()
+
+
+# --- real FastAPI, whichever version is installed ---------------------------
+
+
+def _child_with(path: str) -> APIRouter:
+    child = APIRouter()
+
+    @child.get(path)
+    async def _handler():  # pragma: no cover - never called
+        return {}
+
+    return child
+
+
+def test_real_inclusion_is_flattened_on_this_fastapi():
+    """The property that fails today without this helper.
+
+    ``len(parent.routes)`` is 1 on both shapes here; what differs is *what* that
+    one entry is. The traversal has to yield the leaf either way.
+    """
+    parent = APIRouter()
+    parent.include_router(_child_with("/leaf"))
+
+    paths = [m.path for m in effective_routes(parent)]
+    assert paths == ["/leaf"], f"traversal did not reach the included route; got {paths}"
+
+
+def test_real_constructor_prefix_is_already_in_the_path():
+    """A child's own ``APIRouter(prefix=...)`` is applied at decoration time.
+
+    So it must not be added a second time by the traversal. This holds on both
+    shapes and is the reason the helper never substitutes ``child.prefix`` for
+    an unreadable include-time prefix.
+    """
+    child = APIRouter(prefix="/own")
+
+    @child.get("/leaf")
+    async def _handler():  # pragma: no cover - never called
+        return {}
+
+    parent = APIRouter()
+    parent.include_router(child)
+
+    assert [m.path for m in effective_routes(parent)] == ["/own/leaf"]
+
+
+def test_real_including_routers_own_prefix_is_applied_exactly_once():
+    """The term that differs between the two shapes, pinned on both.
+
+    Eager inclusion folds the including router's prefix into every child path;
+    deferred inclusion leaves it on the parent. Adding it on descent is right
+    both times — but only if it is added exactly once, so this fails on the
+    ``/parent/parent/leaf`` a double-count would produce just as loudly as on
+    the ``/leaf`` that omitting it would produce.
+    """
+    parent = APIRouter(prefix="/parent")
+    parent.include_router(_child_with("/leaf"))
+
+    assert [m.path for m in effective_routes(parent)] == ["/parent/leaf"]
+
+
+def test_real_include_time_prefix_is_either_recovered_or_flagged():
+    """Version-independent by construction, and it records which shape ran.
+
+    On eager inclusion the prefix is rewritten into ``route.path``, so the path
+    is complete. On the deferred shape it is recoverable only if the wrapper
+    exposes it, and what it exposes might be the hop alone or the whole chain.
+    The three-way disjunction below is exactly the set of correct answers;
+    anything else — a lost segment claimed as complete, or a doubled one — fails
+    here rather than reaching a caller as a path nothing serves.
+    """
+    parent = APIRouter(prefix="/parent")
+    parent.include_router(_child_with("/leaf"), prefix="/pre")
+
+    (mounted,) = effective_routes(parent)
+    assert mounted.path == "/parent/pre/leaf" or (not mounted.prefix_complete and mounted.path == "/parent/leaf"), (
+        f"path={mounted.path!r} (prefix_complete={mounted.prefix_complete}) is neither the served "
+        "path nor an honestly-flagged partial one. A hop was invented, doubled or lost."
+    )
+
+
+def test_real_route_count_is_endpoints_not_include_calls():
+    """The property ``len(parent.routes)`` does not have, and cache keys need.
+
+    On the deferred shape ``len(parent.routes)`` counts one entry per
+    ``include_router`` **call**, so it reads 1 for a child holding any number of
+    endpoints and does not move when one is added inside an already-included
+    router. Anything using a route count as a change signal has to use this
+    count or it will not notice the change it exists to notice
+    (``api/self_capabilities.py``).
+    """
+    child = _child_with("/one")
+
+    @child.get("/two")
+    async def _second():  # pragma: no cover - never called
+        return {}
+
+    parent = APIRouter()
+    parent.include_router(child)
+
+    assert effective_route_count(parent) == 2, (
+        f"traversal counted {effective_route_count(parent)} of 2 endpoints; "
+        f"len(parent.routes) is {len(parent.routes)}"
+    )
+
+
+def test_real_app_mount_is_traversable():
+    """Mounting an app defers the same way; it is not a workaround for this."""
+    app = FastAPI()
+    router = APIRouter()
+    router.include_router(_child_with("/leaf"))
+    app.include_router(router)
+
+    assert "/leaf" in {m.path for m in effective_routes(app)}
+
+
+def test_real_dependant_survives_the_traversal():
+    """Whatever the shape, the object yielded must be the real route.
+
+    Handler-level assertions (auth dependencies, response models) are made on
+    these objects; a wrapper reaching a caller would make every such assertion
+    vacuous rather than failing it.
+    """
+    parent = APIRouter()
+    parent.include_router(_child_with("/leaf"))
+
+    (mounted,) = effective_routes(parent)
+    assert getattr(mounted.route, "dependant", None) is not None
+    assert mounted.methods == frozenset({"GET"})
+
+
+def test_non_vacuity_the_real_half_saw_a_deferred_or_eager_shape():
+    """Fails if the real half ever inspects an empty router.
+
+    Every assertion above is over an enumeration; an enumeration that comes back
+    empty makes them all pass while verifying nothing (#15087).
+    """
+    parent = APIRouter()
+    parent.include_router(_child_with("/leaf"))
+
+    assert parent.routes, "non-vacuity: include_router left the parent with no entries at all"
+    assert effective_routes(parent), "non-vacuity: the traversal reached no routes"
+
+
+def test_the_installed_fastapi_shape_is_one_of_the_two_known_ones():
+    """A third inclusion shape must fail loudly, not be traversed as nothing.
+
+    The helper recognises exactly two: real routes in ``parent.routes`` (eager)
+    and a wrapper whose ``original_router`` holds them (deferred). If a future
+    FastAPI introduces a third, every traversal here would come back empty and
+    every assertion built on one would pass while inspecting nothing — the
+    #15087 failure mode, arriving via a dependency bump rather than a bug.
+    """
+    parent = APIRouter()
+    parent.include_router(_child_with("/leaf"))
+    (entry,) = parent.routes
+
+    eager = getattr(entry, "path", None) == "/leaf" and included_router(entry) is None
+    deferred = included_router(entry) is not None
+
+    assert eager or deferred, (
+        "unrecognised include_router shape: parent.routes holds "
+        f"{type(entry).__name__}(path={getattr(entry, 'path', None)!r}) with no original_router. "
+        "autobot_shared/api_routing/router_routes.py must learn it before anything trusts a traversal."
+    )

--- a/repo_tests/router_mount_parity_test.py
+++ b/repo_tests/router_mount_parity_test.py
@@ -46,21 +46,21 @@ reason each — never counted.
 
 from __future__ import annotations
 
-import ast
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Set, Tuple
+from typing import Dict, List
 
 import pytest
 
+from autobot_shared.api_routing.mount_graph import APP_ROOT, MountGraph, build_graph, registry_dirname
+
 _REPO = Path(__file__).resolve().parents[1]
 _BACKEND = _REPO / "autobot-backend"
-_REGISTRY_DIRNAME = "router_registry"
+_REGISTRY_DIRNAME = registry_dirname()
 
-# The synthetic parent for a mount performed by the application factory: every
-# registry entry is included by `app_factory` with `prefix=f"/api{prefix}"` and
-# no `dependencies=`, so the app root contributes no guard.
-APP_ROOT = "<app>"
+# The mount graph itself lives in `autobot_shared/api_routing/mount_graph.py`
+# (#15093): `repo_tests/router_routes_traversal_test.py` needs the same three
+# facts, and a second AST resolver would drift from this one exactly as the two
+# `include_router` regexes drifted before #12985 consolidated them.
 
 # Routers that legitimately reach the app through a mount carrying less than
 # another mount of theirs. Each needs a reason; a bare count is not evidence
@@ -80,344 +80,9 @@ EXEMPT_ROUTERS: Dict[str, str] = {}
 _GATE_HINTS = ("permission", "auth", "admin", "rbac", "require", "verify", "current_user")
 
 
-@dataclass(frozen=True)
-class RouterDef:
-    """A module-level ``X = APIRouter(...)`` binding."""
-
-    key: str
-    own_guards: FrozenSet[str]
-
-
-@dataclass(frozen=True)
-class Mount:
-    """One ``include_router`` (or registry entry) edge in the mount graph."""
-
-    parent: str
-    child: str
-    guards: FrozenSet[str]
-    site: str
-
-
-@dataclass
-class MountGraph:
-    routers: Dict[str, RouterDef] = field(default_factory=dict)
-    edges: List[Mount] = field(default_factory=list)
-    unresolved: List[str] = field(default_factory=list)
-    dynamic: List[str] = field(default_factory=list)
-
-    def paths_to(self, key: str) -> Set[FrozenSet[str]]:
-        """Every distinct guard set that reaches *key* from the app root.
-
-        A guard set is the union of the dependencies named at each hop: the
-        ``dependencies=`` of the ``include_router`` call plus those declared on
-        the parent's own ``APIRouter(...)`` constructor, all the way up --
-        **and the router's own constructor dependencies**, which apply at every
-        mount by construction.
-
-        That last term is the one that matters. A router protected on its own
-        constructor is protected everywhere, which is exactly how #15084 was
-        fixed and how every other gated router in this repo is written. Omitting
-        it made such a router read as ungated on every path, so the comparison
-        was empty-set against empty-set: agreement reached by seeing nothing
-        rather than by seeing a gate.
-        """
-        own = self._own_guards(key)
-        return {path | own for path in self._paths(key, frozenset())}
-
-    def _paths(self, key: str, seen: FrozenSet[str]) -> Set[FrozenSet[str]]:
-        if key in seen:  # a cycle contributes nothing new
-            return set()
-        seen = seen | {key}
-        incoming = [e for e in self.edges if e.child == key]
-        if not incoming:
-            return set()
-        out: Set[FrozenSet[str]] = set()
-        for edge in incoming:
-            hop = edge.guards | self._own_guards(edge.parent)
-            if edge.parent == APP_ROOT:
-                out.add(hop)
-                continue
-            for upstream in self._paths(edge.parent, seen):
-                out.add(hop | upstream)
-        return out
-
-    def _own_guards(self, key: str) -> FrozenSet[str]:
-        found = self.routers.get(key)
-        return found.own_guards if found else frozenset()
-
-    def mounted_keys(self) -> List[str]:
-        return sorted({e.child for e in self.edges})
-
-    def inconsistent(self) -> Dict[str, Set[FrozenSet[str]]]:
-        """Routers whose reachable paths do not all carry the same guards.
-
-        A router mounted once, or mounted many times with identical guards, is
-        consistent. One reachable both behind ``check_admin_permission`` and
-        without it is the defect.
-        """
-        bad: Dict[str, Set[FrozenSet[str]]] = {}
-        for key in self.mounted_keys():
-            if key in EXEMPT_ROUTERS:
-                continue
-            paths = self.paths_to(key)
-            if len(paths) < 2:
-                continue
-            weakest = frozenset.intersection(*paths)
-            strongest = frozenset.union(*paths)
-            if weakest != strongest:
-                bad[key] = paths
-        return bad
-
-
-# --- source parsing ---------------------------------------------------------
-
-
-def _module_name(path: Path, backend: Path) -> str:
-    return path.relative_to(backend).with_suffix("").as_posix().replace("/", ".")
-
-
-def _guards_from_keyword(node: ast.AST) -> FrozenSet[str]:
-    """Dependency names inside a ``dependencies=[Depends(x), ...]`` argument."""
-    names: Set[str] = set()
-    if not isinstance(node, (ast.List, ast.Tuple)):
-        return frozenset()
-    for element in node.elts:
-        target = element
-        if isinstance(element, ast.Call):
-            args = element.args
-            target = args[0] if args else element.func
-        rendered = _dotted(target)
-        if rendered:
-            names.add(rendered)
-    return frozenset(names)
-
-
-def _dotted(node: ast.AST) -> str | None:
-    """Render ``a.b.c`` / ``a`` from an expression; None for anything else."""
-    parts: List[str] = []
-    while isinstance(node, ast.Attribute):
-        parts.append(node.attr)
-        node = node.value
-    if not isinstance(node, ast.Name):
-        return None
-    parts.append(node.id)
-    return ".".join(reversed(parts))
-
-
-def _call_kwarg(call: ast.Call, name: str) -> ast.AST | None:
-    for keyword in call.keywords:
-        if keyword.arg == name:
-            return keyword.value
-    return None
-
-
-def _is_apirouter(call: ast.Call) -> bool:
-    rendered = _dotted(call.func)
-    return bool(rendered) and rendered.split(".")[-1] == "APIRouter"
-
-
-class _ModuleScan:
-    """Local-name -> router-key bindings and mounts within one module."""
-
-    def __init__(self, module: str, tree: ast.AST, backend: Path):
-        self.module = module
-        self.tree = tree
-        self.backend = backend
-        self.local: Dict[str, str] = {}
-        self.defs: List[RouterDef] = []
-        self.edges: List[Mount] = []
-        self.unresolved: List[str] = []
-        self.dynamic: List[str] = []
-        self.loop_targets: Set[str] = set()
-
-    def run(self) -> None:
-        self._collect_loop_targets()
-        self._collect_imports()
-        self._collect_definitions()
-        self._collect_include_calls()
-
-    def _collect_loop_targets(self) -> None:
-        """Names bound by a ``for`` statement.
-
-        ``app_factory`` iterates the loaded registry tuples and calls
-        ``include_router`` on the loop variable. That mount is real but its
-        target is only known at runtime — it is modelled from the registry
-        entries instead, so it must be recorded as *dynamic*, not as an
-        unresolvable reference.
-        """
-        for node in ast.walk(self.tree):
-            if not isinstance(node, ast.For):
-                continue
-            targets = node.target.elts if isinstance(node.target, ast.Tuple) else [node.target]
-            for target in targets:
-                if isinstance(target, ast.Name):
-                    self.loop_targets.add(target.id)
-
-    # imports first: `from api.x import router as y` binds y -> api.x:router.
-    def _collect_imports(self) -> None:
-        for node in ast.walk(self.tree):
-            if not isinstance(node, ast.ImportFrom) or node.module is None:
-                continue
-            source = node.module
-            if node.level:  # relative import, resolve against this package
-                package = self.module.rsplit(".", node.level)[0]
-                source = f"{package}.{node.module}" if package else node.module
-            for alias in node.names:
-                if "router" not in alias.name.lower():
-                    continue
-                self.local[alias.asname or alias.name] = f"{source}:{alias.name}"
-
-    # definitions second, so a module-local `router = APIRouter()` wins over an
-    # imported name of the same spelling.
-    def _collect_definitions(self) -> None:
-        for node in ast.walk(self.tree):
-            if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
-                continue
-            if not _is_apirouter(node.value):
-                continue
-            guards = _guards_from_keyword(_call_kwarg(node.value, "dependencies") or ast.List(elts=[]))
-            for target in node.targets:
-                if not isinstance(target, ast.Name):
-                    continue
-                key = f"{self.module}:{target.id}"
-                self.local[target.id] = key
-                self.defs.append(RouterDef(key=key, own_guards=guards))
-
-    def _resolve(self, node: ast.AST) -> str | None:
-        rendered = _dotted(node)
-        if rendered is None:
-            return None
-        if rendered in self.local:
-            return self.local[rendered]
-        if "." in rendered:  # `api.terminal.router` style reference
-            module, _, attr = rendered.rpartition(".")
-            return f"{module}:{attr}"
-        return None
-
-    def _collect_include_calls(self) -> None:
-        for node in ast.walk(self.tree):
-            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
-                continue
-            if node.func.attr != "include_router" or not node.args:
-                continue
-            site = f"{self.module}:{node.lineno}"
-            child_expr = _dotted(node.args[0])
-            if child_expr in self.loop_targets:
-                self.dynamic.append(site)
-                continue
-            child = self._resolve(node.args[0])
-            if child is None:
-                self.unresolved.append(f"{site} child={ast.dump(node.args[0])[:60]}")
-                continue
-            parent_expr = _dotted(node.func.value) or ""
-            parent = self._resolve(node.func.value)
-            if parent is None:
-                # `app.include_router(...)` and friends: an application object,
-                # not a router. Treat as an app-root mount.
-                parent = APP_ROOT
-                if parent_expr not in {"app", "application", "self.app"}:
-                    self.unresolved.append(f"{site} parent={parent_expr or '<expr>'}")
-            guards = _guards_from_keyword(_call_kwarg(node, "dependencies") or ast.List(elts=[]))
-            self.edges.append(Mount(parent=parent, child=child, guards=guards, site=site))
-
-
-# --- registry entries -------------------------------------------------------
-
-
-def _registry_entry(element: ast.AST, module: str, local: Dict[str, str]) -> str | None:
-    """Router key named by one ``(module, [attr,] prefix, tags, name)`` tuple.
-
-    Both registry shapes are handled: a 4-tuple whose first element is a module
-    path string (``("api.terminal_tools", "", [...], "terminal_tools")``), the
-    5-tuple monitoring form that names the attribute second, and the
-    ``core_routers`` form whose first element is an already-imported router.
-    """
-    if not isinstance(element, (ast.Tuple, ast.List)) or len(element.elts) < 4:
-        return None
-    head = element.elts[0]
-    if isinstance(head, ast.Constant) and isinstance(head.value, str):
-        attr = "router"
-        second = element.elts[1]
-        if len(element.elts) >= 5 and isinstance(second, ast.Constant) and isinstance(second.value, str):
-            # 5-tuple: (module, router_attr, prefix, tags, name)
-            attr = second.value or "router"
-        return f"{head.value}:{attr}"
-    rendered = _dotted(head)
-    if rendered and rendered in local:
-        return local[rendered]
-    if rendered:
-        return f"{module}:{rendered}"
-    return None
-
-
-def _scan_registry(path: Path, backend: Path, local: Dict[str, str]) -> List[Mount]:
-    """Registry entries become app-root mounts carrying no guards.
-
-    ``app_factory.register_routers`` includes each loaded tuple with
-    ``prefix=f"/api{prefix}"`` and no ``dependencies=`` argument, so nothing a
-    registry entry can express adds a gate.
-    """
-    module = _module_name(path, backend)
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    mounts: List[Mount] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.List, ast.Tuple)):
-            continue
-        for element in node.elts:
-            key = _registry_entry(element, module, local)
-            if key is None:
-                continue
-            mounts.append(
-                Mount(
-                    parent=APP_ROOT,
-                    child=key,
-                    guards=frozenset(),
-                    site=f"{module}:{getattr(element, 'lineno', 0)}",
-                )
-            )
-    return mounts
-
-
-def _python_files(backend: Path) -> Iterable[Path]:
-    for path in sorted(backend.rglob("*.py")):
-        parts = set(path.parts)
-        if parts & {"__pycache__", "tests", "node_modules", ".venv", "venv"}:
-            continue
-        yield path
-
-
-def build_graph(backend: Path = _BACKEND) -> MountGraph:
-    """Derive the whole mount graph from source — nothing is handed in.
-
-    Three discovery sources, matching the three ways a router reaches the app:
-    ``APIRouter`` definitions, ``include_router`` call sites, and
-    ``initialization/router_registry/`` entries loaded by the app factory.
-    """
-    graph = MountGraph()
-    registry_files: List[Tuple[Path, Dict[str, str]]] = []
-    for path in _python_files(backend):
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError) as exc:  # pragma: no cover
-            graph.unresolved.append(f"{path}: {exc}")
-            continue
-        scan = _ModuleScan(_module_name(path, backend), tree, backend)
-        scan.run()
-        for definition in scan.defs:
-            graph.routers[definition.key] = definition
-        graph.edges.extend(scan.edges)
-        graph.unresolved.extend(scan.unresolved)
-        graph.dynamic.extend(scan.dynamic)
-        if _REGISTRY_DIRNAME in path.parts:
-            registry_files.append((path, dict(scan.local)))
-    for path, local in registry_files:
-        graph.edges.extend(_scan_registry(path, backend, local))
-    return graph
-
-
 @pytest.fixture(scope="module")
 def graph() -> MountGraph:
-    return build_graph()
+    return build_graph(_BACKEND)
 
 
 # --- non-vacuity ------------------------------------------------------------
@@ -503,7 +168,7 @@ def test_no_router_is_mounted_past_a_gate_its_siblings_carry(graph: MountGraph):
     any other router by name: it compares, for every mounted router, the guard
     sets on every path that reaches it from the app root.
     """
-    bad = graph.inconsistent()
+    bad = graph.inconsistent(EXEMPT_ROUTERS)
     if not bad:
         return
     report: List[str] = []

--- a/repo_tests/router_routes_traversal_test.py
+++ b/repo_tests/router_routes_traversal_test.py
@@ -1,0 +1,424 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Nothing may read ``.routes`` on a router that has children (#15093).
+
+``fastapi>=0.139`` — ``requirements-ci/framework.txt`` pins ``0.141.1`` — changed
+``include_router`` from *copy the child's routes onto me* to *record that I
+include this child*. After the change a parent's ``routes`` list holds one opaque
+wrapper per included child: its ``path`` is ``None``, it has no ``methods``, and
+the real routes are one level down on ``wrapper.original_router.routes``.
+
+The dangerous property is not that a naive walk raises. It is that the obvious
+defensive spelling — ``getattr(route, "path", None)``, ``hasattr(route, "path")``
+— does not raise. It finds **nothing**, and a test asserting over nothing passes.
+CI job ``98088603289`` caught one: the assembled terminal router enumerated three
+entries in CI where the same code enumerated twenty-six locally, because a
+development checkout may resolve a FastAPI below the declared floor (#15091) and
+still flatten eagerly. **A local pass carries no information about this.**
+
+Four files had each worked this out privately, with four different partial
+workarounds and no shared helper — the knowledge existed and did not spread.
+``autobot_shared/api_routing/router_routes.py`` is now the one traversal; this is
+the guard that stops a fifth private copy, and stops the first genuinely broken
+site, which the sweep on #15093 established does not exist yet.
+
+## What this catches
+
+A read of ``<name>.routes`` — or ``getattr(<name>, "routes", ...)``, the same
+read written so it cannot raise — where ``<name>`` resolves to an ``APIRouter``
+that receives at least one ``include_router`` call. That is exactly the premise
+that stopped being true at 0.139. The check is static AST, so it means the same
+thing on both FastAPI shapes; a runtime guard would pass locally and fail in CI,
+or worse, the reverse (#15091, and AC 7 on #15093 forbids depending on that box
+being fixed).
+
+## What this does NOT catch — stated, not implied
+
+* **An attribute chain rooted in a local variable.** ``bridge.router.routes``
+  (``services/mcp_bridge_workers/worker_entrypoint.py``) resolves no further than
+  its literal text, because knowing what ``bridge`` is needs type inference.
+  Those reads are counted as *unresolved* and reported by
+  ``test_unresolved_routes_reads_stay_bounded`` so the blind spot cannot grow
+  silently, but an unresolved read is not failed.
+* **A router reached through a runtime factory** — anything whose target is
+  computed rather than written.
+* **``app.routes`` on a mounted application.** Deliberate: that is what
+  ``api/self_capabilities.py`` and ``scripts/audit_api_wiring.py`` do, feeding it
+  to ``get_openapi(routes=...)``, FastAPI's own supported view, which is correct
+  on every version. It is why ``EXEMPT_READS`` below is empty — those two sidestep
+  the router entirely rather than needing an exemption.
+* **Whether the traversal is then done correctly.** This guard sees that a risky
+  read exists, not that its result is used well. The helper's own contract is
+  pinned by ``autobot_shared/api_routing/router_routes_test.py``, which asserts
+  against a real ``APIRouter`` on whatever FastAPI is installed.
+* **An include-time ``prefix=`` or ``dependencies=``.** Neither is recoverable
+  from the deferred shape by any introspection — that is why
+  ``api/terminal_tools.py`` carries its gate on its own ``APIRouter(...)``
+  constructor, where ``repo_tests/router_mount_parity_test.py`` can read it, and
+  why ``api/terminal_websocket_route_test.py`` proves its gate behaviourally with
+  a real request instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, FrozenSet, List, Set
+
+import pytest
+
+from autobot_shared.api_routing.mount_graph import MountGraph, RoutesRead, build_graph
+
+_REPO = Path(__file__).resolve().parents[1]
+
+#: Never walked: build output, vendored trees, virtualenvs, data.
+_SKIP_ROOTS = frozenset({"__pycache__", "node_modules", ".venv", "venv", "data", "debug", "logs", "backups"})
+
+_SKIP = frozenset({"__pycache__", "node_modules", ".venv", "venv", ".git", "site-packages"})
+
+
+def scan_roots(repo: Path = _REPO) -> List[Path]:
+    """Every top-level directory in the repo that could hold Python.
+
+    Derived rather than listed. A hand-written list of trees is the same shape
+    of mistake this guard exists to catch: it looks complete, it silently stops
+    covering a tree that gets renamed or added, and nothing says so. Each
+    top-level directory is also the namespace its router keys are prefixed with,
+    which is what keeps ``autobot-backend/api/auth.py`` and
+    ``autobot-slm-backend/api/auth.py`` from being read as one router.
+    """
+    return [
+        child
+        for child in sorted(repo.iterdir())
+        if child.is_dir() and not child.name.startswith(".") and child.name not in _SKIP_ROOTS
+    ]
+
+
+# Modules allowed to read `.routes` on a router that has children, each with its
+# reason. Keyed by module rather than by line so a reason cannot be silently
+# re-pointed at a different read by an edit above it;
+# `test_exemptions_are_named_and_still_real` fails when an entry stops naming a
+# module that still contains such a read, so a stale one cannot rot into a hole
+# nothing reports (the lifecycle `router_mount_parity_test.EXEMPT_ROUTERS`
+# demonstrated when #15096 retired its only entry).
+#
+# The two "sidestepping" sites named on #15093 are deliberately absent:
+# `api/self_capabilities.py` and `scripts/audit_api_wiring.py` read `app.routes`
+# on a mounted application and hand it to `get_openapi(routes=...)`, FastAPI's
+# own supported view. An app read is not a router read, so the scanner never
+# proposes them and an entry for either would be stale on arrival.
+EXEMPT_READS: Dict[str, str] = {
+    "autobot_shared::api_routing.router_routes_test": (
+        "The one place that must see the raw shape: it asserts what `include_router` "
+        "leaves in `parent.routes` on the installed FastAPI, which is the fact the shared "
+        "traversal is built on. Routing it through the traversal would make it assert the "
+        "helper against itself."
+    ),
+}
+
+#: A read must resolve to a router the graph knows before it can be judged. Well
+#: below the 24 observed when this was written, so ordinary churn does not trip
+#: it, but far enough above zero that a broken resolver cannot pass.
+_MIN_RESOLVED_READS = 10
+
+#: Unresolved reads are the documented blind spot. Bounding them means the spot
+#: cannot quietly widen; 71 total reads were found when this was written.
+_MAX_UNRESOLVED_SHARE = 0.75
+
+
+@dataclass
+class Scan:
+    """Every ``.routes`` read under a tree, classified against its mount graph."""
+
+    routers: Dict[str, object] = field(default_factory=dict)
+    parents: Set[str] = field(default_factory=set)
+    reads: List[RoutesRead] = field(default_factory=list)
+    #: Bare keys defined in more than one tree, which is why keys are namespaced.
+    shared_keys: Set[str] = field(default_factory=set)
+
+    def deferred_risk(self) -> List[RoutesRead]:
+        """Reads of a router that has children — the #15093 premise."""
+        return [read for read in self.reads if read.target in self.parents]
+
+    def resolved(self) -> List[RoutesRead]:
+        return [read for read in self.reads if read.target in self.routers]
+
+    def unresolved(self) -> List[RoutesRead]:
+        return [read for read in self.reads if read.target is None]
+
+
+def _bare(namespaced: Dict[str, object]) -> Set[str]:
+    """The keys of *namespaced* with their tree prefix removed."""
+    return {key.split("::", 1)[1] for key in namespaced}
+
+
+def scan_tree(*roots: Path, skip: FrozenSet[str] = _SKIP) -> Scan:
+    """Build each root's mount graph and collect every ``.routes`` read under it.
+
+    One parse pass per file: ``build_graph`` already walks every module, and the
+    reads ride along on the same ``ModuleScan``.
+
+    Keys are prefixed with the tree they came from, and that is load-bearing:
+    ``autobot-backend`` and ``autobot-slm-backend`` both define ``api/auth.py``,
+    ``api/settings.py`` and seven more, so bare module keys collide and one
+    backend's ``include_router`` calls would make the other backend's reads read
+    as risky. ``test_key_namespacing_is_load_bearing`` pins that the collisions
+    are real, so the prefix cannot be removed as redundant.
+
+    The cost of the prefix is that a read in one tree of a router defined in
+    another is not matched. No such read exists — ``repo_tests`` and ``scripts``
+    cannot import a backend module, they are not on its path — and it is a false
+    negative rather than a false positive if one ever appears.
+    """
+    scan = Scan()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        graph: MountGraph = build_graph(root, skip=skip)
+        namespace = root.name
+        scan.shared_keys |= {
+            key for key in graph.routers if f"{namespace}::{key}" not in scan.routers and key in _bare(scan.routers)
+        }
+        scan.routers.update({f"{namespace}::{key}": value for key, value in graph.routers.items()})
+        scan.parents |= {f"{namespace}::{key}" for key in graph.routers_with_children()}
+        scan.reads.extend(
+            RoutesRead(
+                site=f"{namespace}::{read.site}",
+                expr=read.expr,
+                target=None if read.target is None else f"{namespace}::{read.target}",
+            )
+            for read in graph.routes_reads
+        )
+    return scan
+
+
+@pytest.fixture(scope="module")
+def scan() -> Scan:
+    return scan_tree(*scan_roots())
+
+
+# --- non-vacuity ------------------------------------------------------------
+#
+# Every assertion below the fold is over an enumeration. #15087 is an open bug
+# where exactly this went wrong: a router enumerated zero routes and the test
+# reported success. An empty scan must be red here, never green.
+
+
+def _module_of(read: RoutesRead) -> str:
+    """``<tree>::<module>`` for a read, dropping the line number."""
+    return read.site.rsplit(":", 1)[0]
+
+
+def test_every_python_tree_is_scanned():
+    """A tree dropped from the sweep is a hole, so name the ones that must be in it.
+
+    ``scan_roots`` derives the list, but a skip entry or a rename could still
+    remove a tree that matters while every other assertion here stayed green on
+    the trees that remain.
+    """
+    names = {root.name for root in scan_roots()}
+    required = {"autobot-backend", "autobot-slm-backend", "autobot_shared", "repo_tests", "scripts"}
+
+    assert required <= names, f"trees missing from the sweep: {sorted(required - names)}"
+
+
+def test_scan_resolved_real_routers(scan: Scan):
+    resolved = scan.resolved()
+    assert len(resolved) >= _MIN_RESOLVED_READS, (
+        f"non-vacuity: only {len(resolved)} of {len(scan.reads)} `.routes` reads resolved to a "
+        f"router the mount graph knows. Name resolution is broken and the guard below judges nothing."
+    )
+
+
+def test_scan_found_routers_with_children(scan: Scan):
+    """The set the guard compares against must not be empty.
+
+    ``llc.api:router`` is named explicitly: it is a package ``__init__`` that
+    includes thirty-eight children, so it exercises import resolution, package
+    naming and ``include_router`` detection at once. If it drops out, the guard
+    still passes while having stopped looking at the largest parent in the repo.
+    """
+    assert len(scan.parents) >= 8, f"non-vacuity: only {len(scan.parents)} routers with children found"
+    assert "autobot-backend::llc.api:router" in scan.parents, (
+        "non-vacuity: llc.api:router (38 include_router calls) is not recognised as having children. "
+        f"Found: {sorted(scan.parents)[:10]}"
+    )
+
+
+def test_unresolved_routes_reads_stay_bounded(scan: Scan):
+    """The documented blind spot may not quietly become the common case."""
+    unresolved, total = len(scan.unresolved()), len(scan.reads)
+    assert total >= 20, f"non-vacuity: only {total} `.routes` reads found across {len(scan_roots())} trees"
+    assert unresolved <= total * _MAX_UNRESOLVED_SHARE, (
+        f"{unresolved} of {total} `.routes` reads could not be resolved to a router. "
+        "Resolution has regressed; the guard is judging a shrinking slice of the repo."
+    )
+
+
+def test_key_namespacing_is_load_bearing(scan: Scan):
+    """The per-tree prefix must not be dropped as redundant.
+
+    ``autobot-backend`` and ``autobot-slm-backend`` both define ``api/auth.py``,
+    ``api/settings.py``, ``api/monitoring.py`` and more, so bare module keys
+    genuinely collide: without the prefix, one backend's ``include_router``
+    calls would make the other backend's ``.routes`` reads report as risky —
+    a false positive naming a router that is not the one being read.
+    """
+    assert scan.shared_keys, (
+        "no router key is defined in two trees any more. Either the second backend stopped "
+        "mirroring the first, or discovery stopped seeing one of them — check before removing "
+        "the namespace prefix in scan_tree()."
+    )
+
+
+# --- the guard --------------------------------------------------------------
+
+
+def test_no_site_reads_routes_on_a_router_with_children(scan: Scan):
+    """The named assertion. Fails on a read whose premise 0.139 removed."""
+    offenders = [read for read in scan.deferred_risk() if _module_of(read) not in EXEMPT_READS]
+    if not offenders:
+        return
+    report = "\n".join(
+        f"    {read.site}  reads {read.expr}.routes  -> {read.target}"
+        for read in sorted(offenders, key=lambda r: r.site)
+    )
+    pytest.fail(
+        "`.routes` read on a router that receives include_router calls (#15093).\n"
+        "Under fastapi>=0.139 that list holds one opaque wrapper per included child, not the\n"
+        "children's routes, so this read finds nothing and every assertion over it passes vacuously.\n"
+        "Use autobot_shared.api_routing.router_routes.effective_routes(), or read a mounted app\n"
+        "through fastapi.openapi.utils.get_openapi(routes=app.routes).\n" + report
+    )
+
+
+def test_exemptions_are_named_and_still_real(scan: Scan):
+    """A stale exemption is a hole nothing reports, so it is an error."""
+    proposed = {_module_of(read) for read in scan.deferred_risk()}
+    assert proposed, (
+        "non-vacuity: the scanner proposed no risky read at all, so every exemption below is "
+        "unverifiable. Candidate detection has broken."
+    )
+    for module, reason in EXEMPT_READS.items():
+        assert reason.strip(), f"exemption {module} has no reason"
+        assert module in proposed, f"exemption {module} no longer reads a router with children — drop it"
+
+
+# --- contrast mutation ------------------------------------------------------
+#
+# A guard nobody has watched fail is a guess. These build the bad pattern in a
+# temp tree, assert it is reported, then remove *only* the `include_router` line
+# and assert the byte-identical remainder is not. The first half proves detection;
+# the second proves the guard is not simply flagging every `.routes` read, which
+# would be an unusable guard that also happened to catch this.
+
+_CHILD = """from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/leaf")
+async def leaf():
+    return {}
+"""
+
+_PARENT = """from fastapi import APIRouter
+
+from .child import router as child_router
+
+router = APIRouter()
+{include}
+"""
+
+_READER = """from pkg.parent import router as parent_router
+
+
+def walk():
+    return [route.path for route in parent_router.routes]
+"""
+
+
+def _fixture_tree(root: Path, *, include: bool) -> Path:
+    package = root / "pkg"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    (package / "child.py").write_text(_CHILD, encoding="utf-8")
+    (package / "parent.py").write_text(
+        _PARENT.format(include="router.include_router(child_router)" if include else ""),
+        encoding="utf-8",
+    )
+    (root / "reader.py").write_text(_READER, encoding="utf-8")
+    return root
+
+
+def test_the_bad_pattern_is_reported(tmp_path: Path):
+    scanned = scan_tree(_fixture_tree(tmp_path / "bad", include=True))
+
+    assert "bad::pkg.parent:router" in scanned.parents, "fixture parent was not seen to include a child"
+    sites = {read.site for read in scanned.deferred_risk()}
+    assert "bad::reader:5" in sites, f"the bad pattern was not reported; risky reads: {sites}"
+
+
+def test_the_same_tree_without_the_include_is_not_reported(tmp_path: Path):
+    """Byte-identical but for the ``include_router`` line, and it must pass.
+
+    A decorator-only router's ``routes`` list is the same on every FastAPI, so
+    reading it is correct. A guard that flagged this too would be noise, and
+    noise gets suppressed rather than fixed.
+    """
+    scanned = scan_tree(_fixture_tree(tmp_path / "good", include=False))
+
+    assert "good::pkg.parent:router" in scanned.routers, "fixture parent was not discovered at all"
+    assert "good::pkg.parent:router" not in scanned.parents
+    assert not scanned.deferred_risk(), f"a decorator-only router was flagged: {scanned.deferred_risk()}"
+    reads = {read.site: read.target for read in scanned.reads}
+    assert (
+        reads.get("good::reader:5") == "good::pkg.parent:router"
+    ), f"the read itself stopped being found, so the negative half proves nothing: {reads}"
+
+
+def test_the_getattr_spelling_is_reported_too(tmp_path: Path):
+    """``getattr(x, "routes", [])`` is the same read, made unable to raise.
+
+    It is the worse spelling — it converts "I cannot see this router's children"
+    into an empty list — so a guard blind to it would push code towards it.
+    """
+    root = _fixture_tree(tmp_path / "getattr", include=True)
+    (root / "reader.py").write_text(
+        "from pkg.parent import router as parent_router\n\n\n"
+        'def walk():\n    return [r.path for r in getattr(parent_router, "routes", [])]\n',
+        encoding="utf-8",
+    )
+
+    sites = {read.site for read in scan_tree(root).deferred_risk()}
+    assert "getattr::reader:5" in sites, f"the getattr spelling was not reported; risky reads: {sites}"
+
+
+def test_the_scanner_reads_the_helper_as_safe(tmp_path: Path):
+    """Routing the same read through the shared helper clears the guard.
+
+    A guard blind to the mechanism that fixes what it guards is not a guard: it
+    would fail identically before and after the fix and teach nothing.
+    """
+    root = _fixture_tree(tmp_path / "helper", include=True)
+    (root / "reader.py").write_text(
+        "from autobot_shared.api_routing.router_routes import effective_routes\n"
+        "from pkg.parent import router as parent_router\n\n\n"
+        "def walk():\n    return [m.path for m in effective_routes(parent_router)]\n",
+        encoding="utf-8",
+    )
+
+    assert not scan_tree(root).deferred_risk()
+
+
+def test_the_fixture_source_is_what_the_scanner_thinks_it_is(tmp_path: Path):
+    """Guards the fixture itself: a typo'd fixture proves nothing either way."""
+    root = _fixture_tree(tmp_path / "shape", include=True)
+    parent = ast.parse((root / "pkg" / "parent.py").read_text(encoding="utf-8"))
+    calls = [
+        n for n in ast.walk(parent) if isinstance(n, ast.Call) and getattr(n.func, "attr", None) == "include_router"
+    ]
+
+    assert len(calls) == 1, "the positive fixture must contain exactly one include_router call"
+    assert (root / "reader.py").read_text(encoding="utf-8").count(".routes") == 1


### PR DESCRIPTION
Closes #15093

## Thinking Path

The premise was re-verified rather than assumed, and it holds with one correction.

`fastapi>=0.139` — the declared floor, pinned in CI at `0.141.1` — changed `include_router` from *copy the child's routes onto me* to *record that I include this child*. The parent's `routes` then holds one opaque wrapper per included child, `path` is `None`, and the real routes live on `wrapper.original_router.routes`. This box resolves `0.135.2` (#15091) and still flattens eagerly, so nothing here could observe the deferred half directly. Two things made that survivable:

1. **Three of the four private workarounds fail on THIS box, today.** Before any change, on the current head: `llc/tests/test_roles_routes_registered.py` (2 tests) and `api/codebase_analytics/endpoints/impact_endpoint_test.py` (1 test) fail — the latter with `AttributeError: 'NoneType' object has no attribute 'routes'`, exactly the version-lock the issue predicts at `impact_endpoint_test.py:164`. So the divergence is directly observable from the *eager* side, and the fix is checkable both ways: all three now pass here, and they no longer encode a FastAPI version.
2. **The guard is static AST**, so it means the same thing on both shapes and needs no box to agree with CI (AC 7).

**One correction to the brief.** The claim "neither the include-time `prefix=` nor a `dependencies=` list is recoverable" is right, but there is a *second* prefix term that was being conflated with it and that **is** recoverable: **the including router's own `prefix`**. Eager inclusion folds it into every child path at include time; deferred inclusion leaves it on the parent. That is why `test_roles_routes_registered.py` prepended `llc_router.prefix` by hand and was correct in CI — and why the same line yields `/llc/llc/...` here. The shared helper adds that term exactly when it descends into a wrapper, which is right on both shapes, and `test_real_including_routers_own_prefix_is_applied_exactly_once` fails on a doubled segment as loudly as on a lost one. The genuinely unrecoverable include-time `prefix=` is reported through `MountedRoute.prefix_complete` rather than guessed at.

**The lift paid for itself before it shipped.** While the AST resolver lived in
`repo_tests/router_mount_parity_test.py` it was **not type-checked at all** — `pyproject.toml`'s
mypy `exclude` drops `.*_test\.py$`. Moving it into `autobot_shared/` put it under the *blocking*
strict sweep (`python3 -m mypy autobot_shared/`, 174 source files), and the checker immediately
produced 23 errors against code that had been running in a required gate for weeks. That is an
argument **for** the consolidation, not a tax on it: the same resolver now decides whether a PR
may merge *and* is verified by the type checker. None were silenced — see *Type narrowing* below.

**Consolidate, not fork.** The mount-graph AST machinery added by #15099 was the closest existing thing and is now shared rather than reimplemented: it moved out of `repo_tests/router_mount_parity_test.py` into `autobot_shared/api_routing/mount_graph.py`, and both guards import it. A second AST resolver would drift the way the two `include_router` regexes drifted before #12985.

## What Changed

**One traversal, replacing four private copies** — `autobot_shared/api_routing/router_routes.py` (new, 175 lines). `effective_routes()` / `effective_route_count()` / `route_method_paths()`, recursive, cycle-guarded, correct on both shapes. `git grep original_router` now returns the helper, its tests, and two comments explaining what was replaced — no call sites.

**The mount graph became shared** — `autobot_shared/api_routing/mount_graph.py` (new, 531 lines), lifted from `repo_tests/router_mount_parity_test.py` (536 → 202 lines, unchanged behaviour, still 9/9 green). Three changes while moving it:
- `module_name` strips `__init__`, so `llc/api/__init__.py` keys as `llc.api` — the name importers and registry entries actually spell. It previously produced two spellings of one router, and a package router's constructor guards attached to a key nothing else referenced.
- One `ast.walk` instead of five, plus a token pre-filter. The full-repo sweep went from >4 minutes to ~6 seconds.
- `MountGraph` now also carries every `.routes` read, so the guard is one parse pass, not a second one.

**The guard** — `repo_tests/router_routes_traversal_test.py` (new, 12 tests). Fails on a read of `<name>.routes`, or `getattr(<name>, "routes", ...)`, where `<name>` resolves to an `APIRouter` that receives `include_router` calls. Roots are *derived* from the repo (29 trees), not listed. Keys are namespaced per tree because `autobot-backend` and `autobot-slm-backend` both define `api/auth.py`, `api/settings.py` and seven more.

**Migrated (AC 1, 6)** — `llc/tests/test_roles_routes_registered.py` and
`api/codebase_analytics/endpoints/impact_endpoint_test.py`. Both were version-locked — they
**failed on an eager-FastAPI checkout before this change** — and both now pass on either shape.

**Three of four copies, not four — corrected after the rebase onto #15113.** This PR originally
migrated `api/terminal_router_dependency_wiring_test.py` too. #15113 then landed on `Dev_new_gui`,
turning that file's `_walk` into a *deliberate, documented* workaround: its docstring now states that
an include-time `prefix=` argument is consumed at include time and left nowhere, cites CI job
`98211256874` dumping `/package-managers` for a route served at `/terminal/package-managers`, and
`TestTerminalRouteDumpPathFidelity` pins that limit rather than hiding it. Deleting it is
**#15126**'s acceptance criterion, and #15126 is gated on this PR landing. So the rebase resolves
that file to the base version **verbatim** — this PR no longer touches it at all — and the fourth
copy is retired by #15126, not here. Verified byte-identical to `origin/Dev_new_gui`, and #15113's
tests pass alongside this branch's (51 tests together).

Consequence to state plainly: `git grep original_router` returns **two real uses in that file**
today, not zero. The guard does not flag them — `_walk` reads `getattr(container, "routes", [])`
where `container` is a *parameter*, which is the "attribute chain rooted in a local variable" blind
spot documented below. That is an honest limit of a static guard, not a claim that the file is clean.

**Degraded sites resolved (AC 5)**
- `api/self_capabilities.py` — the cache key is `_schema_hash(app)` counting through `effective_route_count`, not `len(app.routes)`. The old key moved only when an `include_router` *call* was added, so adding an endpoint inside a mounted router did not bust the cache; the docstrings promising route-change invalidation are now true rather than amended away.
- `api/presence_ws_router_test.py` — asserts `/ws/sessions/{session_id}/presence` is served, not `len(app.routes) > 0`, which a single wrapper satisfied.
- `autobot-infrastructure/shared/scripts/test_real_startup.py` — counts through the traversal. Also fixed a pre-existing unused `app_type` (F841) by putting the app class in the output rather than deleting the line that triggers lazy creation.

`api/terminal.py` was **not** touched — still exactly 1299 lines.

### Type narrowing — no `# type: ignore`

All 23 errors were one root cause **I introduced in the lift**: collapsing five `ast.walk` passes
into one, I bucketed nodes into a `Dict[type, List[ast.AST]]`, which erases the element type. Every
later pass then read `.func` / `.module` / `.targets` / `.args` off a bare `ast.AST`.

The fix is a typed `_Buckets` dataclass — five named lists (`List[ast.For]`, `List[ast.ImportFrom]`,
`List[ast.Assign]`, `List[ast.Call]`, `List[ast.Attribute]`), filled with `isinstance` rather than
`type(node) is …`. That narrows every pass at its source, so `_call_kwarg(node, "dependencies")` at
:415 now receives a real `ast.Call` — the narrowing was missing at the call site, exactly as
diagnosed, not in the helper. `isinstance` also restores the spelling the passes used *before* they
were merged, and stays correct if a node kind ever gains a subclass; none of the five has one today
(`AsyncFor` is a sibling of `For`, `AnnAssign`/`AugAssign` siblings of `Assign`), so both spellings
select the same nodes — verified by differential run over `autobot-backend`: **identical sets, 21 vs 21**.

`:268` — **the `None` is not reachable.** `_is_apirouter` read
`bool(rendered) and rendered.split(".")[-1] == "APIRouter"`; `and` short-circuits, so `.split` never
saw `None`. `_dotted` cannot return `""` either — it always joins at least one identifier. So this
was a narrowing the checker could not follow, **not a latent crash**, and I am not going to claim
otherwise. It is now an explicit `if rendered is None: return False`, which selects exactly the same
calls, with the equivalence stated in the docstring.

Graph output is unchanged across the fix: **341 routers, 425 edges, 0 unresolved, 2 dynamic** on
`autobot-backend`, and `router_mount_parity_test.py` stays 9/9.

Remaining `mypy autobot_shared/` output on a local **mypy 2.1.0** is 7 errors in three files this PR
never touches (`user_management/organization_service.py`, `rate_limiter.py`, `leader_lease.py`). CI
pins **1.16.0**, which reported "23 errors in **1 file**" — mine — so those 7 are newer-mypy
strictness, not a regression here. Filed separately rather than folded in.

## Verification

| AC | Evidence | Kind |
|---|---|---|
| 1 shared helper, three of four copies migrated | `git grep original_router` → helper + its tests + 2 explanatory comments + the two uses inside #15113's deliberate `_walk`, retired by #15126. 16 tests in `router_routes_test.py`, half synthetic (both shapes) and half against a real `APIRouter` | route-level + handler-level |
| 2 guard fails on a new site | `test_no_site_reads_routes_on_a_router_with_children`; scanner reproduced the issue's manual sweep exactly — the same 2 files / 3 reads, found independently | static |
| 3 contrast mutation | below | static |
| 4 non-vacuity | 6 assertions, see below | static |
| 5 degraded sites | 64 backend tests green incl. `self_capabilities_test.py` (15), `self_capabilities_integration_test.py` (10), `presence_ws_router_test.py` (7) | route-level |
| 6 `impact_endpoint_test.py:164` | failed on this box before (`AttributeError: 'NoneType' object has no attribute 'routes'`), passes now | route-level |
| 7 no #15091 dependency | guard is pure AST; the three migrated tests pass on the *eager* box, which is the version-independence claim | static + route-level |

**Contrast mutation, re-run on the final head (`5554a4e47`).** Replaced the migrated traversal in `impact_endpoint_test.py` with the pre-0.139 idiom — `{p for r in router.routes if (p := getattr(r, "path", None))}`, the `getattr`-guarded form that does not raise and silently finds nothing:

```
FAILED repo_tests/router_routes_traversal_test.py::test_no_site_reads_routes_on_a_router_with_children
E   Failed: `.routes` read on a router that receives include_router calls (#15093).
E       autobot-backend::api.codebase_analytics.endpoints.impact_endpoint_test:164
E         reads router.routes  -> autobot-backend::api.codebase_analytics.router:router
```
1 failed, 11 passed. Reverted; 12 passed. Note the mutated test itself **passes** on this box — eager inclusion makes it work — which is the whole point: only the static guard catches it here.

Three more mutations are permanent tests rather than one-offs: `test_the_bad_pattern_is_reported` builds a parent/child/reader fixture in a temp tree and asserts the read is flagged; `test_the_same_tree_without_the_include_is_not_reported` removes **only** the `include_router` line and asserts the byte-identical remainder is clean, plus that the read is still being found (so the negative half cannot pass by the scanner going blind); `test_the_getattr_spelling_is_reported_too` covers the harder spelling.

**Non-vacuity (AC 4).** Observed today: 28 trees, 397 routers, 16 routers-with-children, 62 `.routes` reads, 24 resolved to a router, 24 unresolved.
- `test_exemptions_are_named_and_still_real` asserts the scanner proposed **at least one** router-with-children read before judging any — this is AC 4's literal requirement, and it is non-vacuous because the one allowlisted entry is a real candidate.
- `test_scan_found_routers_with_children` requires ≥8 and names `llc.api:router` (38 children) explicitly.
- `test_scan_resolved_real_routers` requires ≥10 resolved reads — a broken resolver cannot pass by resolving nothing.
- `test_unresolved_routes_reads_stay_bounded` requires ≥20 total reads and caps the unresolved share.
- `test_every_python_tree_is_scanned` names the five trees that must be in the sweep.
- `test_key_namespacing_is_load_bearing` asserts the cross-tree key collisions are real, so the namespace prefix cannot be dropped as redundant.
- In the helper: `test_the_installed_fastapi_shape_is_one_of_the_two_known_ones` fails if a future FastAPI introduces a third inclusion shape, instead of every traversal quietly returning empty — the #15087 failure mode arriving via a dependency bump.

**Shards.** `repo_tests/router_routes_traversal_test.py` → **shard 7/12**. `autobot_shared/api_routing/router_routes_test.py` → **shard 3/12** (same shard as `router_mount_parity_test.py`). Computed with `repo_tests/stable_shard.py` against the committed `.test_durations`.

**Ratchet / registry.** `scripts/check_python_file_size.py` exits 0; `repo_tests/python_file_size_ratchet_test.py` 31/31. No `KNOWN_LARGE` entry added, no ceiling raised; largest new file is 531 lines. No new env vars.

### What this guard would NOT catch — stated, not implied

- **An attribute chain rooted in a local variable.** `bridge.router.routes` (`services/mcp_bridge_workers/worker_entrypoint.py`, the "latent" site on #15093) resolves no further than its literal text; knowing what `bridge` is needs type inference. Such reads are counted as *unresolved* and their share is capped, so the blind spot cannot widen silently — but an unresolved read is not failed. 24 of 62 reads are in this class today.
- **A router reached through a runtime factory**, or any mount whose target is computed.
- **Whether the traversal is then used correctly.** The guard sees that a risky read exists, not that its result is handled well.
- **An include-time `prefix=` or `dependencies=`.** Nothing recovers these from the deferred shape — which is why `api/terminal_tools.py` carries its gate on its own `APIRouter(...)` constructor where `router_mount_parity_test.py` can read it, and why `api/terminal_websocket_route_test.py` proves its gate behaviourally with a real 403.
- **A read in one tree of a router defined in another.** The namespace prefix makes this a false negative rather than a false positive. None exists — `repo_tests` and `scripts` are not on a backend's import path.

### Deliberate deviations from the AC text

- **AC 2 says "reuse `router_prefixes.py` for `include_router` detection rather than a new regex".** No new regex was written, but the reuse is the AST mount graph, not `router_prefixes`. A regex can tell you *that* an `include_router` call exists; it cannot resolve *which router object* a `.routes` read refers to, which is the whole question. The AST resolver already existed (#15099) and is now shared — core rule 2 satisfied more strongly than the letter asks.
- **AC 2's allowlist for `self_capabilities.py` / `audit_api_wiring.py` is empty by construction.** Both read `app.routes` on a mounted application and feed `get_openapi(routes=...)`. An app read is not a router read, so the scanner never proposes them and an entry would be stale on arrival — `test_exemptions_are_named_and_still_real` would fail on it. The allowlist mechanism exists and carries one real entry: `autobot_shared/api_routing/router_routes_test.py`, the one file that *must* see the raw shape, because it is what pins what the raw shape is.

### Not proven

The deferred behaviour itself is **not reproducible on this box** (fastapi 0.135.2, #15091). Everything asserted about it is either version-independent by construction, or asserted as a disjunction that holds on both shapes and fails loudly on a third. CI on this PR is the first run of these assertions against `fastapi==0.141.1`; specifically, whether the deferred wrapper exposes a `prefix` attribute — and if so whether it is the hop or the whole chain — is decided by `test_real_include_time_prefix_is_either_recovered_or_flagged`, which fails rather than guesses.

### Public surface kept open for #15113

That issue needs the **include-time** prefix (`admin_router.include_router(tools_router, prefix="/terminal")`),
which runtime introspection cannot recover but the AST *can*, because it reads the call site. Nothing
here narrows access to it: `Mount`, `MountGraph`, `ModuleScan`, `build_graph` and `python_files` are all
in `__all__`, `ModuleScan.edges` is public, and `router_prefixes.include_router_prefixes()` already
returns `(router_name, prefix)` pairs from source. Adding a `prefix` field to `Mount` is the natural
enabler and is deliberately left to that issue rather than done speculatively here.

## Model Used

Claude Opus 5 (1M context)




