### PR TITLE
fix: exact path match for KNOWN_LARGE in pre-commit hook (closes #13162)

### DIFF
--- a/scripts/check_python_file_size.py
+++ b/scripts/check_python_file_size.py
@@ -30,7 +30,8 @@ def main() -> int:
         p = pathlib.Path(arg)
         # Normalise to forward-slash relative path for set lookup
         rel = str(p).replace("\\", "/")
-        if any(rel.endswith(known.replace("\\", "/")) for known in KNOWN_LARGE):
+        norm_known = {k.replace("\\", "/") for k in KNOWN_LARGE}
+        if rel in norm_known:
             continue
         try:
             line_count = sum(1 for _ in p.open(encoding="utf-8"))


### PR DESCRIPTION
## What
The pre-commit hook used endswith to check if a file is in KNOWN_LARGE, which could cause false positives (e.g., a file named 'my_orchestrator.py' would be incorrectly skipped). This could allow large files with failing tests to bypass the size check.

## Fix
Change the check to use exact path matching on the normalized relative path. This ensures only the exact grandfathered files are excluded.

Closes #13162