### PR TITLE
fix(ci): make autobot-infrastructure/shared/tests collect, and floor every named root (#15161)

### DIFF
--- a/.github/workflows/marker-tests.yml
+++ b/.github/workflows/marker-tests.yml
@@ -339,6 +339,23 @@ jobs:
             --min-passed slm=0 \
             --min-passed infra=10
 
+      # The floor above is judged per INVOCATION, and an invocation names
+      # several roots, so it is cleared by whichever root still works. With
+      # `autobot-infrastructure/shared/tests` collecting nothing,
+      # `--min-collected 1` and `--min-passed infra=10` are both satisfied by
+      # `libs` alone and the infra report is green over a root contributing zero
+      # — measured, not assumed (#15161).
+      #
+      # This step asks the one question that floor cannot: does pytest reach ANY
+      # test under each named root? Collection, not selection — `-m "integration
+      # or slow or ..."` legitimately matches nothing under `tools` or
+      # `scripts`, but a root that collects nothing at all is never legitimate.
+      # Roots are derived from this file, so a root added above is checked the
+      # moment it is added and none is listed twice.
+      - name: Every named pytest root must collect something
+        if: ${{ !cancelled() }}
+        run: python pipeline-scripts/pytest_root_collection_floor.py
+
       - name: Upload marker reports
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7

--- a/autobot-infrastructure/shared/tests/conftest.py
+++ b/autobot-infrastructure/shared/tests/conftest.py
@@ -13,11 +13,36 @@ from typing import Any, Dict
 
 import pytest
 
-# Add project root and user backend to path
+# `autobot-user-backend/` was renamed to `autobot-backend/` wholesale by
+# 00ae80e10c (role-based repo restructuring, #926) — every path under it moved
+# R100 — but this shim kept pointing at the old name, so it added a directory
+# that does not exist and supplied nothing (#15161).
+#
+# What that cost depended entirely on how pytest was invoked, which is why it
+# survived so long:
+#
+#   * `pytest autobot-infrastructure/shared/tests` — rootdir is THIS directory,
+#     so the repo-root pytest.ini is not read, nothing puts `config` on the path,
+#     and the import below aborted collection of the whole tree with
+#     `ImportError: cannot import name 'unified_config_manager' from 'config'`.
+#   * `pytest autobot-infrastructure/shared/tests libs` — what marker-tests.yml
+#     runs. rootdir is the repository root, whose pytest.ini carries
+#     `pythonpath = . autobot-backend ...`, so `config` resolved anyway and the
+#     shim's failure was invisible.
+#
+# Repointing it makes this tree collect on its own terms instead of borrowing a
+# path entry from whichever rootdir the caller happened to select. Appended, not
+# inserted at position 0, so it cannot shadow a repo-root package for the other
+# roots sharing the same pytest session: `autobot-backend/config` is a regular
+# package and the repository root's `config/` is a namespace package, so the
+# regular one wins regardless of order.
 project_root = Path(__file__).parent.parent.parent.parent
-sys.path.insert(0, str(project_root / "autobot-user-backend"))
+_backend_path = str(project_root / "autobot-backend")
+if _backend_path not in sys.path:
+    sys.path.append(_backend_path)
 
-# Import configuration manager
+# Canonical config manager: autobot-backend/config/__init__.py resolves the
+# `unified_config_manager` attribute lazily onto config.manager.ConfigManager.
 from config import unified_config_manager
 
 
@@ -39,7 +64,9 @@ def config() -> Dict[str, Any]:
         "backend": unified_config_manager.get_backend_config(),
         "redis": unified_config_manager.get_redis_config(),
         "services": unified_config_manager.get_distributed_services_config(),
-        "chroma": unified_config_manager.get_chroma_config(),
+        # ConfigManager exposes no get_chroma_config(); the chroma settings are
+        # a config section like `system` below.
+        "chroma": unified_config_manager.get_config_section("chroma") or {},
         "system": unified_config_manager.get_config_section("system") or {},
     }
 

--- a/autobot-infrastructure/shared/tests/pytest.ini
+++ b/autobot-infrastructure/shared/tests/pytest.ini
@@ -22,6 +22,10 @@ markers =
     integration: Integration tests (require services)
     e2e: End-to-end tests (full system)
     slow: Slow-running tests
+    # Registered because `tests/performance/` exists under this rootdir and
+    # marker-tests.yml selects `performance`; without it any run rooted here
+    # fails on `--strict-markers` above (#15161).
+    performance: Performance and benchmark tests
     distributed: Tests requiring distributed VMs
     config: Configuration-related tests
     api: API endpoint tests

--- a/pipeline-scripts/pytest_root_collection_floor.py
+++ b/pipeline-scripts/pytest_root_collection_floor.py
@@ -167,7 +167,11 @@ def counts_by_root(collected: Iterable[str], roots: Sequence[str]) -> Dict[str, 
 
 
 def check(result: subprocess.CompletedProcess, roots: Sequence[str]) -> Dict[str, int]:
-    """Raise unless pytest collected cleanly and every root contributed an item."""
+    """Raise unless pytest started, reached tests, and every root contributed an item.
+
+    Deliberately NOT "collected cleanly": a collection error inside a root that still
+    yields tests is owned by the workflow's own pytest steps, per the module docstring.
+    """
     if not roots:
         raise CollectionFloorError(
             "no pytest root was derived from the workflow — this check would inspect "

--- a/pipeline-scripts/pytest_root_collection_floor.py
+++ b/pipeline-scripts/pytest_root_collection_floor.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""Every pytest root named in marker-tests.yml must collect something (#15161).
+
+`marker_suite_report.py` (#14930) answers "did the selection still match
+tests?" per *invocation*. That is one level too coarse: an invocation names
+several roots, and its floor is cleared by whichever root still works.
+
+#15161 came within one invocation shape of demonstrating it. The conftest of
+`autobot-infrastructure/shared/tests` imported `autobot-user-backend/`, a
+directory renamed away by 00ae80e10c, and aborted collection of the whole tree
+whenever pytest was rooted at it. In `marker-tests.yml` it survived only
+because that invocation also names `libs`, which moves rootdir to the
+repository root, whose pytest.ini happens to carry `autobot-backend` on
+`pythonpath`. Nothing about the infra floor was doing that work: with the tree
+collecting nothing, `--min-collected 1` and `--min-passed infra=10` are both
+cleared by `libs` alone and the report is green over a root contributing zero.
+
+This script closes that gap at the root level, and asks the weaker but
+un-fakeable question: **does pytest reach any test at all under this path?**
+
+* COLLECTION, not selection. `-m "integration or slow or distributed or
+  performance"` legitimately matches nothing under some roots (`tools`,
+  `scripts`), so a per-root *selection* floor would be false. A root that
+  collects zero items, by contrast, is never legitimate — it is either a
+  broken conftest or a path that no longer holds tests, and both are defects.
+* ONE pytest process over every root, so the run costs a single collection pass
+  and the node ids come back relative to the repository root.
+* The roots are DERIVED from the workflow, never listed here. A root added to
+  `marker-tests.yml` is checked the moment it is added; a root renamed at one
+  end breaks this instead of quietly narrowing what is checked.
+
+What it deliberately does NOT own: a collection *error* inside a root that
+still yields tests. Those already fail the workflow's own pytest steps, whose
+`|| [ $? -eq 5 ]` tolerates only "nothing collected" and nothing else. Folding
+them in here would give one condition two owners and two verdicts. The count
+this script reports is what pytest actually reached, so a root eroded by errors
+shows a falling number rather than a hidden one.
+
+Exit status is 0 only when pytest started, reached at least one test overall,
+and every named root contributed at least one item.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "marker-tests.yml"
+
+# A collect-only node id at verbosity < 0: `path/to/module.py::Class::test_x`.
+# Anchored on the `.py::` boundary so pytest's headers, warnings and error
+# blocks cannot be mistaken for collected items.
+_NODEID = re.compile(r"^(?P<path>[^\s]+\.py)::")
+
+
+# pytest's own exit status for "I could not start" — the one code that means
+# this check inspected nothing rather than inspecting a broken tree.
+PYTEST_USAGE_ERROR = 4
+
+
+class CollectionFloorError(RuntimeError):
+    """A root collected nothing, or pytest could not collect at all."""
+
+
+def command_tokens(run: str) -> List[str]:
+    """A shell `run:` block flattened to tokens, line continuations removed."""
+    return run.replace("\\\n", " ").split()
+
+
+def roots_in(tokens: Sequence[str], repo_root: Path) -> List[str]:
+    """The existing paths an invocation names as test roots.
+
+    A bare token that exists as a path and is not the value of the option before
+    it — `-n auto` and `--dist loadscope` name no path, but `-m pytest` would
+    read as one if the preceding option were ignored.
+    """
+    return [
+        token
+        for index, token in enumerate(tokens)
+        if not token.startswith("-")
+        and not (index and tokens[index - 1].startswith("-"))
+        and (repo_root / token).exists()
+    ]
+
+
+def workflow_roots(workflow: Path, repo_root: Path = REPO_ROOT) -> List[str]:
+    """Every root named by every pytest invocation in the workflow, deduplicated.
+
+    Parsed off the raw text rather than the YAML tree: this file only needs the
+    `python -m pytest ...` command lines, and reading them directly keeps the
+    script free of a YAML dependency in a step that runs before the test
+    requirements are necessarily installed.
+    """
+    text = workflow.read_text(encoding="utf-8")
+    seen: Dict[str, None] = {}
+    for block in re.findall(r"python -m pytest(?:.|\n)*?(?=\n\s*\n|\Z)", text):
+        tokens = command_tokens(block)
+        if tokens[:3] != ["python", "-m", "pytest"]:
+            continue
+        for root in roots_in(tokens[3:], repo_root):
+            seen.setdefault(root, None)
+    return list(seen)
+
+
+def collect(roots: Sequence[str], repo_root: Path = REPO_ROOT) -> subprocess.CompletedProcess:
+    """One `--collect-only` pass over every root, node ids on stdout.
+
+    `-q -q` is required, not cosmetic: pytest prints the *tree* form of
+    `--collect-only` at verbosity >= 0, and the repository's `addopts` already
+    carries `--verbose`, so a single `-q` only cancels it back to the tree.
+    Node ids appear only below zero.
+
+    `--continue-on-collection-errors` so the node ids of every root are emitted
+    even when one module fails to import. Without it pytest raises Interrupted
+    at the first error batch, and a root listed after the broken one would read
+    as empty for a reason that has nothing to do with that root.
+    """
+    return subprocess.run(  # nosec B603
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *roots,
+            "--collect-only",
+            "-q",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            "--continue-on-collection-errors",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def nodeids(stdout: str) -> List[str]:
+    """The collected node ids in pytest's `-q -q --collect-only` output."""
+    return [line.strip() for line in stdout.splitlines() if _NODEID.match(line.strip())]
+
+
+def counts_by_root(collected: Iterable[str], roots: Sequence[str]) -> Dict[str, int]:
+    """Node ids attributed to the longest root that prefixes them.
+
+    Longest-first because the roots overlap by construction:
+    `autobot-infrastructure/shared/scripts/hooks` lives under no other root
+    today, but `libs` and a future `libs/<pkg>` would, and the shorter root must
+    not absorb the longer one's items and hide that it collects nothing.
+    """
+    tally = {root: 0 for root in roots}
+    ordered = sorted(roots, key=len, reverse=True)
+    for nodeid in collected:
+        path = nodeid.split("::", 1)[0]
+        for root in ordered:
+            if path == root or path.startswith(f"{root}/"):
+                tally[root] += 1
+                break
+    return tally
+
+
+def check(result: subprocess.CompletedProcess, roots: Sequence[str]) -> Dict[str, int]:
+    """Raise unless pytest collected cleanly and every root contributed an item."""
+    if not roots:
+        raise CollectionFloorError(
+            "no pytest root was derived from the workflow — this check would inspect "
+            "nothing, which must never read as a pass"
+        )
+    if result.returncode == PYTEST_USAGE_ERROR:
+        raise CollectionFloorError(
+            "pytest could not start (usage error), so this check inspected nothing:\n"
+            + "\n".join((result.stdout + result.stderr).splitlines()[-25:])
+        )
+    collected = nodeids(result.stdout)
+    if not collected:
+        raise CollectionFloorError(
+            "pytest collected no test at all across every named root; an empty result must "
+            "never read as a clean one:\n" + "\n".join((result.stdout + result.stderr).splitlines()[-25:])
+        )
+    tally = counts_by_root(collected, roots)
+    empty = sorted(root for root, count in tally.items() if count == 0)
+    if empty:
+        raise CollectionFloorError(
+            "these roots are named by marker-tests.yml and collect NO tests, so the "
+            "invocation that names them reports on nothing while reading as clean "
+            "(#15161):\n  " + "\n  ".join(empty)
+        )
+    return tally
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        help="roots to check; default is every root named by the workflow (CI passes none)",
+    )
+    parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    args = parser.parse_args(argv)
+
+    roots = args.roots or workflow_roots(args.workflow)
+    print(f"Checking {len(roots)} pytest root(s) named by {args.workflow.name}:")
+    for root in roots:
+        print(f"  {root}")
+
+    try:
+        tally = check(collect(roots), roots)
+    except CollectionFloorError as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    width = max(len(root) for root in roots)
+    for root, count in tally.items():
+        print(f"  {root:<{width}}  {count:>6} collected")
+    print(f"OK: every named root collects at least one test ({sum(tally.values())} in total).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline-scripts/pytest_root_collection_floor_test.py
+++ b/pipeline-scripts/pytest_root_collection_floor_test.py
@@ -196,10 +196,9 @@ class TestTheGuardIsWired:
         return [step["run"] for step in job["steps"] if "run" in step]
 
     def test_the_workflow_runs_the_script(self, run_steps):
-        assert any(SCRIPT.name in run for run in run_steps), (
-            f"marker-tests.yml no longer runs {SCRIPT.name} — the per-root floor is "
-            "correct and guarding nothing"
-        )
+        assert any(
+            SCRIPT.name in run for run in run_steps
+        ), f"marker-tests.yml no longer runs {SCRIPT.name} — the per-root floor is correct and guarding nothing"
 
     def test_the_workflow_passes_it_no_root_list(self, run_steps):
         """Roots must stay derived. A hand-written list there would go stale silently."""

--- a/pipeline-scripts/pytest_root_collection_floor_test.py
+++ b/pipeline-scripts/pytest_root_collection_floor_test.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""The per-root collection floor must not be satisfiable by nothing (#15161).
+
+The defect it exists for was an *absence* reading as a presence:
+`autobot-infrastructure/shared/tests` was a declared CI root whose conftest
+raised ImportError, so it contributed zero tests while every report above it
+was green. A guard against that shape is worthless if it can itself inspect
+nothing and pass, so most of these cases feed it exactly that and assert it
+fails.
+
+Two halves, and both are needed:
+
+* **The logic.** Node-id extraction, longest-prefix attribution, and every
+  refusal in `check`.
+* **The wiring.** A guard that is correct and unreferenced guards nothing. The
+  last class asserts `marker-tests.yml` actually runs the script, and that it
+  runs it with no root list of its own — the roots must stay derived from the
+  workflow, or a root added there would go unchecked.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "marker-tests.yml"
+SCRIPT = Path(__file__).with_name("pytest_root_collection_floor.py")
+
+_MODULE_NAME = "pytest_root_collection_floor"
+
+
+def _load_script():
+    """Load the checker, leaving no ``sys.modules`` entry behind.
+
+    Same idiom as this directory's other guard tests — the repo-wide
+    sys.modules leak guard (#13337) fails a shard that strands a synthetic
+    entry, and a sibling import via ``sys.path`` would strand one.
+    """
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, SCRIPT)
+    assert spec is not None and spec.loader is not None, f"cannot build an import spec for {SCRIPT}"
+    module = importlib.util.module_from_spec(spec)
+
+    had_previous = _MODULE_NAME in sys.modules
+    previous = sys.modules.get(_MODULE_NAME)
+    sys.modules[_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        if had_previous:
+            sys.modules[_MODULE_NAME] = previous
+        else:
+            sys.modules.pop(_MODULE_NAME, None)
+    return module
+
+
+_floor = _load_script()
+CollectionFloorError = _floor.CollectionFloorError
+check = _floor.check
+counts_by_root = _floor.counts_by_root
+nodeids = _floor.nodeids
+roots_in = _floor.roots_in
+workflow_roots = _floor.workflow_roots
+
+
+def _result(stdout: str = "", returncode: int = 0, stderr: str = ""):
+    """A stand-in for the CompletedProcess `collect()` returns."""
+    return subprocess.CompletedProcess(args=["pytest"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+HEALTHY = (
+    "libs/autobot-sdk-python/tests/test_integration.py::test_a\n"
+    "autobot-infrastructure/shared/tests/distributed/test_db_initialization.py::TestX::test_b\n"
+)
+
+
+class TestNodeIdExtraction:
+    """Everything downstream is a count of these, so a miss here empties the check."""
+
+    def test_a_plain_node_id_is_read(self):
+        assert nodeids("pkg/test_a.py::test_x\n") == ["pkg/test_a.py::test_x"]
+
+    def test_a_class_qualified_node_id_is_read(self):
+        assert nodeids("pkg/test_a.py::TestX::test_y\n") == ["pkg/test_a.py::TestX::test_y"]
+
+    def test_the_summary_line_is_not_counted_as_a_test(self):
+        assert nodeids("2/2 tests collected in 0.12s\n") == []
+
+    def test_an_error_block_is_not_counted_as_a_test(self):
+        noise = "ERROR pkg/test_a.py - ImportError: cannot import name 'x'\n=== 1 error in 0.10s ===\n"
+        assert nodeids(noise) == []
+
+    def test_the_tree_form_is_not_mistaken_for_node_ids(self):
+        """Verbosity >= 0 prints `<Module ...>`; reading it as items would fake a pass."""
+        assert nodeids("<Module test_a.py>\n  <Function test_x>\n") == []
+
+
+class TestAttribution:
+    def test_items_land_on_the_root_that_contains_them(self):
+        tally = counts_by_root(nodeids(HEALTHY), ["libs", "autobot-infrastructure/shared/tests"])
+        assert tally == {"libs": 1, "autobot-infrastructure/shared/tests": 1}
+
+    def test_a_root_with_no_items_counts_zero_rather_than_vanishing(self):
+        assert counts_by_root(nodeids(HEALTHY), ["libs", "tools"])["tools"] == 0
+
+    def test_the_longest_matching_root_wins(self):
+        """A nested root must not have its items absorbed by its parent."""
+        collected = ["libs/sdk/tests/test_a.py::test_x"]
+        assert counts_by_root(collected, ["libs", "libs/sdk"]) == {"libs": 0, "libs/sdk": 1}
+
+    def test_a_sibling_prefix_does_not_match(self):
+        """`libs` must not claim `libs-extra/...` on a bare string prefix."""
+        assert counts_by_root(["libs-extra/test_a.py::test_x"], ["libs"]) == {"libs": 0}
+
+
+class TestTheCheckRefuses:
+    def test_a_root_that_collects_nothing_fails(self):
+        """The #15161 shape itself: a declared root contributing zero."""
+        with pytest.raises(CollectionFloorError, match="collect NO tests"):
+            check(_result(HEALTHY), ["libs", "autobot-infrastructure/shared/tests", "tools"])
+
+    def test_it_names_the_empty_root(self):
+        with pytest.raises(CollectionFloorError) as raised:
+            check(_result(HEALTHY), ["libs", "autobot-infrastructure/shared/tests", "tools"])
+        assert "tools" in str(raised.value)
+
+    def test_an_empty_root_list_fails_rather_than_passing_vacuously(self):
+        with pytest.raises(CollectionFloorError, match="inspect"):
+            check(_result(HEALTHY), [])
+
+    def test_a_pytest_that_could_not_start_fails(self):
+        with pytest.raises(CollectionFloorError, match="usage error"):
+            check(_result("", returncode=4, stderr="unrecognized arguments"), ["libs"])
+
+    def test_collecting_nothing_at_all_fails(self):
+        with pytest.raises(CollectionFloorError, match="no test at all"):
+            check(_result("no tests ran\n"), ["libs"])
+
+    def test_the_healthy_case_passes_and_reports_counts(self):
+        """Without this the class above would be satisfied by a check that always raises."""
+        assert check(_result(HEALTHY), ["libs", "autobot-infrastructure/shared/tests"]) == {
+            "libs": 1,
+            "autobot-infrastructure/shared/tests": 1,
+        }
+
+    def test_a_collection_error_alongside_real_items_is_not_this_check_s_failure(self):
+        """Owned by the workflow's own pytest steps; see the script's docstring."""
+        assert check(_result(HEALTHY, returncode=2), ["libs", "autobot-infrastructure/shared/tests"])
+
+
+class TestRootDerivation:
+    def test_an_option_value_is_not_read_as_a_root(self, tmp_path):
+        (tmp_path / "auto").mkdir()
+        assert roots_in(["-n", "auto", "repo_tests"], tmp_path) == []
+
+    def test_a_path_that_does_not_exist_is_not_read_as_a_root(self, tmp_path):
+        assert roots_in(["ghost_tree"], tmp_path) == []
+
+    def test_the_real_workflow_yields_its_roots(self):
+        derived = workflow_roots(WORKFLOW)
+        assert "autobot-infrastructure/shared/tests" in derived, (
+            "the root #15161 is about is no longer derived from marker-tests.yml, so the "
+            "floor would stop checking the very tree it was written for"
+        )
+        assert "autobot-backend" in derived
+
+    def test_the_derivation_agrees_with_an_independent_yaml_parse(self):
+        """The script reads the raw text; this reads the YAML. A regex that quietly
+        stopped matching an invocation would narrow the check without any failure."""
+        job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["marker-tests"]
+        expected: list[str] = []
+        for step in job["steps"]:
+            run = step.get("run", "")
+            tokens = run.replace("\\\n", " ").split()
+            if "pytest" not in tokens:
+                continue
+            start = tokens.index("pytest") + 1
+            for root in roots_in(tokens[start:], REPO_ROOT):
+                if root not in expected:
+                    expected.append(root)
+        assert expected, "this comparison parsed no invocation, so it compares nothing"
+        assert workflow_roots(WORKFLOW) == expected
+
+
+class TestTheGuardIsWired:
+    @pytest.fixture(scope="class")
+    def run_steps(self) -> list[str]:
+        job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["marker-tests"]
+        return [step["run"] for step in job["steps"] if "run" in step]
+
+    def test_the_workflow_runs_the_script(self, run_steps):
+        assert any(SCRIPT.name in run for run in run_steps), (
+            f"marker-tests.yml no longer runs {SCRIPT.name} — the per-root floor is "
+            "correct and guarding nothing"
+        )
+
+    def test_the_workflow_passes_it_no_root_list(self, run_steps):
+        """Roots must stay derived. A hand-written list there would go stale silently."""
+        for run in run_steps:
+            if SCRIPT.name not in run:
+                continue
+            tokens = run.replace("\\\n", " ").split()
+            after = tokens[tokens.index(next(t for t in tokens if t.endswith(SCRIPT.name))) + 1 :]
+            assert not [t for t in after if not t.startswith("-")], (
+                f"marker-tests.yml passes explicit roots to {SCRIPT.name}: {after}. "
+                "The roots must be derived from the workflow, not listed twice."
+            )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Thinking Path

**The issue is right about the bug and wrong about the blast radius. The base wins, so this is written from what the code does.**

`conftest.py:18` pointed `sys.path` at `autobot-user-backend/`. `git show 00ae80e10c --name-status -M` shows that directory was renamed to `autobot-backend/` wholesale by the role-based restructuring (#926) — `R100` on every path under it, `config/__init__.py` included. So this is a **moved module, not debris**: the import is repointed, nothing is deleted, and no fixture is removed.

What the shim actually cost depends on how pytest is invoked, which is why it survived:

| invocation | rootdir | result on base |
|---|---|---|
| `pytest autobot-infrastructure/shared/tests` | *that tree* — repo-root `pytest.ini` never read | **exit 4, 0 collected**, `ImportError: cannot import name 'unified_config_manager' from 'config'` |
| `pytest autobot-infrastructure/shared/tests libs` — **what `marker-tests.yml:294` runs** | repository root | **exit 0, 33 collected** |

The repo-root `pytest.ini` carries `pythonpath = . autobot-backend ...`, and naming `libs` alongside moves rootdir up far enough to read it, so `config` resolved regardless of the broken shim. The issue's "Why it matters" paragraph — that `marker-tests.yml:294` "is therefore returning a conftest ImportError ... and has been for as long as the conftest has been broken" — **is not what the base does.** Measured, both shapes, before and after, below.

That does not make the conftest fine. It made the tree collectable only by accident of a sibling argument, and it hid a second break behind the first: `ConfigManager` has no `get_chroma_config()`, so the `config` fixture would have raised `AttributeError` the first time anything used it. Both are fixed.

The guard (AC5) is therefore justified on the *class*, not on a claim I could not reproduce: `marker_suite_report.py`'s floors are per **invocation**, and an invocation names several roots. With this tree contributing zero, `libs` alone clears `--min-collected 1` and `--min-passed infra=10`. That is measured under Verification, not asserted.

## What Changed

| File | Change |
|---|---|
| `autobot-infrastructure/shared/tests/conftest.py` | `sys.path` repointed `autobot-user-backend` → `autobot-backend`; appended rather than `insert(0, …)` so it cannot shadow a repo-root package for sibling roots in the same session (safe: `autobot-backend/config` is a regular package, the repo root's `config/` a namespace package, and a regular package wins regardless of order). `get_chroma_config()` → `get_config_section("chroma") or {}`, matching the `system` entry beside it. |
| `autobot-infrastructure/shared/tests/pytest.ini` | `performance` registered — `tests/performance/` lives under this rootdir and `--strict-markers` is on. |
| `pipeline-scripts/pytest_root_collection_floor.py` | **new.** One `--collect-only` pass over every root **derived** from `marker-tests.yml`, then a per-root non-zero floor. Collection, not selection: `-m "integration or slow or …"` legitimately matches nothing under `tools` or `scripts`, but a root collecting nothing at all never is. |
| `pipeline-scripts/pytest_root_collection_floor_test.py` | **new.** 22 tests: node-id extraction, longest-prefix attribution, every refusal in `check`, and the wiring (the workflow runs it, and passes it **no** root list, so the roots stay derived). |
| `.github/workflows/marker-tests.yml` | new step `Every named pytest root must collect something`, after `Report marker coverage`. |

Nothing was deleted. No test was removed, quarantined or skipped.

## Verification

Local Python is 3.10.12 and **90 of 206 declared dependency versions are below the floors CI installs** — the repo's own `check_dependency_floors` banner says so on every run. Treat these as reproductions of behaviour, not as a CI verdict. CI is authoritative.

**AC1 — collection count, `pytest --collect-only`, that directory specifically**

| shape | before | after |
|---|---|---|
| `pytest autobot-infrastructure/shared/tests --collect-only` | `ImportError while loading conftest` → **exit 4, 0 items** | **exit 0, 28 items** |
| `pytest autobot-infrastructure/shared/tests libs --collect-only` (the CI shape) | exit 0, 33 items | exit 0, 33 items |

"Before" was produced by restoring the committed base file over the working copy and re-running, not inferred.

**AC2/AC3** — `autobot-backend/` exists; `from config import unified_config_manager` resolves to `config.manager.ConfigManager` via `autobot-backend/config/__init__.py`'s lazy `__getattr__`. A throwaway probe test consuming `config`, `backend_url`, `redis_url` and `frontend_url` passes — it would have raised `AttributeError: get_chroma_config` on base. Probe removed; not committed.

**AC4** — `performance` registered in that tree's `pytest.ini`.

**AC5 — the new floor, run for real over all 12 derived roots: exit 0.**

```
autobot-backend 20590 · autobot_shared 1887 · autobot-tts-worker 36 · repo_tests 1511
tools 380 · scripts 266 · pipeline-scripts 501 · .../shared/scripts/hooks 159
.claude/skills/claims-audit 42 · .../shared/tests 28 · libs 5 · autobot-slm-backend 2505
OK: every named root collects at least one test (27910 in total).
```

Green on arrival — the new step is not red-on-merge.

**Contrast mutation 1 — the defect class the guard exists for.** Appended `collect_ignore_glob = ["*"]` to the tree's conftest, so it contributes zero inside the real CI-shaped invocation:

* `pytest .../shared/tests libs -m "<marker expr>"` → `3 passed, 2 skipped`, **exit 0**
* `marker_suite_report.py infra=… --min-collected 1 --min-passed 3` → **exit 0**, table reads `| infra | 5 | 3 | 3 | 0 | 0 | 2 |` — the existing per-invocation floor sees nothing wrong
* `pytest_root_collection_floor.py .../shared/tests libs` → **exit 1**

  ```
  FAIL: these roots are named by marker-tests.yml and collect NO tests, so the
  invocation that names them reports on nothing while reading as clean (#15161):
    autobot-infrastructure/shared/tests
  ```

Reverted; tree clean.

**Contrast mutation 2 — re-break the conftest.** `autobot-backend` → `autobot-user-backend`: `pytest .../shared/tests --collect-only` returns `ImportError: cannot import name 'unified_config_manager' from 'config' (unknown location)`, exit 4, 0 items. Reverted.

**Contrast mutation 3 — disarm the guard's own logic.** `empty = []` and first-match instead of longest-prefix attribution → 3 of the 22 tests go red:

```
FAILED …::TestAttribution::test_the_longest_matching_root_wins
        assert {'libs': 1, 'libs/sdk': 0} == {'libs': 0, 'libs/sdk': 1}
FAILED …::TestTheCheckRefuses::test_a_root_that_collects_nothing_fails
        Failed: DID NOT RAISE <class 'CollectionFloorError'>
FAILED …::TestTheCheckRefuses::test_it_names_the_empty_root
        Failed: DID NOT RAISE <class 'CollectionFloorError'>
```

Reverted; `22 passed`.

**Adjacent guards still green:** `pipeline-scripts/pytest_root_collection_floor_test.py` + `repo_tests/marker_suite_root_coverage_test.py` + `pipeline-scripts/marker_suite_report_test.py` → **70 passed**. `repo_tests/hook_suites_run_in_ci_test.py` (the four-workflow root-list agreement) → **6 passed**; the new step is not a pytest invocation, so it does not disturb that agreement.

**Can each of the 28 now-collected tests fail? Per test, not per count.**

*Selected by the marker run — the 8 that CI actually executes (all pass):*

| test | can it fail? |
|---|---|
| `distributed/test_db_initialization.py` ×6 (`pytestmark = integration`) | **Yes.** Real assertions against `ConversationFileManager` schema on a tmp sqlite path. No skip guard. |
| `integration/test_architecture_compliance.py::TestRedisConnection::test_redis_timeout_configuration` | **Yes.** Four real assertions on `PoolConfig` fields. |
| `integration/test_architecture_compliance.py::TestRedisConnection::test_redis_connectivity` | **No — vacuous.** Its body is `client.ping()` then `assert True`, with `pytest.skip` on `ConnectionError`/`socket.timeout`. With the Redis service `marker-tests.yml` provides it passes without asserting anything; without it, it skips. It is a green tile either way. Reported as a finding rather than changed here — it is outside this issue's ACs. |

*Collected but selected by no workflow* (this tree is not in the repo-root `pytest.ini` `testpaths`, and `ci.yml` never names it), so the count must not be read as coverage. Running them unmarkered gives `10 failed, 14 passed, 4 errors`:

* `test_architecture_compliance.py` — 13 unmarked tests, **7 fail** against distributed-VM config that is `None` on this host.
* `test_distributed_system_integration.py` — 3 tests carry `@pytest.mark.asyncio` **only**, so the marker run deselects them. They dial real services and take ~4.5 min to fail.
* `test_redis_db_ssot.py` — 4 tests, no markers, all **error** at fixture setup: `test_redis_db_ssot.py:20` builds the SSOT path as `parents[2] / "config" / "redis-databases.yaml"` — one level too high. The file is at `autobot-infrastructure/shared/config/redis-databases.yaml`, so `parents[1]` is correct. Same defect class as this issue, outside its ACs, left for separate filing.

These are live tests that genuinely go red — the opposite of vacuous — but they run nowhere, which is #14917 territory rather than this issue's.

**AC6 is NOT met, and cannot be met here.** It asserts the two #14979 files "were converted correctly and carry valid markers (`performance`, `distributed`)". On this base neither is true, and **#14979 is still open**:

* `performance/test_performance_optimization.py` — **collects 0 items.** Its five `test_*` methods hang off `class PerformanceOptimizationTester`, which does not match `python_classes = Test*`. It carries no `pytest.mark` at all. This is exactly #14979's own title ("90 `test_*` methods sit in live-service validation drivers pytest cannot collect").
* `integration/test_distributed_system_integration.py` — collects 3, carries `@pytest.mark.asyncio` only. Not `distributed`, so `-m "integration or slow or distributed or performance"` deselects it.

Converting them is #14979's scope, not this one's, so this PR does not claim it. Hence `Refs`, not `Closes`.

**Not verified:** anything about the GitHub-hosted runner. The new step's cost (one `--collect-only` pass, ~4 min locally over 27,910 items) and its behaviour under the CI dependency set are measured only on this host.

## Model Used

Claude Opus 5 (`claude-opus-5[1m]`), one agent, no delegation.

Refs #15161
