### PR TITLE
test(terminal): fail the terminal route sweep when it enumerates nothing (#15087)

### DIFF
--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -216,26 +216,86 @@ class TestTerminalRouteDumpIsComplete:
     ``api.terminal`` nests three deep, which makes it a usable canary: a route
     declared on ``router``, a route declared on ``admin_router`` (included into
     ``router``), and a route from ``api.terminal_tools``' router (included into
-    ``admin_router`` under a prefix). Naming one path per level means a walk
-    that stops early fails saying *which* level it lost, instead of a
-    downstream gate assertion naming only its own symptom.
+    ``admin_router``). Naming one route per level means a walk that stops early
+    fails saying *which* level it lost, instead of a downstream gate assertion
+    naming only its own symptom.
     """
 
-    #: One path per nesting level, with the include that puts it there.
+    #: One route per nesting level: ``(needle, match_by_suffix, owner)``.
+    #:
+    #: The third is matched by **suffix**, for the reason
+    #: ``test_a_dumped_path_only_ever_loses_its_include_prefix`` below states
+    #: and pins: the dump cannot recover an include-time ``prefix=`` under a
+    #: deferring fastapi, so this route is ``/terminal/package-managers`` on
+    #: the eager local version (#15091) and ``/package-managers`` in CI (job
+    #: 98211256874). The suffix is unique within the dump and identical on
+    #: both, so the level stays pinned without this guard depending on the one
+    #: part of the dump that is version-sensitive.
     _LEVELS = (
-        ("/ws/{session_id}", "router -- declared directly, present even without flattening"),
-        ("/", "admin_router -- included into router at the end of api/terminal.py"),
-        ("/terminal/package-managers", "api.terminal_tools' router -- included into admin_router under /terminal"),
+        ("/ws/{session_id}", False, "router -- declared directly, present even without flattening"),
+        ("/", False, "admin_router -- included into router at the end of api/terminal.py"),
+        ("/package-managers", True, "api.terminal_tools' router -- included into admin_router"),
     )
 
-    @pytest.mark.parametrize("path,owner", _LEVELS)
-    def test_the_dump_reaches_every_nesting_level(self, terminal_route_spec, path, owner):
-        assert path in terminal_route_spec, (
-            f"{path} is absent from the clean-import dump -- it is owned by {owner}, "
-            "so the enumeration stopped before flattening that inclusion. Every "
-            "dependency assertion in this module sweeps that truncated surface.\n"
+    @pytest.mark.parametrize("needle,by_suffix,owner", _LEVELS)
+    def test_the_dump_reaches_every_nesting_level(self, terminal_route_spec, needle, by_suffix, owner):
+        found = [p for p in terminal_route_spec if (p.endswith(needle) if by_suffix else p == needle)]
+        assert found, (
+            f"the dump holds no route {'ending in' if by_suffix else 'at'} {needle}. "
+            f"That route is owned by {owner}, so the walk never reached that "
+            "inclusion at all -- a dropped include prefix would still leave the "
+            "suffix, so this is absence, not truncation. Every dependency "
+            "assertion in this module sweeps that shortened surface.\n"
             f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
         )
+
+
+class TestTerminalRouteDumpPathFidelity:
+    """What the dump's paths do and do not mean (#15126).
+
+    ``api/terminal.py:198`` is ``admin_router.include_router(tools_router,
+    prefix="/terminal")``, and ``api.terminal_tools``' router carries no
+    ``prefix`` of its own -- so that ``/terminal`` is purely the **include-time
+    ``prefix=`` argument**. #15112 established that this term is consumed at
+    include time and left nowhere on the deferred wrapper: it is not
+    recoverable by runtime introspection, and three attempts to recover it are
+    the evidence. (The *including router's own* ``.prefix`` is a different term
+    and is recoverable -- it simply is not the one in play here.)
+
+    So this dump reports those four routes unprefixed in CI and prefixed on the
+    eager fastapi this repo resolves locally. Rather than let that trip a test
+    up again, it is asserted: a dumped path is never *wrong*, only ever missing
+    a leading include prefix. That holds on both versions, fails if the walk
+    ever starts inventing paths, and is the honest statement of the limit.
+
+    The stronger test -- build the expected full paths from a static mount
+    graph, which *can* see the include site, and compare -- is gated on #15112
+    (`autobot_shared/api_routing/`, open at the time of writing). When it lands,
+    this class and the suffix match above are what it replaces; do not write a
+    private copy of that graph in the meantime (#15093).
+    """
+
+    #: The paths the application actually serves for the tool routes. Not an
+    #: assumption: ``terminal_websocket_route_test.py``'s
+    #: ``TestTerminalToolRoutesKeepTheirGate`` drives each of these through a
+    #: real ``TestClient`` request and asserts a non-404 on both versions.
+    _SERVED_TOOL_PATHS = (
+        "/terminal/package-managers",
+        "/terminal/install-tool",
+        "/terminal/check-tool",
+        "/terminal/validate-command",
+    )
+
+    @pytest.mark.parametrize("served", _SERVED_TOOL_PATHS)
+    def test_a_dumped_path_only_ever_loses_its_include_prefix(self, terminal_route_spec, served):
+        matches = [p for p in terminal_route_spec if served.endswith(p) and p != "/"]
+        assert matches, (
+            f"{served} is served by the application but nothing in the dump is "
+            "even a trailing part of it. The walk is not merely dropping the "
+            f"include prefix from api/terminal.py:198 -- it has lost the route.\n"
+            f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
+        )
+        assert len(matches) == 1, f"{served} matched more than one dumped path, so neither identifies it: {matches}"
 
 
 def _dump_routes_main() -> None:
@@ -299,6 +359,25 @@ def _dump_routes_main() -> None:
         ``api/self_capabilities_integration_test.py`` -- copied here rather than
         invented, though the fact that four files now carry it by hand is its
         own problem.
+
+        **The reconstructed prefix is not trustworthy, and a caller must not
+        key an assertion on one.** Two different terms both read as "prefix"
+        and only one of them survives deferral (#15112): the *including
+        router's own* ``.prefix`` stays on the parent object and is
+        recoverable, while an include-time ``prefix=`` **argument** is consumed
+        at include time and left nowhere -- ``sub_prefix`` then resolves empty
+        and the path comes back short. ``api/terminal.py:198`` uses the second
+        kind, so CI job 98211256874 dumped ``/package-managers`` for a route
+        the application serves at ``/terminal/package-managers``, while the
+        eager fastapi this repo resolves locally (#15091) dumps it prefixed.
+
+        Nothing in this module reads a prefixed path -- the routes it asserts
+        on are all included without one -- and
+        ``TestTerminalRouteDumpPathFidelity`` pins the limit rather than
+        leaving the next reader to trip over it. Filed as #15126; the static
+        mount graph that *can* see the include site is #15112. Do not patch
+        this by guessing at a wrapper attribute, and do not fork a private
+        copy of that graph (#15093). Match by a unique suffix until it lands.
         """
         found = []
         for route in getattr(container, "routes", []) or []:

--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -27,16 +27,34 @@ from pathlib import Path
 
 import pytest
 
-# --- clean-interpreter route/dependency enumeration (#14998, shard-12 pollution) ---
+# --- clean-interpreter route/dependency enumeration (#14998, #15087) ---
 #
-# Every structural gate assertion below reads from this, never from the
-# in-process ``terminal_router`` bound at collection time: that name observed
-# zero routes under python-suite shard 12/12 (CI job 98074498060) even though
-# this file passes in isolation -- some earlier-collected test in the same
-# xdist worker leaves shared state (import machinery or the router object
-# itself) in a way this file's own module-level import inherits. Filed as
-# #15087, unidentified polluter. A subprocess that imports ``api.terminal``
-# fresh sidesteps the mechanism entirely rather than needing to name it.
+# Every structural gate assertion below reads from this, never from an
+# in-process ``terminal_router.routes`` walk bound at collection time.
+#
+# #15087 recorded such a walk finding **zero** matching routes under
+# ``python-suite shard 12/12`` (CI job 98074498060) while passing locally, and
+# read that as ``sys.modules`` pollution from a neighbouring test. It is not
+# pollution. The mechanism is the fastapi version CI resolves (#15093):
+# ``api/terminal.py`` ends with ``router.include_router(admin_router)``, and
+# under fastapi >= 0.139 ``include_router`` **defers** -- it appends a single
+# ``_IncludedRouter`` wrapper whose ``path`` is ``None`` instead of copying the
+# child's routes onto the parent. The top level of ``api.terminal.router`` is
+# therefore three entries there (the two WebSocket routes plus that wrapper --
+# dumped verbatim by CI job 98088603289) against 26 on the older fastapi this
+# repo resolves locally (#15091). Filtering those three by path for anything
+# owned by ``admin_router`` -- every HTTP route, and the four tool routes a
+# further level down -- yields precisely the reported empty set,
+# ``StopIteration`` and "found 0".
+#
+# "Only under shard 12/12" was not a neighbour effect either.
+# ``repo_tests/stable_shard.py`` assigns a module by sha256 of its own path, so
+# shard 12 is the only shard that ever runs those files: there was no other
+# shard for the result to differ from, and no polluter to find.
+#
+# A subprocess that imports ``api.terminal`` fresh and enumerates a **mounted
+# app** is immune to both halves -- it asks what the application serves, which
+# is the same question on either version.
 
 _ADMIN_DEP = "auth_middleware.check_admin_permission"
 
@@ -156,6 +174,26 @@ class TestTerminalRouterDependencyWiring:
     """
 
     def test_websocket_routes_carry_no_admin_dependency(self, terminal_route_spec):
+        """The #14998 fix itself -- stated as an absence, so it needs a witness.
+
+        ``_run_terminal_route_dump`` already refuses a dump with zero *routes*.
+        Nothing until now refused a dump with zero *dependencies*, and that is
+        the enumeration this assertion actually reads. An always-empty
+        dependency list is not hypothetical: fastapi 0.141.1 reports a
+        dependency inherited through ``include_router(dependencies=)`` as
+        empty on the route object (CI job 98114928835), the same deferral that
+        produced #15087. Under one, "the admin Depends is absent from the WS
+        routes" holds for every router ever written, and this test reports the
+        fix intact without having checked it. The witness below is the
+        cheapest thing that cannot be true of an empty enumeration.
+        """
+        gated = sorted(path for path, deps in terminal_route_spec.items() if _ADMIN_DEP in deps)
+        assert gated, (
+            f"no route in the clean-import dump carries {_ADMIN_DEP} at all -- "
+            "the dump is not resolving dependencies, so the absence asserted "
+            "below is vacuous and proves nothing about the #14998 fix"
+        )
+
         for path in ("/ws/{session_id}", "/ws/ssh/{host_id}"):
             assert path in terminal_route_spec, f"route {path} missing from a clean import"
             assert _ADMIN_DEP not in terminal_route_spec[path], f"{path} must not carry the router-level admin Depends"
@@ -163,6 +201,41 @@ class TestTerminalRouterDependencyWiring:
     def test_http_routes_keep_the_admin_dependency(self, terminal_route_spec):
         assert "/" in terminal_route_spec, "route / missing from a clean import"
         assert _ADMIN_DEP in terminal_route_spec["/"], "HTTP routes must keep check_admin_permission"
+
+
+class TestTerminalRouteDumpIsComplete:
+    """#15087: the dump reached every level of the merged router, not just the top.
+
+    The defect this guards against reads a router's ``.routes`` and stops
+    there. Under fastapi >= 0.139 that is three entries for this module and
+    the answer looks plausible -- the two WebSocket routes are genuinely at
+    the top level, so nothing is obviously missing and nothing raises. Every
+    gate assertion downstream then sweeps a surface with no HTTP routes in it
+    and reports whatever an empty sweep reports.
+
+    ``api.terminal`` nests three deep, which makes it a usable canary: a route
+    declared on ``router``, a route declared on ``admin_router`` (included into
+    ``router``), and a route from ``api.terminal_tools``' router (included into
+    ``admin_router`` under a prefix). Naming one path per level means a walk
+    that stops early fails saying *which* level it lost, instead of a
+    downstream gate assertion naming only its own symptom.
+    """
+
+    #: One path per nesting level, with the include that puts it there.
+    _LEVELS = (
+        ("/ws/{session_id}", "router -- declared directly, present even without flattening"),
+        ("/", "admin_router -- included into router at the end of api/terminal.py"),
+        ("/terminal/package-managers", "api.terminal_tools' router -- included into admin_router under /terminal"),
+    )
+
+    @pytest.mark.parametrize("path,owner", _LEVELS)
+    def test_the_dump_reaches_every_nesting_level(self, terminal_route_spec, path, owner):
+        assert path in terminal_route_spec, (
+            f"{path} is absent from the clean-import dump -- it is owned by {owner}, "
+            "so the enumeration stopped before flattening that inclusion. Every "
+            "dependency assertion in this module sweeps that truncated surface.\n"
+            f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
+        )
 
 
 def _dump_routes_main() -> None:

--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -256,11 +256,10 @@ class TestTerminalRouteDumpPathFidelity:
     ``api/terminal.py:198`` is ``admin_router.include_router(tools_router,
     prefix="/terminal")``, and ``api.terminal_tools``' router carries no
     ``prefix`` of its own -- so that ``/terminal`` is purely the **include-time
-    ``prefix=`` argument**. #15112 established that this term is consumed at
-    include time and left nowhere on the deferred wrapper: it is not
-    recoverable by runtime introspection, and three attempts to recover it are
-    the evidence. (The *including router's own* ``.prefix`` is a different term
-    and is recoverable -- it simply is not the one in play here.)
+    ``prefix=`` argument**. #15112 separates that term from the one it was
+    being conflated with and states of it: "nothing recovers these from the
+    deferred shape". The *including router's own* ``.prefix`` is the other
+    term, and it is recoverable -- it simply is not the one in play here.
 
     So this dump reports those four routes unprefixed in CI and prefixed on the
     eager fastapi this repo resolves locally. Rather than let that trip a test
@@ -270,9 +269,12 @@ class TestTerminalRouteDumpPathFidelity:
 
     The stronger test -- build the expected full paths from a static mount
     graph, which *can* see the include site, and compare -- is gated on #15112
-    (`autobot_shared/api_routing/`, open at the time of writing). When it lands,
-    this class and the suffix match above are what it replaces; do not write a
-    private copy of that graph in the meantime (#15093).
+    (`autobot_shared/api_routing/`, open at the time of writing). It already
+    carries the piece needed: ``router_prefixes.include_router_prefixes()``
+    returns ``(router_name, prefix)`` from source, and that PR proposes
+    surfacing it as a ``prefix`` field on ``Mount``. Consume that when it
+    lands; do not write a private copy of it in the meantime (#15093). This
+    class and the suffix match above are what it replaces (#15126).
     """
 
     #: The paths the application actually serves for the tool routes. Not an


### PR DESCRIPTION
## Thinking Path

**There is no polluter, and there never was.** #15087 reports
`api.terminal.router` enumerating zero routes under `python-suite shard 12/12`
and reads it as `sys.modules` pollution from a neighbouring test. Three pieces
of evidence refute that and name the real mechanism.

**1. The read site, recovered from git.** Job `98074498060` ran the revision at
`85bbb2608767`, where the enumeration was:

```python
def _tool_routes():
    from api.terminal import router as merged_router
    return [r for r in merged_router.routes if getattr(r, "path", "") in _TOOL_PATHS]
```

A flat `.routes` read, filtered by path.

**2. What that read returns on the version CI resolves.** `api/terminal.py:1299`
is `router.include_router(admin_router)`, and `api/terminal.py:198` is
`admin_router.include_router(tools_router, prefix="/terminal")`. Under
`fastapi >= 0.139` (CI pins **0.141.1 / starlette 1.6.0**) `include_router`
**defers**: it appends one `_IncludedRouter` wrapper with `path = None` instead
of copying the child's routes onto the parent (#15093). So the top level of
`api.terminal.router` there is exactly three entries — CI job `98088603289`
dumped them verbatim as `[APIWebSocketRoute /ws/{session_id},
APIWebSocketRoute /ws/ssh/{host_id}, _IncludedRouter path=null]`. Every HTTP
route lives one level down on `admin_router`; the four tool routes live two
levels down. Filtering those three by path for either set yields the empty set.

That reproduces the reported signature term for term: `found []` for the tool
paths, `StopIteration` x4 from `next(r for r in _tool_routes() if ...)`, and
`expected exactly one route for /, found 0`. Nothing else has to be true.

**3. "Only under shard 12/12" was not a neighbour effect.**
`repo_tests/stable_shard.py` assigns a module by `sha256` of its own path
(`bucket_of`, `shard_of`), so shard membership is a pure function of the path
and independent of what else was collected. Computed against `.test_durations`
at this branch's base:

| module | shard |
|---|---|
| `autobot-backend/api/terminal_websocket_route_test.py` | **12** |
| `autobot-backend/api/terminal_tools_test.py` | **12** |
| `autobot-backend/api/terminal_router_dependency_wiring_test.py` | 2 |

Shard 12 is the **only** shard that ever runs those files. There was no second
shard for the result to differ from, so "fails only under shard 12/12" says
nothing about neighbours — it says the observation exists only there. The
local/CI split is the fastapi version (#15091: this box resolves 0.135.2, below
the declared `fastapi>=0.141.1` floor, and does not defer), not scheduling.

**The vacuity that is still live.** The route sweep is already guarded —
`_run_terminal_route_dump` refuses a dump with zero routes, an unparsable one,
or any route it cannot name. The **dependency** sweep was not, and that is the
enumeration `test_websocket_routes_carry_no_admin_dependency` actually reads.
It is an absence assertion: `_ADMIN_DEP not in spec[path]`. Force every route's
dependency list to `[]` and it passes — while its sibling positive assertion
fails. An always-empty dependency list is not hypothetical here: fastapi
0.141.1 reports a dependency inherited through `include_router(dependencies=)`
as empty on the route object (CI job `98114928835`), the same deferral that
produced this issue. That assertion **is** the #14998 fix, and it was reporting
the fix intact without checking it.

**Scope.** The generic class — a shared helper and a repo-wide guard for
deferred `include_router` — is #15093 and is being worked separately. This PR
deliberately forks neither, and does not touch
`repo_tests/router_mount_parity_test.py`.

## What Changed

`autobot-backend/api/terminal_router_dependency_wiring_test.py` only
(264 -> 418 lines; `api/terminal.py` untouched, still exactly 1299).

- **Non-vacuity witness** in `test_websocket_routes_carry_no_admin_dependency`:
  the test now asserts that *some* route in the dump carries the admin
  dependency before asserting its absence on the two WebSocket routes. An empty
  dependency enumeration can no longer read as "the fix holds".
- **`TestTerminalRouteDumpIsComplete`** — one parametrized case per nesting
  level of the merged router (`/ws/{session_id}` on `router`, `/` on
  `admin_router`, `/package-managers` on the included tools router, matched by
  unique suffix). A walk that never reaches an inclusion fails naming *which*
  one, instead of a downstream gate assertion reporting only its own symptom.
- **`TestTerminalRouteDumpPathFidelity`** — states the dump's real limit as an
  assertion: every tool path the application serves must have exactly one
  dumped path that is a trailing part of it. The walk may lose a leading
  include prefix; it may never produce a *wrong* path. True on both fastapi
  versions.
- **Corrected the root-cause note** at the top of the module. It was the only
  place in the repo carrying the "unidentified polluter / earlier-collected
  test leaves shared state" theory; it now records the deferral mechanism, the
  three-entry CI dump, and the `stable_shard` reasoning that rules out a
  neighbour effect. `_dump_routes_main`'s docstring records the prefix limit
  and the two terms it turns on.

All tests land in **shard 2** (the module's existing shard — a function of the
path, unchanged).

### The include prefix: what the first revision got wrong

The first push keyed the third level on `/terminal/package-managers` and went
red on `python-suite shard 2/12` (job `98211256874`). **The test's expectation
was wrong, not the code under it.** Read that dump: `/package-managers`,
`/install-tool` and `/check-tool` are all *present*, unprefixed. The walk did
not stop before flattening `admin_router.include_router(tools_router,
prefix="/terminal")` — it flattened it and dropped the include-time prefix.

Two terms read as "prefix" and #15112 established that only one survives
deferral: the **including router's own** `.prefix` stays on the parent and is
recoverable; an include-time **`prefix=` argument** is consumed at include time
and left nowhere. Checked which is in play here — `api/terminal_tools.py:44` is
`APIRouter(tags=[...], dependencies=[...])` with **no `prefix` of its own**, so
the `/terminal` at `api/terminal.py:198` is entirely the unrecoverable kind.
The recoverable term does not apply.

**Took option (a)**, because option (b) is gated: #15112 (`Closes #15093`,
which adds `autobot_shared/api_routing/mount_graph.py` — an AST graph that
*can* see the include site) is **OPEN, `mergedAt: null`**, checked at the time
of writing. Building the full expectation from that graph is the stronger test
and is the right follow-up; forking a private copy of it now is the exact
duplication #15093 exists to end. So: assert the recoverable truth (suffix),
and assert the limitation itself rather than trip over it. Filed as **#15126**,
whose ACs require the suffix match, `TestTerminalRouteDumpPathFidelity` and the
docstring caveat all to be **deleted** when #15112 lands — the workaround
cannot outlive its reason.

The failure message was also wrong in the first revision: it said "the
enumeration stopped before flattening that inclusion", which would have sent
the next reader hunting a truncation that was not there. It now distinguishes
the two, in its own words:

```
the dump holds no route ending in /package-managers. That route is owned by
api.terminal_tools' router -- included into admin_router, so the walk never
reached that inclusion at all -- a dropped include prefix would still leave
the suffix, so this is absence, not truncation.
```

## Verification

Everything below was re-run against the **final** head (`dbabe8a04`); every
earlier revision's runs are superseded.

**The vacuity, demonstrated on the baseline.** Forcing `_dep_names` to return
`[]` for every route, *before* this PR:

```
autobot-backend/api/terminal_router_dependency_wiring_test.py .F   [100%]
FAILED ...::test_http_routes_keep_the_admin_dependency
1 failed, 1 passed
```

The `.` is `test_websocket_routes_carry_no_admin_dependency` — the assertion
that *is* the #14998 fix — passing on an enumeration containing nothing.

**Probe A** — same forced-empty dependency sweep, after:

```
E   AssertionError: no route in the clean-import dump carries
    auth_middleware.check_admin_permission at all -- the dump is not resolving
    dependencies, so the absence asserted below is vacuous and proves nothing
    about the #14998 fix
2 failed, 7 passed
```

**Probe B** — sweep truncated to the deferred top level (genuine absence):

```
E   the dump holds no route at /. That route is owned by admin_router ...
    so the walk never reached that inclusion at all -- a dropped include
    prefix would still leave the suffix, so this is absence, not truncation.
E   /terminal/package-managers is served by the application but nothing in the
    dump is even a trailing part of it. The walk is not merely dropping the
    include prefix from api/terminal.py:198 -- it has lost the route.
8 failed, 1 passed
```

**Probe C** — CI job `98211256874`'s dump reproduced locally by construction:
every `/terminal/...` path rewritten to drop the prefix, routes otherwise
intact.

```
9 passed
```

The shape that reddened the first revision now passes, and it passes because
the guard was corrected to assert what is true on both versions — not because
the local fastapi happens to be the eager one.

**Contrast mutations, production code, final head** (each reverted; `git
status` clean after):

| mutation in `api/terminal.py` | result |
|---|---|
| `@router.websocket("/ws/{session_id}")` -> `@admin_router.websocket(...)` (the #14998 defect) | `test_websocket_routes_carry_no_admin_dependency` FAILS: `/ws/{session_id} must not carry the router-level admin Depends`. Witness passed, so the failure is the real assertion. `1 failed, 8 passed` |
| `admin_router.include_router(tools_router, prefix="/terminal")` deleted | `5 failed, 4 passed` — the level guard and all four fidelity cases, each naming the lost inclusion |

A third commit (`dbabe8a04`) corrects one docstring sentence only: it had
asserted "three attempts to recover it are the evidence", which I had not
verified. It now quotes #15112's own wording — *"nothing recovers these from
the deferred shape"* — and points at the concrete hook that PR already carries
(`router_prefixes.include_router_prefixes()` returning `(router_name, prefix)`,
proposed as a `prefix` field on `Mount`). #15112's body independently names
this exact call site as the case needing it. No behaviour changed, but the
mutations above were re-run against that head rather than cited from an
earlier one.

**Green:** `47 passed` across `terminal_router_dependency_wiring_test.py`,
`terminal_websocket_route_test.py`, `terminal_tools_test.py` and
`repo_tests/router_mount_parity_test.py`. `black` and `ruff check` clean.
`scripts/check_python_file_size.py` clean (418 lines, ceiling 600); no
`KNOWN_LARGE` entry added or changed; `api/terminal.py` unchanged at 1299.

**Local vs CI.** Root cause evidence is **CI**: jobs `98074498060`,
`98088603289`, `98114928835`, `98211256874`, plus the git object at
`85bbb2608767`. The shard arithmetic is **local** and version-independent
(sha256 of the path). Probes and mutations are **local** and version-independent
by construction — each forces the sweep into the shape CI produced rather than
relying on the installed fastapi to produce it. Per #15091 a local pass carries
no information about the deferral itself, which is why nothing here depends on
observing it locally.

**Issue AC3 was already met before this PR.** `python-suite shard 12/12` at
base `9b88068b5` — run `32973816898`, job `98193828293` — **success** on Python
3.14.7, `2476 passed, 33 skipped`, with `terminal_websocket_route_test.py`
running and passing. #15085/#15100/#15101/#15105 fixed the failure itself; what
was left was the root cause and the trap.

**What I could not prove**
- I could not observe the deferral first-hand. This box resolves fastapi
  0.135.2 (#15091), which flattens eagerly, and installing is not permitted.
  The mechanism is established from the CI dumps plus #15112's finding, not
  from a local run.
- I did not run a Python 3.14 + `-n 2 --dist loadscope` transition probe. It is
  unnecessary: the shard arithmetic shows there is no cross-shard difference to
  explain, so there is nothing for such a probe to find.
- The include-time prefix is asserted *as unrecoverable*, not *made*
  recoverable. That needs #15112's mount graph and is #15126.
- **AC2 of the issue is refuted, not satisfied.** It asks that the polluter
  "installs/mutates shared state inside a `try/finally`, or is added to
  `repo_tests/sys_modules_leak_baseline.txt`". No test mutates shared state
  here, so there is nothing to wrap and nothing to baseline. `Refs`, not
  `Closes`, for that reason alone — AC1 (mechanism named at `file:line`) and
  AC3 (shard 12/12 green on CI's 3.14) are both met.

Refs #15087
Related: #15126 (filed here), #15112 / #15093, #15091

## Model Used

Claude Opus 5 (1M context)
