### PR TITLE
fix(test): enumerate both python_files halves so the 878 test_*.py files are checked (#15018)

### DIFF
--- a/repo_tests/collection_coverage_test.py
+++ b/repo_tests/collection_coverage_test.py
@@ -25,14 +25,40 @@ directory that nothing runs fails here instead of going unnoticed.
 
 The allowlist records the status quo as measured; a reason string is not an
 endorsement, and several entries are worth revisiting.
+
+#15018: for its whole life this module enumerated with
+``git ls-files "*_test.py" "test_*.py"`` and the second pathspec matched
+**nothing**. A bare git pathspec carries no ``:(glob)`` magic, so it is anchored
+at the start of the path: ``test_*.py`` matches only a file of that name sitting
+at the repository root, and there are none. ``pytest.ini`` declares
+``python_files = test_*.py *_test.py``, so the guard built to prove that every
+test file is accounted for had never seen 878 of the 2045 files pytest itself
+would collect -- including every suite this module's own docstring cites. The
+one floor that existed asserted the *combined* list was non-empty, which
+``*_test.py`` alone satisfied comfortably; a per-half floor is the assertion
+that would have caught it, and is now here.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
+
+
+#: Git variables a hook exports into its child processes. With ``GIT_DIR`` set
+#: and no ``GIT_WORK_TREE``, git treats the *current directory* as the work
+#: tree, so ``rev-parse --show-toplevel`` answers `repo_tests/` rather than the
+#: repository root and every path derived from it is wrong. The pre-push hook
+#: runs this module, so that is a real environment here, not a hypothetical.
+_AMBIENT_GIT_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE")
+
+
+def _git_env() -> dict[str, str]:
+    """The environment minus whatever git state a calling hook exported."""
+    return {k: v for k, v in os.environ.items() if k not in _AMBIENT_GIT_VARS}
 
 
 def project_root() -> Path:
@@ -55,13 +81,15 @@ def project_root() -> Path:
         capture_output=True,
         text=True,
         cwd=str(Path(__file__).resolve().parent),
+        env=_git_env(),
         check=False,
     )
     if out.returncode != 0:
         pytest.skip("not a git checkout — these checks enumerate tracked files")
     return Path(out.stdout.strip())
 
-#: Directories collected by ci.yml's backend pytest invocation.
+
+#: Top-level directories collected by ci.yml's backend pytest invocation.
 BACKEND_RUN = {
     "autobot-backend",
     "autobot_shared",
@@ -69,11 +97,39 @@ BACKEND_RUN = {
     "repo_tests",
     "tools",
     "scripts",
+    # #13880 put this on ci.yml's backend invocation and on pytest.ini's
+    # testpaths. It was still recorded below as "run by
+    # unwired-tracker-audit.yml, not the main suite" -- a reason string that
+    # had stopped being true. Corrected here rather than left to read as an
+    # exclusion (#15018).
+    "pipeline-scripts",
 }
 
 #: Collected by the separate slm-backend invocation (#13084 keeps them apart:
 #: both backends define identically-named top-level packages).
 SLM_RUN = {"autobot-slm-backend"}
+
+#: Path prefix -> the runner collecting it, for trees collected by a path
+#: NARROWER than their top-level directory. ci.yml's backend invocation and
+#: pytest.ini's testpaths name these exact paths and nothing above them, so a
+#: top-level lookup cannot express them (#14884, #14986). Checked before
+#: ``INTENTIONALLY_UNCOLLECTED``: ``autobot-infrastructure`` legitimately
+#: appears in both, the hooks subtree collected and the rest not.
+NARROWLY_COLLECTED = {
+    ".claude/skills/claims-audit": (
+        "backend-run: named explicitly in ci.yml and pytest.ini's testpaths "
+        "(#14986); `.claude/` as a whole is harness territory and does not collect"
+    ),
+    "autobot-infrastructure/shared/scripts/hooks": (
+        "backend-run: named explicitly in ci.yml and pytest.ini's testpaths "
+        "(#14884); autobot-infrastructure as a whole does not collect"
+    ),
+    "libs": (
+        "marker-tests.yml, the 'marked tests -- infrastructure and libs' step "
+        "(#13543); the suite is marker-selected, so ci.yml's invocations, which "
+        "deselect every marker, would collect it and run nothing"
+    ),
+}
 
 #: Path prefix -> why nothing collects it. Reasons, not endorsements.
 INTENTIONALLY_UNCOLLECTED = {
@@ -81,31 +137,86 @@ INTENTIONALLY_UNCOLLECTED = {
         "not in either ci.yml invocation; pytest.ini only --ignore's its resources/ "
         "subdirectory (Windows-only, PySide6), so the other suites are simply uncollected"
     ),
-    "pipeline-scripts": "run by unwired-tracker-audit.yml, not the main suite",
     "autobot-infrastructure": "conftest imports unified_config_manager, which no longer resolves",
     "plugins": "optional plugin tools; deps not installed by the CI requirements",
     "autobot-frontend": "Python helper beside the Vue app; not part of either backend suite",
 }
 
+#: Minimum tracked files each half of ``python_files`` must match. The floor
+#: that existed before #15018 was on the COMBINED list, which ``*_test.py``
+#: alone kept non-empty while ``test_*.py`` matched zero for months. Only a
+#: per-half floor can see that. Measured on Dev_new_gui: ``test_*.py`` -> 878,
+#: ``*_test.py`` -> 1174; recorded ~10% under so that ordinary consolidation
+#: does not trip the guard. Raise these as the tree grows. NEVER lower one to
+#: make this pass -- a half whose count collapsed is a broken pathspec, which
+#: is the entire defect this records.
+PATTERN_FLOORS = {"test_*.py": 790, "*_test.py": 1050}
+
+
+def _python_files_patterns() -> list[str]:
+    """The ``python_files`` patterns, read from pytest.ini rather than repeated.
+
+    pytest collects by these and this guard must enumerate by exactly the same
+    set, or the two drift apart silently -- which is how #15018 happened.
+    """
+    ini = (project_root() / "pytest.ini").read_text(encoding="utf-8")
+    patterns: list[str] = []
+    for line in ini.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("python_files"):
+            patterns = stripped.partition("=")[2].split()
+            break
+
+    assert patterns, (
+        "pytest.ini declares no `python_files` patterns, so this guard has "
+        "nothing to enumerate by and must not report a clean tree"
+    )
+    return patterns
+
+
+def _tracked_test_files_by_pattern() -> dict[str, list[str]]:
+    """Tracked files matching each ``python_files`` half, kept separate.
+
+    ``:(glob)`` magic is load-bearing. Without it a pathspec is anchored at the
+    start of the path and ``test_*.py`` matches only the repository root. With
+    it, a leading ``**/`` matches zero directories too, so the same pathspec
+    still covers root-level files -- which
+    ``test_no_test_file_sits_at_the_repository_root`` depends on. The anchored
+    form is listed alongside it so that dependence is written down rather than
+    assumed.
+    """
+    root = str(project_root())
+    matched: dict[str, list[str]] = {}
+    for pattern in _python_files_patterns():
+        out = subprocess.run(
+            ["git", "ls-files", f":(glob){pattern}", f":(glob)**/{pattern}"],
+            capture_output=True,
+            text=True,
+            cwd=root,
+            env=_git_env(),
+            check=False,
+        )
+        matched[pattern] = sorted({line for line in out.stdout.splitlines() if line})
+    return matched
+
 
 def _tracked_test_files() -> list[str]:
-    out = subprocess.run(
-        ["git", "ls-files", "*_test.py", "test_*.py"],
-        capture_output=True,
-        text=True,
-        cwd=str(project_root()),
-        check=False,
-    )
-    return [line for line in out.stdout.split() if line]
+    matched = _tracked_test_files_by_pattern()
+    return sorted({path for paths in matched.values() for path in paths})
 
 
 def _classify(path: str) -> str | None:
     """Return the runner accounting for *path*, or None if unaccounted."""
+    for prefix, runner in NARROWLY_COLLECTED.items():
+        if path.startswith(f"{prefix}/"):
+            return runner
+
     top = Path(path).parts[0]
     if top in BACKEND_RUN:
         return "backend-run"
     if top in SLM_RUN:
         return "slm-run"
+
     for prefix, reason in INTENTIONALLY_UNCOLLECTED.items():
         if path.startswith(f"{prefix}/"):
             return f"excluded: {reason}"
@@ -141,18 +252,74 @@ def test_no_test_file_sits_at_the_repository_root() -> None:
 
 
 def test_allowlist_has_no_stale_entries() -> None:
-    """An allowlist prefix that matches nothing is dead weight."""
+    """A recorded prefix that matches nothing is dead weight.
+
+    Covers both prefix maps: a ``NARROWLY_COLLECTED`` entry naming a tree that
+    no longer holds tests is the same dead weight as a stale exclusion, and it
+    is the more dangerous of the two -- it would keep accounting for a renamed
+    tree that had stopped being collected.
+    """
     files = _tracked_test_files()
 
     stale = sorted(
-        prefix
-        for prefix in INTENTIONALLY_UNCOLLECTED
+        f"{name}[{prefix}]"
+        for name, mapping in (
+            ("INTENTIONALLY_UNCOLLECTED", INTENTIONALLY_UNCOLLECTED),
+            ("NARROWLY_COLLECTED", NARROWLY_COLLECTED),
+        )
+        for prefix in mapping
         if not any(p.startswith(f"{prefix}/") for p in files)
     )
 
     assert not stale, (
-        "INTENTIONALLY_UNCOLLECTED entries match no test file and should be "
-        f"removed: {stale}"
+        f"these recorded prefixes match no test file and should be removed: {stale}"
+    )
+
+
+def test_every_python_files_half_is_recorded_with_a_floor() -> None:
+    """``PATTERN_FLOORS`` must name exactly what pytest.ini collects by.
+
+    Adding a third pattern to ``python_files`` without a floor here would leave
+    that half unfloored -- free to silently match zero, which is #15018 again.
+    An empty pattern list fails here too, so the enumeration can never be
+    vacuous.
+    """
+    patterns = set(_python_files_patterns())
+
+    assert patterns == set(PATTERN_FLOORS), (
+        "pytest.ini's `python_files` and PATTERN_FLOORS disagree. Every half "
+        "pytest collects by needs a recorded floor, or it can match zero "
+        f"unnoticed: pytest.ini={sorted(patterns)} floors={sorted(PATTERN_FLOORS)}"
+    )
+
+
+def test_every_python_files_half_matches_at_depth() -> None:
+    """Each half separately must match, and match a non-trivial number.
+
+    The pre-#15018 floor asserted only that the COMBINED list was non-empty, so
+    ``*_test.py`` alone kept it green while ``test_*.py`` matched zero. A
+    combined total hides exactly this bug.
+    """
+    matched = _tracked_test_files_by_pattern()
+    assert matched, "no `python_files` patterns were enumerated at all"
+
+    empty = sorted(pattern for pattern, files in matched.items() if not files)
+    assert not empty, (
+        "these `python_files` patterns matched NO tracked file. A bare git "
+        "pathspec carries no `:(glob)` magic and is anchored at the start of "
+        "the path, so a leading-literal pattern matches only at the repository "
+        f"root (#15018): {empty}"
+    )
+
+    below = sorted(
+        f"{pattern}: {len(files)} < {PATTERN_FLOORS[pattern]}"
+        for pattern, files in matched.items()
+        if len(files) < PATTERN_FLOORS[pattern]
+    )
+    assert not below, (
+        "a `python_files` half matched far fewer files than recorded. Either "
+        "the pathspec is broken, or the floor is stale -- check the pathspec "
+        "first, and never lower a floor to make this pass:\n  " + "\n  ".join(below)
     )
 
 


### PR DESCRIPTION
## Thinking Path

`repo_tests/collection_coverage_test.py` exists to prove that every tracked test file is
accounted for by some runner. It enumerated with
`git ls-files "*_test.py" "test_*.py"`.

A bare git pathspec carries no `:(glob)` magic and is anchored at the start of the path, so
`test_*.py` matches only a file of that name at the repository root — and there are none.
Measured on the base commit:

```
$ git ls-files "*_test.py" | wc -l
1174
$ git ls-files "test_*.py" | wc -l
0
$ git ls-files ':(glob)**/test_*.py' | wc -l
878
```

`pytest.ini` declares `python_files = test_*.py *_test.py`, so 878 of the 2045 files pytest
itself collects had never been seen by this guard — including every suite its own docstring
cites as the reason it exists.

The one floor that existed asserted the *combined* list was non-empty, which `*_test.py`
alone satisfied comfortably. That is why a pathspec matching zero read as a clean tree for
the whole life of the module. A combined total cannot see this defect; a per-half floor can.

Two questions had to be settled against the tree rather than the issue text, and the tree
won both:

- The issue reports `libs/autobot-sdk-python/tests` as collected by nothing. It is not:
  `marker-tests.yml`'s *"Run marked tests — infrastructure and libs"* step runs
  `pytest autobot-infrastructure/shared/tests libs` (#13543). It is marker-selected, so
  ci.yml — which deselects every marker — would collect it and run nothing. Recorded as
  collected by that named runner.
- The corrected enumeration surfaces **6** unaccounted files, not a large population: the
  five under `.claude/skills/claims-audit` (landed on ci.yml and `pytest.ini` testpaths via
  #14986) and the one under `libs`. Both are genuinely collected today, so no ratchet
  baseline is needed and none was added — recording a population as tolerated would have
  been the wrong shape for a population that is already zero.

## What Changed

`repo_tests/collection_coverage_test.py` only.

- `_python_files_patterns()` reads `python_files` from `pytest.ini`. The guard no longer
  writes the patterns out a second time, so it cannot drift from what pytest collects by —
  which is how this bug happened.
- `_tracked_test_files_by_pattern()` enumerates each half separately with
  `:(glob)<pattern>` and `:(glob)**/<pattern>`. `_tracked_test_files()` is the sorted union
  (2045 files; the two halves overlap on 7).
- `PATTERN_FLOORS` records a per-half floor, and
  `test_every_python_files_half_matches_at_depth` fails when a half matches zero — naming
  the anchored-pathspec cause — or falls below its floor. Floors are ~10% under the measured
  counts so ordinary consolidation does not trip them; they go up, never down.
- `test_every_python_files_half_is_recorded_with_a_floor` requires `PATTERN_FLOORS` to equal
  `pytest.ini`'s patterns exactly, so a third pattern cannot be added unfloored, and an empty
  pattern list fails rather than reading as a clean tree.
- `NARROWLY_COLLECTED` records trees collected by a path *narrower* than their top-level
  directory, which a top-level lookup cannot express: `.claude/skills/claims-audit` and
  `autobot-infrastructure/shared/scripts/hooks` (both named explicitly in ci.yml and
  `testpaths`), and `libs` (marker-tests.yml). Checked before `INTENTIONALLY_UNCOLLECTED`,
  because `autobot-infrastructure` legitimately appears in both — the hooks subtree collects,
  the other 56 files do not.
- `pipeline-scripts` moves from `INTENTIONALLY_UNCOLLECTED` into `BACKEND_RUN`. #13880 put it
  on ci.yml's invocation and on `testpaths`; its recorded reason ("run by
  unwired-tracker-audit.yml, not the main suite") had stopped being true. Correcting it is not
  cosmetic — the corrected enumeration surfaces a `test_*.py` file in that tree, and leaving a
  false reason string is the failure mode this module exists to end.
- `test_allowlist_has_no_stale_entries` now covers `NARROWLY_COLLECTED` too. A stale
  *collected* prefix is the more dangerous of the two: it would keep accounting for a renamed
  tree that had stopped being collected.
- `project_root()` scrubs `GIT_DIR`/`GIT_WORK_TREE`/`GIT_COMMON_DIR`/`GIT_INDEX_FILE` before
  `rev-parse`. A git hook exports `GIT_DIR` into its children, and with it set (and no
  `GIT_WORK_TREE`) git calls the *current directory* the work tree, so `--show-toplevel`
  answered `repo_tests/` under the pre-push hook. The pre-push run caught this: reading
  `pytest.ini` from that root raised `FileNotFoundError`. The same perturbation was already
  latent — every path this module derives was wrong in that environment — it just had nothing
  that failed on it.

## Verification

Counts, re-measured on this branch — these differ from the issue's (1123/0/869); the tree has
moved and the base wins:

```
$ git ls-files "test_*.py" | wc -l
0
$ git ls-files ':(glob)test_*.py' ':(glob)**/test_*.py' | sort -u | wc -l
878
$ git ls-files ':(glob)*_test.py' ':(glob)**/*_test.py' | sort -u | wc -l
1174
$ union: 2045   overlap: 7
```

Unaccounted files under the corrected enumeration, before this change's classifier updates: 6
— the five `.claude/skills/claims-audit` files and `libs/autobot-sdk-python/tests/test_integration.py`.
After: 0.

**`**/` matches zero directories**, so one pathspec covers root-level files too — which
`test_no_test_file_sits_at_the_repository_root` depends on. Verified in a throwaway repo
rather than assumed:

```
$ git ls-files ':(glob)**/test_*.py'
a/b/test_deep.py
a/test_mid.py
test_root.py
```

The anchored `:(glob)<pattern>` form is listed alongside it so that dependence is written down.

**Contrast mutation** — the broken bare pathspec restored
(`["git", "ls-files", pattern]`), 2 of 13 red:

```
AssertionError: these `python_files` patterns matched NO tracked file. A bare git pathspec
carries no `:(glob)` magic and is anchored at the start of the path, so a leading-literal
pattern matches only at the repository root (#15018): ['test_*.py']

AssertionError: these recorded prefixes match no test file and should be removed:
['NARROWLY_COLLECTED[.claude/skills/claims-audit]', 'NARROWLY_COLLECTED[libs]']
```

Reverted; the file was byte-identical to the pre-mutation snapshot afterwards (md5 checked).

**Vacuity probe A** — enumeration forced to `[]`, 3 of 13 red, including
`AssertionError: these `python_files` patterns matched NO tracked file [...] ['*_test.py', 'test_*.py']`.
Reverted, md5 checked.

**Vacuity probe B** — `pytest.ini`'s `python_files` line made unfindable so the pattern list is
empty: **5 of 13 red**, every enumeration-dependent test. The guard cannot pass by finding
nothing at either level. Reverted, md5 checked.

**Hook-environment regression** — `GIT_DIR=... pytest collection_coverage_test.py` from inside
`repo_tests/`: 13 passed (it was this that failed the first push).

Suite: `pytest repo_tests/collection_coverage_test.py` → **13 passed**.
`pytest repo_tests -m "not integration and not slow and not distributed and not performance"`
→ **606 passed, 11 skipped, 1 failed**. The failure is
`repo_tests/pip_ignore_scope_test.py::test_include_resolution_finds_the_known_chains`,
`ModuleNotFoundError: No module named 'tomllib'` — unrelated, and a local-interpreter artefact
(see below).

`ruff format --check` clean; `mypy` clean. `ruff check` reports 2 pre-existing `F541` in this
file (lines 233, 254 region) that are present on the base commit unchanged — left alone.

**Not verified locally.** This interpreter is python 3.10 and sits below 90 of the repo's 206
declared dependency floors, which the suite prints on every run. A local pass here carries less
information than CI, which installs the declared set on 3.14. The guard itself only shells out
to git and reads `pytest.ini`, so it is about as environment-independent as a check in this
repo gets — but the statement that it passes *in CI* rests on this PR's checks, not on the runs
above.

## Model Used

Claude Opus 5 (1M context)

Closes #15018
