### PR TITLE
feat(ci): name which of five conditions produced a red check (#15139)

### DIFF
--- a/.github/workflows/ci-dispatch-watchdog.yml
+++ b/.github/workflows/ci-dispatch-watchdog.yml
@@ -132,6 +132,53 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 pipeline-scripts/ci_dispatch_watchdog.py --check probe
 
+      # #15139: a red tile does not say WHICH condition produced it — a run that
+      # never got a runner, toolchain provisioning failing, a superseded run, or
+      # a real test failure all render identically, and `gh pr checks` buckets
+      # every one of them under `fail`. The classifier names it, reading
+      # GET /actions/jobs/{id} because that is the only endpoint carrying a
+      # `steps` array; /commits/{sha}/check-runs has none, so anything reading
+      # `steps` off the listing finds nothing on every check and classifies by
+      # its default instead.
+      #
+      # It publishes no status and re-queues nothing, so it can never turn a red
+      # check green. --exit-zero keeps a *classification* from being mistaken for
+      # a gate — the required contexts remain the gate — but it cannot suppress
+      # exit 2, so a head with no check runs, or an unreachable API, still fails
+      # this step loudly instead of reading as "all clear". continue-on-error
+      # keeps that informational failure from reddening the sweep it rides on,
+      # the same idiom pr-queue-gate.yml uses for its never-blocks job.
+      #
+      # This runs before the self-modification guard below for the same reason
+      # the capability probe does: the classifier issues GET requests only —
+      # it approves nothing, publishes no status, and writes nothing back — so
+      # a PR head's copy of it cannot spend the job's write permissions.
+      - name: Classify any red checks on the swept head
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -uo pipefail
+          # The exit code is the point, so it is captured rather than piped away:
+          # `... | tee` would report tee's status and this step could never fail.
+          REPORT="$RUNNER_TEMP/ci-red-cause.txt"
+          python3 pipeline-scripts/ci_red_cause.py --sha "$HEAD_SHA" --exit-zero \
+            >"$REPORT" 2>&1
+          rc=$?
+          {
+            echo "### Red-check causes for \`$HEAD_SHA\`"
+            echo ''
+            echo '```'
+            cat "$REPORT"
+            echo "exit=$rc"
+            echo '```'
+          } >>"$GITHUB_STEP_SUMMARY"
+          cat "$REPORT"
+          exit "$rc"
+
       - name: Sweep open PRs
         if: ${{ !cancelled() }}
         env:

--- a/docs/developer/CLAUDE_REVIEW.md
+++ b/docs/developer/CLAUDE_REVIEW.md
@@ -64,9 +64,31 @@ root causes and both are yours to fix:
    blocked if a required context never reported at all. Count reported contexts
    against `gh api repos/{owner}/{repo}/branches/Dev_new_gui/protection --jq
    '.required_status_checks.contexts[]'`.
-3. **Root-cause and fix it** in the same PR. If the check itself is wrong, fix the
+3. **Name the cause before you debug the diff (#15139).** Five conditions render as
+   the same red tile, and `gh pr checks` buckets every one of them under `fail` —
+   `fail` there is **not** `conclusion: failure` and must be confirmed against the
+   run object. Run `pipeline-scripts/ci_red_cause.py --pr N` (add `--json` to parse
+   it). It reads `GET /actions/jobs/{id}`, the only endpoint carrying a `steps`
+   array — `GET /commits/{sha}/check-runs` has none, so anything classifying from
+   the check-runs listing alone is guessing.
+
+   | cause | what happened | remedy |
+   |---|---|---|
+   | `runner-starvation` | job executed 0 steps — it never got a runner | re-queue |
+   | `provisioning-failure` | first failing step is toolchain setup (`apt` exit 124) | re-queue |
+   | `superseded` | `conclusion: cancelled` — a newer push retired the run | wait for the fresh run |
+   | `test-failure` | first failing step is a work step | **fix the diff; never re-queue** |
+   | `undetermined` | the cause could not be established | **treat as a real failure** |
+
+   Read the **first** failing step, never the last: a setup failure makes later test
+   steps fail downstream, so the last failure lies about the cause.
+
+   **A named cause never makes a red check green.** The tool publishes no status and
+   re-queues nothing; it exits 1 on any red whatever the cause, and exits 2 when
+   nothing could be classified — which is never "clean".
+4. **Root-cause and fix it** in the same PR. If the check itself is wrong, fix the
    check — in the same PR or a fast-follow that lands first.
-4. **If it genuinely cannot be fixed now:** label the PR `blocked`, post a
+5. **If it genuinely cannot be fixed now:** label the PR `blocked`, post a
    one-paragraph root-cause writeup on it, and move to the next issue. Do not merge,
    do not `--admin` past it, and do not interrupt a `/loop` to ask about it.
 
@@ -154,6 +176,23 @@ After merging all PRs in a batch:
 - Only cancel/retrigger when a check has been in a non-running state for >30 minutes with no activity
 
 **Why:** Sessions wasted time canceling/retriggering smoke tests that were running normally.
+
+**A deep queue is the hosted-runner cap, not a dead self-hosted pool (#15139).**
+Measured 2026-08-28: **155** runs queued, **14** jobs executing — **13 of them on
+`ubuntu-latest`, 1 on self-hosted** — with both self-hosted runners `online`. A
+12-run sample of the queued runs found `ubuntu-latest` on every job. So queue depth
+tracks the GitHub-hosted concurrency cap; it is neither a dispatch gate nor a starved
+self-hosted pool, and **idle self-hosted runners next to a long queue is expected**,
+not evidence of a fault. Re-measure before assuming otherwise:
+
+```bash
+gh api 'repos/{owner}/{repo}/actions/runs?status=queued&per_page=1' --jq .total_count
+gh api repos/{owner}/{repo}/actions/runners --jq '[.runners[] | {name, status, busy}]'
+```
+
+A run queued past `WATCHDOG_STALL_MINUTES` (default **45**) is the threshold
+`ci_dispatch_watchdog.py --check runner-starvation` reports on. Below it, waiting is
+normal and your diff is not the reason.
 
 ---
 

--- a/docs/developer/CLAUDE_REVIEW.md
+++ b/docs/developer/CLAUDE_REVIEW.md
@@ -72,16 +72,30 @@ root causes and both are yours to fix:
    array — `GET /commits/{sha}/check-runs` has none, so anything classifying from
    the check-runs listing alone is guessing.
 
-   | cause | what happened | remedy |
-   |---|---|---|
-   | `runner-starvation` | job executed 0 steps — it never got a runner | re-queue |
-   | `provisioning-failure` | first failing step is toolchain setup (`apt` exit 124) | re-queue |
-   | `superseded` | `conclusion: cancelled` — a newer push retired the run | wait for the fresh run |
-   | `test-failure` | first failing step is a work step | **fix the diff; never re-queue** |
-   | `undetermined` | the cause could not be established | **treat as a real failure** |
+   | cause | what happened | at fault | remedy |
+   |---|---|---|---|
+   | `runner-starvation` | job executed 0 steps — it never got a runner | environment | nothing ran; push a new head commit |
+   | `provisioning-failure` | first failing step is toolchain setup (`apt` exit 124) | environment | no test result; push a new head commit |
+   | `superseded` | `conclusion: cancelled` — a newer push retired the run | neither | wait for the run already queued on the current head |
+   | `test-failure` | first failing step is a work step | **the diff** | fix the diff |
+   | `undetermined` | the cause could not be established | **assume the diff** | establish the cause before acting |
 
    Read the **first** failing step, never the last: a setup failure makes later test
    steps fail downstream, so the last failure lies about the cause.
+
+   **`infrastructure: true` means the diff is not indicted — it does NOT mean
+   re-running will fix it (#15139).** Measured on run `33149960063`:
+   `POST /actions/runs/{id}/rerun-failed-jobs` reported success and advanced the run
+   to `attempt=2`, but the failed matrix leg `python-suite shard 12/12` was **carried
+   forward, not re-executed** — same job id, same `started_at` — and only its
+   dependents re-ran 18 minutes later, so the `python-suite` rollup failed again on
+   `Fail if any shard failed`. All fourteen already-executed jobs kept their original
+   attempt-1 timestamps. Re-queueing twice and getting the same red does not mean the
+   classifier is wrong; it means the remedy is.
+
+   What is structurally guaranteed instead: **a new head commit starts a new run at
+   `attempt=1`**, and an attempt-1 run has no previous attempt to carry a job forward
+   from, so every job must execute. That guarantees re-execution — not success.
 
    **A named cause never makes a red check green.** The tool publishes no status and
    re-queues nothing; it exits 1 on any red whatever the cause, and exits 2 when

--- a/pipeline-scripts/ci_red_cause.py
+++ b/pipeline-scripts/ci_red_cause.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+"""
+Classify WHY a check on a commit is red — #15139.
+
+A red tile on a pull request is produced by at least four different conditions
+that GitHub renders identically, and the repository's standing rule is that red
+CI never merges. A rule that cannot tell those conditions apart is the reason
+people override it, so this tool names the cause instead of leaving the reader
+to guess:
+
+* ``runner-starvation`` — the run never obtained a runner. Its job executed
+  **zero** steps, or the run has no job at all (``jobs: []``). Nothing was
+  tested. Re-queueable.
+* ``provisioning-failure`` — the job got a runner and ran, but the first step
+  that failed is toolchain provisioning (a local composite action, an
+  ``actions/setup-*``, a checkout, a cache restore). The observed instance is
+  ``apt-get`` returning exit 124 three times inside
+  ``.github/actions/setup-python-suite``; a later test step then fails
+  downstream, so the *last* failing step lies about the cause and only the
+  *first* one tells the truth. No test result was produced. Re-queueable.
+* ``test-failure`` — the first failing step is real work. **Never re-queue.**
+* ``superseded`` — ``conclusion: cancelled``, normally a newer push retiring an
+  obsolete run. Not a test result; a fresh run must report. ``gh pr checks``
+  buckets this under ``fail``, which is why a superseded gate reads as a red
+  one to anything parsing that output.
+* ``undetermined`` — the cause could not be established. **Deliberately graded
+  as a real failure.**
+
+THE STRUCTURAL FACT THIS TOOL EXISTS FOR. ``GET /commits/{sha}/check-runs``
+carries no ``steps`` array — only ``GET /actions/jobs/{id}`` does. Any gate that
+reads ``steps`` off the listing finds nothing on every check, every time, and
+then classifies by whatever its default is. Defaulting to "infrastructure"
+turns the merge gate into a re-queue loop that retries genuine test failures
+until they merge. Defaulting to "real failure" costs a needless investigation.
+Only the second direction is survivable, so an absent ``steps`` array is
+``undetermined`` and ``undetermined`` grades as a real failure.
+
+THIS TOOL NEVER MAKES A RED CHECK GREEN. It publishes no commit status, writes
+no check conclusion, and re-queues nothing. Every classified cause carries
+``blocks_merge=True``; the classification says what to *do* about a red, never
+that the red may be ignored. ``--exit-zero`` exists for report-only callers and
+still refuses to hide an indeterminate result (see ``resolve_exit_code``).
+
+Usage:
+    pipeline-scripts/ci_red_cause.py --pr 15155
+    pipeline-scripts/ci_red_cause.py --sha 8d3fa7d2...
+    pipeline-scripts/ci_red_cause.py --pr 15155 --json
+
+Environment:
+    GITHUB_TOKEN                      required — API credential
+    GITHUB_REPOSITORY                 required — "owner/repo"
+    GITHUB_API_URL                    API root (default https://api.github.com)
+    CI_RED_CAUSE_PROVISIONING_MARKERS comma-separated lowercase substrings that
+                                      mark a step as toolchain provisioning
+    CI_RED_CAUSE_TIMEOUT_SECONDS      per-request timeout
+
+Exit codes:
+    0  check runs were found for the commit and none of them is red.
+    1  at least one red check run was found. ALWAYS 1 regardless of cause —
+       an infrastructure red is still red.
+    2  nothing could be classified: missing configuration, the API could not be
+       reached, or the commit carries no check runs at all. Never conflated
+       with 0, because "I classified nothing" must not read as "all clear".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
+
+# `pipeline-scripts` is not an importable package name, so the sibling module
+# is reached by path — the same idiom as check_gating_precommit_hooks.py. The
+# HTTP client is REUSED rather than re-written: one transport, one place where
+# a transport failure is turned into a status code instead of a traceback.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from ci_dispatch_watchdog import (  # noqa: E402
+    NO_RESPONSE_STATUS,
+    GitHubApi,
+    WatchdogConfigError,
+)
+
+# Only the Actions app exposes a job with steps. A check run published by any
+# other app has no step list to reason about, so its cause is not knowable here.
+ACTIONS_APP_SLUG = "github-actions"
+
+# Conclusions that render as a red/failed tile. `gh pr checks` buckets all of
+# these under `fail`, which is precisely the conflation #15139 reports.
+RED_CONCLUSIONS = frozenset({"failure", "cancelled", "timed_out", "startup_failure", "action_required", "stale"})
+
+# A step with either of these has not run. `skipped` means a condition excluded
+# it; `None` means it never got that far.
+UNEXECUTED_STEP_CONCLUSIONS = frozenset({"skipped"})
+
+CAUSE_STARVATION = "runner-starvation"
+CAUSE_PROVISIONING = "provisioning-failure"
+CAUSE_TEST = "test-failure"
+CAUSE_SUPERSEDED = "superseded"
+CAUSE_UNDETERMINED = "undetermined"
+
+# Causes whose remedy is "run it again". Everything absent from this set must
+# never be re-queued — and `undetermined` is absent on purpose.
+REQUEUEABLE_CAUSES = frozenset({CAUSE_STARVATION, CAUSE_PROVISIONING})
+
+# Causes that mean a defect in the diff. `undetermined` is graded here because
+# mislabelling a real failure as a flake is the costly direction (#15139).
+REAL_FAILURE_CAUSES = frozenset({CAUSE_TEST, CAUSE_UNDETERMINED})
+
+# Substrings identifying a step as toolchain provisioning rather than work.
+# Deliberately NARROW: a provisioning failure misread as a test failure costs a
+# wasted investigation, while a test failure misread as provisioning gets
+# re-queued until it merges. The default list matches the step names the runner
+# generates for `uses:` steps that carry no `name:`.
+DEFAULT_PROVISIONING_MARKERS = (
+    "run ./.github/actions/",
+    "run actions/setup-",
+    "run actions/checkout",
+    "run actions/cache",
+    "run docker/setup-",
+    "set up job",
+    "initialize containers",
+)
+
+DEFAULT_TIMEOUT_SECONDS = 30
+DEFAULT_API_ROOT = "https://api.github.com"
+MAX_CHECKS_PER_PAGE = 100
+
+
+class RedCause(NamedTuple):
+    """One red check run, with the cause that produced it."""
+
+    check_name: str
+    conclusion: str
+    cause: str
+    detail: str
+    job_id: Optional[int]
+    executed_steps: Optional[int]
+    total_steps: Optional[int]
+    url: str
+
+    @property
+    def requeueable(self) -> bool:
+        return self.cause in REQUEUEABLE_CAUSES
+
+    @property
+    def real_failure(self) -> bool:
+        return self.cause in REAL_FAILURE_CAUSES
+
+    @property
+    def blocks_merge(self) -> bool:
+        """Always. A cause is information attached to a red, not a way past it."""
+        return True
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = dict(self._asdict())
+        payload["requeueable"] = self.requeueable
+        payload["real_failure"] = self.real_failure
+        payload["blocks_merge"] = self.blocks_merge
+        return payload
+
+
+class Report(NamedTuple):
+    """The outcome of classifying every check run on one commit."""
+
+    sha: str
+    checks_seen: int
+    reds: List[RedCause]
+    indeterminate: bool
+    message: str
+
+
+def provisioning_markers() -> Tuple[str, ...]:
+    """Marker substrings, overridable so a new setup step needs no code change."""
+    raw = os.environ.get("CI_RED_CAUSE_PROVISIONING_MARKERS", "").strip()
+    if not raw:
+        return DEFAULT_PROVISIONING_MARKERS
+    parsed = tuple(part.strip().lower() for part in raw.split(",") if part.strip())
+    return parsed or DEFAULT_PROVISIONING_MARKERS
+
+
+def request_timeout() -> int:
+    raw = os.environ.get("CI_RED_CAUSE_TIMEOUT_SECONDS", "").strip()
+    if not raw.isdigit() or int(raw) <= 0:
+        return DEFAULT_TIMEOUT_SECONDS
+    return int(raw)
+
+
+def is_red(check_run: Dict[str, Any]) -> bool:
+    """A completed check whose conclusion renders as a failed tile."""
+    if (check_run.get("status") or "") != "completed":
+        return False
+    return (check_run.get("conclusion") or "") in RED_CONCLUSIONS
+
+
+def is_provisioning_step(name: Optional[str]) -> bool:
+    lowered = (name or "").strip().lower()
+    if not lowered:
+        return False
+    return any(marker in lowered for marker in provisioning_markers())
+
+
+def executed_steps(steps: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Steps that actually ran — a queued or skipped step is not evidence."""
+    return [
+        step
+        for step in steps
+        if step.get("conclusion") is not None and step.get("conclusion") not in UNEXECUTED_STEP_CONCLUSIONS
+    ]
+
+
+def first_failing_step(steps: Sequence[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    The EARLIEST failing step, ordered by ``number``.
+
+    Job 98783580325 failed at step 4 (the setup action) and again at step 9 (a
+    test step) purely downstream of it. Reading the last failure would call that
+    job a test failure when no test ever ran.
+    """
+    failed = [s for s in steps if (s.get("conclusion") or "") in {"failure", "timed_out"}]
+    if not failed:
+        return None
+    return min(failed, key=lambda s: s.get("number") or 0)
+
+
+def classify_steps(steps: Sequence[Dict[str, Any]]) -> Tuple[str, str]:
+    """Cause and detail from a job's step list. Pure — no I/O."""
+    ran = executed_steps(steps)
+    if not ran:
+        return (
+            CAUSE_STARVATION,
+            f"job executed 0 of {len(steps)} steps — it never obtained a runner",
+        )
+    failing = first_failing_step(ran)
+    if failing is None:
+        return (
+            CAUSE_UNDETERMINED,
+            f"{len(ran)} steps executed and none of them failed — cause not in the step list",
+        )
+    name = failing.get("name") or "?"
+    number = failing.get("number")
+    if is_provisioning_step(name):
+        return (
+            CAUSE_PROVISIONING,
+            f"first failing step {number} ({name!r}) is toolchain provisioning — no test result",
+        )
+    return CAUSE_TEST, f"first failing step {number} ({name!r}) is a work step"
+
+
+def classify_job_payload(
+    check_run: Dict[str, Any], job: Optional[Dict[str, Any]], fetch_error: str = ""
+) -> Tuple[str, str, Optional[int], Optional[int]]:
+    """
+    Cause, detail, executed-step count and total-step count for one red check.
+
+    Every branch that cannot see a step list lands on ``undetermined``. That is
+    the whole point: an unreachable jobs endpoint, a non-Actions app, and a
+    payload taken from ``/check-runs`` (which has no ``steps``) all look like
+    "zero steps" to a naive reader, and calling any of them starvation is how a
+    real failure gets re-queued.
+    """
+    conclusion = check_run.get("conclusion") or ""
+    if conclusion == "cancelled":
+        return (
+            CAUSE_SUPERSEDED,
+            "conclusion is 'cancelled' — normally a newer push retiring this run; "
+            "no test result, a fresh run must report",
+            None,
+            None,
+        )
+    if fetch_error:
+        return CAUSE_UNDETERMINED, fetch_error, None, None
+    if job is None:
+        return (
+            CAUSE_UNDETERMINED,
+            "no Actions job could be resolved for this check run",
+            None,
+            None,
+        )
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return (
+            CAUSE_UNDETERMINED,
+            "job payload carried no 'steps' array — /commits/{sha}/check-runs never "
+            "has one; only GET /actions/jobs/{id} does",
+            None,
+            None,
+        )
+    cause, detail = classify_steps(steps)
+    return cause, detail, len(executed_steps(steps)), len(steps)
+
+
+def fetch_job(api: GitHubApi, job_id: int) -> Tuple[Optional[Dict[str, Any]], str]:
+    """``GET /actions/jobs/{id}`` — the only endpoint carrying ``steps``."""
+    status, body = api.request("GET", f"/repos/{api.repository}/actions/jobs/{job_id}")
+    if status == NO_RESPONSE_STATUS:
+        return None, f"jobs endpoint unreachable for job {job_id}: {body}"
+    if status != 200 or not isinstance(body, dict):
+        return None, f"jobs endpoint returned HTTP {status} for job {job_id}"
+    return body, ""
+
+
+def classify_check_run(api: GitHubApi, check_run: Dict[str, Any]) -> RedCause:
+    """Resolve one red check run to its cause, fetching the job when it can."""
+    app_slug = ((check_run.get("app") or {}).get("slug")) or ""
+    job: Optional[Dict[str, Any]] = None
+    fetch_error = ""
+    job_id: Optional[int] = None
+    if (check_run.get("conclusion") or "") != "cancelled":
+        if app_slug != ACTIONS_APP_SLUG:
+            fetch_error = f"check published by app {app_slug!r}, which exposes no job steps"
+        else:
+            # For the Actions app the check-run id IS the job id; details_url is
+            # .../actions/runs/{run}/job/{id} with the same number.
+            job_id = check_run.get("id")
+            if not isinstance(job_id, int):
+                fetch_error = "check run carried no usable id"
+            else:
+                job, fetch_error = fetch_job(api, job_id)
+    cause, detail, ran, total = classify_job_payload(check_run, job, fetch_error)
+    return RedCause(
+        check_name=check_run.get("name") or "?",
+        conclusion=check_run.get("conclusion") or "?",
+        cause=cause,
+        detail=detail,
+        job_id=job_id,
+        executed_steps=ran,
+        total_steps=total,
+        url=check_run.get("html_url") or check_run.get("details_url") or "",
+    )
+
+
+def list_check_runs(api: GitHubApi, sha: str) -> Tuple[List[Dict[str, Any]], str]:
+    path = f"/repos/{api.repository}/commits/{sha}/check-runs?per_page={MAX_CHECKS_PER_PAGE}"
+    status, body = api.request("GET", path)
+    if status != 200 or not isinstance(body, dict):
+        return [], f"cannot list check runs for {sha} (HTTP {status})"
+    runs = body.get("check_runs")
+    return (list(runs) if isinstance(runs, list) else []), ""
+
+
+def head_sha_for_pr(api: GitHubApi, number: int) -> str:
+    status, body = api.request("GET", f"/repos/{api.repository}/pulls/{number}")
+    if status != 200 or not isinstance(body, dict):
+        raise WatchdogConfigError(f"cannot read PR #{number} (HTTP {status})")
+    sha = ((body.get("head") or {}).get("sha")) or ""
+    if not sha:
+        raise WatchdogConfigError(f"PR #{number} has no head sha")
+    return sha
+
+
+def classify_commit(api: GitHubApi, sha: str) -> Report:
+    """
+    Classify every red check on one commit.
+
+    A commit with NO check runs is reported as indeterminate, not as clean.
+    "I found nothing to classify" and "I classified everything and it is green"
+    are different answers, and only one of them may exit 0.
+    """
+    checks, error = list_check_runs(api, sha)
+    if error:
+        return Report(sha, 0, [], True, error)
+    if not checks:
+        return Report(
+            sha,
+            0,
+            [],
+            True,
+            f"{sha} carries no check runs at all — nothing was classified, so "
+            "this is NOT a clean bill of health (see #12823 for parked runs)",
+        )
+    reds = [classify_check_run(api, check) for check in checks if is_red(check)]
+    if not reds:
+        return Report(sha, len(checks), [], False, f"{len(checks)} checks, none red")
+    return Report(sha, len(checks), reds, False, f"{len(reds)} of {len(checks)} checks are red")
+
+
+def _emit(text: str, *, err: bool = False) -> None:
+    """
+    The one place this module writes to a stream.
+
+    A CI script's output IS its product — there is no logger a workflow step
+    reads — so stdout is correct here. Funnelling it through a single call
+    keeps that a deliberate, once-stated exception to the no-print rule
+    (#1082) rather than eight scattered ones.
+    """
+    print(text, file=sys.stderr if err else sys.stdout)  # noqa: print
+
+
+def render(report: Report) -> None:
+    _emit(f"commit {report.sha}: {report.message}")
+    for red in report.reds:
+        steps = (
+            f"{red.executed_steps}/{red.total_steps} steps executed"
+            if red.executed_steps is not None
+            else "steps unavailable"
+        )
+        verdict = "REAL FAILURE" if red.real_failure else "not a test result"
+        requeue = "re-queueable" if red.requeueable else "DO NOT RE-QUEUE"
+        _emit(f"  [{red.cause}] {red.check_name} ({red.conclusion}, {steps})")
+        _emit(f"      {red.detail}")
+        _emit(f"      verdict: {verdict} · {requeue} · blocks merge: yes")
+        if red.url:
+            _emit(f"      {red.url}")
+    if report.indeterminate:
+        _emit("INDETERMINATE — this run vouches for nothing.", err=True)
+
+
+def _payload(report: Report) -> Dict[str, Any]:
+    return {
+        "sha": report.sha,
+        "checks_seen": report.checks_seen,
+        "indeterminate": report.indeterminate,
+        "message": report.message,
+        "reds": [red.as_dict() for red in report.reds],
+    }
+
+
+def resolve_exit_code(report: Report, exit_zero: bool) -> int:
+    """
+    2 for indeterminate, 1 for any red, 0 only for "checks seen, none red".
+
+    ``--exit-zero`` suppresses only the *red* exit. It cannot suppress 2, so a
+    report-only caller still cannot mistake "nothing classified" for "clean".
+    """
+    if report.indeterminate:
+        return 2
+    if report.reds and not exit_zero:
+        return 1
+    return 0
+
+
+def build_api() -> GitHubApi:
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if not token:
+        raise WatchdogConfigError("GITHUB_TOKEN is required")
+    if "/" not in repository:
+        raise WatchdogConfigError("GITHUB_REPOSITORY must be 'owner/repo'")
+    api_root = os.environ.get("GITHUB_API_URL", DEFAULT_API_ROOT).strip() or DEFAULT_API_ROOT
+    return GitHubApi(token, repository, api_root, request_timeout())
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Classify why a commit's checks are red.")
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pr", type=int, help="pull request number; its head sha is used")
+    target.add_argument("--sha", help="commit sha to classify")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable output")
+    parser.add_argument(
+        "--exit-zero",
+        action="store_true",
+        help="report-only: do not exit 1 on red (exit 2 on indeterminate still stands)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        api = build_api()
+        sha = args.sha.strip() if args.sha else head_sha_for_pr(api, args.pr)
+        report = classify_commit(api, sha)
+    except WatchdogConfigError as exc:
+        _emit(f"ci-red-cause: {exc}", err=True)
+        return 2
+    if args.json:
+        _emit(json.dumps(_payload(report), indent=2))
+    else:
+        render(report)
+    return resolve_exit_code(report, args.exit_zero)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pipeline-scripts/ci_red_cause.py
+++ b/pipeline-scripts/ci_red_cause.py
@@ -12,15 +12,16 @@ to guess:
 
 * ``runner-starvation`` — the run never obtained a runner. Its job executed
   **zero** steps, or the run has no job at all (``jobs: []``). Nothing was
-  tested. Re-queueable.
+  tested. Environmental — the diff is not indicted.
 * ``provisioning-failure`` — the job got a runner and ran, but the first step
   that failed is toolchain provisioning (a local composite action, an
   ``actions/setup-*``, a checkout, a cache restore). The observed instance is
   ``apt-get`` returning exit 124 three times inside
   ``.github/actions/setup-python-suite``; a later test step then fails
   downstream, so the *last* failing step lies about the cause and only the
-  *first* one tells the truth. No test result was produced. Re-queueable.
-* ``test-failure`` — the first failing step is real work. **Never re-queue.**
+  *first* one tells the truth. No test result was produced. Environmental —
+  the diff is not indicted.
+* ``test-failure`` — the first failing step is real work. The diff IS indicted.
 * ``superseded`` — ``conclusion: cancelled``, normally a newer push retiring an
   obsolete run. Not a test result; a fresh run must report. ``gh pr checks``
   buckets this under ``fail``, which is why a superseded gate reads as a red
@@ -36,6 +37,17 @@ turns the merge gate into a re-queue loop that retries genuine test failures
 until they merge. Defaulting to "real failure" costs a needless investigation.
 Only the second direction is survivable, so an absent ``steps`` array is
 ``undetermined`` and ``undetermined`` grades as a real failure.
+
+``infrastructure=True`` MEANS "THE DIFF IS NOT INDICTED". It does NOT mean
+"re-running will fix it", and the two are not the same claim. Measured on run
+``33149960063`` (2026-08-28): ``POST /actions/runs/{id}/rerun-failed-jobs``
+reported success and advanced the run to ``attempt=2``, but the failed matrix
+leg ``python-suite shard 12/12`` was **carried forward, not re-executed** — same
+job id, same ``started_at`` (07:54:14Z) — while only its dependents re-ran, 18
+minutes later, and the rollup then failed on ``Fail if any shard failed``. Every
+one of the fourteen jobs that had already executed kept its original timestamp
+in attempt 2. So each cause carries a ``remedy`` string saying what is actually
+known to work, rather than an implied "re-run it".
 
 THIS TOOL NEVER MAKES A RED CHECK GREEN. It publishes no commit status, writes
 no check conclusion, and re-queues nothing. Every classified cause carries
@@ -104,13 +116,30 @@ CAUSE_TEST = "test-failure"
 CAUSE_SUPERSEDED = "superseded"
 CAUSE_UNDETERMINED = "undetermined"
 
-# Causes whose remedy is "run it again". Everything absent from this set must
-# never be re-queued — and `undetermined` is absent on purpose.
-REQUEUEABLE_CAUSES = frozenset({CAUSE_STARVATION, CAUSE_PROVISIONING})
+# Causes that do NOT indict the diff — the environment failed, not the code.
+# This is a statement about BLAME, not about the remedy: see `REMEDIES` for what
+# is actually known to work. `undetermined` is absent on purpose.
+INFRASTRUCTURE_CAUSES = frozenset({CAUSE_STARVATION, CAUSE_PROVISIONING})
 
 # Causes that mean a defect in the diff. `undetermined` is graded here because
 # mislabelling a real failure as a flake is the costly direction (#15139).
 REAL_FAILURE_CAUSES = frozenset({CAUSE_TEST, CAUSE_UNDETERMINED})
+
+# What is known to work, per cause. Deliberately not "re-queue": on run
+# 33149960063 `rerun-failed-jobs` advanced the attempt without re-executing the
+# failed matrix leg at all. A new head commit starts a NEW run at attempt 1,
+# which has no previous attempt to carry a job forward from, so every job must
+# execute — that is a structural guarantee of RE-EXECUTION, not of success.
+REMEDIES: Dict[str, str] = {
+    CAUSE_STARVATION: "nothing ran; a new head commit forces a fresh run at attempt 1",
+    CAUSE_PROVISIONING: (
+        "no test result; rerun-failed-jobs has been observed NOT to re-execute a "
+        "failed matrix leg (run 33149960063) — a new head commit forces a fresh run"
+    ),
+    CAUSE_SUPERSEDED: "wait for the run already queued on the current head",
+    CAUSE_TEST: "fix the diff",
+    CAUSE_UNDETERMINED: "treat as a real failure; establish the cause before acting",
+}
 
 # Substrings identifying a step as toolchain provisioning rather than work.
 # Deliberately NARROW: a provisioning failure misread as a test failure costs a
@@ -145,8 +174,13 @@ class RedCause(NamedTuple):
     url: str
 
     @property
-    def requeueable(self) -> bool:
-        return self.cause in REQUEUEABLE_CAUSES
+    def infrastructure(self) -> bool:
+        """The environment failed, not the diff. Says nothing about the remedy."""
+        return self.cause in INFRASTRUCTURE_CAUSES
+
+    @property
+    def remedy(self) -> str:
+        return REMEDIES.get(self.cause, REMEDIES[CAUSE_UNDETERMINED])
 
     @property
     def real_failure(self) -> bool:
@@ -159,7 +193,8 @@ class RedCause(NamedTuple):
 
     def as_dict(self) -> Dict[str, Any]:
         payload = dict(self._asdict())
-        payload["requeueable"] = self.requeueable
+        payload["infrastructure"] = self.infrastructure
+        payload["remedy"] = self.remedy
         payload["real_failure"] = self.real_failure
         payload["blocks_merge"] = self.blocks_merge
         return payload
@@ -262,7 +297,7 @@ def classify_job_payload(
     the whole point: an unreachable jobs endpoint, a non-Actions app, and a
     payload taken from ``/check-runs`` (which has no ``steps``) all look like
     "zero steps" to a naive reader, and calling any of them starvation is how a
-    real failure gets re-queued.
+    real failure gets re-run until it merges.
     """
     conclusion = check_run.get("conclusion") or ""
     if conclusion == "cancelled":
@@ -401,10 +436,11 @@ def render(report: Report) -> None:
             else "steps unavailable"
         )
         verdict = "REAL FAILURE" if red.real_failure else "not a test result"
-        requeue = "re-queueable" if red.requeueable else "DO NOT RE-QUEUE"
+        blame = "environment, not the diff" if red.infrastructure else "the diff"
         _emit(f"  [{red.cause}] {red.check_name} ({red.conclusion}, {steps})")
         _emit(f"      {red.detail}")
-        _emit(f"      verdict: {verdict} · {requeue} · blocks merge: yes")
+        _emit(f"      verdict: {verdict} · at fault: {blame} · blocks merge: yes")
+        _emit(f"      remedy: {red.remedy}")
         if red.url:
             _emit(f"      {red.url}")
     if report.indeterminate:

--- a/repo_tests/ci_red_cause_test.py
+++ b/repo_tests/ci_red_cause_test.py
@@ -97,7 +97,7 @@ def test_zero_executed_steps_is_runner_starvation(rc):
     cause, detail = rc.classify_steps(steps)
     assert cause == rc.CAUSE_STARVATION
     assert "0 of 14" in detail
-    assert cause in rc.REQUEUEABLE_CAUSES
+    assert cause in rc.INFRASTRUCTURE_CAUSES
     assert cause not in rc.REAL_FAILURE_CAUSES
 
 
@@ -113,7 +113,7 @@ def test_setup_action_failure_is_provisioning(rc):
     cause, detail = rc.classify_steps(steps)
     assert cause == rc.CAUSE_PROVISIONING
     assert "setup-python-suite" in detail
-    assert cause in rc.REQUEUEABLE_CAUSES
+    assert cause in rc.INFRASTRUCTURE_CAUSES
     assert cause not in rc.REAL_FAILURE_CAUSES
 
 
@@ -127,7 +127,7 @@ def test_test_step_failure_is_a_real_failure(rc):
     assert cause == rc.CAUSE_TEST
     assert "unit tests" in detail
     assert cause in rc.REAL_FAILURE_CAUSES
-    assert cause not in rc.REQUEUEABLE_CAUSES
+    assert cause not in rc.INFRASTRUCTURE_CAUSES
 
 
 def test_downstream_test_failure_does_not_mask_the_setup_failure(rc):
@@ -150,7 +150,7 @@ def test_cancelled_is_superseded_not_a_failure_and_not_requeueable(rc):
     assert cause == rc.CAUSE_SUPERSEDED
     assert "fresh run" in detail
     assert cause not in rc.REAL_FAILURE_CAUSES
-    assert cause not in rc.REQUEUEABLE_CAUSES
+    assert cause not in rc.INFRASTRUCTURE_CAUSES
     assert (ran, total) == (None, None)
 
 
@@ -169,7 +169,7 @@ def test_absent_steps_array_is_undetermined_never_starvation(rc):
     assert cause == rc.CAUSE_UNDETERMINED
     assert "no 'steps' array" in detail
     assert cause in rc.REAL_FAILURE_CAUSES
-    assert cause not in rc.REQUEUEABLE_CAUSES
+    assert cause not in rc.INFRASTRUCTURE_CAUSES
     assert (ran, total) == (None, None)
 
 
@@ -184,6 +184,7 @@ def test_non_actions_app_is_undetermined(rc):
     red = rc.classify_check_run(api, _check(app={"slug": "some-linter"}))
     assert red.cause == rc.CAUSE_UNDETERMINED
     assert red.real_failure is True
+    assert red.infrastructure is False
     assert api.calls == [], "a non-Actions check has no job to fetch"
 
 
@@ -202,9 +203,40 @@ def test_no_cause_ever_stops_blocking_the_merge(rc, cause):
     assert red.blocks_merge is True
 
 
-def test_undetermined_is_in_neither_the_requeue_nor_the_clean_set(rc):
-    assert rc.CAUSE_UNDETERMINED not in rc.REQUEUEABLE_CAUSES
+def test_undetermined_is_in_neither_the_infrastructure_nor_the_clean_set(rc):
+    assert rc.CAUSE_UNDETERMINED not in rc.INFRASTRUCTURE_CAUSES
     assert rc.CAUSE_UNDETERMINED in rc.REAL_FAILURE_CAUSES
+
+
+def test_every_cause_has_a_remedy_and_none_of_them_says_re_queue(rc):
+    """
+    Measured on run 33149960063: `rerun-failed-jobs` advanced the attempt
+    WITHOUT re-executing the failed matrix leg — same job id, same started_at,
+    only the dependents re-ran. `infrastructure=True` therefore means "the diff
+    is not indicted", never "re-running will fix it", and no remedy string may
+    imply otherwise.
+    """
+    causes = {
+        rc.CAUSE_STARVATION,
+        rc.CAUSE_PROVISIONING,
+        rc.CAUSE_SUPERSEDED,
+        rc.CAUSE_TEST,
+        rc.CAUSE_UNDETERMINED,
+    }
+    assert set(rc.REMEDIES) == causes
+    for cause, remedy in rc.REMEDIES.items():
+        assert remedy.strip(), cause
+        assert "re-queue" not in remedy.lower(), cause
+
+
+def test_infrastructure_is_about_blame_not_about_the_remedy(rc):
+    red = rc.RedCause("c", "failure", rc.CAUSE_PROVISIONING, "d", None, 9, 14, "")
+    assert red.infrastructure is True
+    assert red.real_failure is False
+    assert "rerun-failed-jobs" in red.remedy
+    assert "new head commit" in red.remedy
+    assert red.as_dict()["infrastructure"] is True
+    assert red.as_dict()["remedy"] == red.remedy
 
 
 # --------------------------------------------------------------------------

--- a/repo_tests/ci_red_cause_test.py
+++ b/repo_tests/ci_red_cause_test.py
@@ -1,0 +1,295 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15139 — a red check must name WHICH of its causes produced it.
+
+Three non-code conditions and one real one render as the same red tile:
+
+* a run that never obtained a runner (zero executed steps),
+* toolchain provisioning failing (the first failing step is the setup action),
+* a superseded run (``conclusion: cancelled``), and
+* an actual test failure.
+
+The first two are re-queueable and the last must never be, so the classifier is
+only useful if it is right about which is which. These tests pin all four, and
+pin the direction it fails in when it cannot tell: ``undetermined`` grades as a
+REAL failure, because re-queueing a genuine test failure until it merges is the
+unsurvivable error.
+
+The vacuity tests exist because the naive version of this tool reads ``steps``
+off ``GET /commits/{sha}/check-runs``, which has no ``steps`` array at all, and
+therefore sees "zero steps executed" on every red check ever. A classifier that
+can pass by classifying nothing is worse than none.
+"""
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "pipeline-scripts" / "ci_red_cause.py"
+
+SHA = "8d3fa7d22af3dba8728665f9ff73c1c38c8f5498"
+REPO = "mrveiss/AutoBot-AI"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("ci_red_cause", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rc():
+    return _load()
+
+
+def _step(number: int, name: str, conclusion) -> Dict[str, Any]:
+    return {"number": number, "name": name, "conclusion": conclusion, "status": "completed"}
+
+
+def _check(**overrides) -> Dict[str, Any]:
+    check = {
+        "id": 98783580325,
+        "name": "python-suite shard 12/12",
+        "status": "completed",
+        "conclusion": "failure",
+        "app": {"slug": "github-actions"},
+        "html_url": "https://example.invalid/job",
+    }
+    check.update(overrides)
+    return check
+
+
+class _FakeApi:
+    """Records the paths asked for, so a test can prove the jobs endpoint was used."""
+
+    def __init__(self, responses: Dict[str, Tuple[int, Any]], default=(404, None)):
+        self.responses = responses
+        self.default = default
+        self.repository = REPO
+        self.calls: List[str] = []
+
+    def request(self, method: str, path: str):
+        self.calls.append(path)
+        for fragment, response in self.responses.items():
+            if fragment in path:
+                return response
+        return self.default
+
+
+def _checks_response(checks: List[Dict[str, Any]]) -> Tuple[int, Any]:
+    return 200, {"total_count": len(checks), "check_runs": checks}
+
+
+# --------------------------------------------------------------------------
+# The three causes, told apart.  One test per class, all against step lists
+# shaped like the real payloads recorded on the issue.
+# --------------------------------------------------------------------------
+
+
+def test_zero_executed_steps_is_runner_starvation(rc):
+    """Run 32984154162: status queued, jobs: [], not a single step executed."""
+    steps = [_step(n, f"step {n}", None) for n in range(1, 15)]
+    cause, detail = rc.classify_steps(steps)
+    assert cause == rc.CAUSE_STARVATION
+    assert "0 of 14" in detail
+    assert cause in rc.REQUEUEABLE_CAUSES
+    assert cause not in rc.REAL_FAILURE_CAUSES
+
+
+def test_setup_action_failure_is_provisioning(rc):
+    """Job 98783580325: 9 of 14 steps ran, step 4 was the setup action."""
+    steps = [
+        _step(1, "Set up job", "success"),
+        _step(2, "Run actions/checkout@v7", "success"),
+        _step(3, "Prepare", "success"),
+        _step(4, "Run ./.github/actions/setup-python-suite", "failure"),
+        _step(9, "Run unit tests — slm-backend", "failure"),
+    ]
+    cause, detail = rc.classify_steps(steps)
+    assert cause == rc.CAUSE_PROVISIONING
+    assert "setup-python-suite" in detail
+    assert cause in rc.REQUEUEABLE_CAUSES
+    assert cause not in rc.REAL_FAILURE_CAUSES
+
+
+def test_test_step_failure_is_a_real_failure(rc):
+    steps = [
+        _step(1, "Set up job", "success"),
+        _step(2, "Run ./.github/actions/setup-python-suite", "success"),
+        _step(3, "Run unit tests — slm-backend", "failure"),
+    ]
+    cause, detail = rc.classify_steps(steps)
+    assert cause == rc.CAUSE_TEST
+    assert "unit tests" in detail
+    assert cause in rc.REAL_FAILURE_CAUSES
+    assert cause not in rc.REQUEUEABLE_CAUSES
+
+
+def test_downstream_test_failure_does_not_mask_the_setup_failure(rc):
+    """
+    The LAST failing step in job 98783580325 is a test step, and reading it
+    would call a provisioning outage a code defect. Only the FIRST one is
+    evidence.
+    """
+    steps = [
+        _step(4, "Run ./.github/actions/setup-python-suite", "failure"),
+        _step(9, "Run unit tests — slm-backend", "failure"),
+    ]
+    assert rc.first_failing_step(steps)["number"] == 4
+    assert rc.classify_steps(steps)[0] == rc.CAUSE_PROVISIONING
+
+
+def test_cancelled_is_superseded_not_a_failure_and_not_requeueable(rc):
+    """Check run 98236533493 — a newer push retired it. `gh pr checks` says `fail`."""
+    cause, detail, ran, total = rc.classify_job_payload(_check(conclusion="cancelled"), None)
+    assert cause == rc.CAUSE_SUPERSEDED
+    assert "fresh run" in detail
+    assert cause not in rc.REAL_FAILURE_CAUSES
+    assert cause not in rc.REQUEUEABLE_CAUSES
+    assert (ran, total) == (None, None)
+
+
+# --------------------------------------------------------------------------
+# Fail-safe: everything unknowable grades as a real failure.
+# --------------------------------------------------------------------------
+
+
+def test_absent_steps_array_is_undetermined_never_starvation(rc):
+    """
+    THE bug this tool exists to prevent. A check-runs list element has no
+    ``steps``; a classifier that reads it as "zero steps executed" calls every
+    genuine red a starved runner and re-queues it.
+    """
+    cause, detail, ran, total = rc.classify_job_payload(_check(), {"id": 1, "conclusion": "failure"})
+    assert cause == rc.CAUSE_UNDETERMINED
+    assert "no 'steps' array" in detail
+    assert cause in rc.REAL_FAILURE_CAUSES
+    assert cause not in rc.REQUEUEABLE_CAUSES
+    assert (ran, total) == (None, None)
+
+
+def test_unreachable_jobs_endpoint_is_undetermined(rc):
+    cause, _, _, _ = rc.classify_job_payload(_check(), None, fetch_error="jobs endpoint unreachable")
+    assert cause == rc.CAUSE_UNDETERMINED
+    assert cause in rc.REAL_FAILURE_CAUSES
+
+
+def test_non_actions_app_is_undetermined(rc):
+    api = _FakeApi({})
+    red = rc.classify_check_run(api, _check(app={"slug": "some-linter"}))
+    assert red.cause == rc.CAUSE_UNDETERMINED
+    assert red.real_failure is True
+    assert api.calls == [], "a non-Actions check has no job to fetch"
+
+
+def test_no_cause_in_the_step_list_is_undetermined(rc):
+    steps = [_step(1, "Set up job", "success"), _step(2, "Run tests", "success")]
+    assert rc.classify_steps(steps)[0] == rc.CAUSE_UNDETERMINED
+
+
+@pytest.mark.parametrize(
+    "cause",
+    ["runner-starvation", "provisioning-failure", "test-failure", "superseded", "undetermined"],
+)
+def test_no_cause_ever_stops_blocking_the_merge(rc, cause):
+    """A cause is information attached to a red, never a way to pass one."""
+    red = rc.RedCause("c", "failure", cause, "d", None, None, None, "")
+    assert red.blocks_merge is True
+
+
+def test_undetermined_is_in_neither_the_requeue_nor_the_clean_set(rc):
+    assert rc.CAUSE_UNDETERMINED not in rc.REQUEUEABLE_CAUSES
+    assert rc.CAUSE_UNDETERMINED in rc.REAL_FAILURE_CAUSES
+
+
+# --------------------------------------------------------------------------
+# Vacuity: the tool must not be able to pass by classifying nothing.
+# --------------------------------------------------------------------------
+
+
+def test_commit_with_no_check_runs_is_indeterminate_not_clean(rc):
+    api = _FakeApi({"check-runs": _checks_response([])})
+    report = rc.classify_commit(api, SHA)
+    assert report.indeterminate is True
+    assert report.reds == []
+    assert rc.resolve_exit_code(report, exit_zero=False) == 2
+    assert "NOT a clean bill of health" in report.message
+
+
+def test_unreachable_check_runs_listing_is_indeterminate(rc):
+    api = _FakeApi({"check-runs": (rc.NO_RESPONSE_STATUS, {"message": "transport failure"})})
+    report = rc.classify_commit(api, SHA)
+    assert report.indeterminate is True
+    assert rc.resolve_exit_code(report, exit_zero=False) == 2
+
+
+def test_exit_zero_cannot_suppress_an_indeterminate_result(rc):
+    """--exit-zero is for report-only callers. It may hide red; never silence."""
+    api = _FakeApi({"check-runs": _checks_response([])})
+    report = rc.classify_commit(api, SHA)
+    assert rc.resolve_exit_code(report, exit_zero=True) == 2
+
+
+def test_red_present_exits_one_whatever_the_cause(rc):
+    """An infrastructure red is still red — the exit code never grades on cause."""
+    job = {"steps": [_step(n, f"step {n}", None) for n in range(1, 5)]}
+    api = _FakeApi({"check-runs": _checks_response([_check()]), "actions/jobs/": (200, job)})
+    report = rc.classify_commit(api, SHA)
+    assert [red.cause for red in report.reds] == [rc.CAUSE_STARVATION]
+    assert rc.resolve_exit_code(report, exit_zero=False) == 1
+
+
+def test_green_commit_with_checks_exits_zero(rc):
+    green = _check(conclusion="success")
+    api = _FakeApi({"check-runs": _checks_response([green])})
+    report = rc.classify_commit(api, SHA)
+    assert report.indeterminate is False
+    assert report.reds == []
+    assert rc.resolve_exit_code(report, exit_zero=False) == 0
+
+
+def test_classification_reads_the_jobs_endpoint_not_the_listing(rc):
+    """
+    Only ``GET /actions/jobs/{id}`` carries ``steps``. If this stops being
+    called the tool is guessing, and every red becomes ``undetermined``.
+    """
+    job = {"steps": [_step(1, "Run tests", "failure")]}
+    api = _FakeApi({"check-runs": _checks_response([_check()]), "actions/jobs/": (200, job)})
+    rc.classify_commit(api, SHA)
+    assert any("/actions/jobs/98783580325" in call for call in api.calls)
+
+
+# --------------------------------------------------------------------------
+# Supporting behaviour.
+# --------------------------------------------------------------------------
+
+
+def test_every_red_rendering_conclusion_is_treated_as_red(rc):
+    for conclusion in ("failure", "cancelled", "timed_out", "startup_failure", "stale"):
+        assert rc.is_red(_check(conclusion=conclusion)) is True
+    assert rc.is_red(_check(conclusion="success")) is False
+    assert rc.is_red(_check(status="in_progress", conclusion=None)) is False
+
+
+def test_skipped_and_queued_steps_do_not_count_as_executed(rc):
+    steps = [_step(1, "a", "skipped"), _step(2, "b", None), _step(3, "c", "success")]
+    assert [s["number"] for s in rc.executed_steps(steps)] == [3]
+
+
+def test_provisioning_markers_are_overridable(rc, monkeypatch):
+    monkeypatch.setenv("CI_RED_CAUSE_PROVISIONING_MARKERS", "install the toolchain")
+    assert rc.is_provisioning_step("Install the toolchain") is True
+    assert rc.is_provisioning_step("Run ./.github/actions/setup-python-suite") is False
+    monkeypatch.setenv("CI_RED_CAUSE_PROVISIONING_MARKERS", "   ,  ")
+    assert rc.is_provisioning_step("Run ./.github/actions/setup-python-suite") is True
+
+
+def test_timed_out_step_counts_as_a_failing_step(rc):
+    """exit 124 surfaces as `timed_out` on some runners — the apt case (#15139)."""
+    steps = [_step(4, "Run ./.github/actions/setup-python-suite", "timed_out")]
+    assert rc.classify_steps(steps)[0] == rc.CAUSE_PROVISIONING


### PR DESCRIPTION
## Thinking Path

`GET /commits/{sha}/check-runs` carries **no `steps` array** — only
`GET /actions/jobs/{id}` does. Verified against this repository: the keys on a
check-run list element are `app, check_suite, completed_at, conclusion,
details_url, external_id, head_sha, html_url, id, name, node_id, output,
pull_requests, started_at, status, url`. Anything classifying a red from the
listing alone therefore sees "no steps" on every check, every time, and answers
with whatever its default is. Defaulting to *infrastructure* re-queues genuine
test failures until they merge; defaulting to *real failure* costs a wasted
investigation. Only the second is survivable, so **an undeterminable cause is
graded as a real failure**.

Reading the *last* failing step is the second trap. Job `98783580325`
(`python-suite shard 12/12`) executed 9 of 14 steps: step 4
`Run ./.github/actions/setup-python-suite` failed on `apt` exit 124 × 3, and
step 9 `Run unit tests — slm-backend` then failed purely downstream. The last
failure names a test; only the **first** one tells the truth.

Both facts were confirmed against the live API before anything was written.

**What this deliberately does not do.** It never makes a red check green. It
publishes no commit status, writes no check conclusion, and re-queues nothing.
Every classified cause carries `blocks_merge=True`. The issue's first
acceptance criterion offers "a `neutral`/`cancelled` conclusion" as an option —
that is not implemented on purpose, because `neutral` **satisfies** a required
context, which converts *red never merges* into *red sometimes merges*. See
"Not delivered" below.

`CI Dispatch Watchdog` and `PR Queue Gate` were both checked (AC 4). The
watchdog is the right home — it already owns "CI did not do what the tile
says" — so this extends it rather than adding a third mechanism: the new step
rides in the existing `watchdog` job. The logic is a new module only because
`pipeline-scripts/ci_dispatch_watchdog.py` sits at **exactly** its recorded
down-only ceiling of 1487 lines (`scripts/python_file_size_known_large.py:528`),
and that number may not be raised to make room. `PR Queue Gate` is a warn-only
notice about open-PR count and is unrelated.

## What Changed

| File | Change |
|---|---|
| `pipeline-scripts/ci_red_cause.py` | New. Classifies every red check on a commit into one of five named causes. 512 lines, under the 600 ceiling. Reuses `GitHubApi` from the watchdog — one HTTP transport, not two. |
| `repo_tests/ci_red_cause_test.py` | 27 tests: one per cause, the fail-safe direction, and four vacuity guards. |
| `.github/workflows/ci-dispatch-watchdog.yml` | New step in the existing `watchdog` job writing the classification to the run summary. |
| `docs/developer/CLAUDE_REVIEW.md` | "Red CI Never Merges" step 3 — name the cause before debugging the diff. "CI Diagnosis" — the queue-depth finding. |

The five causes, and what each is for:

| cause | evidence | at fault | remedy |
|---|---|---|---|
| `runner-starvation` | job executed 0 steps / run has no job | environment | nothing ran; push a new head commit |
| `provisioning-failure` | first failing step is toolchain setup | environment | no test result; push a new head commit |
| `superseded` | `conclusion: cancelled` | neither | wait for the run on the current head |
| `test-failure` | first failing step is a work step | **the diff** | fix the diff |
| `undetermined` | cause not establishable | **assume the diff** | establish the cause first |

**`infrastructure: true` means the diff is not indicted — not that re-running
fixes it.** The boolean was originally named for the remedy, which claimed
something the API does not deliver; it is now `infrastructure`, a statement about
blame, and each cause carries an explicit `remedy` string instead. Measured on run
`33149960063` (see Verification): `rerun-failed-jobs` advanced the run to
`attempt=2` **without re-executing the failed matrix leg at all**. No remedy
string offers a re-run as the fix, and a test enforces that.

Exit codes: `0` only when checks were found and none is red · `1` on any red,
whatever its cause · `2` when nothing could be classified. `--exit-zero`
suppresses the red exit for report-only callers and **cannot** suppress `2`.

The `cancelled` case also answers the first comment on the issue: `gh pr checks`
buckets `cancelled` under `fail`, so `fail` there is not `conclusion: failure`.
That is now stated in `CLAUDE_REVIEW.md` next to the classifier.

## Verification

**Live, against this repository** — PR #15155 head `8d3fa7d2`, 70 checks, 2 red:

```
[test-failure] python-suite (failure, 3/4 steps executed)
    first failing step 2 ('Fail if any shard failed') is a work step
    verdict: REAL FAILURE · DO NOT RE-QUEUE · blocks merge: yes
[provisioning-failure] python-suite shard 12/12 (failure, 9/14 steps executed)
    first failing step 4 ('Run ./.github/actions/setup-python-suite') is
    toolchain provisioning — no test result
    verdict: not a test result · re-queueable · blocks merge: yes
exit=1
```

**Contrast mutations** — one per class, each reverted from a pristine copy and
confirmed byte-identical with `diff -q`:

| mutation | observed | tests that caught it |
|---|---|---|
| drop the zero-executed-steps branch | zero-step job → `undetermined` (was `runner-starvation`) | `test_zero_executed_steps_is_runner_starvation`, `test_red_present_exits_one_whatever_the_cause` |
| `is_provisioning_step` → `False` | setup-action failure → `test-failure` (was `provisioning-failure`) | 4 tests |
| first failing step → **last** failing step | setup-action failure → `test-failure`; the downstream test step masks the outage | `test_setup_action_failure_is_provisioning`, `test_downstream_test_failure_does_not_mask_the_setup_failure` |
| grade `undetermined` as infrastructure | absent `steps` array and unreachable jobs endpoint both → `infrastructure=True, real_failure=False` — exactly the bug that re-queues real failures | 4 tests |

Baseline, unmutated:

```
A zero-executed-steps job -> runner-starvation    infrastructure=True  real_failure=False
B setup-action failure    -> provisioning-failure infrastructure=True  real_failure=False
C test-step failure       -> test-failure         infrastructure=False real_failure=True
D no steps array          -> undetermined         infrastructure=False real_failure=True
E unreachable jobs endpt  -> undetermined         infrastructure=False real_failure=True
```

**Vacuity probes** — it cannot pass by classifying nothing:

| probe | result |
|---|---|
| unreachable API root | `INDETERMINATE — this run vouches for nothing.` · exit **2** |
| same, with `--exit-zero` | exit **2** — the flag cannot silence it |
| commit carrying no check runs | exit **2**, message says explicitly this is *not* a clean bill of health |
| a red whose jobs endpoint is unreachable | `undetermined` → real failure, exit 1 — never "starved" |

**`rerun-failed-jobs` does not re-execute the failed job in this shape —
independently verified.** Run `33149960063`, `run_attempt: 2`, conclusion
`failure`. Every job in attempt 2, ordered by `started_at`:

```
07:23:11 success  Detect changed paths
07:29:10 success  python-suite shard 10/12
  ... ten more shards, all 07:29-07:56 ...
07:54:14 failure  python-suite shard 12/12   <-- the failed job
07:56:18 success  python-suite shard 1/12
08:14:03 failure  python-suite               <-- re-executed
08:14:08 skipped  deployment-check           <-- re-executed
08:24:01 success  notify                     <-- re-executed
```

Fourteen jobs carry their original pre-rerun timestamps into attempt 2, the
failed shard among them (id `98783580325`, `started_at 07:54:14Z`, unchanged).
Only three jobs — the failed job's *dependents* — actually executed, 18 minutes
later, and the `python-suite` rollup then failed on `Fail if any shard failed`.
`GET /attempts/1/jobs` now returns `total_count: 0`, so attempt 1 is no longer
retrievable at all. `python-shard` is a `strategy.matrix` job
(`.github/workflows/ci.yml:110`). **Cause not established — reported, not
diagnosed.**

**What is structurally guaranteed instead.** PR #15155's head moved to
`c2d01e7a` and produced run `33157994603` at **`run_attempt: 1`**. An attempt-1
run has no previous attempt to carry a job forward from, so every job must
execute. That is a guarantee of **re-execution, not of success** — and it is
worded that way in both the tool and the doc. Not asserted: that the fresh run
goes green (it was still `queued` when checked).

**Gates run locally:** `pre-commit run --files <the four changed files>` — all
hooks pass (`black`, `isort`, `flake8`, `check yaml`, file-size ceiling, env-var
registry, encoding, workflow path filters, no-print). `pytest
repo_tests/ci_red_cause_test.py` — 27 passed. `check-doc-references.py` — 93
references resolve.

**What a local pass does not cover.** The local interpreter is below ~90 of the
repository's declared dependency floors (`fastapi 0.135.2` vs `>=0.141.1`,
`pydantic 2.12.5` vs `>=2.13.4`, and so on), so CI is the stronger signal. The
new workflow step has not executed on a runner yet — its first real exercise is
this PR's own watchdog run. Note that this PR touches
`ci-dispatch-watchdog.yml`, so the watchdog's self-modification guard will drop
the *sweep* to `--dry-run`; the classify step is unaffected because it issues
GET requests only.

**Queue finding (AC 2 / AC 3), measured 2026-08-28.** 155 runs queued, 14 jobs
executing — **13 on `ubuntu-latest`, 1 on self-hosted** — with both self-hosted
runners `online, busy=true`. A 12-run sample of the queued runs found
`ubuntu-latest` on every job. So the queue is the **GitHub-hosted concurrency
cap**, not a dispatch gate and not a starved self-hosted pool: idle self-hosted
runners beside a long queue is expected, not a fault. Recorded in
`docs/developer/CLAUDE_REVIEW.md` under "CI Diagnosis", with the re-measure
commands and the `WATCHDOG_STALL_MINUTES` (45) threshold below which waiting is
normal.

**Not delivered — why this is `Refs`, not `Closes`.** AC 1 offers three
remedies: a `neutral`/`cancelled` conclusion, a named annotation, or an
automatic re-queue. None is implemented. A `neutral` conclusion satisfies a
required context, so it would let an infrastructure red merge — the wrong
design. Annotations and conclusions on an Actions-produced check cannot be
written by another app in any case. The clause that *is* met is the one that
matters: a starved run is now reported distinguishably, and named. Whether the
remaining remedies are wanted is the owner's call.

## Model Used

Claude Opus 5 (1M context)

Refs #15139

