### PR TITLE
test(perf): mock _store_result in the single multimodal benchmark so it stops timing SQLite (#15232)

### DIFF
--- a/autobot-backend/system_benchmarks_performance_test.py
+++ b/autobot-backend/system_benchmarks_performance_test.py
@@ -55,6 +55,10 @@ pytestmark = pytest.mark.performance
 # is 600, ~1.9x the worst reading. Every other site is CPU-shaped, tracks the
 # unit closely, and is held to 8x its highest observation (3x for the large
 # steady ones). Ratchet DOWN as runs report lower — the only direction allowed.
+# #15232: `Single multimodal processing` was the same shape and was missed here —
+# it was the one processing benchmark still running `_store_result` live, so it
+# timed SQLite writes. It now mocks storage like its two siblings, which makes it
+# CPU-shaped, and its budget is re-derived at the call site from that measurement.
 
 
 @pytest.fixture(autouse=True)
@@ -171,8 +175,19 @@ class TestSystemPerformanceBenchmarks:
             data="Test processing performance",
         )
 
-        # Mock the context processor for consistent timing
-        with patch.object(processor.context_processor, "process", new_callable=AsyncMock) as mock_process:
+        # Mock the context processor for consistent timing. #15232: `_store_result`
+        # is mocked here too, for the reason its two siblings below already record
+        # under #13162 — it writes the result to the shared SQLite memory database,
+        # so leaving it live made this benchmark measure disk contention rather than
+        # the processing path its name refers to. That is not a gap calibration can
+        # close: a work unit is a slice of pure-Python CPU work (#15055), and a
+        # CPU-bound yardstick does not track a disk-bound numerator, which is the
+        # same limitation `Multimodal processor startup` documents at its budget.
+        # The storage call is still asserted below, off the clock.
+        with (
+            patch.object(processor.context_processor, "process", new_callable=AsyncMock) as mock_process,
+            patch.object(processor, "_store_result", new_callable=AsyncMock) as mock_store,
+        ):
             mock_process.return_value = Mock(
                 success=True,
                 confidence=0.8,
@@ -185,12 +200,21 @@ class TestSystemPerformanceBenchmarks:
 
             result, processing_time = await self.measure_async_execution_time(processor.process(test_input))
 
-            # First-observation ceiling, not a measurement: this is the one
-            # processing benchmark that does NOT mock `_store_result`, so it
-            # writes to the shared SQLite memory database, and the local
-            # interpreter has no torch. Ratchet it DOWN to the reported units.
-            assert_within_work_budget(processing_time, 50.0, "Single multimodal processing")
+            # 20.8 units. DERIVATION in the module header's terms: 17 local runs
+            # with storage mocked read 0.596-1.626 units (was 68.709 unmocked, and
+            # 164.422 on CI run 33161132835), so the highest local observation is
+            # 1.626; x3.2 for the CI conversion the header records = 5.2. HEADROOM
+            # 4x, between the header's two classes on purpose: the numerator is
+            # milliseconds, not the single-digit microseconds that put a site in
+            # the 8x class, but its spread is load-driven at cv ~33% rather than
+            # the under-12% that puts a site in the 3x class. Ratchet DOWN as runs
+            # report lower.
+            assert_within_work_budget(processing_time, 20.8, "Single multimodal processing")
             assert result.success is True
+            # #15232: mocking storage removes it from the clock, not from the
+            # contract. Without this, a change that stopped persisting results
+            # would make the benchmark faster and still pass.
+            mock_store.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_concurrent_processing_performance(self):

--- a/autobot-backend/system_benchmarks_performance_test.py
+++ b/autobot-backend/system_benchmarks_performance_test.py
@@ -183,11 +183,11 @@ class TestSystemPerformanceBenchmarks:
 
             result, processing_time = await self.measure_async_execution_time(processor.process(test_input))
 
-            # 20.8 units, down from a 50.0 first-observation ceiling over the disk-bound measurement. DERIVATION in
-            # the header's terms: 17 local runs with storage mocked read 0.596-1.626 units (68.709 unmocked locally,
-            # 164.422 on CI run 33161132835); local high 1.626 x3.2 CI conversion = 5.2, x4 headroom — between the
-            # header's classes: milliseconds, not the 8x class's microseconds, but a load-driven cv ~33%. Ratchet DOWN.
-            assert_within_work_budget(processing_time, 20.8, "Single multimodal processing")
+            # 6.5 units, down from a 50.0 first-observation ceiling over the disk-bound measurement. DERIVATION: with
+            # storage mocked, marker run 33181196014 read 0.250 units on CI and 17 local runs 0.596-1.626 (against
+            # 68.709 unmocked locally, 164.422 on CI run 33161132835). 4x the highest reading anywhere, 1.626; the
+            # header's x3.2 local->CI conversion does not apply, that CI figure sitting below every local one.
+            assert_within_work_budget(processing_time, 6.5, "Single multimodal processing")
             assert result.success is True
             # #15232: storage is off the clock, not out of the contract — dropping the write must not read as faster.
             mock_store.assert_awaited_once()

--- a/autobot-backend/system_benchmarks_performance_test.py
+++ b/autobot-backend/system_benchmarks_performance_test.py
@@ -25,40 +25,28 @@ from multimodal_processor import (
 )
 from services.config_service import ConfigService
 
-# #13162: every test in this module asserts a wall-clock budget (ms elapsed) or
-# an RSS delta — there is not one functional-only test here, and the filename
-# already declares it (`*_performance_test.py`). That makes the module a
-# benchmark suite, so it belongs to the `performance` selection rather than the
-# unit selection, where a millisecond budget measures the CI runner's
-# contention instead of the code. No budget in this file was changed.
+# #13162: every test in this module asserts a wall-clock budget (ms elapsed) or an RSS delta — there is not one
+# functional-only test here, and the filename already declares it (`*_performance_test.py`). That makes the module a
+# benchmark suite, so it belongs to the `performance` selection rather than the unit selection, where a millisecond
+# budget measures the CI runner's contention instead of the code. No budget in this file was changed.
 pytestmark = pytest.mark.performance
 
 
-# #15055: the budgets below are RUNNER-CALIBRATED WORK UNITS, not milliseconds
-# against a hardcoded constant. The doctrine, the unit and the assertion live in
-# `autobot_shared.perf_work_budget` — read its module docstring before changing
-# any number here. In one line: a millisecond ceiling measures the runner, so
-# each budget is a ratio against a fixed slice of pure-Python work timed in the
-# same process, and a uniformly slow runner scales both sides.
-# DERIVATION. Five local runs gave a highest-observed value per site. Run
-# 33156790797 then measured `Config manager startup` at 1.474 units on CI against
-# a local high of 0.459, so ordinary Python work costs ~3.2x more units on that
-# runner; every local figure is converted by that factor before headroom. Headroom
-# on top: 3x where the measurement is large and steady (cv of units under ~12%
-# across the five runs), 8x where it is single-digit microseconds and timer
+# #15055: the budgets below are RUNNER-CALIBRATED WORK UNITS, not milliseconds against a hardcoded constant. The
+# doctrine, the unit and the assertion live in `autobot_shared.perf_work_budget` — read its module docstring before
+# changing any number here. In one line: a millisecond ceiling measures the runner, so each budget is a ratio against a
+# fixed slice of pure-Python work timed in the same process, and a uniformly slow runner scales both sides.
+# DERIVATION. Five local runs gave a highest-observed value per site. Run 33156790797 then measured `Config manager
+# startup` at 1.474 units on CI against a local high of 0.459, so ordinary Python work costs ~3.2x more units on that
+# runner; every local figure is converted by that factor before headroom. Headroom on top: 3x where the measurement is
+# large and steady (cv of units under ~12% across the five runs), 8x where it is single-digit microseconds and timer
 # granularity rather than load sets the spread, floored at 0.20 units.
-# ONE SITE KEEPS A WIDE BUDGET ON PURPOSE. `Multimodal processor startup` read
-# 315.602, 177.909 and 114.306 units on runs 33156790797, 33158382218 and
-# 33161132835 — a 2.76x spread in the RATIO, not merely in the milliseconds.
-# Calibration cannot normalise it: the cost is model-file and HF-cache disk I/O
-# and a CPU-bound yardstick does not track a disk-bound numerator, so its budget
-# is 600, ~1.9x the worst reading. Every other site is CPU-shaped, tracks the
-# unit closely, and is held to 8x its highest observation (3x for the large
-# steady ones). Ratchet DOWN as runs report lower — the only direction allowed.
-# #15232: `Single multimodal processing` was the same shape and was missed here —
-# it was the one processing benchmark still running `_store_result` live, so it
-# timed SQLite writes. It now mocks storage like its two siblings, which makes it
-# CPU-shaped, and its budget is re-derived at the call site from that measurement.
+# ONE SITE KEEPS A WIDE BUDGET ON PURPOSE. `Multimodal processor startup` read 315.602, 177.909 and 114.306 units on
+# runs 33156790797, 33158382218 and 33161132835 — a 2.76x spread in the RATIO, not merely in the milliseconds.
+# Calibration cannot normalise it: the cost is model-file and HF-cache disk I/O and a CPU-bound yardstick does not track
+# a disk-bound numerator, so its budget is 600, ~1.9x the worst reading. Every other site is CPU-shaped, tracks the unit
+# closely, and is held to 8x its highest observation (3x for the large steady ones). Ratchet DOWN as runs report lower —
+# the only direction allowed.
 
 
 @pytest.fixture(autouse=True)
@@ -175,15 +163,10 @@ class TestSystemPerformanceBenchmarks:
             data="Test processing performance",
         )
 
-        # Mock the context processor for consistent timing. #15232: `_store_result`
-        # is mocked here too, for the reason its two siblings below already record
-        # under #13162 — it writes the result to the shared SQLite memory database,
-        # so leaving it live made this benchmark measure disk contention rather than
-        # the processing path its name refers to. That is not a gap calibration can
-        # close: a work unit is a slice of pure-Python CPU work (#15055), and a
-        # CPU-bound yardstick does not track a disk-bound numerator, which is the
-        # same limitation `Multimodal processor startup` documents at its budget.
-        # The storage call is still asserted below, off the clock.
+        # Mock the context processor for consistent timing. #15232: `_store_result` is mocked here too, for the reason
+        # the two siblings below record under #13162 — it writes to the shared SQLite memory database, so leaving it
+        # live timed disk contention instead of the processing path this test names, and a CPU-bound work unit (#15055)
+        # cannot normalise a disk-bound numerator — the limitation `Multimodal processor startup` records at its budget.
         with (
             patch.object(processor.context_processor, "process", new_callable=AsyncMock) as mock_process,
             patch.object(processor, "_store_result", new_callable=AsyncMock) as mock_store,
@@ -200,20 +183,13 @@ class TestSystemPerformanceBenchmarks:
 
             result, processing_time = await self.measure_async_execution_time(processor.process(test_input))
 
-            # 20.8 units. DERIVATION in the module header's terms: 17 local runs
-            # with storage mocked read 0.596-1.626 units (was 68.709 unmocked, and
-            # 164.422 on CI run 33161132835), so the highest local observation is
-            # 1.626; x3.2 for the CI conversion the header records = 5.2. HEADROOM
-            # 4x, between the header's two classes on purpose: the numerator is
-            # milliseconds, not the single-digit microseconds that put a site in
-            # the 8x class, but its spread is load-driven at cv ~33% rather than
-            # the under-12% that puts a site in the 3x class. Ratchet DOWN as runs
-            # report lower.
+            # 20.8 units, down from a 50.0 first-observation ceiling over the disk-bound measurement. DERIVATION in
+            # the header's terms: 17 local runs with storage mocked read 0.596-1.626 units (68.709 unmocked locally,
+            # 164.422 on CI run 33161132835); local high 1.626 x3.2 CI conversion = 5.2, x4 headroom — between the
+            # header's classes: milliseconds, not the 8x class's microseconds, but a load-driven cv ~33%. Ratchet DOWN.
             assert_within_work_budget(processing_time, 20.8, "Single multimodal processing")
             assert result.success is True
-            # #15232: mocking storage removes it from the clock, not from the
-            # contract. Without this, a change that stopped persisting results
-            # would make the benchmark faster and still pass.
+            # #15232: storage is off the clock, not out of the contract — dropping the write must not read as faster.
             mock_store.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Thinking Path

`test_multimodal_processor_performance` was the only one of the three processing
benchmarks in this module that did not mock `_store_result`. Its two siblings
(`test_concurrent_processing_performance`, `test_multimodal_processor_scalability`)
mock it under an explicit `#13162` note saying why: `_store_result` writes the
result to the shared SQLite memory database, so leaving it live makes the
benchmark measure disk contention instead of the processing path.

#15055 replaced 20 wall-clock constants in this file with ratios against a work
unit — a fixed slice of pure-Python CPU work timed in the same process. That
normalises a uniformly slow runner, but only for a CPU-shaped numerator. A
CPU-bound yardstick cannot track a disk-bound one, which is exactly the
limitation the module header already records for `Multimodal processor startup`
(2.76x spread in the ratio, budget left wide at 600 for that reason).

So the calibration that fixed the other 19 sites could not fix this one, and the
budget was never a measurement — its own comment called it a "first-observation
ceiling".

**Option taken: mock `_store_result`, matching the siblings.** The alternative
(keep storage live and widen the budget in the `Multimodal processor startup`
style) was rejected: it would leave the benchmark named "Single multimodal
processing" measuring storage, and a wide budget is a weaker detector than a
tight one over a CPU-shaped measurement. Confirmed by the numbers below — mocking
storage made the site *more* sensitive, not less.

The budget was not raised. It went **50.0 -> 6.5**.

## What Changed

`autobot-backend/system_benchmarks_performance_test.py`, one test:

- `_store_result` is now mocked alongside `context_processor.process`, with the
  reason recorded at the call site and cross-referenced to the siblings' `#13162`
  note and to the header's `#15055` derivation.
- Budget re-derived from the new, CPU-shaped measurement: **50.0 -> 6.5 units**,
  with the derivation recorded at the constant. Marker run 33181196014,
  dispatched on this branch, reported the site at **0.250 units** on CI; 17 local
  runs read 0.596-1.626. The budget is 4x the highest reading anywhere (1.626, on
  a contended local machine) and 26x the CI reading. The header's x3.2 local->CI
  conversion is explicitly *not* applied here: the CI figure sits below every
  local one, and that factor was derived for `Config manager startup`, not this
  site.
- `mock_store.assert_awaited_once()` added. Mocking storage takes it off the
  clock, not out of the contract: without this, a change that stopped persisting
  results would make the benchmark faster and still pass.
- The module's two header comment blocks are rewrapped to the repo's own
  120-column limit. Reason: the file sits **exactly at** the 600-line ceiling in
  `scripts/check_python_file_size.py` (`MAX_LINES = 600`) and has no
  `KNOWN_LARGE` entry, so it can absorb no net growth, and adding a
  grandfathering entry would be a ceiling moved the wrong way. The rewrap is
  wording-preserving — the edit asserts the unwrapped word sequence is identical
  before and after — and pays for the new documentation. **The file is 600 lines
  before and after this PR.**

## Verification

CI is the authority. Everything below is a local run and demonstrates the test's
*shape*; this environment sits below 90 of 206 declared dependency floors, so it
is not evidence about behaviour where the code ships. `marker-tests.yml` only
triggers on changes to itself, so this PR would otherwise never run the suite it
fixes; a `workflow_dispatch` was therefore fired on this branch.

**CI: Marker-excluded Tests, two `success` runs.**

| run | commit | reported |
|---|---|---|
| 33181196014 | `6766af06` | `Single multimodal processing: 0.250 work units = 0.389ms / 1.559ms unit` |
| 33183259273 | `58f5703c` (head) | `Single multimodal processing: 0.254 work units = 0.326ms / 1.283ms unit` |

0.250 and 0.254 — a ~1% spread in the ratio across two runs, against the 164.422
the same site reported before this change. That is the point of the fix: with
storage off the clock the site is CPU-shaped and tracks the work unit closely,
which is what the header says a calibrated budget requires. The budget was
ratcheted 20.8 -> 6.5 after the first of these; the second run is green at 6.5.

On the PR itself, every check on head `58f5703c` is success or skipped
(48 success, 9 skipped). Three checks read `fail` in `gh pr checks` — they are
superseded runs cancelled by a PR-body edit; the latest run of each
(33183371931, 33183371810, 33183371780) succeeded.

Effect of the change (same file, unchanged elsewhere):

| | measured | units | budget | result |
|---|---|---|---|---|
| Before, CI run 33161132835 | 142.385ms | 164.422 | 50.0 | FAIL |
| Before, local | 145.706ms | 68.709 | 50.0 | FAIL |
| After, CI run 33181196014 | 0.389ms | **0.250** | 6.5 | PASS |
| After, local (17 runs) | 1.264-3.877ms | 0.596-1.626 | 6.5 | PASS |

Storage was ~98% of the measured time. Full module: 14 passed.

**Regression mutation.** Injected a real slowdown into the processing path under
test — an `await asyncio.sleep(0.05)` in `MultiModalProcessor.process()`
immediately before `_route_to_processor`:

```
AssertionError: Single multimodal processing: 52.508 work units (budget 6.5)
  = 53.451ms / 1.018ms unit.
```

Red, as required. A 10x smaller injection (`asyncio.sleep(0.01)`) is caught too:

```
AssertionError: Single multimodal processing: 7.691 work units (budget 6.5)
  = 12.472ms / 1.622ms unit.
```

Note the *old* budget of 50.0 would have let the 50ms regression through on a
quieter moment (26.527 units on an earlier run of the identical injection), and
the 10ms one always — the site now detects regressions it previously could
not. The same injection also reddened both sibling benchmarks
(`Concurrent processing (10 inputs)` 51.846/12.0, `Scaling to 50 concurrent
requests` 45.207/30.0), which is the expected cross-check. Mutation reverted;
`diff -q` against a pristine copy confirms the file is byte-identical, and
`git status` shows only the benchmark file changed.

**Contract mutation.** Commented out the `await self._store_result(result)` call
in `process()`:

```
AssertionError: Expected _store_result to have been awaited once. Awaited 0 times.
```

Red. Reverted and confirmed with `diff -q`.

**Vacuity probes.** Forcing the measurement to be absent or zero:

```
processing_time = 0.0  -> AssertionError: Single multimodal processing: measured 0.0ms
                          — the operation under test did not run
processing_time = None -> AssertionError: Single multimodal processing: no measurement
                          was taken (got None)
```

Both red. The assertion cannot pass vacuously. Reverted and confirmed with
`diff -q`.

**Sweep for other unmocked storage paths.** All three sites that call
`processor.process()` (lines 197, 258, 560 post-change) now mock `_store_result`;
that set is complete. Of the file's other work-unit sites none touches the memory
database: `test_memory_manager_performance` does write through a real
`MemoryManager`, but its assertion is an RSS delta, not a work-unit budget, so
disk time does not enter it. One separate observation is reported to the issue
owner rather than fixed here, since it is a different site with a different cause.

**Not verified.** The 6.5 budget rests on two CI observations (0.250, 0.254)
plus 17 local ones. Two runs are a thin spread, and 6.5 is 4x the highest local
reading rather than a multiple of the CI ones, so it is deliberately loose: it
should ratchet down again as further runs accumulate — down is the only
direction allowed. It is already tight enough to redden a 10ms regression.

## Model Used

Claude Opus 5 (1M context)

Closes #15232




