### PR TITLE
fix(test): stop probing two agent endpoints that no router has ever served (#15133)

### DIFF
--- a/autobot-backend/agents/multi_agent_workflow_probe_endpoints_test.py
+++ b/autobot-backend/agents/multi_agent_workflow_probe_endpoints_test.py
@@ -1,0 +1,126 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Every path the workflow validator probes must be one the backend serves (#15133).
+
+``multi_agent_workflow_validation_test.py`` probed ``/api/intelligent-agent/deploy``
+and ``/api/research/deploy`` from the day it was written. Neither prefix was
+right, but that was not the defect: **no router has ever served a ``/deploy``
+path under either name, at any commit.** ``git log -S '/deploy"'`` over
+``autobot-backend/``, ``backend/`` and ``src/`` returns only the #926 restructure
+moving this very file, plus one unrelated ``/api/nodes/{id}/certificate/deploy``
+in the SLM backend. The probes asserted a capability that was never built.
+
+It read as healthy for a year because the validator only runs against a live
+backend, treats a non-200 as an agent that happens to be down, and -- being a
+``*_test.py`` module with no ``test_`` function and no ``Test`` class -- collected
+**zero** pytest items. Nothing ever executed the list, so nothing ever noticed.
+
+This module is the missing execution. It resolves each probed path against the
+router registry ``app_factory._register_routers`` mounts from, so a probe of a
+path no router serves fails here, in CI, without a backend.
+
+Cost note: importing ``core_routers`` pulls in every core router module (~25s
+cold). That is the price of checking the real route table instead of a
+transcription of it, and it is paid once per shard.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from agents.multi_agent_workflow_validation_test import AGENT_ENDPOINTS
+
+#: Core alone mounted 713 routes when this landed. The floor exists to catch the
+#: enumeration collapsing -- an import that silently yields nothing would mark
+#: every probe unserved, or worse, be read as "nothing to check".
+MINIMUM_EXPECTED_ROUTES = 400
+
+#: Paths that must stay absent. These are the two fictions this issue removed;
+#: if one is ever served for real, this test is the thing that says so.
+NEVER_SERVED = ("/api/intelligent-agent/deploy", "/api/research/deploy")
+
+
+def _collect(served: set[tuple[str, str]], router, prefix: str) -> None:
+    """Record every ``(method, full path)`` a router contributes under *prefix*."""
+    for route in router.routes:
+        path = getattr(route, "path", None)
+        if path is None:  # an included sub-router carries no path of its own
+            continue
+        for method in getattr(route, "methods", None) or ("WEBSOCKET",):
+            served.add((method, f"/api{prefix}{path}"))
+
+
+@pytest.fixture(scope="module")
+def served_routes() -> set[tuple[str, str]]:
+    """The ``(method, path)`` pairs the app factory would mount.
+
+    Core routers are enumerated in full. Feature routers are imported only when
+    their declared prefix covers a probed path, because importing all 172 costs
+    minutes. A probe served **only** by a feature router mounted at the root
+    prefix would therefore read as unserved -- extend this fixture rather than
+    the probe list if that ever happens.
+    """
+    from initialization.router_registry.core_routers import load_core_routers
+    from initialization.router_registry.feature_routers import FEATURE_ROUTER_CONFIGS
+
+    served: set[tuple[str, str]] = set()
+    for router, prefix, _tags, _name in load_core_routers():
+        _collect(served, router, prefix)
+
+    probed = [path for path, _agent in AGENT_ENDPOINTS]
+    for module_path, prefix, _tags, _name in FEATURE_ROUTER_CONFIGS:
+        if not prefix or not any(path.startswith(f"/api{prefix}/") for path in probed):
+            continue
+        _collect(served, importlib.import_module(module_path).router, prefix)
+    return served
+
+
+class TestTheEnumerationsAreReal:
+    """Neither side of the comparison may be empty, or the verdict is worthless."""
+
+    def test_probe_list_is_not_empty(self):
+        assert AGENT_ENDPOINTS, (
+            "AGENT_ENDPOINTS is empty -- the coordination check would probe nothing and "
+            "report every run as passing (#15133)"
+        )
+
+    def test_route_table_has_not_collapsed(self, served_routes):
+        assert len(served_routes) >= MINIMUM_EXPECTED_ROUTES, (
+            f"only {len(served_routes)} routes enumerated from the router registry, expected at "
+            f"least {MINIMUM_EXPECTED_ROUTES}; an empty or truncated route table makes every "
+            "assertion below vacuous"
+        )
+
+
+class TestEveryProbedPathIsServed:
+    def test_each_probe_resolves_to_a_get_route(self, served_routes):
+        unserved = [(path, agent) for path, agent in AGENT_ENDPOINTS if ("GET", path) not in served_routes]
+        assert not unserved, (
+            "these probed paths are not served as GET by any registered router:\n  "
+            + "\n  ".join(f"{path}  ({agent})" for path, agent in unserved)
+            + "\n\nThe validator would get a 404 and report it as an agent being down. "
+            "Point the probe at a path the backend actually exposes, or drop it and name "
+            "the capability it was checking (#15133)."
+        )
+
+    def test_agent_names_are_distinct(self):
+        names = [agent for _path, agent in AGENT_ENDPOINTS]
+        assert len(names) == len(set(names)), f"duplicate agent labels would double-count: {names}"
+
+
+class TestTheRemovedProbesWereFiction:
+    """Guards the guard: the paths this issue deleted must still be unserved."""
+
+    @pytest.mark.parametrize("path", NEVER_SERVED)
+    def test_deploy_path_is_served_by_nothing(self, served_routes, path):
+        methods = sorted(method for method, served in served_routes if served == path)
+        assert not methods, (
+            f"{path} is now served ({', '.join(methods)}). An agent deployment endpoint has "
+            "appeared since #15133 -- reinstate the probe deliberately instead of leaving "
+            "this assertion to fail."
+        )
+
+    @pytest.mark.parametrize("path", NEVER_SERVED)
+    def test_no_probe_points_at_a_removed_path(self, path):
+        assert path not in [probed for probed, _agent in AGENT_ENDPOINTS]

--- a/autobot-backend/agents/multi_agent_workflow_probe_endpoints_test.py
+++ b/autobot-backend/agents/multi_agent_workflow_probe_endpoints_test.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import importlib
 
 import pytest
+
 from agents.multi_agent_workflow_validation_test import AGENT_ENDPOINTS
 
 #: Core alone mounted 713 routes when this landed. The floor exists to catch the

--- a/autobot-backend/agents/multi_agent_workflow_validation_test.py
+++ b/autobot-backend/agents/multi_agent_workflow_validation_test.py
@@ -36,14 +36,28 @@ class WorkflowTestResult:
     details: Dict = None
 
 
+#: Paths probed to decide whether each agent is reachable. Every entry is a GET
+#: the backend actually serves, enforced against the router registry by
+#: ``multi_agent_workflow_probe_endpoints_test.py``. The first two entries used
+#: to be ``/api/intelligent-agent/deploy`` and ``/api/research/deploy``: no
+#: router has served a ``/deploy`` path under either prefix at any commit, under
+#: any spelling -- the capability does not exist and never did (#15133).
+AGENT_ENDPOINTS: tuple[tuple[str, str], ...] = (
+    ("/api/intelligent_agent/system-info", "Intelligent Agent"),
+    ("/api/research-browser/sessions", "Research Agent"),
+    ("/api/knowledge_base/health/status", "Knowledge Agent"),
+    ("/api/llm/status", "LLM Agent"),
+)
+
+
 class MultiAgentWorkflowValidator:
     """Validates multi-agent coordination and workflow execution"""
 
     def __init__(self):
         self.results = []
-        self.backend_host = "10.0.0.20"
-        self.backend_port = 8001
-        self.base_url = f"http://{self.backend_host}:{self.backend_port}"
+        # #15133: the host and port were hard-coded here, so the script probed
+        # one fixed node regardless of where the backend actually runs.
+        self.base_url = config.backend_url
 
     def log_result(
         self,
@@ -116,17 +130,9 @@ class MultiAgentWorkflowValidator:
             )
             return
 
-        # Test agent deployment endpoints
-        agent_endpoints = [
-            ("/api/intelligent-agent/deploy", "Intelligent Agent"),
-            ("/api/research/deploy", "Research Agent"),
-            ("/api/knowledge_base/search", "Knowledge Agent"),
-            ("/api/llm/status", "LLM Agent"),
-        ]
-
         active_agents = []
 
-        for endpoint, agent_name in agent_endpoints:
+        for endpoint, agent_name in AGENT_ENDPOINTS:
             try:
                 response = requests.get(f"{self.base_url}{endpoint}", timeout=10)
                 if response.status_code == 200:
@@ -138,10 +144,21 @@ class MultiAgentWorkflowValidator:
                         agents_involved=[agent_name],
                         performance_metrics={"response_time": f"{response.elapsed.total_seconds():.3f}s"},
                     )
+                elif response.status_code == 404:
+                    # The backend answered, so it is up; it does not serve this
+                    # path. That is a defect in this list, never a sleeping
+                    # agent, and it must not read as one (#15133).
+                    self.log_result(
+                        f"Agent Availability - {agent_name}",
+                        "fail",
+                        f"no router serves {endpoint} - probed path is not exposed by the backend",
+                        agents_involved=[agent_name],
+                        details={"status_code": 404, "unserved_path": endpoint},
+                    )
                 else:
                     self.log_result(
                         f"Agent Availability - {agent_name}",
-                        "warning" if response.status_code == 404 else "fail",
+                        "fail",
                         f"{agent_name} returned HTTP {response.status_code}",
                         agents_involved=[agent_name],
                         details={"status_code": response.status_code},


### PR DESCRIPTION
## Thinking Path

The issue says the two probed prefixes were copied from stale registry values. Correcting the
spelling is not the fix, and the deeper reading is that neither probe was ever pointing at
anything.

**Was `/deploy` ever real?** No — and not under any spelling.
`git log --all -S '/deploy"' -- autobot-backend backend src` returns exactly two commits: the #926
restructure moving this very file, and a changelog. The only `/deploy` route in the repo's whole
history is `/api/nodes/{node_id}/certificate/deploy` in the SLM backend — certificate deployment,
unrelated. The introducing commit (2025-09-10) added the file with these two probes already in it,
against endpoints that did not exist that day and have not existed since.

**Is there a successor?** For the literal capability — deploying an agent — no. Nothing in the tree
deploys an agent over HTTP. So the deploy probes are option 2 in the issue's terms: a fiction, and
they are removed with the capability named.

For what the surrounding code actually *consumed*, yes. The loop only ever used the 200/non-200
result to count `active_agents` for the "Agent Coordination Status" line — an availability probe,
not a deployment. Both agents expose a real, mounted, GET availability path, so that half is
repointed rather than deleted.

**Where the real prefixes come from.** `app_factory._register_routers` mounts from
`initialization/router_registry/`, not from `api/registry.py`:
- `core_routers.py:483` → `/intelligent_agent`, mounted as `/api/intelligent_agent`
- `feature_routers.py:214` → `/research-browser`, mounted as `/api/research-browser`

`api/registry.py` is untouched here.

**The more important half.** The module is named `*_test.py`, sits under `testpaths`, and is
imported by pytest on every run — but it defines no `test_` function and no `Test` class, so
`pytest --collect-only` reports `collected 0 items`. It has contributed zero assertions since
2025-09-10. Nothing ever executed the endpoint list, which is why probing two nonexistent paths
went unnoticed for a year. That vacuity is fixed here too.

**Third defect found while verifying.** `/api/knowledge_base/search` exists but is **POST-only**, so
the GET probe returned 405 rather than proving anything. It now probes
`/api/knowledge_base/health/status`, which is a real GET.

**Fourth.** The backend address was hard-coded (`10.0.0.20:8001`), so the script probed one fixed
node wherever it ran. It now uses `config.backend_url` from the SSOT.

## What Changed

`autobot-backend/agents/multi_agent_workflow_validation_test.py`
- `AGENT_ENDPOINTS` is now a module-level constant, so it can be asserted over. All four entries
  are GETs verified against the mounted route table:
  | before | after | why |
  |---|---|---|
  | `/api/intelligent-agent/deploy` | `/api/intelligent_agent/system-info` | `/deploy` never existed; prefix also wrong |
  | `/api/research/deploy` | `/api/research-browser/sessions` | `/deploy` never existed; prefix also wrong |
  | `/api/knowledge_base/search` (GET) | `/api/knowledge_base/health/status` | the old path is POST-only; a GET got 405 |
  | `/api/llm/status` | unchanged | already correct |
- A 404 is now a `fail` naming the unserved path, not a `warning`. The backend answered, so it is
  up; it simply does not serve that path. That is the exact case the old code could not express.
- `config.backend_url` replaces the hard-coded host and port.

`autobot-backend/agents/multi_agent_workflow_probe_endpoints_test.py` (new, 126 lines)
- Resolves every probed path against the router registry the app factory mounts from, so a probe of
  an unserved path fails in CI with no backend running.
- Asserts the probe list is non-empty and that the route table has not collapsed — either being
  empty would make every other assertion vacuous.
- Asserts the two removed paths are still served by nothing, and that no probe points back at them.

## Verification

| Criterion | Evidence | Kind |
|---|---|---|
| `/deploy` never existed under any spelling | `git log --all -S '/deploy"' -- autobot-backend backend src` → only #926 + a changelog; sole historical `/deploy` is the SLM certificate route | forensic |
| Probe list was never executed | `pytest --collect-only` on the module → `collected 0 items` | unit |
| Real mount prefixes | `core_routers.py:483`, `feature_routers.py:214` | static |
| All four probes served as GET | route table built from `load_core_routers()` + `FEATURE_ROUTER_CONFIGS`: `system-info` GET, `sessions` GET, `health/status` GET, `llm/status` GET | unit |
| Old paths served by nothing | same table: `/api/intelligent-agent/deploy` and `/api/research/deploy` → no methods at all | unit |
| Suite green | `pytest .../multi_agent_workflow_probe_endpoints_test.py .../multi_agent_workflow_validation_test.py -q` → **8 passed in 8.41s** | unit |
| Line ceiling | `scripts/check_python_file_size.py` on both files → exit 0; validator is 600 lines, at the limit, not over | static |
| Lint/format | `black --check` clean, `flake8 autobot-backend/agents/` → 0 | static |

**Shard:** `multi_agent_workflow_probe_endpoints_test.py` → **shard 4 of 12**
(`stable_shard.shard_of`, `--shard-splits 12`). The validator module stays in shard 5.

### Contrast mutations (run against this branch's final head)

**1. Restore the original fictional probe** — put `/api/intelligent-agent/deploy` back into
`AGENT_ENDPOINTS`:

```
FAILED ...::TestEveryProbedPathIsServed::test_each_probe_resolves_to_a_get_route
E   AssertionError: these probed paths are not served as GET by any registered router:
E       /api/intelligent-agent/deploy  (Intelligent Agent)
E     The validator would get a 404 and report it as an agent being down. Point the probe at a
E     path the backend actually exposes, or drop it and name the capability it was checking (#15133).
FAILED ...::TestTheRemovedProbesWereFiction::test_no_probe_points_at_a_removed_path[/api/intelligent-agent/deploy]
```

So the guard catches the exact bug this issue reports.

**2. Empty the enumeration** — `AGENT_ENDPOINTS = ()`:

```
FAILED ...::TestTheEnumerationsAreReal::test_probe_list_is_not_empty
E   AssertionError: AGENT_ENDPOINTS is empty -- the coordination check would probe nothing and
E   report every run as passing (#15133)
E   assert ()
```

So the test cannot go vacuous by the list being emptied.

## Model Used

Claude Opus 5 (1M context)

Closes #15133
