### PR TITLE
fix(bedrock): resolve AWS credentials once and thread the pair through (#15071)

### DIFF
--- a/autobot-backend/llm_shared/providers/bedrock.py
+++ b/autobot-backend/llm_shared/providers/bedrock.py
@@ -28,7 +28,12 @@ from llm_shared.models import LLMRequest, LLMResponse, ToolCall
 from llm_shared.types import ProviderType
 
 from ..base_provider import BaseProvider
-from .bedrock_credentials import _AWS_REGION_PATTERN, load_credentials_from_vault, validate_credential_pair
+from .bedrock_credentials import (
+    build_boto3_client,
+    load_credentials_from_vault,
+    scrub_credentials,
+    validate_credential_pair,
+)
 
 logger = get_logger(__name__)
 
@@ -119,32 +124,21 @@ class BedrockProvider(BaseProvider):
         validate_credential_pair(access_key, secret_key)
         return access_key, secret_key, region
 
-    def _ensure_runtime_client(self):
-        """Lazily initialize the bedrock-runtime client."""
+    def _ensure_runtime_client(self, credentials: tuple[str | None, str | None, str | None] | None = None):
+        """Lazily initialize the bedrock-runtime client.
+
+        *credentials* lets a caller that has already resolved a pair thread it
+        through, so a single operation never resolves twice and therefore cannot
+        straddle a change of credential source between the two reads (#15071).
+        Omitted, the pair is resolved here as before.
+        """
         if self._runtime_client is not None:
             return self._runtime_client
 
-        try:
-            import boto3
-        except ImportError as exc:
-            raise ImportError("boto3 not installed. Run: pip install boto3") from exc
-
-        access_key, secret_key, region = self._resolve_credentials()
-        if not region or not _AWS_REGION_PATTERN.match(region):
-            # Region can originate from a SecretsService vault entry, which is a
-            # trust boundary, not a format guarantee. Reject anything that isn't
-            # AWS-region-shaped before it is used to build a boto3 endpoint host,
-            # and never echo the malformed value back into a log/exception.
-            raise ValueError("Bedrock: resolved AWS region has an unexpected format, refusing to initialize client")
-        self._region = region
-
-        # Explicit creds are only added when both are present; otherwise IAM role applies.
-        client_kwargs: Dict[str, Any] = {"region_name": region, "service_name": "bedrock-runtime"}
-        if access_key and secret_key:
-            client_kwargs["aws_access_key_id"] = access_key
-            client_kwargs["aws_secret_access_key"] = secret_key
-
-        self._runtime_client = boto3.client(**client_kwargs)
+        if credentials is None:
+            credentials = self._resolve_credentials()
+        self._runtime_client = build_boto3_client("bedrock-runtime", credentials)
+        self._region = credentials[2]
         logger.info("Initialized Bedrock runtime client")
         return self._runtime_client
 
@@ -558,21 +552,20 @@ class BedrockProvider(BaseProvider):
 
     async def is_available(self) -> bool:
         """Return True if Bedrock credentials are configured and the service is reachable."""
+        credentials: tuple[str | None, str | None, str | None] = (None, None, None)
         try:
-            self._ensure_runtime_client()
+            # Resolved once and threaded through both clients. Resolving per
+            # client re-reads mutable state, so the two reads can straddle a
+            # settings reload or a vault rotation and build a client from a
+            # mismatched key pair -- which does not raise, it fails opaquely at
+            # call time and surfaces here only as False (#15071).
+            credentials = self._resolve_credentials()
+            self._ensure_runtime_client(credentials)
             # Simple health check - list foundation models (no cost)
-            import boto3
-
-            bedrock_client = boto3.client(
-                "bedrock",
-                region_name=self._region,
-                aws_access_key_id=self._resolve_credentials()[0],
-                aws_secret_access_key=self._resolve_credentials()[1],
-            )
-            bedrock_client.list_foundation_models(maxResults=1)
+            build_boto3_client("bedrock", credentials).list_foundation_models(maxResults=1)
             return True
         except Exception as exc:
-            logger.debug("Bedrock availability check failed: %s", exc)
+            logger.debug("Bedrock availability check failed: %s", scrub_credentials(str(exc), credentials))
             return False
 
     async def list_models(self) -> List[str]:

--- a/autobot-backend/llm_shared/providers/bedrock_credentials.py
+++ b/autobot-backend/llm_shared/providers/bedrock_credentials.py
@@ -26,6 +26,7 @@ import json
 import re
 
 from autobot_shared.logging_manager import get_logger
+from autobot_shared.security.redaction import redact_text
 from services.secrets_audit_store import (
     REASON_LOOKUP_ERROR,
     REASON_MALFORMED_VALUE,
@@ -68,6 +69,67 @@ _AWS_ACCESS_KEY_PATTERN = re.compile(r"^(AKIA|ASIA)[0-9A-Z]{16}$")
 
 #: AWS secret-access-key shape: exactly 40 base64 characters (A-Za-z0-9+/).
 _AWS_SECRET_KEY_PATTERN = re.compile(r"^[A-Za-z0-9+/]{40}$")
+
+
+#: Replacement for any credential value removed from text on its way to a log.
+_CREDENTIAL_MASK = "***"
+
+
+def scrub_credentials(text: str, credentials: tuple[str | None, str | None, str | None]) -> str:
+    """Return *text* with the canonical redactions applied and *credentials* masked out.
+
+    The AWS SDK names the key it rejected in some of its error messages, and an
+    availability probe logs whatever it caught. Masking by *value* on top of the
+    shared pattern redactor is what makes the result provable rather than
+    probable: the resolved values are in hand here, so nothing is left to a
+    pattern's coverage (#15071).
+
+    Only the access key and the secret key are masked; the region is not a
+    secret and removing it would cost the log line its only useful detail.
+    """
+    scrubbed = redact_text(text)
+    for value in credentials[:2]:
+        if isinstance(value, str) and value:
+            scrubbed = scrubbed.replace(value, _CREDENTIAL_MASK)
+    return scrubbed
+
+
+def build_boto3_client(service_name: str, credentials: tuple[str | None, str | None, str | None]):
+    """Build a boto3 client for *service_name* from one already-resolved credential tuple.
+
+    Takes the resolved tuple rather than resolving its own, so every client built
+    during a single operation is provably built from the *same* pair. Two
+    resolutions can disagree -- a settings reload, an environment mutation, or a
+    vault rotation landing between them -- and a mismatched access-key/secret-key
+    pair does not raise: it fails opaquely at call time, which the caller then
+    sees only as an unexplained ``is_available() -> False`` (#15071).
+
+    Explicit credentials are added only when both are present, so an unset pair
+    falls through to boto3's own chain (IAM role / instance profile) instead of
+    being handed ``None`` for each.
+
+    Raises:
+        ImportError: If boto3 is not installed.
+        ValueError: If the region is absent or not AWS-region-shaped. A region
+            can originate from a vault entry, which is a trust boundary and not
+            a format guarantee, so it is checked before it is used to build a
+            boto3 endpoint host -- and never echoed back, per
+            validate_credential_pair.
+    """
+    try:
+        import boto3
+    except ImportError as exc:
+        raise ImportError("boto3 not installed. Run: pip install boto3") from exc
+
+    access_key, secret_key, region = credentials
+    if not region or not _AWS_REGION_PATTERN.match(region):
+        raise ValueError("Bedrock: resolved AWS region has an unexpected format, refusing to initialize client")
+
+    client_kwargs: dict[str, object] = {"region_name": region, "service_name": service_name}
+    if access_key and secret_key:
+        client_kwargs["aws_access_key_id"] = access_key
+        client_kwargs["aws_secret_access_key"] = secret_key
+    return boto3.client(**client_kwargs)
 
 
 def validate_credential_pair(access_key: object, secret_key: object) -> None:

--- a/autobot-backend/llm_shared/providers/bedrock_test.py
+++ b/autobot-backend/llm_shared/providers/bedrock_test.py
@@ -21,6 +21,7 @@ dotted path -- patching the wrong one would silently no-op.
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -222,6 +223,163 @@ def test_every_real_aws_partition_is_accepted(region):
 )
 def test_non_region_values_are_refused(value):
     assert not _AWS_REGION_PATTERN.match(value), f"{value!r} is not a region and must not reach boto3"
+
+
+# --- is_available(): one resolution, threaded through (#15071) -----------------------
+#
+# is_available() used to call _resolve_credentials() once per keyword argument, taking
+# the access key from one resolution and the secret key from the next. Both re-read
+# mutable state -- provider settings, the process environment, and since #15023 the
+# secrets vault -- so a change landing between the two produced a client built from a
+# mismatched pair. boto3 does not reject that at construction; it fails opaquely at
+# call time, and the blanket `except Exception` below turned it into a bare False.
+#
+# boto3 is an optional dependency and is not installed in CI, so every test here
+# installs a stand-in module: `build_boto3_client` imports it inside the call, which
+# resolves through sys.modules.
+
+
+class _RotatingCredentials:
+    """A ``_resolve_credentials`` stand-in returning a *different* pair on each call.
+
+    Stands in for the source changing underneath the provider -- a settings reload,
+    an environment mutation, a vault rotation. Each pair is stamped with its own
+    generation marker, so a client built from two different resolutions is visible
+    in the kwargs rather than merely possible in principle.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self) -> tuple[str, str, str]:
+        self.calls += 1
+        marker = str(self.calls)
+        return ("AKIA" + marker * 16, marker * 40, "us-east-1")
+
+
+def _fake_boto3(monkeypatch) -> MagicMock:
+    """Install a stand-in ``boto3`` module and return it."""
+    module = MagicMock()
+    monkeypatch.setitem(sys.modules, "boto3", module)
+    return module
+
+
+def _patch_debug(monkeypatch) -> MagicMock:
+    """Collect ``logger.debug`` calls from the provider module."""
+    debug_mock = MagicMock()
+    monkeypatch.setitem(_PROVIDER_GLOBALS, "logger", MagicMock(debug=debug_mock, info=MagicMock(), warning=MagicMock()))
+    return debug_mock
+
+
+async def test_is_available_resolves_credentials_exactly_once(monkeypatch):
+    """The single-resolution property, asserted directly so a reintroduced second call fails CI."""
+    rotating = _RotatingCredentials()
+    _fake_boto3(monkeypatch)
+    provider = BedrockProvider(settings={})
+    monkeypatch.setattr(provider, "_resolve_credentials", rotating)
+
+    assert await provider.is_available() is True
+    assert rotating.calls == 1
+
+
+async def test_a_source_changing_mid_check_cannot_produce_a_mismatched_client(monkeypatch):
+    """Every client built during one check carries an access key and secret from the SAME pair."""
+    rotating = _RotatingCredentials()
+    boto3_module = _fake_boto3(monkeypatch)
+    provider = BedrockProvider(settings={})
+    monkeypatch.setattr(provider, "_resolve_credentials", rotating)
+
+    assert await provider.is_available() is True
+
+    calls = boto3_module.client.call_args_list
+    assert calls, "no boto3 client was built, so this test asserted nothing"
+    for call in calls:
+        access_key, secret_key = call.kwargs["aws_access_key_id"], call.kwargs["aws_secret_access_key"]
+        generation = access_key[4]
+        assert set(access_key[4:]) == {generation}, f"access key is not one generation: {access_key!r}"
+        assert set(secret_key) == {generation}, "secret key came from a different resolution than the access key"
+
+
+async def test_both_clients_of_one_check_are_built_from_the_same_credentials(monkeypatch):
+    """The runtime client and the health-check client are the two clients in question."""
+    rotating = _RotatingCredentials()
+    boto3_module = _fake_boto3(monkeypatch)
+    provider = BedrockProvider(settings={})
+    monkeypatch.setattr(provider, "_resolve_credentials", rotating)
+
+    await provider.is_available()
+
+    built = [(c.kwargs["service_name"], c.kwargs["aws_access_key_id"]) for c in boto3_module.client.call_args_list]
+    assert [service for service, _ in built] == ["bedrock-runtime", "bedrock"]
+    assert len({access_key for _, access_key in built}) == 1, f"clients disagree on credentials: {built!r}"
+
+
+async def test_is_available_omits_absent_credentials_so_the_iam_chain_applies(monkeypatch):
+    """With nothing configured, boto3 must be left to its own chain rather than handed None."""
+    _patch_vault(monkeypatch, _vault_returning(None))
+    boto3_module = _fake_boto3(monkeypatch)
+
+    assert await BedrockProvider(settings={}).is_available() is True
+
+    calls = boto3_module.client.call_args_list
+    assert calls, "no boto3 client was built, so this test asserted nothing"
+    for call in calls:
+        assert "aws_access_key_id" not in call.kwargs
+        assert "aws_secret_access_key" not in call.kwargs
+        assert call.kwargs["region_name"] == "us-east-1"
+
+
+async def test_is_available_is_true_on_a_successful_list_foundation_models(monkeypatch):
+    """Unchanged behaviour: a successful probe with configured credentials still returns True."""
+    _patch_vault(
+        monkeypatch,
+        _vault_returning(
+            '{"aws_access_key_id": "%s", "aws_secret_access_key": "%s", "region": "us-east-1"}'
+            % (_WELL_FORMED_VAULT_ACCESS_KEY_ID, _WELL_FORMED_VAULT_SECRET_ACCESS_KEY)
+        ),
+    )
+    boto3_module = _fake_boto3(monkeypatch)
+
+    assert await BedrockProvider(settings={}).is_available() is True
+    boto3_module.client.return_value.list_foundation_models.assert_called_with(maxResults=1)
+
+
+async def test_is_available_is_false_when_the_probe_call_fails(monkeypatch):
+    """Unchanged behaviour: any failure is still swallowed into False."""
+    _patch_vault(monkeypatch, _vault_returning(None))
+    boto3_module = _fake_boto3(monkeypatch)
+    boto3_module.client.return_value.list_foundation_models.side_effect = RuntimeError("service unreachable")
+
+    assert await BedrockProvider(settings={}).is_available() is False
+
+
+async def test_a_failed_probe_never_logs_the_credential_or_a_fragment_of_one(monkeypatch):
+    """AWS names the key it rejected; that message must not reach the log intact (#15080 precedent)."""
+    _patch_vault(
+        monkeypatch,
+        _vault_returning(
+            '{"aws_access_key_id": "%s", "aws_secret_access_key": "%s", "region": "us-east-1"}'
+            % (_WELL_FORMED_VAULT_ACCESS_KEY_ID, _WELL_FORMED_VAULT_SECRET_ACCESS_KEY)
+        ),
+    )
+    boto3_module = _fake_boto3(monkeypatch)
+    boto3_module.client.return_value.list_foundation_models.side_effect = RuntimeError(
+        f"UnrecognizedClientException: key {_WELL_FORMED_VAULT_ACCESS_KEY_ID} "
+        f"with secret {_WELL_FORMED_VAULT_SECRET_ACCESS_KEY} was rejected"
+    )
+    debug = _patch_debug(monkeypatch)
+
+    assert await BedrockProvider(settings={}).is_available() is False
+
+    logged = " ".join(str(arg) for call in debug.call_args_list for arg in call.args)
+    assert logged, "nothing was logged, so this test asserted nothing"
+    assert _WELL_FORMED_VAULT_ACCESS_KEY_ID not in logged
+    assert _WELL_FORMED_VAULT_SECRET_ACCESS_KEY not in logged
+    # Not a fragment either: the 16 characters after the AKIA prefix are the secret part.
+    assert _WELL_FORMED_VAULT_ACCESS_KEY_ID[4:] not in logged
+    assert _WELL_FORMED_VAULT_SECRET_ACCESS_KEY[:16] not in logged
+    # The diagnostic value of the line survives the scrubbing.
+    assert "UnrecognizedClientException" in logged
 
 
 # --- validate_credential_pair() (#15080) --------------------------------------------


### PR DESCRIPTION
## Thinking Path

The issue title says "resolves credentials twice", which reads as waste. It is not: the two
calls are separate reads of mutable state — provider settings, the process environment, and
since #15023 the secrets vault. A settings reload, an env mutation or a vault rotation landing
between `bedrock.py:544` and `:545` gave `boto3.client()` an access key from resolution *n* and
a secret key from resolution *n+1*. boto3 accepts a mismatched pair at construction and fails
opaquely at call time, where the blanket `except Exception` turned it into a bare `False`. The
duplicate call is the symptom; **the mismatched pair is the bug**, so the fix had to make
availability and construction provably talk about the same credentials, not merely call less.

That ruled out memoising `_resolve_credentials()`: a cache makes the two reads agree by
accident and adds a staleness question. Resolving once and threading the tuple through is the
property itself, and it extends to `_ensure_runtime_client()` — otherwise one `is_available()`
still builds its two clients from two resolutions, just one layer down. `_ensure_runtime_client`
therefore takes an optional pre-resolved pair; every existing caller is unchanged.

Client construction moved to `build_boto3_client()` in `bedrock_credentials.py` rather than
growing a second copy in `bedrock.py`. That module already owns `_AWS_REGION_PATTERN` and
`validate_credential_pair()`, and its docstring records that it exists because `bedrock.py` hit
the 600-line ceiling. Three things fell out: `bedrock.py` no longer reaches across a module
boundary for a private `_AWS_REGION_PATTERN`; the health-check client now gets the region
validation it never had; and it gets the conditional-kwargs shape the runtime client already
used, which is the third smell the issue names — `bedrock.py:117-120` deliberately omitted the
keys when unset so the IAM chain applies, while `:544-545` passed `None` unconditionally.

One thing the issue does not mention and I did not expect to touch: the failure path logs
`exc` directly. Now that resolved credentials flow into that path, and because AWS names the
key it rejected in some of its error messages, that log line is a credential leak waiting to
happen. Scrubbing by *value* through the canonical redactor is provable in a way a pattern
match is not — the values are in hand. `_AWS_ACCESS_KEY_PATTERN` and the `*_VAULT_ENTRY_*`
names were left exactly as they are (B105 keys on the identifier).

### Overlap with #15106 — it merged mid-task, and this branch is rebased onto it

**#15106 merged at 14:19Z, while this was being written.** It is now in the base as
`fb9dbc1ab`, and this branch has been rebased onto it. The prediction below was made before
that happened; it is left as written because the rebase confirmed it exactly.

The rebase produced **one** conflict, the single import line predicted below, resolved by
keeping both imports. `bedrock_test.py` — the other file both PRs touch — auto-merged with no
conflict, which is what the mid-file insertion was for. Post-rebase, the two PRs' tests run
together: 621 passed / 128 skipped across `autobot-backend/llm_shared/`, up from 616 before
the rebase, the extra five being #15106's own new tests.

### The prediction, as written before #15106 merged

#15106 edits `bedrock_credentials.py` and `bedrock_test.py`, adding
audit emission on credential-resolution failure. I read its diff and designed around it rather
than branching on top of it:

- It changes `load_credentials_from_vault()` and inserts `_audit_vault_rejection` immediately
  above it. This PR adds its two functions **above** `validate_credential_pair()` instead, so
  the two insertions do not touch.
- It appends a test section at the end of `bedrock_test.py`. This PR inserts its section at an
  existing section boundary mid-file instead of appending.
- The one expected textual overlap is a single line in `bedrock_credentials.py`'s import block:
  both PRs add an import after `autobot_shared.logging_manager`. Trivial either way round.
- Nothing here touches #15106's branch, its audit reasons, or the paths it modifies inside
  `load_credentials_from_vault()`.

The two compose on substance as well as on text: #15106 makes a *failed* resolution audited,
this one makes a *successful* resolution singular. #15106 landing second strengthens the case
here, since a vault fetch that can fail and rotate independently is exactly what makes the
two-reads-can-disagree hazard live rather than theoretical.

## What Changed

| File | Change |
|---|---|
| `autobot-backend/llm_shared/providers/bedrock.py` | `is_available()` resolves once and threads the pair through both clients; `_ensure_runtime_client()` accepts an optional pre-resolved pair; client construction delegated; failure log scrubbed |
| `autobot-backend/llm_shared/providers/bedrock_credentials.py` | New `build_boto3_client()` (single construction path, region validation, conditional credential kwargs) and `scrub_credentials()` (canonical redactor plus by-value masking) |
| `autobot-backend/llm_shared/providers/bedrock_test.py` | Seven tests for the single-resolution property, the mismatch impossibility, the IAM fall-through, unchanged True/False behaviour, and the log-leak assertion |

`bedrock.py` goes 583 → 576 lines, so the file-size ratchet moves in the allowed direction and
no `KNOWN_LARGE` entry is added or changed.

## Verification

Contrast mutations, all re-run against this PR's final, **rebased** head (`5a99aa2`) — the pre-rebase run against `ddf80b9` was discarded, since a mutation recorded against a superseded revision proves nothing:

**Mutant A — restore the double resolution** (build the health-check client from
`self._resolve_credentials()[0]` and `self._resolve_credentials()[1]`). 3 tests fail:

```
E   assert 3 == 1
E    +  where 3 = <_RotatingCredentials object>.calls
E   AssertionError: secret key came from a different resolution than the access key
E   assert {'3'} == {'2'}
E   AssertionError: clients disagree on credentials:
E     [('bedrock-runtime', 'AKIA1111111111111111'), ('bedrock', 'AKIA2222222222222222')]
```

The third line is the bug itself, printed: an access key stamped generation 2 paired with a
secret key stamped generation 3.

**Mutant B — pass the credential kwargs unconditionally.** 1 test fails:

```
E   AssertionError: assert 'aws_access_key_id' not in {'aws_access_key_id': None,
E     'aws_secret_access_key': None, 'region_name': 'us-east-1', 'service_name': 'bedrock-runtime'}
```

**Mutant C — log the raw exception instead of the scrubbed one.** 1 test fails:

```
E   AssertionError: assert 'AKIAVVVVVVVVVVVVVVVV' not in 'Bedrock ava...was rejected'
E     'AKIAVVVVVVVVVVVVVVVV' is contained here:
E       tion: key AKIAVVVVVVVVVVVVVVVV with secret VVVV... was rejected
```

Per-criterion evidence:

| Acceptance criterion | Kind | Evidence |
|---|---|---|
| `_resolve_credentials()` called at most once; both keys from the same tuple | unit | `test_is_available_resolves_credentials_exactly_once`, `test_a_source_changing_mid_check_cannot_produce_a_mismatched_client`, `test_both_clients_of_one_check_are_built_from_the_same_credentials` — mutant A |
| Credentials omitted when either is falsy, IAM chain applies | unit | `test_is_available_omits_absent_credentials_so_the_iam_chain_applies` — mutant B |
| Single-resolution property asserted directly with a counting stub | unit | `_RotatingCredentials.calls == 1` |
| `boto3.client` called without the key kwargs when unconfigured | unit | asserted per call in the same test |
| No behaviour change: `True` on success, `False` on any failure | unit | `test_is_available_is_true_on_a_successful_list_foundation_models`, `test_is_available_is_false_when_the_probe_call_fails` |
| No credential or fragment reaches the log | unit | `test_a_failed_probe_never_logs_the_credential_or_a_fragment_of_one` — mutant C |
| Ratchet unchanged | static | `scripts/check_python_file_size.py` rc=0; `bedrock.py` 583 → 576 lines |

Local, post-rebase: 621 passed / 128 skipped across `autobot-backend/llm_shared/` (49 in `bedrock_test.py`: 42 pre-existing incl. #15106's five, plus 7 new); flake8 rc=0; bandit clean on
both changed modules; black/isort clean. New tests are in the existing
`autobot-backend/llm_shared/providers/bedrock_test.py`, so they run in whichever of the 12
coverage shards already carries that file — `pytest-split` assigns it, there is no fixed shard
number to quote.

Not proven locally: semgrep (the local binary is absent, rc=2 — CI is the only verdict), and
the CI Python 3.14.7 / fastapi 0.141.1 combination. boto3 is not installed in either
environment, so every new test injects a stand-in module through `sys.modules`; that is also
why the existing suite never reached this code path.

## Model Used

Claude Opus 5 (1M context)

Closes #15071