### PR TITLE
fix(sdk): carry every agent-config field and guard the SDK/route contract (#15072)

### DIFF
--- a/libs/autobot-sdk-python/autobot_sdk/__init__.py
+++ b/libs/autobot-sdk-python/autobot_sdk/__init__.py
@@ -27,6 +27,8 @@ from .client import API_PREFIX, AutoBotClient, api_path, default_base_url
 from .defaults import DEFAULT_OFFSET, DEFAULT_PAGE_SIZE, DEFAULT_SEARCH_LIMIT
 from .models import (
     AgentConfig,
+    AgentConfigHealthCheck,
+    AgentConfigOptions,
     AgentHealth,
     AnalyticsPerformance,
     AnalyticsUsage,
@@ -56,6 +58,8 @@ __all__ = [
     "AnalyticsPerformance",
     "AnalyticsUsage",
     "AgentConfig",
+    "AgentConfigHealthCheck",
+    "AgentConfigOptions",
     "AgentHealth",
     "ChatMessage",
     "DataResponse",

--- a/libs/autobot-sdk-python/autobot_sdk/models.py
+++ b/libs/autobot-sdk-python/autobot_sdk/models.py
@@ -85,11 +85,48 @@ class AgentHealth(BaseModel):
     components: dict[str, Any] | None = None
 
 
+class AgentConfigHealthCheck(BaseModel):
+    """Inline ``health_check`` block of /api/agent_config/agents/{id}.
+
+    Mirrors ``AgentConfigDetailHealthCheck`` in
+    ``autobot-backend/api/schemas_agent.py``. It carries ``status`` and
+    ``response_time``, which are the only liveness signal on that route, so
+    modelling it as an untyped dict cost a consumer every hint about what is
+    in there (#15072).
+    """
+
+    last_check: str | None = None
+    response_time: float | None = None
+    status: str | None = None
+
+
+class AgentConfigOptions(BaseModel):
+    """Inline ``configuration_options`` block of /api/agent_config/agents/{id}.
+
+    Mirrors ``AgentConfigDetailOptions`` in
+    ``autobot-backend/api/schemas_agent.py`` (#15072).
+    """
+
+    available_models: list[str] | None = None
+    available_providers: list[str] | None = None
+    configurable_settings: list[str] | None = None
+
+
 class AgentConfig(BaseModel):
     """One agent's configuration, as served flat by /api/agent_config/agents/{id}.
 
     Not wrapped in a DataResponse envelope — that route returns the document
     itself (#15053).
+
+    Every field the route emits is carried here. Pydantic's default
+    ``extra='ignore'`` means a key this model does not declare is dropped in
+    silence -- no error, no ``None``, nothing for a consumer to inspect -- so a
+    field missing here is indistinguishable from a field the backend never sent
+    (#15072). ``repo_tests/sdk_response_model_contract_test.py`` fails when the
+    two field sets drift again.
+
+    Every field stays optional so an older backend that omits one does not break
+    SDK consumers.
     """
 
     id: str | None = None
@@ -102,7 +139,10 @@ class AgentConfig(BaseModel):
     priority: int | None = None
     status: str | None = None
     tasks: list[str] | None = None
-    configuration_options: dict[str, Any] | None = None
+    mcp_tools: list[str] | None = None
+    config_source: str | None = None
+    configuration_options: AgentConfigOptions | None = None
+    health_check: AgentConfigHealthCheck | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/repo_tests/sdk_response_model_contract_test.py
+++ b/repo_tests/sdk_response_model_contract_test.py
@@ -1,0 +1,264 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every SDK response model must agree with the route it parses (#15072).
+
+Pydantic's default ``extra='ignore'`` is the whole problem. ``models.py`` sets no
+``model_config`` anywhere, so ``Model.model_validate(raw)`` discards a key the model
+does not declare **in silence** -- not as an error, not as ``None``, not as an
+``extra`` dict. A field the SDK forgot is therefore indistinguishable, from the
+consumer's side, from a field the backend never sent. ``AgentConfig`` dropped
+``mcp_tools``, ``config_source`` and ``health_check`` that way, and the only reason
+anyone noticed was a code review.
+
+Silence is the defect this guard removes. Whichever way a field resolves -- carried
+by the SDK, or genuinely not part of the route -- a *future* divergence has to fail
+something rather than vanish.
+
+Both trees are importable in this run (``pytest.ini`` puts ``autobot-backend`` and
+``libs/autobot-sdk-python`` on ``pythonpath``), so the comparison uses the real
+``model_fields`` rather than a static parse: that picks up inherited fields, aliases
+and anything a plain source scan would miss.
+
+This is a *test-time* coupling only. The SDK still ships to PyPI depending on
+``httpx`` and ``pydantic`` alone -- nothing imported here is imported by the SDK at
+runtime (cf. #15053's note on ``sdk_defaults_match_ssot_test.py``).
+
+Pairs that do not agree today are listed with an explicit waiver naming the issue
+that tracks them, rather than omitted -- an omitted pair is exactly the silence this
+file exists to end. Those issues are #15114 (SDK models requiring a field the route
+never emits, which raises), #15116 (SDK parsing a ``DataResponse`` envelope out of a
+flat route, so ``data`` is always ``None``) and #15118 (SDK naming fields the route
+never emits, so the attribute is permanently ``None``).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import pytest
+from autobot_sdk import models as sdk
+from pydantic import BaseModel
+
+from api.schemas_agent import (
+    AgentConfigDetailHealthCheck,
+    AgentConfigDetailOptions,
+    AgentConfigDetailResponse,
+    AgentHealthResponse,
+)
+from api.schemas_analytics import AnalyticsPerformanceMetricsResponse, AnalyticsUsageStatisticsResponse
+from api.schemas_chat import (
+    SessionCreateData,
+    SessionDeleteData,
+    SessionListData,
+    SessionMessagesData,
+    SessionUpdateData,
+)
+from knowledge.schemas.entries import KnowledgeEntriesResponse
+from knowledge.schemas.entries import KnowledgeEntry as BackendKnowledgeEntry
+from knowledge.schemas.ingestion import AddTextResponse
+from knowledge.schemas.operations import KnowledgeStatsResponse
+from knowledge.schemas.search import KnowledgeSearchResponse
+
+
+@dataclass(frozen=True)
+class Pair:
+    """One SDK model and the backend response model it is fed from.
+
+    ``waiver`` is the issue tracking a known divergence. ``None`` means the two
+    field sets must match exactly, in both directions.
+    """
+
+    sdk_model: type[BaseModel]
+    backend_model: type[BaseModel]
+    route: str
+    waiver: str | None = None
+
+
+#: Every SDK model built from a backend response body, and the model that describes
+#: that body. Derived by following each ``model_validate`` call in
+#: ``libs/autobot-sdk-python/autobot_sdk/resources/`` to the route it requests and
+#: that route's ``response_model=``.
+CONTRACT: tuple[Pair, ...] = (
+    # --- agreed: guarded in both directions -----------------------------------
+    Pair(sdk.AgentConfig, AgentConfigDetailResponse, "GET /agent_config/agents/{id}"),
+    Pair(sdk.AgentConfigOptions, AgentConfigDetailOptions, "GET /agent_config/agents/{id}.configuration_options"),
+    Pair(sdk.AgentConfigHealthCheck, AgentConfigDetailHealthCheck, "GET /agent_config/agents/{id}.health_check"),
+    # --- known divergences, each tracked ---------------------------------------
+    Pair(sdk.AgentHealth, AgentHealthResponse, "GET /agent/health/detailed", waiver="#15118"),
+    Pair(sdk.SessionList, SessionListData, "GET /chat/sessions", waiver="#15118"),
+    Pair(sdk.SessionMessages, SessionMessagesData, "GET /chat/sessions/{id}", waiver="#15118"),
+    Pair(sdk.SessionCreate, SessionCreateData, "POST /chat/sessions", waiver="#15114"),
+    Pair(sdk.SessionUpdate, SessionUpdateData, "PUT /chat/sessions/{id}", waiver="#15114"),
+    Pair(sdk.SessionDelete, SessionDeleteData, "DELETE /chat/sessions/{id}", waiver="#15118"),
+    Pair(sdk.KnowledgeStats, KnowledgeStatsResponse, "GET /knowledge_base/stats", waiver="#15116"),
+    Pair(sdk.KnowledgeAddResult, AddTextResponse, "POST /knowledge_base/add_text", waiver="#15116"),
+    Pair(sdk.KnowledgeSearchResult, KnowledgeSearchResponse, "POST /knowledge_base/search", waiver="#15116"),
+    Pair(sdk.KnowledgeSearchResult, KnowledgeEntriesResponse, "GET /knowledge_base/entries", waiver="#15116"),
+    Pair(sdk.KnowledgeEntry, BackendKnowledgeEntry, "GET /knowledge_base/entries[].entry", waiver="#15118"),
+    Pair(sdk.AnalyticsUsage, AnalyticsUsageStatisticsResponse, "GET /analytics/usage/statistics", waiver="#15116"),
+    Pair(
+        sdk.AnalyticsPerformance,
+        AnalyticsPerformanceMetricsResponse,
+        "GET /analytics/performance/metrics",
+        waiver="#15116",
+    ),
+)
+
+GUARDED: tuple[Pair, ...] = tuple(pair for pair in CONTRACT if pair.waiver is None)
+WAIVED: tuple[Pair, ...] = tuple(pair for pair in CONTRACT if pair.waiver is not None)
+
+
+def field_names(model: type[BaseModel]) -> frozenset[str]:
+    """Declared field names of *model*, refusing to return an empty set.
+
+    An enumeration that comes back empty makes every ``issubset`` assertion below
+    pass without comparing anything, which is how a guard rots into decoration
+    (#15087). A pydantic model with no fields is either the wrong class or a
+    contract that was never written down; both are failures, not passes.
+    """
+    names = frozenset(model.model_fields)
+    if not names:
+        raise AssertionError(
+            f"{model.__module__}.{model.__name__} enumerated zero fields -- "
+            "either the model moved or it declares no contract at all; "
+            "an empty enumeration must fail here, never pass vacuously"
+        )
+    return names
+
+
+def _pair_id(pair: Pair) -> str:
+    return f"{pair.sdk_model.__name__}<-{pair.backend_model.__name__}"
+
+
+def test_the_contract_table_enumerates_pairs_to_check():
+    """The table itself is an enumeration, so it gets the same empty-set treatment."""
+    assert CONTRACT, "no SDK/route pairs enumerated -- this file would assert nothing"
+    assert GUARDED, "every pair is waived -- the guard has stopped guarding anything"
+
+
+@pytest.mark.parametrize("pair", GUARDED, ids=_pair_id)
+def test_the_sdk_carries_every_field_the_route_returns(pair: Pair):
+    """The #15072 defect proper: a route field absent from the SDK model is dropped in silence."""
+    dropped = field_names(pair.backend_model) - field_names(pair.sdk_model)
+    assert not dropped, (
+        f"{pair.route} returns {sorted(dropped)}, which {pair.sdk_model.__name__} does not declare. "
+        "extra='ignore' discards them without an error, so an SDK consumer cannot see them at all. "
+        "Add the fields, or -- if they genuinely do not belong on the client -- stop the route "
+        "advertising them and record the decision here."
+    )
+
+
+@pytest.mark.parametrize("pair", GUARDED, ids=_pair_id)
+def test_the_sdk_declares_no_field_the_route_never_sends(pair: Pair):
+    """The mirror failure: a field the route never sends reads as a supported, permanently-None one."""
+    phantom = field_names(pair.sdk_model) - field_names(pair.backend_model)
+    assert not phantom, (
+        f"{pair.sdk_model.__name__} declares {sorted(phantom)}, which {pair.route} never emits. "
+        "Those attributes exist on the object and are always None, which is indistinguishable "
+        "from the backend having omitted them."
+    )
+
+
+@pytest.mark.parametrize("pair", WAIVED, ids=_pair_id)
+def test_every_waiver_names_the_issue_that_tracks_it(pair: Pair):
+    """A waiver without a tracked issue is a silently-accepted defect wearing a comment."""
+    assert pair.waiver is not None and re.fullmatch(
+        r"#\d+", pair.waiver
+    ), f"{_pair_id(pair)} is waived as {pair.waiver!r}, which is not an issue reference"
+
+
+@pytest.mark.parametrize("pair", WAIVED, ids=_pair_id)
+def test_a_waived_pair_still_diverges(pair: Pair):
+    """A waiver that no longer applies must be dropped, not left to rot into noise."""
+    sdk_fields = frozenset(pair.sdk_model.model_fields)
+    backend_fields = frozenset(pair.backend_model.model_fields)
+    assert sdk_fields != backend_fields, (
+        f"{_pair_id(pair)} now agrees exactly; remove the {pair.waiver} waiver " "so the pair is guarded from here on"
+    )
+
+
+def test_an_empty_field_enumeration_fails_instead_of_passing_vacuously():
+    """#15087 in miniature, proved rather than asserted: the helper is fed an empty model."""
+
+    class NoFields(BaseModel):
+        pass
+
+    with pytest.raises(AssertionError, match="enumerated zero fields"):
+        field_names(NoFields)
+
+
+#: One agent-config document carrying every key the route emits, with a distinguishable
+#: value per field so a dropped key is visible as a missing value rather than as a
+#: coincidental default. Mirrors the literal built at ``api/agent_config.py:1024``.
+FULL_AGENT_CONFIG_DOCUMENT = {
+    "id": "research",
+    "name": "Research Agent",
+    "description": "Researches things",
+    "current_model": "gpt-4o",
+    "provider": "openai",
+    "enabled": True,
+    "priority": 3,
+    "tasks": ["research", "summarize"],
+    "mcp_tools": ["web_search", "fetch"],
+    "default_model": "gpt-4o-mini",
+    "status": "connected",
+    "config_source": "slm",
+    "configuration_options": {
+        "available_models": ["gpt-4o", "gpt-4o-mini"],
+        "available_providers": ["openai", "bedrock"],
+        "configurable_settings": ["model", "provider", "enabled", "priority"],
+    },
+    "health_check": {"last_check": "2026-01-01T00:00:00+00:00", "response_time": 1.5, "status": "healthy"},
+}
+
+
+def test_the_fixture_covers_every_key_the_route_declares():
+    """Guards the guard: a route field the fixture forgot would make the round-trip vacuous."""
+    declared = field_names(AgentConfigDetailResponse)
+    assert frozenset(FULL_AGENT_CONFIG_DOCUMENT) == declared, (
+        "FULL_AGENT_CONFIG_DOCUMENT no longer matches AgentConfigDetailResponse: "
+        f"missing {sorted(declared - frozenset(FULL_AGENT_CONFIG_DOCUMENT))}, "
+        f"unknown {sorted(frozenset(FULL_AGENT_CONFIG_DOCUMENT) - declared)}"
+    )
+    AgentConfigDetailResponse.model_validate(FULL_AGENT_CONFIG_DOCUMENT)
+
+
+def test_a_full_route_document_round_trips_through_the_sdk_model():
+    """AC: get_config() round-trips every key the route returns, values included (#15072)."""
+    parsed = sdk.AgentConfig.model_validate(FULL_AGENT_CONFIG_DOCUMENT)
+    dumped = parsed.model_dump()
+
+    assert frozenset(dumped) >= frozenset(
+        FULL_AGENT_CONFIG_DOCUMENT
+    ), f"dropped {sorted(frozenset(FULL_AGENT_CONFIG_DOCUMENT) - frozenset(dumped))}"
+    for key, expected in FULL_AGENT_CONFIG_DOCUMENT.items():
+        assert dumped[key] == expected, f"{key} did not survive the round trip: {dumped[key]!r} != {expected!r}"
+
+
+def test_the_nested_blocks_are_typed_rather_than_bare_dicts():
+    """AC: health_check and configuration_options are modelled, not untyped dicts (#15072)."""
+    parsed = sdk.AgentConfig.model_validate(FULL_AGENT_CONFIG_DOCUMENT)
+
+    assert isinstance(parsed.health_check, sdk.AgentConfigHealthCheck)
+    assert parsed.health_check.status == "healthy"
+    assert parsed.health_check.response_time == 1.5
+    assert isinstance(parsed.configuration_options, sdk.AgentConfigOptions)
+    assert parsed.configuration_options.available_models == ["gpt-4o", "gpt-4o-mini"]
+
+
+def test_an_older_backend_omitting_the_new_fields_still_parses():
+    """AC: every added field stays optional, so an older backend does not break consumers (#15072)."""
+    legacy = {
+        k: v for k, v in FULL_AGENT_CONFIG_DOCUMENT.items() if k not in ("mcp_tools", "config_source", "health_check")
+    }
+    assert legacy, "the legacy fixture is empty, so this test would assert nothing"
+
+    parsed = sdk.AgentConfig.model_validate(legacy)
+
+    assert parsed.mcp_tools is None
+    assert parsed.config_source is None
+    assert parsed.health_check is None
+    assert parsed.id == "research"


### PR DESCRIPTION
## Thinking Path

The issue asks whether each of the three dropped fields should be carried or does not belong.
The route settles it: `GET /api/agent_config/agents/{agent_id}`
(`autobot-backend/api/agent_config.py:991`) declares
`response_model=AgentConfigDetailResponse` and its handler builds a literal dict at `:1024`
containing all fourteen keys, `mcp_tools`, `config_source` and `health_check` among them. They
are not aspirational schema entries — they are emitted on every successful call. So all three
are carried, and none of them is a case of the route over-advertising.

The interesting part is the *mechanism*, which is what makes this worth a guard rather than
three added lines. `models.py` sets no `model_config` anywhere in the file, so every SDK model
runs pydantic's default `extra='ignore'`. `AgentConfig.model_validate(raw)` therefore discards
an unknown key with no error, no `None`, and no `extra` dict. A field the SDK forgot is
indistinguishable, from the consumer's side, from a field the backend never sent. That is the
defect the issue names as silence, and adding three fields does not remove it — it only clears
today's instance.

So I mapped every SDK model that is built from a backend response back to the route it parses
and that route's `response_model`, to apply the check as a class rather than one instance
(AC5). **That map is the finding of this PR, and it is much worse than #15072 implies.** Of
sixteen pairs, three agree. The rest fail in three distinct ways, none of which anything
currently detects:

1. **Two raise on every success.** `SessionCreate` and `SessionUpdate` declare `session_id` as
   a *required* field; `SessionCreateData`/`SessionUpdateData` (`api/schemas_chat.py:49-67`)
   emit `id` and never `session_id`. `DataResponse.data` is typed `T | None`, so a non-null
   payload fails `SessionCreate` and then fails `None`, and pydantic raises. There is no path
   on which a successful `sessions.create()` parses. Filed as **#15114**.
2. **Six parse an envelope out of a flat route.** The SDK asks for `DataResponse[X]` from six
   routes that return the document itself. Every `DataResponse` field is defaulted, so
   validation *succeeds* and yields `data=None`; three of the six have a top-level `message`
   that binds to the envelope's `message`, so the result reads as populated and successful
   while carrying nothing. Filed as **#15116**.
3. **Several name fields the route never emits** — `total` against `count`/`total_count`/
   `total_results`, `KnowledgeStats.total_entries`, `AgentHealth.version`/`uptime`/`components`
   — so the attribute exists and is permanently `None`. `SessionDelete.success` is the sharp
   one: it defaults to `True`, and the payload's real flag is `deleted`, so a *failed* delete
   reads as a success. Filed as **#15118**.

Two more fell out of the same sweep: request-shape drift (`offset` sent to a cursor-paginated
route, so `knowledge.entries()` never advances past page one; `period` sent to two analytics
routes that do not accept it) filed as **#15119**, and `api/registry.py:143` advertising
`/api/agent-config` where the live mount is `/api/agent_config`, filed as **#15120**.

Fixing all of that here would be one PR spanning five unrelated risk profiles, so this PR
fixes `AgentConfig` and lists every other pair in the guard with an **explicit waiver naming
its issue**. A waived pair is still enumerated and still asserted on — omitting it would
recreate exactly the silence this file exists to end — and a waiver whose pair starts agreeing
fails, so no waiver can quietly outlive its defect.

On construction: I used real imports rather than the `ast` parsing its sibling
`sdk_defaults_match_ssot_test.py` uses. That file's reason was that the SDK is not importable
in the repo test run, but `pytest.ini:42` puts both `autobot-backend` and
`libs/autobot-sdk-python` on `pythonpath`, so it is. Real `model_fields` also picks up
inherited fields and aliases that a source scan would miss. This is a test-time coupling only —
the shipped SDK still depends on `httpx` and `pydantic` alone, and nothing imported by the
guard is imported by the SDK at runtime.

On the empty-enumeration hazard (#15087): a set-difference assertion over an empty enumeration
passes while comparing nothing, which is the precise failure mode that bit this project before.
`field_names()` raises rather than returning an empty set, the pair table asserts it still
holds unwaived pairs, the round-trip fixture asserts it still covers every declared route key,
and one test feeds `field_names()` a field-less model to prove the refusal actually fires —
proved rather than claimed.

## What Changed

| File | Change |
|---|---|
| `libs/autobot-sdk-python/autobot_sdk/models.py` | `AgentConfig` carries `mcp_tools`, `config_source`, `health_check`; new `AgentConfigHealthCheck` and `AgentConfigOptions` nested models replace the untyped dicts; all fields stay `\| None = None` |
| `libs/autobot-sdk-python/autobot_sdk/__init__.py` | Exports the two new public models |
| `repo_tests/sdk_response_model_contract_test.py` | New guard: 16 SDK↔route model pairs, drift asserted in both directions, waivers required to name an issue and to still diverge, four independent empty-enumeration refusals |

## Verification

Contrast mutations, all run against this PR's final head (`06ed3eb`):

**Mutant A — drop `mcp_tools` from `AgentConfig` again.** 3 tests fail:

```
E   AssertionError: GET /agent_config/agents/{id} returns ['mcp_tools'], which AgentConfig
E     does not declare. extra='ignore' discards them without an error, so an SDK consumer
E     cannot see them at all.
E   AssertionError: dropped ['mcp_tools']
E   AttributeError: 'AgentConfig' object has no attribute 'mcp_tools'
```

**Mutant B — remove the empty-enumeration refusal from `field_names()`** (return the raw set).
1 test fails, which is the #15087 guard proving itself:

```
E   Failed: DID NOT RAISE <class 'AssertionError'>
FAILED ...::test_an_empty_field_enumeration_fails_instead_of_passing_vacuously
```

**Mutant C — revert the nested blocks to `dict[str, Any] | None`.** 1 test fails:

```
E   AssertionError: assert False
E    +  where False = isinstance({'last_check': '2026-01-01T00:00:00+00:00', 'response_time':
E        1.5, 'status': 'healthy'}, <class 'autobot_sdk.models.AgentConfigHealthCheck'>)
```

Per-criterion evidence:

| Acceptance criterion | Kind | Evidence |
|---|---|---|
| `AgentConfig` carries all three fields; `get_config()` round-trips every route key | unit + route-derived | `test_a_full_route_document_round_trips_through_the_sdk_model` asserts values, not just keys; its fixture is itself pinned to `AgentConfigDetailResponse` by `test_the_fixture_covers_every_key_the_route_declares` — mutant A |
| `health_check` modelled as a nested type | unit | `test_the_nested_blocks_are_typed_rather_than_bare_dicts` — mutant C |
| `configuration_options` modelled as a nested type | unit | same test, asserts `available_models` through the typed attribute |
| Fixture with every key of `AgentConfigDetailResponse`, no key dropped | static + unit | `test_the_sdk_carries_every_field_the_route_returns[AgentConfig<-AgentConfigDetailResponse]` compares real `model_fields` |
| Same check applied to, or waived with a reason for, the other SDK models | static | 16 pairs enumerated; 3 guarded, 13 waived against #15114/#15116/#15118; `test_every_waiver_names_the_issue_that_tracks_it` and `test_a_waived_pair_still_diverges` |
| Optional-by-default preserved | unit | `test_an_older_backend_omitting_the_new_fields_still_parses` |
| Enumeration cannot be empty | unit | `test_an_empty_field_enumeration_fails_instead_of_passing_vacuously` — mutant B — plus `test_the_contract_table_enumerates_pairs_to_check` |

Local: 38 passed in the new guard; 46 passed / 2 skipped across
`repo_tests/sdk_defaults_match_ssot_test.py`, `repo_tests/sdk_request_url_test.py` and
`libs/autobot-sdk-python/tests/`; flake8 rc=0; black/isort clean; file-size check rc=0 (new
file 264 lines, `models.py` 196).

The new file is `repo_tests/sdk_response_model_contract_test.py`; `pytest-split` assigns
`repo_tests/` across the 12 coverage shards, so there is no fixed shard number to quote.

Not proven locally: semgrep (local binary absent, rc=2 — CI only), and the CI Python 3.14.7 /
fastapi 0.141.1 combination. Also not proven here: that the three carried fields are populated
against a *live* backend — the round-trip is driven by the handler's literal dict shape at
`api/agent_config.py:1024`, read from source, not from a running route. Worth noting that the
handler returns a bare `JSONResponse`, so FastAPI does not enforce `response_model` on it at
runtime; the guard pins the SDK to the declared schema, and the handler dict matching that
schema is verified by reading, not by execution.

## Model Used

Claude Opus 5 (1M context)

Closes #15072
