### PR TITLE
test(repo-guards): stop three sweeps erasing their own tree in a worktree checkout (#15121)

### DIFF
--- a/repo_tests/with_error_handling_single_definition_test.py
+++ b/repo_tests/with_error_handling_single_definition_test.py
@@ -31,19 +31,34 @@ _BACKEND = _REPO / "autobot-backend"
 
 _TARGET_NAME = "with_error_handling"
 
+# Directory names skipped, matched against parts of the path RELATIVE to the
+# scan root -- never a substring of the absolute path (#15121). This repo's
+# whole workflow runs from `<main-tree>/.worktrees/<branch>/` checkouts, so
+# `"/.worktrees/" in path.as_posix()` is true of the repo root itself and skips
+# every file in the tree; the guard then inspects nothing and fails its own
+# non-vacuity assertion. `tests` has the identical failure mode for a checkout
+# under any directory of that name. Same form as
+# `first_party_imports_resolve_test.py:33` and
+# `shell_lib_sources_resolve_test.py:58`.
+_SKIP_PARTS = {"node_modules", ".worktrees", "tests", "__pycache__", "venv", ".venv"}
+
 # The one file allowed to define it. Anything else defining a function or
 # async function with this exact name is the fork this test exists to catch.
 _CANONICAL_DEFINER = (_BACKEND / "utils" / "error_boundaries" / "decorators.py").resolve()
 
 
-def _production_sources() -> List[Path]:
-    """Backend .py files, excluding tests, node_modules and worktree copies."""
+def _production_sources(root: Path = _BACKEND) -> List[Path]:
+    """Backend .py files, excluding tests, node_modules and worktree copies.
+
+    `root` is a parameter so the exclusion logic can be exercised against a
+    fixture tree that itself lives under `.worktrees/` -- the arrangement this
+    scan silently erased before #15121.
+    """
     out: List[Path] = []
-    for path in _BACKEND.rglob("*.py"):
-        posix = path.as_posix()
+    for path in root.rglob("*.py"):
         if path.name.endswith("_test.py") or path.name.startswith("test_"):
             continue
-        if "/node_modules/" in posix or "/.worktrees/" in posix or "/tests/" in posix:
+        if any(part in _SKIP_PARTS for part in path.relative_to(root).parts):
             continue
         out.append(path)
     return out
@@ -61,6 +76,53 @@ def _defines_target(path: Path) -> List[int]:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == _TARGET_NAME:
             lines.append(node.lineno)
     return lines
+
+
+def test_the_scan_sees_the_tree_it_is_pointed_at():
+    """A guard that skipped every file would report clean, not report a skip.
+
+    Split out from the assertion below so the two failures read differently:
+    "the scan found nothing to inspect" is a defect in this file, while
+    "with_error_handling vanished" is a defect in the code under guard. Before
+    #15121 the first masqueraded as the second in every worktree checkout.
+    """
+    sources = _production_sources()
+
+    assert len(sources) > 100, (
+        f"only {len(sources)} backend sources survived the exclusion filter — "
+        "the filter is eating the tree, so every assertion below is vacuous"
+    )
+    assert _CANONICAL_DEFINER in {path.resolve() for path in sources}
+
+
+def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
+    """#15121: the filter must key on parts relative to the scan root.
+
+    The fixture reproduces the mandated layout exactly — the scan root itself
+    sits under `.worktrees/<branch>/`. Matching a substring of the absolute path
+    skips every file here; matching relative parts finds the definer. Same
+    fixture shape as `scripts/check_ansible_file_references_test.py:40-45` and
+    `repo_tests/lint/canonical/test_context.py:76-78`.
+    """
+    root = tmp_path / ".worktrees" / "issue-9999" / "autobot-backend"
+    (root / "utils" / "error_boundaries").mkdir(parents=True)
+    definer = root / "utils" / "error_boundaries" / "decorators.py"
+    definer.write_text(f"def {_TARGET_NAME}():\n    pass\n", encoding="utf-8")
+
+    # Genuinely excluded content, to prove the filter still filters.
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "vendored.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "tests").mkdir()
+    (root / "tests" / "helper.py").write_text("y = 1\n", encoding="utf-8")
+
+    scanned = _production_sources(root)
+
+    assert definer in scanned, (
+        "a scan rooted under .worktrees/ skipped its own tree — the exclusion "
+        "is matching the absolute path instead of parts relative to the root"
+    )
+    assert {path.name for path in scanned} == {"decorators.py"}
+    assert _defines_target(definer) == [1]
 
 
 def test_exactly_one_definition_exists_in_the_tracked_tree():

--- a/repo_tests/workflow_planner_deprecation_test.py
+++ b/repo_tests/workflow_planner_deprecation_test.py
@@ -62,15 +62,25 @@ _WIRING_INSTRUCTIONS = (
 )
 
 
-def _production_sources() -> List[Path]:
-    """Backend .py files excluding tests and the deprecated module itself."""
+_SKIP_PARTS = {"tests", "node_modules", ".worktrees", "__pycache__", "venv", ".venv"}
+
+
+def _production_sources(root: Path = _BACKEND) -> List[Path]:
+    """Backend .py files excluding tests and the deprecated module itself.
+
+    `root` is a parameter so the exclusion can be exercised against a fixture
+    tree that itself lives under `.worktrees/` (#15121).
+    """
     skip_names = {_MODULE.name}
     out: List[Path] = []
-    for path in _BACKEND.rglob("*.py"):
+    for path in root.rglob("*.py"):
         name = path.name
         if name in skip_names or name.endswith("_test.py") or name.startswith("test_"):
             continue
-        if "/tests/" in path.as_posix() or "/node_modules/" in path.as_posix():
+        # Relative parts, not an absolute substring (#15121): a checkout under a
+        # directory named `tests` or `.worktrees` -- the mandated layout here --
+        # would otherwise match on the repo root and skip the whole tree.
+        if any(part in _SKIP_PARTS for part in path.relative_to(root).parts):
             continue
         out.append(path)
     return out
@@ -164,3 +174,26 @@ def test_deprecated_code_is_retained_in_full():
     defined = {n.name for n in planner.body if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
     missing = [m for m in _REQUIRED_METHODS if m not in defined]
     assert not missing, f"Deprecated-in-place module lost methods {missing}; code is retained, never deleted (#13751)"
+
+
+def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
+    """#15121: the exclusion keys on parts relative to the scan root.
+
+    An absolute-substring check matches the repo root itself in the mandated
+    `.worktrees/<branch>/` layout and skips every file, leaving the assertions
+    above iterating an empty list — a guard that passes because it looked at
+    nothing.
+    """
+    root = tmp_path / ".worktrees" / "issue-9999" / "tests" / "autobot-backend"
+    (root / "orchestration").mkdir(parents=True)
+    live = root / "orchestration" / "caller.py"
+    live.write_text("x = 1\n", encoding="utf-8")
+    (root / "node_modules").mkdir()
+    (root / "node_modules" / "vendored.py").write_text("y = 1\n", encoding="utf-8")
+
+    scanned = _production_sources(root)
+
+    assert scanned == [live], (
+        "a scan rooted under .worktrees/ and tests/ skipped its own tree — the "
+        "exclusion is matching the absolute path instead of relative parts"
+    )

--- a/scripts/tokenizers_transformers_range_test.py
+++ b/scripts/tokenizers_transformers_range_test.py
@@ -50,6 +50,19 @@ _REQUIREMENT_FILES = (
     "autobot-infrastructure/autobot-npu-worker/docker/requirements-npu.txt",
 )
 
+_SKIP_PARTS = {"venv", ".venv", "node_modules", ".worktrees", ".claude", "__pycache__"}
+
+
+def _outside_excluded_dirs(path: Path, root: Path = _REPO_ROOT) -> bool:
+    """True when no part of `path` RELATIVE to `root` is an excluded directory.
+
+    Relative, never a substring of the absolute path (#15121): this repo runs
+    from `.worktrees/<branch>/` checkouts, where an absolute match hits the repo
+    root itself, skips every requirements file, and leaves the assertion below
+    comparing an empty set against the expected one.
+    """
+    return not any(part in _SKIP_PARTS for part in path.relative_to(root).parts)
+
 _TOKENIZERS_LINE = re.compile(r"^tokenizers\s*(?P<spec>[^#\n]*)", re.M)
 _SPEC = re.compile(r"(?P<op>>=|<=|==|<|>)\s*(?P<version>\d+(?:\.\d+)*)")
 
@@ -144,7 +157,7 @@ def test_every_file_declaring_tokenizers_is_covered():
     declaring = {
         str(p.relative_to(_REPO_ROOT))
         for p in _REPO_ROOT.rglob("requirements*.txt")
-        if not any(skip in str(p) for skip in ("venv/", "node_modules/", ".worktrees/", ".claude/"))
+        if _outside_excluded_dirs(p)
         and _TOKENIZERS_LINE.search(p.read_text(encoding="utf-8", errors="replace"))
     }
     # The windows npu-worker resource file pins an old, independent stack
@@ -184,3 +197,12 @@ def test_version_comparison_is_length_normalised(spec, version, expected):
     specs = [(m.group("op"), _version(m.group("version"))) for m in _SPEC.finditer(spec)]
 
     assert _admits(specs, version) is expected
+
+
+def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
+    """#15121: the sweep must see a tree rooted inside `.worktrees/`."""
+    root = tmp_path / ".worktrees" / "issue-9999"
+    (root / "venv").mkdir(parents=True)
+
+    assert _outside_excluded_dirs(root / "requirements.txt", root)
+    assert not _outside_excluded_dirs(root / "venv" / "requirements.txt", root)


### PR DESCRIPTION
## Thinking Path

The issue's diagnosis is exactly right, and reproduces first try from inside a worktree:

```
AssertionError: with_error_handling vanished from its canonical module — this guard expects it to exist
```

`_production_sources()` matched `"/.worktrees/" in path.as_posix()`. A worktree lives at `<main-tree>/.worktrees/<branch>/`, so that substring is true of the **scan root itself** and every file under it is skipped. The scan returns `[]`, `definers` is empty, and the guard fails its own non-vacuity assertion — while the function it guards is present and correct the whole time. It is green in CI only because CI paths happen to have no `.worktrees` component; there is no configuration in which it inspects a *subset*.

Two things follow from that, and the second is the one worth stating:

1. The failure is indistinguishable from the real defect the guard exists to catch, so it trains people to ignore it.
2. **A guard that quietly skips its subject is indistinguishable from a guard that passes.** The non-vacuity assert at :73 is the only thing that turned this into a red rather than a silent green — it is correct and is not touched here. What was wrong was the filter above it. So the fix is the filter, plus an assertion that names the skip directly instead of letting it surface as "the function vanished".

The repo settled the correct idiom four times over (`shell_lib_test.py:81`, `shell_lib_sources_resolve_test.py:58`, `first_party_imports_resolve_test.py:33`, `check_ansible_file_references.py:46`), and `import_identity_test.py:65` states the rule outright. This copies that form rather than inventing a fifth.

The sweep found the same idiom in two more places, one of them live.

## What Changed

**`repo_tests/with_error_handling_single_definition_test.py`** — the reported guard.

- `_SKIP_PARTS` set matched against `path.relative_to(root).parts`, the `first_party_imports_resolve_test.py:33` / `shell_lib_sources_resolve_test.py:58` form. `tests` and `node_modules` get the same treatment: `/tests/` has the identical failure mode for a checkout under any directory of that name.
- `_production_sources(root=_BACKEND)` takes the root as a parameter, so the exclusion can be exercised against a fixture tree that itself lives under `.worktrees/`.
- `test_the_scan_sees_the_tree_it_is_pointed_at` — the assertion that makes a skip visible *as a skip*. Split out deliberately so the two failures read differently: "the filter is eating the tree" is a defect in the guard, "with_error_handling vanished" is a defect in the code under guard. Until now the first masqueraded as the second.
- `test_a_checkout_under_worktrees_is_still_scanned` — the regression test asked for: a fixture under `tmp_path/".worktrees"/"issue-9999"/`, holding one canonical definer plus genuinely-excluded `node_modules/` and `tests/` content, asserting the definer is found and the exclusions still exclude. Same fixture shape as `check_ansible_file_references_test.py:40-45` and `lint/canonical/test_context.py:76-78`.

**`scripts/tokenizers_transformers_range_test.py`** — the same bug, also live. `if not any(skip in str(p) for skip in ("venv/", "node_modules/", ".worktrees/", ".claude/"))` over an absolute path skipped every `requirements*.txt` in a worktree, leaving `declaring` empty. Verified failing before the fix:

```
AssertionError: unguarded tokenizers pins: []
assert set() == {'autobot-infrastructure/shared/docker/ai-stack/requirements-ai.txt', ...}
```

The predicate is now a named `_outside_excluded_dirs(path, root)` keyed on relative parts, with a fixture assertion — so the fix is asserted in CI, where the absolute form cannot fail on its own.

**`repo_tests/workflow_planner_deprecation_test.py`** — the same idiom, latent. Its filter was `"/tests/" in path.as_posix() or "/node_modules/" in path.as_posix()`. It did not fail in a worktree only because `.worktrees` was absent from its list; a checkout under a directory named `tests` would have erased the tree exactly as above. Relativised, widened to the same `_SKIP_PARTS`, root parameterised, and given the same fixture assertion.

Nothing else in the sweep is a hit. `pipeline-scripts/audit_unwired_trackers.py:77` keeps absolute-looking fragments but relativises first at `should_skip_path` (#7128b, regression test at `test_audit_unwired_trackers.py:123`); `scripts/systemd_heredoc_expansion_test.py:35` likewise relativises at its use site (:74). The four files the issue lists as already correct were left alone.

## Verification

**Verified from inside a worktree** — `/…/.worktrees/issue-15121-worktree-relative-filter`, i.e. the exact condition the bug requires. `git rev-parse --git-common-dir` confirms a linked worktree, not the main checkout. Verifying only from the main tree would prove nothing here, since the main tree is where the bug cannot occur.

| Criterion | Evidence | Kind |
|---|---|---|
| AC1 — filter keys on relative parts | `with_error_handling_single_definition_test.py` **5 passed** from inside a worktree (was 1 failed); `tests` and `node_modules` given the same treatment | unit |
| AC2 — regression test with a `.worktrees` fixture | `test_a_checkout_under_worktrees_is_still_scanned` in each of the three files; environment-independent, so it holds in CI too | unit |
| AC3 — sweep | `git grep -n worktrees -- '*.py'` plus a targeted `as_posix()` sweep across `repo_tests scripts tools autobot_shared pipeline-scripts`: **3 absolute-path filters found** — 1 reported, 1 further live, 1 latent. All three fixed; 2 near-misses confirmed already-relative and left alone | static |
| The guard's own assertion still correct | `test_exactly_one_definition_exists_in_the_tracked_tree` unchanged and passing; the non-vacuity assert was not weakened | unit |
| Shards not otherwise disturbed | run as CI invokes them: **shard 4 → 372 passed**, **shard 3 → 96 passed, 3 skipped**, **shard 9 → 145 passed** | unit |

Module shards: `with_error_handling_single_definition_test.py` → **shard 4**, `workflow_planner_deprecation_test.py` → **shard 3**, `tokenizers_transformers_range_test.py` → **shard 9** (`stable_shard.shard_of` against `.test_durations`, 12 splits).

Contrast mutations, all against this PR's final head (`6f91124`), all run from inside the worktree:

| Mutation | Observed failure |
|---|---|
| `with_error_handling…`: filter back to absolute matching | `AssertionError: only 0 backend sources survived the exclusion filter — the filter is eating the tree, so every assertion below is vacuous` **and** `AssertionError: a scan rooted under .worktrees/ skipped its own tree — the exclusion is matching the absolute path instead of parts relative to the root` |
| `workflow_planner…`: filter back to absolute matching | `AssertionError: Expected reference(s) to WorkflowPlanner disappeared from ['autobot-backend/orchestrator.py', …]; update this allow-list.` **and** `AssertionError: a scan rooted under .worktrees/ and tests/ skipped its own tree — the exclusion is matching the absolute path instead of relative parts` |
| `tokenizers…`: `_outside_excluded_dirs` back to absolute matching | `AssertionError: unguarded tokenizers pins: []` **and** `AssertionError: assert False` (the fixture assertion) |

Each mutation produces two failures: the environment-dependent one (only reachable from a worktree) and the new fixture assertion (reachable anywhere). The second is the one that will hold the fix in CI.

No new `KNOWN_LARGE` entry and no ceiling change — the three modules are 171 / 199 / 208 lines against a 600 ceiling, and none appears in either ratchet carrier.

Not proven here: that the `workflow_planner_deprecation_test.py` change fixes a *currently observable* failure. It does not — that one was latent, and is fixed on the idiom rather than on a reproduction. Its mutation above is against the widened `_SKIP_PARTS`, not against the original two-entry list.

## Model Used

Claude Opus 5 (1M context)

Closes #15121
