### PR TITLE
types(shared): fix the seven type errors the required mypy gate cannot see (#15134)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -129,7 +129,21 @@ jobs:
         python -m pip install --upgrade pip
         # Pin versions to match .pre-commit-config.yaml (Issue #2128)
         python -m pip install black==26.3.1 isort==8.0.1 flake8==7.3.0 autoflake==2.3.3 'bandit[toml]==1.9.4'
-        # mypy and stubs (GH#7105)
+        # mypy and stubs (GH#7105).
+        #
+        # This version is pinned in two places -- here and as the mirrors-mypy
+        # rev in .pre-commit-config.yaml. repo_tests/mypy_pin_parity_test.py
+        # fails if they diverge, so a bump either moves both or is rejected by
+        # name; the same test pins the stub list below (#15134).
+        #
+        # What the version is NOT is load-bearing. Measured on python 3.14.6
+        # against autobot_shared/: mypy 1.16.0, 2.1.0 and 2.3.0 report the same
+        # findings for the same installed packages. What changes the result is
+        # the dependency set -- this step installs stubs only, so every type
+        # flowing from redis or sqlalchemy is Any here and errors that a local
+        # CI-parity venv sees are invisible to this gate. #15134 fixed the
+        # seven that were hiding behind that; read it before widening the
+        # install list, which would surface more of them at once.
         python -m pip install \
           mypy==1.16.0 \
           pydantic-settings \

--- a/autobot_shared/rate_limiter.py
+++ b/autobot_shared/rate_limiter.py
@@ -367,7 +367,9 @@ class RateLimiter:
                     hour_key, minute_cutoff, "+inf", start=0, num=1, withscores=True
                 )
                 if oldest_in_minute:
-                    oldest_ts = oldest_in_minute[0][1]
+                    # withscores yields the score as a float at runtime; redis-py
+                    # types the member/score pair loosely, so coerce (#15134).
+                    oldest_ts = float(oldest_in_minute[0][1])
                     wait = max(wait, 60.0 - (now - oldest_ts))
 
             if hour_count >= self._rph:
@@ -375,7 +377,7 @@ class RateLimiter:
                     hour_key, hour_cutoff, "+inf", start=0, num=1, withscores=True
                 )
                 if oldest_in_hour:
-                    oldest_ts = oldest_in_hour[0][1]
+                    oldest_ts = float(oldest_in_hour[0][1])
                     wait = max(wait, 3600.0 - (now - oldest_ts))
 
             return max(0, int(wait) + 1)  # +1 for safe rounding

--- a/autobot_shared/rate_limiter_score_coercion_15134_test.py
+++ b/autobot_shared/rate_limiter_score_coercion_15134_test.py
@@ -67,9 +67,11 @@ async def test_retry_after_is_computed_whatever_spelling_the_score_arrives_in(sc
 async def test_retry_after_string_score_does_not_fall_into_the_error_path():
     """A string score must produce the real answer, not the swallowed-exception default.
 
-    ``get_retry_after_seconds`` catches broadly and returns 1 on failure, so a
-    ``TypeError`` from the subtraction would look like a plausible answer rather
-    than a fault. Pinning the exact value is what tells the two apart.
+    ``get_retry_after_seconds`` catches broadly and returns 0 on failure -- "no
+    wait" -- so a ``TypeError`` from the subtraction does not surface as an
+    error, it surfaces as a client being told to retry immediately while the
+    limiter is still refusing it. Pinning the exact value is what tells the two
+    apart.
     """
     limiter = RateLimiter("t15134", requests_per_minute=1, requests_per_hour=1000)
     redis = _redis_reporting(oldest_offset=45.0, score_spelling="str")

--- a/autobot_shared/rate_limiter_score_coercion_15134_test.py
+++ b/autobot_shared/rate_limiter_score_coercion_15134_test.py
@@ -1,0 +1,78 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Sorted-set scores reaching arithmetic are coerced, not assumed (#15134).
+
+``get_retry_after_seconds`` subtracts a ``ZRANGEBYSCORE ... WITHSCORES`` score
+from a timestamp. redis-py types the member/score pair loosely, so a checker
+that can see the real package rejects the subtraction -- and the rejection is
+pointing at something true: nothing in the client contract guarantees the
+score arrives already numeric, and a string one would raise ``TypeError``
+inside the very helper whose job is to answer "how long until you may retry".
+
+These live in their own module because ``rate_limiter_test.py`` sits exactly on
+its recorded 618-line ceiling, which the size ratchet enforces in both
+directions; appending there would fail the gate.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from autobot_shared.rate_limiter import RateLimiter
+
+_PATCH_TARGET = "autobot_shared.rate_limiter.get_async_redis_client"
+
+#: Every score representation a Redis client may hand back for the same instant.
+#: Empty would make the parametrised assertions below vacuous, so it is asserted.
+SCORE_SPELLINGS = ("float", "str", "bytes")
+
+assert SCORE_SPELLINGS, "score spellings must not be empty -- an empty case asserts nothing"
+
+
+def _redis_reporting(oldest_offset: float, score_spelling: str) -> AsyncMock:
+    """A client whose window is full and whose oldest entry is *oldest_offset* old."""
+    oldest = time.time() - oldest_offset
+    raw: float | str | bytes = oldest
+    if score_spelling == "str":
+        raw = str(oldest)
+    elif score_spelling == "bytes":
+        raw = str(oldest).encode("utf-8")
+
+    redis = AsyncMock()
+    # Above the per-minute allowance and below the per-hour one, so only the
+    # minute branch contributes and the expected value is unambiguous.
+    redis.zcount = AsyncMock(return_value=10)
+    redis.zrangebyscore = AsyncMock(return_value=[("member", raw)])
+    return redis
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("score_spelling", SCORE_SPELLINGS)
+async def test_retry_after_is_computed_whatever_spelling_the_score_arrives_in(score_spelling):
+    """The same instant yields the same answer whether the score is a float or a string."""
+    limiter = RateLimiter("t15134", requests_per_minute=1, requests_per_hour=1000)
+    redis = _redis_reporting(oldest_offset=10.0, score_spelling=score_spelling)
+
+    with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+        retry_after = await limiter.get_retry_after_seconds("caller")
+
+    # 60s window, oldest entry 10s old -> just under 50s left, floored, +1 rounding.
+    assert retry_after == 50
+
+
+@pytest.mark.asyncio
+async def test_retry_after_string_score_does_not_fall_into_the_error_path():
+    """A string score must produce the real answer, not the swallowed-exception default.
+
+    ``get_retry_after_seconds`` catches broadly and returns 1 on failure, so a
+    ``TypeError`` from the subtraction would look like a plausible answer rather
+    than a fault. Pinning the exact value is what tells the two apart.
+    """
+    limiter = RateLimiter("t15134", requests_per_minute=1, requests_per_hour=1000)
+    redis = _redis_reporting(oldest_offset=45.0, score_spelling="str")
+
+    with patch(_PATCH_TARGET, AsyncMock(return_value=redis)):
+        assert await limiter.get_retry_after_seconds("caller") == 15

--- a/autobot_shared/url_safety.py
+++ b/autobot_shared/url_safety.py
@@ -237,7 +237,15 @@ async def resolve_safe_ip_async(
 
     safe_ip: str | None = None
     for info in infos:
-        ip_str = info[4][0].split("%", 1)[0]  # strip IPv6 scope id
+        # getaddrinfo was asked for SOCK_STREAM, so every result is AF_INET or
+        # AF_INET6 and sockaddr[0] is the address string. typeshed widens it to
+        # str | int for the packet families this call cannot return; narrow it
+        # rather than assume, and let anything else fall to the no-usable-IP
+        # raise below instead of being treated as an address (#15134).
+        host_part = info[4][0]
+        if not isinstance(host_part, str):
+            continue
+        ip_str = host_part.split("%", 1)[0]  # strip IPv6 scope id
         try:
             ip = ipaddress.ip_address(ip_str)
         except ValueError:

--- a/autobot_shared/url_safety_test.py
+++ b/autobot_shared/url_safety_test.py
@@ -420,3 +420,34 @@ async def test_async_wrapper_forwards_the_opt_in_when_requested(monkeypatch):
     monkeypatch.setattr(url_safety, "is_public_url", _accepts_kwarg)
     await url_safety.is_public_url_async("https://example.com/x", allow_private=True)
     assert seen["allow_private"] is True
+
+
+# ---------------------------------------------------------------------------
+# sockaddr[0] is narrowed, not assumed (#15134)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_safe_ip_skips_a_non_string_sockaddr_and_keeps_going() -> None:
+    """A sockaddr whose first element is not a string is skipped, not parsed.
+
+    typeshed types ``sockaddr[0]`` as ``str | int`` because it covers address
+    families this call cannot return. The loop narrows instead of assuming, and
+    the narrowing must fall through to the next candidate rather than abandoning
+    resolution — otherwise a single odd entry would hide a perfectly good IP.
+    """
+    fake_infos = [
+        (17, 3, 0, "", (1, 0)),  # not an address family this call asked for
+        (2, 1, 6, "", ("93.184.216.34", 0)),
+    ]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        assert await resolve_safe_ip_async("mixed.example") == "93.184.216.34"
+
+
+@pytest.mark.asyncio
+async def test_resolve_safe_ip_raises_when_every_sockaddr_is_non_string() -> None:
+    """Skipping is never silent: with nothing usable left the call still raises."""
+    fake_infos = [(17, 3, 0, "", (1, 0)), (17, 3, 0, "", (2, 0))]
+    with patch("autobot_shared.url_safety.socket.getaddrinfo", return_value=fake_infos):
+        with pytest.raises(ValueError, match="no usable public IP"):
+            await resolve_safe_ip_async("nothing-usable.example")

--- a/autobot_shared/user_management/organization_service.py
+++ b/autobot_shared/user_management/organization_service.py
@@ -521,7 +521,7 @@ class OrganizationService(BaseService):
         settings: dict | None,
         subscription_tier: str | None,
         max_users: int | None,
-    ) -> dict:
+    ) -> dict[str, dict[str, str | int | None]]:
         """
         Apply field updates to organization and track changes.
 
@@ -538,7 +538,7 @@ class OrganizationService(BaseService):
 
         Issue #620.
         """
-        changes = {}
+        changes: dict[str, dict[str, str | int | None]] = {}  # heterogeneous; inference locks it wrong (#15134)
 
         if name and name != org.name:
             changes["name"] = {"old": org.name, "new": name}

--- a/autobot_shared/user_management/organization_service_test.py
+++ b/autobot_shared/user_management/organization_service_test.py
@@ -19,6 +19,7 @@ properties that makes safe:
 
 import ast
 import pathlib
+import types
 
 import pytest
 
@@ -150,3 +151,57 @@ def test_backend_subclass_reexports_the_error_classes(backend):
 
     for error in _ERRORS:
         assert error.__name__ in source, f"{backend} drops {error.__name__}"
+
+
+# ---------------------------------------------------------------------------
+# The tracked-change payload is heterogeneous by construction (#15134)
+# ---------------------------------------------------------------------------
+
+
+def _stub_org(**attrs):
+    """A bare stand-in for the concrete Organization model.
+
+    `_apply_organization_updates` reads and writes attributes and touches
+    nothing on `self`, so it can be exercised without either backend's model
+    or a session.
+    """
+    return types.SimpleNamespace(
+        name="acme",
+        description=None,
+        settings={},
+        subscription_tier="free",
+        max_users=10,
+        updated_at=None,
+        **attrs,
+    )
+
+
+def test_tracked_changes_carry_none_and_int_values_unconverted():
+    """The audit payload keeps the real values, so its type cannot be dict[str, str].
+
+    `description` is nullable and `max_users` is an int. A checker that sees the
+    concrete model infers the whole dict from whichever branch is written first
+    and rejects the rest, which is why the declaration is explicit rather than
+    inferred. This asserts the runtime fact that declaration encodes: nothing
+    here is stringified on the way into the audit log.
+    """
+    org = _stub_org()
+    changes = OrganizationService._apply_organization_updates(
+        None, org, name=None, description="now set", settings=None, subscription_tier=None, max_users=25
+    )
+
+    assert changes["description"] == {"old": None, "new": "now set"}
+    assert changes["description"]["old"] is None
+    assert changes["max_users"] == {"old": 10, "new": 25}
+    assert isinstance(changes["max_users"]["old"], int)
+    assert isinstance(changes["max_users"]["new"], int)
+
+
+def test_untouched_fields_are_absent_from_the_tracked_changes():
+    """Only fields actually supplied are recorded — the caller keys audit on it."""
+    org = _stub_org()
+    changes = OrganizationService._apply_organization_updates(
+        None, org, name=None, description=None, settings=None, subscription_tier=None, max_users=None
+    )
+
+    assert changes == {}

--- a/repo_tests/mypy_pin_parity_test.py
+++ b/repo_tests/mypy_pin_parity_test.py
@@ -1,0 +1,150 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every lint-tool version is pinned twice; this keeps the two copies equal (#15134).
+
+``.github/workflows/code-quality.yml`` installs exact versions and says they
+"match .pre-commit-config.yaml". Nothing checked that. The two files can drift,
+and the drift is invisible in the worst direction: the local hook passes on one
+version while the required CI context runs another, so a developer's green run
+means less than it reads.
+
+The mypy pin is the one this issue arrived through. ``mypy autobot_shared/`` is
+a **required** context, and moving it is a deliberate act -- but a bump landing
+in only one of the two files is not a decision, it is an accident. This makes
+that accident fail with the two versions named.
+
+The set of stub packages installed alongside mypy is checked the same way: a
+type checker with different stubs is a different type checker, so the hook and
+the gate must be handed the same ones.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODE_QUALITY = REPO_ROOT / ".github" / "workflows" / "code-quality.yml"
+PRE_COMMIT = REPO_ROOT / ".pre-commit-config.yaml"
+
+#: pre-commit repo slug -> the distribution name the CI workflow pip-installs.
+#: Only tools pinned in both places belong here; anything else is not a parity
+#: claim and must not be invented into one.
+TOOL_BY_PRE_COMMIT_REPO = {
+    "psf/black": "black",
+    "pycqa/isort": "isort",
+    "pycqa/flake8": "flake8",
+    "pycqa/autoflake": "autoflake",
+    "pre-commit/mirrors-mypy": "mypy",
+    "pycqa/bandit": "bandit",
+}
+
+#: A pip requirement pinned to an exact version, extras tolerated:
+#: ``black==26.3.1``, ``'bandit[toml]==1.9.4'``, ``mypy==1.16.0 \``.
+_PINNED = re.compile(r"([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([0-9][A-Za-z0-9.]*)")
+
+
+def _ci_pins() -> dict[str, str]:
+    """Exact versions ``code-quality.yml`` pip-installs, keyed by distribution."""
+    text = CODE_QUALITY.read_text(encoding="utf-8")
+    return {name.lower(): version for name, version in _PINNED.findall(text)}
+
+
+def _pre_commit_pins() -> dict[str, str]:
+    """Exact versions ``.pre-commit-config.yaml`` pins, keyed by distribution."""
+    config = yaml.safe_load(PRE_COMMIT.read_text(encoding="utf-8"))
+    pins: dict[str, str] = {}
+    for repo in config.get("repos", []):
+        url = str(repo.get("repo", ""))
+        slug = "/".join(url.rstrip("/").split("/")[-2:]).lower()
+        tool = TOOL_BY_PRE_COMMIT_REPO.get(slug)
+        if tool is not None:
+            pins[tool] = str(repo.get("rev", "")).lstrip("v")
+    return pins
+
+
+def _pre_commit_mypy_stub_sets() -> list[set[str]]:
+    """``additional_dependencies`` of each mypy hook, one set per hook."""
+    config = yaml.safe_load(PRE_COMMIT.read_text(encoding="utf-8"))
+    out: list[set[str]] = []
+    for repo in config.get("repos", []):
+        if "mirrors-mypy" not in str(repo.get("repo", "")):
+            continue
+        for hook in repo.get("hooks", []):
+            if hook.get("id") == "mypy":
+                out.append({str(dep).strip().lower() for dep in hook.get("additional_dependencies", [])})
+    return out
+
+
+def _ci_mypy_stub_set() -> set[str]:
+    """Packages installed next to mypy in the workflow's mypy install step.
+
+    Read from the continued ``pip install`` block the ``mypy==`` line opens, so
+    the unrelated formatter pins in the step above are not swept in.
+    """
+    lines = CODE_QUALITY.read_text(encoding="utf-8").splitlines()
+    start = next((i for i, line in enumerate(lines) if "mypy==" in line), None)
+    if start is None:
+        return set()
+    collected: set[str] = set()
+    continued = lines[start].rstrip().endswith("\\")
+    for line in lines[start + 1 :]:
+        if not continued:
+            break
+        candidate = line.strip().rstrip("\\").strip()
+        continued = line.rstrip().endswith("\\")
+        if candidate:
+            collected.add(candidate.lower())
+    return collected
+
+
+CI_PINS = _ci_pins()
+PRE_COMMIT_PINS = _pre_commit_pins()
+SHARED_TOOLS = sorted(set(CI_PINS) & set(PRE_COMMIT_PINS))
+
+
+def test_the_sweep_found_tools_to_compare():
+    """An empty enumeration would make every parametrised case below vacuous.
+
+    Both files are checked in, so finding nothing means the parsing broke, not
+    that the repo stopped pinning anything.
+    """
+    assert CI_PINS, f"no pinned versions parsed from {CODE_QUALITY.name}"
+    assert PRE_COMMIT_PINS, f"no pinned revs parsed from {PRE_COMMIT.name}"
+    assert SHARED_TOOLS, "no tool is pinned in both files -- the parity claim cannot be checked"
+
+
+def test_mypy_is_among_the_tools_compared():
+    """The required type gate is the pin this test exists for; never let it drop out."""
+    assert (
+        "mypy" in SHARED_TOOLS
+    ), f"mypy is not pinned in both files: CI={CI_PINS.get('mypy')}, hook={PRE_COMMIT_PINS.get('mypy')}"
+
+
+@pytest.mark.parametrize("tool", SHARED_TOOLS)
+def test_ci_and_pre_commit_pin_the_same_version(tool):
+    """The local hook and the CI gate must run the same checker."""
+    assert CI_PINS[tool] == PRE_COMMIT_PINS[tool], (
+        f"{tool} is pinned to {CI_PINS[tool]} in {CODE_QUALITY.name} but "
+        f"{PRE_COMMIT_PINS[tool]} in {PRE_COMMIT.name}. Bump both, or neither."
+    )
+
+
+def test_every_mypy_hook_gets_the_stubs_ci_installs():
+    """Different stubs make a different checker, whatever the version says."""
+    hook_sets = _pre_commit_mypy_stub_sets()
+    ci_stubs = _ci_mypy_stub_set()
+
+    assert hook_sets, "no mypy hook found in .pre-commit-config.yaml"
+    assert ci_stubs, "no stub packages parsed from the workflow's mypy install step"
+
+    for index, hook_stubs in enumerate(hook_sets):
+        assert hook_stubs == ci_stubs, (
+            f"mypy hook #{index} installs {sorted(hook_stubs)} while "
+            f"{CODE_QUALITY.name} installs {sorted(ci_stubs)}"
+        )


### PR DESCRIPTION
## Thinking Path

The issue's premise is that `mypy autobot_shared/` is clean on the pinned 1.16.0 and reports 7 errors on 2.1.0, making the pin load-bearing for a required context. **Measurement contradicts that.** The variable is not the checker version, it is the set of packages installed next to it.

Five environments, all on python 3.14.6, all against the same tree:

| Environment | mypy 1.16.0 | mypy 2.1.0 | mypy 2.3.0 |
|---|---|---|---|
| CI-exact — the stub list `code-quality.yml` installs, no project dependencies | 0 | 0 | — |
| + real `redis` + `sqlalchemy`, stubs still present | 4 | 4 | — |
| + real `redis` + `sqlalchemy`, `types-redis` removed | 6 | 6 | 7 |

Three readings fall out of that table:

1. **1.16.0 and 2.1.0 are indistinguishable here.** Every environment gives them byte-identical output. A bump to 2.1.0 reddens nothing; the pin was never holding these back.
2. **The blocking gate is dependency-blind.** `code-quality.yml` installs mypy plus seven stub packages and nothing else, so every type flowing from `redis` or `sqlalchemy` is `Any` on CI. Six real errors were invisible to a *required* context purely because the packages that give them types were absent. That is the actual defect the issue found, and it is larger than a pin.
3. **The three `await` `[misc]` errors the issue lists do not reproduce** in any of the five environments. `get_async_redis_client` is annotated `-> async_redis.Redis | None`, which is correctly async-typed, so `await redis.eval(...)` is well-formed; the `Awaitable[str] | str` shape belongs to the *sync* client. So the proposed remedy — adding `rate_limiter` and `leader_lease` to the `pyproject.toml` `ignore_errors` override — would have suppressed errors that do not exist, and would have blinded two modules permanently to buy nothing. **Not done, deliberately.**

What the worst-case environment does show is seven errors in three files — a different seven from the issue's. All are real, and all are fixed at the root; none is suppressed.

**mypy is not bumped in this PR.** Stated explicitly, as asked: every error observed on 2.1.0 *and* on 2.3.0 is now resolved, so a bump is no longer blocked by `autobot_shared/` — but it also buys nothing measurable, moves the informational backend sweeps and every developer's pre-commit hook at the same time, and is a decision of its own. The new parity test makes that bump a two-file change that fails loudly if only one file moves.

## What Changed

- `autobot_shared/user_management/organization_service.py` — `_apply_organization_updates` declares its tracked-change payload as `dict[str, dict[str, str | int | None]]` instead of letting inference read the type off whichever branch is written first. The values genuinely are heterogeneous: `description` is nullable and `max_users` is an `int`. Return annotation tightened from bare `dict` to match. Line-neutral: the file sits one line under the 600-line ceiling and stays there.
- `autobot_shared/rate_limiter.py` — the `ZRANGEBYSCORE ... WITHSCORES` score reaching arithmetic in `get_retry_after_seconds` is coerced with `float(...)`. Nothing in the client contract promises it arrives numeric, and the method catches broadly and returns `0` on failure — so a string score did not surface as an error, it surfaced as a rate-limited caller being told to retry immediately.
- `autobot_shared/url_safety.py` — `resolve_safe_ip_async` narrows `sockaddr[0]` with `isinstance` rather than assuming it is a string, falling through to the existing "no usable public IP" raise instead of treating a non-address as one. Skipping is never silent: with nothing usable left the call still raises.
- `repo_tests/mypy_pin_parity_test.py` (new) — every lint-tool version pinned in both `code-quality.yml` and `.pre-commit-config.yaml` must agree (black, isort, flake8, autoflake, mypy, bandit), and every mypy hook must be handed the same stub list CI installs. Guards against a bump landing in one file only. Fails when either enumeration comes back empty, and asserts `mypy` specifically is among the tools compared so it can never quietly drop out of the sweep.
- `.github/workflows/code-quality.yml` — comment at the pin recording the measurement above, naming the parity test, and warning that widening the install list will surface more errors at once.
- Tests for each of the three fixes, listed under Verification.

## Verification

Every claim below was run against the final head of this branch (`2d251a2`).

**Static — mypy, final head, five environments**

| Environment | 1.16.0 | 2.1.0 | 2.3.0 |
|---|---|---|---|
| CI-exact stub list | `Success: no issues found in 172 source files` | `Success` | — |
| real `redis` + `sqlalchemy`, no `types-redis` | `Success` | `Success` | `Success` |

Before the fix, the same three columns in the second row reported 6, 6 and 7 errors.

**Unit — `137 passed`** across `autobot_shared/url_safety_test.py`, `autobot_shared/user_management/organization_service_test.py`, `autobot_shared/rate_limiter_score_coercion_15134_test.py`, `autobot_shared/rate_limiter_test.py` and `repo_tests/mypy_pin_parity_test.py`.

New tests and their shards (12-way, `repo_tests/stable_shard.py`):

| Test file | Shard |
|---|---|
| `autobot_shared/url_safety_test.py` (2 added) | 12 |
| `autobot_shared/user_management/organization_service_test.py` (2 added) | 7 |
| `autobot_shared/rate_limiter_score_coercion_15134_test.py` (new, 4 tests) | 11 |
| `repo_tests/mypy_pin_parity_test.py` (new, 9 tests) | 7 |

`rate_limiter_test.py` sits exactly on its recorded 618-line ceiling, which the ratchet enforces in both directions, so the score-coercion tests could not be appended there and live in their own module. That is stated in the new file's docstring.

**Contrast mutations — five, each against this final head**

| Mutation | Observed failure |
|---|---|
| Revert the `isinstance` narrowing in `url_safety` | `E   AttributeError: 'int' object has no attribute 'split'` (2 failed, 64 deselected) |
| Revert both `float(...)` coercions in `rate_limiter` | `E   assert 0 == 50` with `rate_limiter: get_retry_after failed ...: unsupported operand type(s) for -: 'float' and 'str'` (3 failed, 1 passed) |
| Stringify the tracked `max_users` values | `E   AssertionError: assert {'old': '10', 'new': '25'} == {'old': 10, 'new': 25}` |
| Bump the mypy pin in `code-quality.yml` only | `E   AssertionError: mypy is pinned to 2.1.0 in code-quality.yml but 1.16.0 in .pre-commit-config.yaml. Bump both, or neither.` |
| Drop `types-redis` from the pre-commit hook only | `E   AssertionError: mypy hook #0 installs [...] while code-quality.yml installs [...]` / `Extra items in the right set: 'types-redis'` |

**Forensic** — the `await` `[misc]` claim was tested by reading `get_async_redis_client`'s annotation (`-> async_redis.Redis | None`, correctly async) and by running all three checkers in all environments; it never appears. The `dict-item` group was tested for version-dependence by running 1.16.0 and 2.1.0 side by side with the dependencies installed: both report all four, which is what rules out "2.x introduced them".

## Risks

- Not reproducing the issue's `await` errors means the reporter had a sixth environment I did not reconstruct. If one turns up, the fix is still not the override — it is to find what makes `redis.asyncio` resolve to the sync client there.
- `url_safety` now skips a `sockaddr` whose first element is not a string. Every address family this call can return (it asks for `SOCK_STREAM`) gives a string, so no live resolution changes behaviour; a host that somehow yields only non-string sockaddrs now raises "no usable public IP" instead of `AttributeError`, which is the better of the two.
- The parity test will fail any dependabot bump that touches only one of the two files. That is the intent, and the failure names both versions.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #15134

## Changelog fragment
- [x] N/A — internal typing and CI-guard change, no user-visible behaviour.

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated
- [x] Documentation updated if behavior changed — comment recorded at the pin
- [x] Pre-commit hooks pass
- [x] PR targets `Dev_new_gui`
- [x] No secrets or credentials in the diff
