### PR TITLE
test(repo-guards): pin the with_error_handling scan as prefix-invariant, not .worktrees-only (#15140)

### DIFF
--- a/repo_tests/with_error_handling_single_definition_test.py
+++ b/repo_tests/with_error_handling_single_definition_test.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import List
+from typing import List, Set
+
+import pytest
 
 _REPO = Path(__file__).resolve().parents[1]
 _BACKEND = _REPO / "autobot-backend"
@@ -95,25 +97,35 @@ def test_the_scan_sees_the_tree_it_is_pointed_at():
     assert _CANONICAL_DEFINER in {path.resolve() for path in sources}
 
 
+def _write_fixture_tree(root: Path) -> Path:
+    """One canonical definer plus genuinely excluded files; returns the definer.
+
+    Same fixture shape as `scripts/check_ansible_file_references_test.py:40-45`
+    and `repo_tests/lint/canonical/test_context.py:76-78`.
+    """
+    (root / "utils" / "error_boundaries").mkdir(parents=True)
+    definer = root / "utils" / "error_boundaries" / "decorators.py"
+    definer.write_text(f"def {_TARGET_NAME}():\n    pass\n", encoding="utf-8")
+    for excluded in ("node_modules", "tests"):
+        (root / excluded).mkdir()
+        (root / excluded / "vendored.py").write_text("x = 1\n", encoding="utf-8")
+    return definer
+
+
+def _relative_scan(root: Path) -> Set[str]:
+    """`_production_sources` as repo-relative posix strings, so two trees compare."""
+    return {path.relative_to(root).as_posix() for path in _production_sources(root)}
+
+
 def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
     """#15121: the filter must key on parts relative to the scan root.
 
     The fixture reproduces the mandated layout exactly — the scan root itself
     sits under `.worktrees/<branch>/`. Matching a substring of the absolute path
-    skips every file here; matching relative parts finds the definer. Same
-    fixture shape as `scripts/check_ansible_file_references_test.py:40-45` and
-    `repo_tests/lint/canonical/test_context.py:76-78`.
+    skips every file here; matching relative parts finds the definer.
     """
     root = tmp_path / ".worktrees" / "issue-9999" / "autobot-backend"
-    (root / "utils" / "error_boundaries").mkdir(parents=True)
-    definer = root / "utils" / "error_boundaries" / "decorators.py"
-    definer.write_text(f"def {_TARGET_NAME}():\n    pass\n", encoding="utf-8")
-
-    # Genuinely excluded content, to prove the filter still filters.
-    (root / "node_modules").mkdir()
-    (root / "node_modules" / "vendored.py").write_text("x = 1\n", encoding="utf-8")
-    (root / "tests").mkdir()
-    (root / "tests" / "helper.py").write_text("y = 1\n", encoding="utf-8")
+    definer = _write_fixture_tree(root)
 
     scanned = _production_sources(root)
 
@@ -123,6 +135,32 @@ def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
     )
     assert {path.name for path in scanned} == {"decorators.py"}
     assert _defines_target(definer) == [1]
+
+
+@pytest.mark.parametrize("ancestor", sorted(_SKIP_PARTS))
+def test_an_excluded_name_above_the_scan_root_changes_nothing(tmp_path, ancestor):
+    """#15140: the filter must be prefix-invariant for *every* skipped name.
+
+    The test above pins `.worktrees` alone, so reintroducing the absolute form
+    for just one of the other names — `if "/tests/" in path.as_posix()` — keeps
+    this file green while emptying the tree for any checkout under a directory
+    of that name. Measured: that partial regression left the suite 5-green.
+    Comparing the same tree at two prefixes pins the invariant instead of one
+    case of it.
+    """
+    under = tmp_path / "under" / ancestor / "issue-9999" / "autobot-backend"
+    plain = tmp_path / "plain" / "checkout" / "autobot-backend"
+    _write_fixture_tree(under)
+    _write_fixture_tree(plain)
+
+    # Non-vacuity first: if the neutral tree scanned empty the comparison below
+    # would pass by finding nothing at either prefix.
+    assert _relative_scan(plain) == {"utils/error_boundaries/decorators.py"}
+    assert _relative_scan(under) == _relative_scan(plain), (
+        f"a scan root nested under a directory named {ancestor!r} enumerated a "
+        "different set than the same tree elsewhere — the exclusion is matching "
+        "the absolute path instead of parts relative to the root"
+    )
 
 
 def test_exactly_one_definition_exists_in_the_tracked_tree():


### PR DESCRIPTION
## Thinking Path

#15140 says `_production_sources()` filters on the absolute path, so `/.worktrees/` matches the
repo root itself in every worktree checkout and the scan enumerates nothing. I checked that claim
against the code before acting on it, and it is **no longer true**: it is the same root cause as
#15121, and #15121's fix (`0c0949d8c`, PR #15131) already closed it completely. #15140 was filed
at 15:52Z on 2026-08-26; #15131 merged at 18:27Z the same day. Same file, same line, same
mechanism — a duplicate that was fixed in flight, not a second path and not an incomplete fix.

Measured, current base, using the guard's own `_production_sources()`:

| Location | pre-#15121 absolute filter | current relative filter |
|---|---|---|
| main checkout | 2308 | 2308 |
| a checkout under `.worktrees/` | **0** | **2308** |

So all four acceptance criteria of #15140 are already met: the guard passes from a `.worktrees/`
checkout, it still excludes nested worktree/`node_modules`/`tests` content, the non-vacuity
assertion is retained, and `test_a_checkout_under_worktrees_is_still_scanned` pins the fix.

This is not the `git rev-parse --show-toplevel` / `GIT_DIR` mechanism tracked as #15176. This
guard runs no git command at all; its roots come from `Path(__file__).resolve()`, so nothing
here is sensitive to an exported `GIT_DIR`/`GIT_WORK_TREE`.

What is *not* fully done is criterion 3 — "a test pins the behaviour, so the absolute-path form
cannot come back". The existing pin covers `.worktrees` only. Reintroducing the absolute form
for any one of the other skipped names leaves the whole file green:

```
+   if "/tests/" in path.as_posix():
+       continue
    if any(part in _SKIP_PARTS for part in path.relative_to(root).parts):
=> 5 passed
```

That regression would empty the tree for any checkout under a directory named `tests`,
`node_modules`, `venv`, `.venv` or `__pycache__` — the identical failure mode the module comment
already warns about at line 39 but nothing enforced. That is the gap this PR closes.

## What Changed

`repo_tests/with_error_handling_single_definition_test.py` only:

- Extracted `_write_fixture_tree()` and `_relative_scan()` so both fixture tests build the same
  shape and can be compared as repo-relative path sets.
- Added `test_an_excluded_name_above_the_scan_root_changes_nothing`, parametrized over every name
  in `_SKIP_PARTS`: it builds the same tree twice — once under a directory of that name, once
  under a neutral prefix — and asserts the two enumerations are equal. It pins the *invariant*
  (the filter must not depend on the absolute prefix) rather than one instance of it.
- The comparison is guarded against passing by finding nothing: it first asserts the neutral tree
  enumerates exactly `utils/error_boundaries/decorators.py`, so two empty scans cannot compare
  equal and pass.
- No production code changed; no filter behaviour changed; no ratchet or baseline touched.

## Verification

Enumeration counts from both locations, before and after this diff — unchanged, because the
enumeration was already correct:

| Location | before | after |
|---|---|---|
| main checkout | 2308 | 2308 |
| worktree checkout | 2308 | 2308 |

Suite: 5 passed → **11 passed** (5 originals + 6 parametrized invariance cases).

**Contrast mutation** — reintroduced the pre-#15121 absolute filter in place of the relative one,
run from a `.worktrees/` checkout:

```
AssertionError: only 0 backend sources survived the exclusion filter — the filter is
eating the tree, so every assertion below is vacuous
assert 0 > 100
AssertionError: a scan rooted under .worktrees/ skipped its own tree — the exclusion is
matching the absolute path instead of parts relative to the root
AssertionError: with_error_handling vanished from its canonical module
3 failed, 2 passed
```

Reverted from a pristine copy and confirmed with `diff -q` (clean).

**Partial-regression mutation** — the `"/tests/" in path.as_posix()` form above. Before this
diff: `5 passed`. After this diff:

```
AssertionError: a scan root nested under a directory named 'tests' enumerated a different
set than the same tree elsewhere — the exclusion is matching the absolute path instead of
parts relative to the root
FAILED ...::test_an_excluded_name_above_the_scan_root_changes_nothing[tests]
1 failed, 10 passed
```

Reverted and confirmed with `diff -q` (clean).

**Vacuity probe** — forced `_production_sources()` to return `[]` unconditionally. The guard goes
red on its floor (`assert len(sources) > 100`, at
`with_error_handling_single_definition_test.py:92`) rather than reporting clean: `3 failed,
2 passed`. Reverted and confirmed clean. The floor pre-dates this diff; it is cited, not added.

**What I could not verify locally:** 90 of 206 declared dependency versions are unsatisfied by the
local interpreter (python 3.10.12), and the repo's own floor banner says a local pass carries no
information about CI. This guard imports nothing from those packages, but the authoritative signal
is the CI run on this PR. I did not run the full `repo_tests/` suite, only this file.

## Model Used

Claude Opus 5 (1M context)

Refs #15140

