### PR TITLE
fix(code-sync): stop _COMPONENT_PYTHON_TARGET claiming a component it cannot reach (#15075)

### DIFF
--- a/autobot-slm-backend/api/code_sync.py
+++ b/autobot-slm-backend/api/code_sync.py
@@ -1549,13 +1549,13 @@ _COMPONENT_PIP_PATHS: Dict[str, Tuple[str, str]] = {
     ),
 }
 
-# Target CPython interpreter per backend component (#11323).
-# Every Python service, including the NPU worker, targets py3.14 (#13747) —
-# this is the single authoritative mapping; do not hardcode elsewhere.
+# Target CPython interpreter for the components code-sync provisions (#11323).
+# Authoritative for _COMPONENT_PIP_PATHS keys ONLY — both readers are reached
+# from that branch alone, so any other key would be unread (#15075). The NPU
+# worker targets 3.14 too (#13747), decided in roles/npu-worker/tasks/main.yml.
 _COMPONENT_PYTHON_TARGET: Dict[str, str] = {
     "autobot-backend": "python3.14",
     "autobot-slm-backend": "python3.14",
-    "autobot-npu-worker": "python3.14",
 }
 
 # Ansible assets that provision the target interpreter on THIS host (#11343).

--- a/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
+++ b/autobot-slm-backend/tests/api/test_code_sync_deploy_bugs.py
@@ -100,10 +100,10 @@ def test_constraints_source_subdir_constant() -> None:
 
 
 def test_component_python_target_has_backends() -> None:
-    """Every mapped component targets python3.14 (#13747: NPU worker moved off 3.11)."""
+    """Every mapped component targets python3.14; the unread NPU entry is gone (#15075)."""
     assert _COMPONENT_PYTHON_TARGET["autobot-backend"] == "python3.14"
     assert _COMPONENT_PYTHON_TARGET["autobot-slm-backend"] == "python3.14"
-    assert _COMPONENT_PYTHON_TARGET["autobot-npu-worker"] == "python3.14"
+    assert "autobot-npu-worker" not in _COMPONENT_PYTHON_TARGET  # ansible decides it (#13747)
 
 
 # ---------------------------------------------------------------------------

--- a/autobot-slm-backend/tests/api/test_python_target_reachable_15075.py
+++ b/autobot-slm-backend/tests/api/test_python_target_reachable_15075.py
@@ -1,0 +1,127 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15075 — every key of ``_COMPONENT_PYTHON_TARGET`` must actually be consulted.
+
+The map used to carry an ``autobot-npu-worker`` entry that nothing could read.
+Its two readers (``_ensure_target_python_installed``, ``_ensure_venv_python``)
+are called only from ``_run_post_sync_steps``'s ``if component in
+_COMPONENT_PIP_PATHS:`` branch, and that map has never held the worker — the
+exclusion is deliberate (MVA-79: the backend branch recreates the venv, which
+would wipe the venv the chroma binary lives in). So the entry read as the
+single authoritative interpreter for a component it could not reach: editing
+it looked like a version bump and changed nothing on the host, which is the
+silently-unapplied-config failure #13747 is about.
+
+What the guard asserts, in the two directions that can go wrong:
+
+* **reachability** — every key is in ``_COMPONENT_PIP_PATHS`` (the gate the
+  readers sit behind), and passing that key through a reader produces a step
+  naming the interpreter it maps to. A fourth entry dropped into the same dead
+  slot fails here rather than sitting inert;
+* **vacuity** — the map, and the set of keys the loop iterates, are asserted
+  non-empty first. A test that enumerates and asserts per item passes when the
+  enumeration is empty, which is how #15087's router guard came to assert
+  nothing; emptying this map must fail this file, not silence it.
+
+``test_worker_dispatch_never_reaches_the_python_target_readers`` pins the
+premise itself: it is the dispatch gate, not a convention, that makes a
+non-``_COMPONENT_PIP_PATHS`` key unreadable.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+# ---------------------------------------------------------------------------
+# #12572: import api.code_sync with real Pydantic schema stand-ins installed
+# then removed — see _code_sync_import.py for why this dance is necessary.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _code_sync_import import import_code_sync  # noqa: E402
+
+import_code_sync()
+
+import asyncio  # noqa: E402
+
+from api import code_sync  # noqa: E402
+from api.code_sync import (  # noqa: E402
+    _COMPONENT_PIP_PATHS,
+    _COMPONENT_PYTHON_TARGET,
+    _WORKER_COMPONENTS,
+    _ensure_target_python_installed,
+    _run_post_sync_steps,
+)
+
+#: Path of the ansible tasks file the map's comment now points readers at for
+#: the NPU worker's interpreter. Asserted to exist and to still pin 3.14, so
+#: the pointer cannot rot into a second dead reference (#15075 AC2).
+_NPU_ROLE_TASKS = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "npu-worker" / "tasks" / "main.yml"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_the_python_target_map_is_not_empty() -> None:
+    """An empty map would make every per-key assertion below vacuous (#15087)."""
+    assert _COMPONENT_PYTHON_TARGET, "_COMPONENT_PYTHON_TARGET is empty — the guard would assert nothing"
+
+
+def test_every_python_target_key_sits_behind_the_branch_that_reads_it() -> None:
+    """Keys outside _COMPONENT_PIP_PATHS are unreachable: the readers are gated on it."""
+    unreachable = sorted(set(_COMPONENT_PYTHON_TARGET) - set(_COMPONENT_PIP_PATHS))
+    assert not unreachable, (
+        f"{unreachable} cannot be read: _ensure_target_python_installed and _ensure_venv_python "
+        "are called only from _run_post_sync_steps's `if component in _COMPONENT_PIP_PATHS:` "
+        "branch. Add the component there (only if the backend-shaped steps genuinely apply — "
+        "MVA-79), or decide its interpreter where its ansible role does (#15075)."
+    )
+
+
+def test_every_python_target_value_reaches_an_observable_step() -> None:
+    """Each mapped interpreter must show up in the steps log for its own component."""
+    components = sorted(_COMPONENT_PYTHON_TARGET)
+    assert components, "no components to check — see test_the_python_target_map_is_not_empty (#15087)"
+    for component in components:
+        target = _COMPONENT_PYTHON_TARGET[component]
+        steps: list[str] = []
+        with patch.object(code_sync.shutil, "which", return_value=f"/usr/bin/{target}"):
+            _run(_ensure_target_python_installed(component, steps))
+        assert any(target in step for step in steps), (
+            f"{component}: nothing in the steps log names {target}, so the mapped value was " "never read (#15075)"
+        )
+
+
+def test_worker_dispatch_never_reaches_the_python_target_readers(tmp_path) -> None:
+    """The premise: a worker component is routed past both readers entirely.
+
+    This is what makes an entry outside _COMPONENT_PIP_PATHS dead rather than
+    merely unconventional — and it is preserved deliberately (MVA-79), so it is
+    asserted rather than assumed.
+    """
+    assert "autobot-npu-worker" in _WORKER_COMPONENTS
+    with (
+        patch.object(code_sync, "_compute_deps_changed", AsyncMock(return_value=False)),
+        patch.object(code_sync, "_snapshot_component", AsyncMock(return_value=None)),
+        patch.object(code_sync, "_run_post_sync_worker_branch", AsyncMock(return_value=True)) as worker,
+        patch.object(code_sync, "_ensure_target_python_installed", AsyncMock()) as ensure_target,
+        patch.object(code_sync, "_ensure_venv_python", AsyncMock(return_value=False)) as ensure_venv,
+    ):
+        _run(_run_post_sync_steps("autobot-npu-worker", str(tmp_path), str(tmp_path), restart=False))
+    assert worker.await_count == 1, "the worker branch is what handles autobot-npu-worker"
+    assert ensure_target.await_count == 0
+    assert ensure_venv.await_count == 0
+
+
+def test_the_npu_worker_interpreter_is_decided_where_the_comment_says() -> None:
+    """The map's comment redirects a version bump to the ansible role; keep it true."""
+    assert _NPU_ROLE_TASKS.is_file(), f"{_NPU_ROLE_TASKS.name} moved — update the comment in code_sync.py (#15075)"
+    body = _NPU_ROLE_TASKS.read_text(encoding="utf-8")
+    assert "python3.14" in body, (
+        "roles/npu-worker/tasks/main.yml no longer pins python3.14. That file, not "
+        "_COMPONENT_PYTHON_TARGET, is where the NPU worker's interpreter is decided (#13747, #15075)."
+    )


### PR DESCRIPTION
## Thinking Path

The default assumption was that the entry *should* be read and the call site
was never wired. I checked that first and it does not hold — on the record
already in this file, not on a judgement call.

Grepping the behaviour rather than the symbol: `autobot-npu-worker` is handled
by `_run_post_sync_worker_branch`, reached from `_run_post_sync_steps`'s
`elif component in _WORKER_COMPONENTS:`. That branch calls
`_install_pip_deps_for_component`, then either `refuse_explicit_list` or a
`_WORKER_COMPONENT_PIP` reconcile, then restart — it consults
`_COMPONENT_PYTHON_TARGET` at no point, and does not fall back to a default
interpreter either. The map's only two readers,
`_ensure_target_python_installed` and `_ensure_venv_python`, are called solely
from the `if component in _COMPONENT_PIP_PATHS:` branch, and that map holds the
two backends. So the entry changed nothing and a future edit to it would change
nothing, while reading as the authoritative interpreter for that component.

Wiring it in would mean routing the worker through `_COMPONENT_PIP_PATHS`,
which the file already rules out in the `_WORKER_COMPONENTS` note: that branch
is backend-shaped (constraints deploy, interpreter provisioning, venv
recreation, alembic, `autobot_shared` symlink restore) and venv recreation
would wipe the venv the chroma binary lives in (MVA-79). Adding a read-only
interpreter assertion instead would need the worker's venv path, which lives on
a different host and is not known to code-sync at all.

So the honest fix: the worker's interpreter really is decided by
`autobot-slm-backend/ansible/roles/npu-worker/tasks/main.yml` — the `python314`
role include at the `Install target Python interpreter` task, the
`ensure_venv_version` include with `venv_python: python3.14`, and the
`python3.14 -m venv` that follows. The map now says so and names that file, so
the next bump lands where it takes effect.

## What Changed

- `_COMPONENT_PYTHON_TARGET` drops the `autobot-npu-worker` key and its comment
  no longer claims to be the single authoritative mapping. It now states the
  real scope — `_COMPONENT_PIP_PATHS` keys only, because that is the gate its
  readers sit behind — and points a worker version bump at the ansible role.
- `tests/api/test_python_target_reachable_15075.py` (new, 5 tests) asserts the
  invariant three ways: every key is inside `_COMPONENT_PIP_PATHS`; every mapped
  value reaches an observable step (`_ensure_target_python_installed` is run per
  key and the steps log must name the interpreter); and the worker dispatch
  really does bypass both readers, so the reachability rule is a pinned premise
  rather than a convention. It also asserts the ansible file the comment now
  points at exists and still pins 3.14, so the pointer cannot rot.
- Vacuity: the map and the iterated key set are asserted non-empty before any
  per-key assertion, so emptying the map fails this file instead of silencing it
  (#15087).
- `tests/api/test_code_sync_deploy_bugs.py::test_component_python_target_has_backends`
  now asserts the key is *absent* instead of asserting the dead value.
- No behaviour change for `autobot-backend` / `autobot-slm-backend`, and the
  deliberate worker exclusion from the backend-shaped branch is untouched.
- Both edited files are at their file-size ceilings, so both edits are exactly
  line-neutral — no ratchet entry moved in either direction.

## Verification

| Criterion | Kind | Evidence |
|---|---|---|
| AC1 comment no longer claims authority it lacks | static | map comment rewritten; scope stated as `_COMPONENT_PIP_PATHS` keys only |
| AC2 comment names the file that decides the worker's interpreter | static + unit | comment names `roles/npu-worker/tasks/main.yml`; `test_the_npu_worker_interpreter_is_decided_where_the_comment_says` asserts that file exists and still pins `python3.14` |
| AC3 a test asserts the invariant, and a fourth dead entry cannot be added unnoticed | unit | `test_every_python_target_key_sits_behind_the_branch_that_reads_it` + `test_every_python_target_value_reaches_an_observable_step` |
| AC3 the test fails rather than passes on an empty key set | unit | mutation B below |
| AC4 no behaviour change for the two backends | unit | 96 passed across `test_python_target_reachable_15075.py` + `test_code_sync_deploy_bugs.py`; 139 passed across the five code-sync/drift/resolve modules |
| AC5 worker exclusion preserved | unit | `test_worker_dispatch_never_reaches_the_python_target_readers`: worker branch awaited once, both readers awaited zero times |
| ratchet untouched | static | `check_python_file_size.py --audit-ceilings`: 4877 scanned, 509 grandfathered, all at size; `code_sync.py` still 6053 lines |

New test module lands in **shard 5 of 12** (`repo_tests/stable_shard.py`, 512
buckets, `.test_durations`); the edited `test_code_sync_deploy_bugs.py` stays in
shard 2.

**Contrast mutations** (both run against this PR's final head):

*A — put the dead entry back:*
```
FAILED tests/api/test_python_target_reachable_15075.py::test_every_python_target_key_sits_behind_the_branch_that_reads_it
E   AssertionError: ['autobot-npu-worker'] cannot be read: _ensure_target_python_installed
    and _ensure_venv_python are called only from _run_post_sync_steps's
    `if component in _COMPONENT_PIP_PATHS:` branch. ...
1 failed, 4 passed
```

*B — empty the map (the #15087 shape):*
```
FAILED ...::test_the_python_target_map_is_not_empty
E   AssertionError: _COMPONENT_PYTHON_TARGET is empty — the guard would assert nothing
FAILED ...::test_every_python_target_value_reaches_an_observable_step
E   AssertionError: no components to check — see test_the_python_target_map_is_not_empty (#15087)
2 failed, 3 passed
```
Both mutations reverted; tree clean, `code_sync.py` back at 6053 lines, 96/96 green.

Local runs are Python 3.10.12 / fastapi 0.135.2 while CI pins 3.14.7 / 0.141.1
(#15091), so CI remains the authority on the shard runs.

## Model Used

Claude Opus 5 (1M context).

Closes #15075
