### PR TITLE
test-guard(repo_tests): an assert under a swallowing handler is not protection (#15195)

### DIFF
--- a/repo_tests/collected_test_model.py
+++ b/repo_tests/collected_test_model.py
@@ -1,0 +1,325 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""What pytest would collect, and which of a test's assertions can actually fire.
+
+Static model shared by the guards that reason about the collected test
+population. Two questions live here, both answered from the AST alone with no
+execution:
+
+* **What would pytest collect?** ``test_modules`` applies pytest's own
+  ``python_files`` globs as a denylist walk from the repo root, and
+  ``collectable_tests`` applies ``python_classes`` / ``python_functions``. The
+  options are read out of ``pytest.ini`` rather than restated, so the model
+  cannot drift from the runner by anyone editing one and not the other.
+* **Can this test fail?** ``propagating_guards`` answers whether an ``assert``
+  or ``raise`` in a collected test can actually reach pytest, which is a
+  different question from whether one is written down (#15195, below).
+
+Split out of ``tests_that_return_instead_of_asserting_test.py`` when a second
+guard needed the same model. Two copies of "what pytest collects" would drift,
+and a drifted collection model is the failure this repository has already hit
+twice: #14927 matched ``python_classes`` by name and missed every
+``unittest.TestCase``, and #15018 enumerated half of nothing and called it
+covered. Same reason ``uncollected_class_model.py`` exists next door.
+
+This module holds no ratchet and no budget. The numbers live with the guards
+that enforce them.
+
+WHEN AN ASSERT DOES NOT COUNT AS PROTECTION (#15195)
+----------------------------------------------------
+A test that asserts as well as returns is exempt, because it can still fail.
+That held only while an ``assert`` which is PRESENT was an ``assert`` which can
+FIRE, and for one very common shape it is not::
+
+    def test_thing():
+        try:
+            assert cache.get("k") == "v"
+            return True
+        except Exception:
+            return False
+
+``except Exception`` catches ``AssertionError``. The assertion is inert, the
+function returns on both branches, and the test cannot fail whichever way it
+goes — while reading as defended to a sweep that only looked for the node. Nine
+of the ten functions in #15189 were exactly this, and this guard passed over
+every one of them for as long as the file existed.
+
+So the exemption is now spent only on assertions that can reach pytest. An
+``assert`` or ``raise`` is discounted when it sits in the ``try`` body of a
+``try`` whose handler catches ``Exception``, ``BaseException`` or
+``AssertionError`` and neither re-raises nor calls a pytest outcome
+(``fail``/``exit``/``skip``/``xfail``). The rule is deliberately narrow in three
+directions, because a guard that over-flags is a guard somebody switches off:
+
+* a handler naming a specific non-assertion exception (``except ValueError``)
+  protects nothing away and is not counted;
+* ``else`` and ``finally`` clauses, and the handler bodies themselves, are not
+  covered by that try's own handlers, so assertions there stay live;
+* the ownership rule is unchanged — a nested helper's swallow is the helper's.
+
+The same machinery drives ``_SWALLOWED_ASSERTIONS``, a second down-only ceiling
+covering the general form: an inert assertion in a test that does NOT return a
+value. The ceiling on returns cannot see those, and there are nine of them.
+"""
+
+from __future__ import annotations
+
+import ast
+import configparser
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTEST_INI = REPO_ROOT / "pytest.ini"
+
+SKIP = {
+    ".git",
+    ".worktrees",
+    # Harness territory: tooling config plus the agent worktrees checked out
+    # under it, which hold other branches' work in progress and are not always
+    # parseable. pytest's own testpaths never reach it either, so nothing here
+    # is collectable and nothing here is this sweep's subject.
+    ".claude",
+    "__pycache__",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".tox",
+}
+
+def pytest_option(name: str) -> list[str]:
+    parser = configparser.ConfigParser(inline_comment_prefixes=("#",))
+    parser.read(PYTEST_INI, encoding="utf-8")
+    values = parser.get("pytest", name, fallback="").split()
+    assert values, f"pytest.ini declares no {name} — the population cannot be derived"
+    return values
+
+
+def parse_module(path: Path) -> ast.Module:
+    """Parse one swept file, failing loudly and by name if it cannot be parsed.
+
+    This sweep is a denylist walk from the repo root, filtered only by ``SKIP``,
+    so it reaches files pytest's ``testpaths`` allowlist never would: scratch
+    copies, templates, half-written drafts. An unparseable one must never read as
+    "clean" -- skipping it silently is the exact under-reporting failure this
+    guard exists to catch -- so it is raised as a failure that names the file and
+    says how to take it out of the sweep on purpose.
+    """
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        relative = path.relative_to(REPO_ROOT)
+        raise AssertionError(
+            f"{relative}:{exc.lineno or 0} is not parseable Python ({exc.msg}). "
+            "This guard sweeps every *.py under the repo root as a denylist, so it "
+            "sees files pytest's own testpaths allowlist never reaches. Fix the "
+            "file, or -- if it is scratch, vendored or another branch's work and "
+            "does not belong in the sweep -- add its top-level directory to SKIP "
+            "in every repo_tests guard that sweeps, the way .claude and .worktrees "
+            "already are. Do not silence this by skipping the file: a file the "
+            "sweep cannot read is not a file the sweep has cleared."
+        ) from exc
+
+
+def test_modules() -> list[Path]:
+    """Every file pytest's own ``python_files`` globs would consider."""
+    patterns = pytest_option("python_files")
+    return sorted(
+        path
+        for path in REPO_ROOT.rglob("*.py")
+        if not SKIP.intersection(path.relative_to(REPO_ROOT).parts)
+        and any(path.match(pattern) for pattern in patterns)
+    )
+
+
+def prefixes() -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """``python_functions`` and ``python_classes`` as plain name prefixes."""
+    functions = tuple(p.rstrip("*") for p in pytest_option("python_functions"))
+    classes = tuple(p.rstrip("*") for p in pytest_option("python_classes"))
+    return functions, classes
+
+
+def collectable_tests(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Functions pytest would collect as tests from this module.
+
+    Module-level ``test_*`` functions, and ``test_*`` methods of ``Test*``
+    classes. A method of any other class is not collected, so its return value
+    is nobody's verdict.
+    """
+    functions, classes = prefixes()
+    found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            found.append(node)
+        elif isinstance(node, ast.ClassDef) and node.name.startswith(classes):
+            found.extend(
+                child
+                for child in node.body
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+            )
+    return [node for node in found if node.name.startswith(functions)]
+
+
+def own_nodes(function: ast.AST, wanted: tuple[type, ...]) -> list[ast.AST]:
+    """Nodes belonging to ``function`` itself, never to a nested definition."""
+    found: list[ast.AST] = []
+    stack: list[ast.AST] = list(ast.iter_child_nodes(function))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            continue
+        if isinstance(node, wanted):
+            found.append(node)
+        stack.extend(ast.iter_child_nodes(node))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Is an assertion able to fire? (#15195)
+#
+# The exemption below spares a test that asserts AND returns, on the reasoning
+# that such a test can still fail. That reasoning assumes an ``assert`` which is
+# PRESENT is an ``assert`` which can FIRE. Under a handler that catches
+# ``AssertionError``, it cannot: the assertion is inert, the test cannot fail
+# whichever way it goes, and the sweep built to find tests that cannot fail read
+# it as defended. Nine of the ten functions in #15189 had exactly this shape.
+#
+# So an assertion is counted as protective only when nothing lexically between
+# it and the function boundary would catch what it raises.
+# ---------------------------------------------------------------------------
+
+# Handlers that catch an AssertionError: a bare ``except:``, and any handler
+# naming one of these. ``Exception`` is the one that does the damage in
+# practice, because it is the one people write without meaning to catch a
+# failed assertion.
+ASSERTION_CATCHING = frozenset({"Exception", "BaseException", "AssertionError"})
+
+# A handler that catches the assertion but turns it back into a verdict is NOT
+# swallowing it. ``raise`` re-raises, an ``assert`` in the handler re-checks,
+# and pytest's outcome calls end the test rather than let it report green.
+# ``skip``/``xfail`` are in the set deliberately: a skipped test is not a
+# passing test, and a guard that over-flags is a guard somebody switches off —
+# which would be worse than the blindness this rule removes.
+OUTCOME_CALLS = frozenset({"fail", "exit", "skip", "xfail"})
+
+TRY_NODES: tuple[type, ...] = (
+    (ast.Try, ast.TryStar) if hasattr(ast, "TryStar") else (ast.Try,)
+)
+
+
+def catches_an_assertion(handler: ast.ExceptHandler) -> bool:
+    """Would this handler catch an ``AssertionError`` raised in the try body?"""
+    if handler.type is None:
+        return True
+    named = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    for node in named:
+        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
+        if name in ASSERTION_CATCHING:
+            return True
+    return False
+
+
+def reports_the_failure(handler: ast.ExceptHandler) -> bool:
+    """Does the handler hand the failure back on, rather than absorb it?"""
+    for node in own_nodes(handler, (ast.Raise, ast.Assert, ast.Call)):
+        if isinstance(node, (ast.Raise, ast.Assert)):
+            return True
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name in OUTCOME_CALLS:
+            return True
+    return False
+
+
+def swallows_assertions(node: ast.AST) -> bool:
+    """True when this ``try`` neutralises assertions made in its own body."""
+    return any(
+        catches_an_assertion(handler) and not reports_the_failure(handler)
+        for handler in getattr(node, "handlers", ())
+    )
+
+
+def collect_guards(node: ast.AST, swallowed: bool, found: list[ast.AST]) -> None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    if isinstance(node, (ast.Assert, ast.Raise)):
+        if not swallowed:
+            found.append(node)
+        return
+    if isinstance(node, TRY_NODES):
+        inside = swallowed or swallows_assertions(node)
+        for child in node.body:
+            collect_guards(child, inside, found)
+        # ``else``, ``finally`` and the handler bodies are NOT covered by this
+        # try's own handlers — anything raised there propagates — so they keep
+        # whatever protection state the enclosing scope had.
+        for child in (*node.handlers, *node.orelse, *node.finalbody):
+            collect_guards(child, swallowed, found)
+        return
+    for child in ast.iter_child_nodes(node):
+        collect_guards(child, swallowed, found)
+
+
+def propagating_guards(function: ast.AST) -> list[ast.AST]:
+    """``assert``/``raise`` owned by ``function`` that can actually reach pytest.
+
+    Same ownership rule as ``_own_nodes``: a nested definition owns its own.
+    """
+    found: list[ast.AST] = []
+    for child in ast.iter_child_nodes(function):
+        collect_guards(child, False, found)
+    return found
+
+
+def is_fixture(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in function.decorator_list:
+        node = decorator.func if isinstance(decorator, ast.Call) else decorator
+        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
+        if name == "fixture":
+            return True
+    return False
+
+
+def swallowed_assertions(source: str) -> list[tuple[str, int]]:
+    """``(test name, line)`` for every test holding an assertion that cannot fire.
+
+    The general form of the #15195 defect, independent of whether the function
+    also returns a value. Driven from source text for the same reason
+    ``offending_returns`` is: a detector only ever pointed at the live tree
+    cannot be distinguished from one that has stopped detecting.
+    """
+    return swallowed_assertions_in(ast.parse(source))
+
+
+def swallowed_assertions_in(tree: ast.Module) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for function in collectable_tests(tree):
+        if is_fixture(function):
+            continue
+        live = {id(node) for node in propagating_guards(function)}
+        inert = [
+            node
+            for node in own_nodes(function, (ast.Assert,))
+            if id(node) not in live
+        ]
+        if inert:
+            found.append((function.name, inert[0].lineno))
+    return found
+
+
+def test_functions_by_tree() -> dict[str, int]:
+    """Collectable test functions per top-level tree.
+
+    The presence half of the ratchet: a per-tree count, because the repo-wide
+    floors below cannot notice one tree's walk collapsing inside a population
+    of 27,000.
+    """
+    counts: dict[str, int] = {}
+    for module in test_modules():
+        tree = module.relative_to(REPO_ROOT).parts[0]
+        found = collectable_tests(parse_module(module))
+        counts[tree] = counts.get(tree, 0) + len(found)
+    return counts

--- a/repo_tests/collected_test_model_test.py
+++ b/repo_tests/collected_test_model_test.py
@@ -1,0 +1,160 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the shared collected-test model (#15195).
+
+The guards that use this model are repo-wide sweeps: they can only tell you
+that today's tree happens to be clean, never that a branch of the model is
+right. So every branch gets a synthetic case here — especially the ones that
+must NOT fire. A guard that over-flags a legitimate ``try``/``except`` is a
+guard somebody switches off, and a switched-off guard is worse than the blind
+spot #15195 removed.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from repo_tests.collected_test_model import (
+    collectable_tests,
+    own_nodes,
+    propagating_guards,
+    swallowed_assertions,
+)
+
+
+def _function(source: str) -> ast.AST:
+    """The single collected test in ``source``."""
+    found = collectable_tests(ast.parse(source))
+    assert len(found) == 1, f"expected one collected test, found {len(found)}"
+    return found[0]
+
+
+def _live(source: str) -> int:
+    return len(propagating_guards(_function(source)))
+
+
+def _written(source: str) -> int:
+    return len(own_nodes(_function(source), (ast.Assert, ast.Raise)))
+
+
+SWALLOWED = (
+    "def test_a():\n"
+    "    try:\n"
+    "        assert False\n"
+    "    except Exception:\n"
+    "        pass\n"
+)
+
+
+def test_a_handler_catching_assertions_makes_the_assert_in_its_body_inert() -> None:
+    assert _written(SWALLOWED) == 1, "the assertion is written down"
+    assert _live(SWALLOWED) == 0, "and it cannot reach pytest"
+    assert swallowed_assertions(SWALLOWED) == [("test_a", 3)]
+
+
+def test_every_spelling_that_catches_an_assertion_error_is_recognised() -> None:
+    for catcher in (
+        "except Exception:",
+        "except BaseException:",
+        "except AssertionError:",
+        "except:",
+        "except (ValueError, Exception):",
+        "except Exception as exc:",
+        "except (KeyError, AssertionError, OSError):",
+    ):
+        source = SWALLOWED.replace("except Exception:", catcher)
+        assert _live(source) == 0, f"`{catcher}` catches AssertionError"
+
+
+def test_a_handler_that_hands_the_failure_back_on_is_not_a_swallow() -> None:
+    """The counter-cases. Over-flagging here is the expensive failure."""
+    for handler, why in (
+        ("        raise\n", "a bare re-raise"),
+        ("        raise RuntimeError('x')\n", "raising something else still ends the test"),
+        ("        assert False\n", "the handler re-checks"),
+        ("        pytest.fail('x')\n", "pytest.fail ends the test"),
+        ("        pytest.skip('x')\n", "a skipped test is not a passing test"),
+        ("        self.fail('x')\n", "unittest's own outcome call"),
+    ):
+        source = SWALLOWED.replace("        pass\n", handler)
+        # >= 1 rather than == 1: a `raise` in the handler is itself a live
+        # guard node, so the re-raise cases legitimately report two.
+        assert _live(source) >= 1, f"{why} — the assertion still counts"
+        assert not swallowed_assertions(source), why
+
+
+def test_a_handler_naming_a_non_assertion_exception_protects_nothing_away() -> None:
+    for catcher in ("except ValueError:", "except (KeyError, TypeError):", "except OSError:"):
+        source = SWALLOWED.replace("except Exception:", catcher)
+        assert _live(source) == 1, f"`{catcher}` does not catch AssertionError"
+        assert not swallowed_assertions(source)
+
+
+def test_only_the_try_body_is_covered_by_that_trys_own_handlers() -> None:
+    """``else``, ``finally`` and the handler bodies all propagate."""
+    for clause in ("else", "finally"):
+        source = (
+            "def test_a():\n"
+            "    try:\n"
+            "        pass\n"
+            "    except Exception:\n"
+            "        pass\n"
+            f"    {clause}:\n"
+            "        assert False\n"
+        )
+        assert _live(source) == 1, f"an assert in `{clause}` is not caught by that try"
+    handler_body = (
+        "def test_a():\n"
+        "    try:\n"
+        "        pass\n"
+        "    except Exception:\n"
+        "        assert False\n"
+    )
+    assert _live(handler_body) == 1, "a handler does not catch what it raises itself"
+
+
+def test_an_outer_swallow_survives_an_inner_handler_that_re_raises() -> None:
+    nested = (
+        "def test_a():\n"
+        "    try:\n"
+        "        try:\n"
+        "            assert False\n"
+        "        except ValueError:\n"
+        "            raise\n"
+        "    except Exception:\n"
+        "        pass\n"
+    )
+    assert _live(nested) == 0, (
+        "nothing here reaches pytest: the inner handler's `raise` is itself "
+        "inside the OUTER try body, so the outer bare except eats that too"
+    )
+    assert swallowed_assertions(nested) == [("test_a", 4)], (
+        "and the inner assert is eaten by the outer bare except, not saved by "
+        "the inner handler that re-raises"
+    )
+
+
+def test_a_nested_definitions_swallow_belongs_to_the_nested_definition() -> None:
+    helper = (
+        "def test_a():\n"
+        "    def helper():\n"
+        "        try:\n"
+        "            assert False\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "\n"
+        "    assert helper() is None\n"
+    )
+    assert _live(helper) == 1, "the test's own assert is live"
+    assert not swallowed_assertions(helper), (
+        "the helper's swallow is the helper's — attributing it to the enclosing "
+        "test is the naive walk this model exists to avoid"
+    )
+
+
+def test_a_test_with_no_try_at_all_is_untouched_by_the_rule() -> None:
+    plain = "def test_a():\n    assert True\n    raise SystemExit(0)\n"
+    assert _live(plain) == 2
+    assert not swallowed_assertions(plain)

--- a/repo_tests/tests_that_return_instead_of_asserting_test.py
+++ b/repo_tests/tests_that_return_instead_of_asserting_test.py
@@ -69,39 +69,17 @@ Measured on this branch, each derived from the code rather than from a list:
 
 WHEN AN ASSERT DOES NOT COUNT AS PROTECTION (#15195)
 ----------------------------------------------------
-A test that asserts as well as returns is exempt, because it can still fail.
-That held only while an ``assert`` which is PRESENT was an ``assert`` which can
-FIRE, and for one very common shape it is not::
+The exemption above spends itself only on assertions that can actually FIRE.
+One sitting in the body of a ``try`` whose handler catches ``Exception``,
+``BaseException`` or ``AssertionError`` without re-raising is inert: the test
+returns on both branches and cannot fail, while reading as defended to a sweep
+that only looked for the node. Nine of the ten functions in #15189 were exactly
+that. ``propagating_guards`` in ``repo_tests/collected_test_model`` decides it,
+and carries the full rule and its deliberate narrowness.
 
-    def test_thing():
-        try:
-            assert cache.get("k") == "v"
-            return True
-        except Exception:
-            return False
-
-``except Exception`` catches ``AssertionError``. The assertion is inert, the
-function returns on both branches, and the test cannot fail whichever way it
-goes — while reading as defended to a sweep that only looked for the node. Nine
-of the ten functions in #15189 were exactly this, and this guard passed over
-every one of them for as long as the file existed.
-
-So the exemption is now spent only on assertions that can reach pytest. An
-``assert`` or ``raise`` is discounted when it sits in the ``try`` body of a
-``try`` whose handler catches ``Exception``, ``BaseException`` or
-``AssertionError`` and neither re-raises nor calls a pytest outcome
-(``fail``/``exit``/``skip``/``xfail``). The rule is deliberately narrow in three
-directions, because a guard that over-flags is a guard somebody switches off:
-
-* a handler naming a specific non-assertion exception (``except ValueError``)
-  protects nothing away and is not counted;
-* ``else`` and ``finally`` clauses, and the handler bodies themselves, are not
-  covered by that try's own handlers, so assertions there stay live;
-* the ownership rule is unchanged — a nested helper's swallow is the helper's.
-
-The same machinery drives ``_SWALLOWED_ASSERTIONS``, a second down-only ceiling
-covering the general form: an inert assertion in a test that does NOT return a
-value. The ceiling on returns cannot see those, and there are nine of them.
+``_SWALLOWED_ASSERTIONS`` below is the general form of the same defect — an
+inert assertion in a test that does NOT return a value, which the returns
+ceiling structurally cannot see.
 
 THE RATCHET
 -----------
@@ -132,30 +110,22 @@ repository's other baseline guards:
 from __future__ import annotations
 
 import ast
-import configparser
-from pathlib import Path
 
 import pytest
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
-_PYTEST_INI = _REPO_ROOT / "pytest.ini"
+from repo_tests.collected_test_model import (
+    REPO_ROOT,
+    collectable_tests,
+    is_fixture,
+    own_nodes,
+    parse_module,
+    propagating_guards,
+    pytest_option,
+    swallowed_assertions_in,
+    test_functions_by_tree,
+    test_modules,
+)
 
-_SKIP = {
-    ".git",
-    ".worktrees",
-    # Harness territory: tooling config plus the agent worktrees checked out
-    # under it, which hold other branches' work in progress and are not always
-    # parseable. pytest's own testpaths never reach it either, so nothing here
-    # is collectable and nothing here is this sweep's subject.
-    ".claude",
-    "__pycache__",
-    "node_modules",
-    ".venv",
-    "venv",
-    "dist",
-    "build",
-    ".tox",
-}
 
 # Measured on this branch, per top-level tree:
 #   tree: (return statements that must not be exceeded,
@@ -286,199 +256,6 @@ _MIN_MODULES = 1800
 _MIN_TEST_FUNCTIONS = 25000
 
 
-def _pytest_option(name: str) -> list[str]:
-    parser = configparser.ConfigParser(inline_comment_prefixes=("#",))
-    parser.read(_PYTEST_INI, encoding="utf-8")
-    values = parser.get("pytest", name, fallback="").split()
-    assert values, f"pytest.ini declares no {name} — the population cannot be derived"
-    return values
-
-
-def _parse_module(path: Path) -> ast.Module:
-    """Parse one swept file, failing loudly and by name if it cannot be parsed.
-
-    This sweep is a denylist walk from the repo root, filtered only by ``_SKIP``,
-    so it reaches files pytest's ``testpaths`` allowlist never would: scratch
-    copies, templates, half-written drafts. An unparseable one must never read as
-    "clean" -- skipping it silently is the exact under-reporting failure this
-    guard exists to catch -- so it is raised as a failure that names the file and
-    says how to take it out of the sweep on purpose.
-    """
-    try:
-        return ast.parse(path.read_text(encoding="utf-8"))
-    except SyntaxError as exc:
-        relative = path.relative_to(_REPO_ROOT)
-        raise AssertionError(
-            f"{relative}:{exc.lineno or 0} is not parseable Python ({exc.msg}). "
-            "This guard sweeps every *.py under the repo root as a denylist, so it "
-            "sees files pytest's own testpaths allowlist never reaches. Fix the "
-            "file, or -- if it is scratch, vendored or another branch's work and "
-            "does not belong in the sweep -- add its top-level directory to _SKIP "
-            "in every repo_tests guard that sweeps, the way .claude and .worktrees "
-            "already are. Do not silence this by skipping the file: a file the "
-            "sweep cannot read is not a file the sweep has cleared."
-        ) from exc
-
-
-def _test_modules() -> list[Path]:
-    """Every file pytest's own ``python_files`` globs would consider."""
-    patterns = _pytest_option("python_files")
-    return sorted(
-        path
-        for path in _REPO_ROOT.rglob("*.py")
-        if not _SKIP.intersection(path.relative_to(_REPO_ROOT).parts)
-        and any(path.match(pattern) for pattern in patterns)
-    )
-
-
-def _prefixes() -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """``python_functions`` and ``python_classes`` as plain name prefixes."""
-    functions = tuple(p.rstrip("*") for p in _pytest_option("python_functions"))
-    classes = tuple(p.rstrip("*") for p in _pytest_option("python_classes"))
-    return functions, classes
-
-
-def _collectable_tests(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
-    """Functions pytest would collect as tests from this module.
-
-    Module-level ``test_*`` functions, and ``test_*`` methods of ``Test*``
-    classes. A method of any other class is not collected, so its return value
-    is nobody's verdict.
-    """
-    functions, classes = _prefixes()
-    found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
-    for node in tree.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            found.append(node)
-        elif isinstance(node, ast.ClassDef) and node.name.startswith(classes):
-            found.extend(
-                child
-                for child in node.body
-                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
-            )
-    return [node for node in found if node.name.startswith(functions)]
-
-
-def _own_nodes(function: ast.AST, wanted: tuple[type, ...]) -> list[ast.AST]:
-    """Nodes belonging to ``function`` itself, never to a nested definition."""
-    found: list[ast.AST] = []
-    stack: list[ast.AST] = list(ast.iter_child_nodes(function))
-    while stack:
-        node = stack.pop()
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-            continue
-        if isinstance(node, wanted):
-            found.append(node)
-        stack.extend(ast.iter_child_nodes(node))
-    return found
-
-
-# ---------------------------------------------------------------------------
-# Is an assertion able to fire? (#15195)
-#
-# The exemption below spares a test that asserts AND returns, on the reasoning
-# that such a test can still fail. That reasoning assumes an ``assert`` which is
-# PRESENT is an ``assert`` which can FIRE. Under a handler that catches
-# ``AssertionError``, it cannot: the assertion is inert, the test cannot fail
-# whichever way it goes, and the sweep built to find tests that cannot fail read
-# it as defended. Nine of the ten functions in #15189 had exactly this shape.
-#
-# So an assertion is counted as protective only when nothing lexically between
-# it and the function boundary would catch what it raises.
-# ---------------------------------------------------------------------------
-
-# Handlers that catch an AssertionError: a bare ``except:``, and any handler
-# naming one of these. ``Exception`` is the one that does the damage in
-# practice, because it is the one people write without meaning to catch a
-# failed assertion.
-_ASSERTION_CATCHING = frozenset({"Exception", "BaseException", "AssertionError"})
-
-# A handler that catches the assertion but turns it back into a verdict is NOT
-# swallowing it. ``raise`` re-raises, an ``assert`` in the handler re-checks,
-# and pytest's outcome calls end the test rather than let it report green.
-# ``skip``/``xfail`` are in the set deliberately: a skipped test is not a
-# passing test, and a guard that over-flags is a guard somebody switches off —
-# which would be worse than the blindness this rule removes.
-_OUTCOME_CALLS = frozenset({"fail", "exit", "skip", "xfail"})
-
-_TRY_NODES: tuple[type, ...] = (
-    (ast.Try, ast.TryStar) if hasattr(ast, "TryStar") else (ast.Try,)
-)
-
-
-def _catches_an_assertion(handler: ast.ExceptHandler) -> bool:
-    """Would this handler catch an ``AssertionError`` raised in the try body?"""
-    if handler.type is None:
-        return True
-    named = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
-    for node in named:
-        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
-        if name in _ASSERTION_CATCHING:
-            return True
-    return False
-
-
-def _reports_the_failure(handler: ast.ExceptHandler) -> bool:
-    """Does the handler hand the failure back on, rather than absorb it?"""
-    for node in _own_nodes(handler, (ast.Raise, ast.Assert, ast.Call)):
-        if isinstance(node, (ast.Raise, ast.Assert)):
-            return True
-        func = node.func
-        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
-        if name in _OUTCOME_CALLS:
-            return True
-    return False
-
-
-def _swallows_assertions(node: ast.AST) -> bool:
-    """True when this ``try`` neutralises assertions made in its own body."""
-    return any(
-        _catches_an_assertion(handler) and not _reports_the_failure(handler)
-        for handler in getattr(node, "handlers", ())
-    )
-
-
-def _collect_guards(node: ast.AST, swallowed: bool, found: list[ast.AST]) -> None:
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
-        return
-    if isinstance(node, (ast.Assert, ast.Raise)):
-        if not swallowed:
-            found.append(node)
-        return
-    if isinstance(node, _TRY_NODES):
-        inside = swallowed or _swallows_assertions(node)
-        for child in node.body:
-            _collect_guards(child, inside, found)
-        # ``else``, ``finally`` and the handler bodies are NOT covered by this
-        # try's own handlers — anything raised there propagates — so they keep
-        # whatever protection state the enclosing scope had.
-        for child in (*node.handlers, *node.orelse, *node.finalbody):
-            _collect_guards(child, swallowed, found)
-        return
-    for child in ast.iter_child_nodes(node):
-        _collect_guards(child, swallowed, found)
-
-
-def _propagating_guards(function: ast.AST) -> list[ast.AST]:
-    """``assert``/``raise`` owned by ``function`` that can actually reach pytest.
-
-    Same ownership rule as ``_own_nodes``: a nested definition owns its own.
-    """
-    found: list[ast.AST] = []
-    for child in ast.iter_child_nodes(function):
-        _collect_guards(child, False, found)
-    return found
-
-
-def _is_fixture(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    for decorator in function.decorator_list:
-        node = decorator.func if isinstance(decorator, ast.Call) else decorator
-        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
-        if name == "fixture":
-            return True
-    return False
-
-
 def offending_returns(source: str) -> list[tuple[str, int]]:
     """``(test name, line)`` for every value-return a collected test makes.
 
@@ -492,8 +269,8 @@ def offending_returns(source: str) -> list[tuple[str, int]]:
 def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
     """The tree-driven half, so the repo sweep parses each module once."""
     found: list[tuple[str, int]] = []
-    for function in _collectable_tests(tree):
-        if _is_fixture(function) or _own_nodes(function, (ast.Yield, ast.YieldFrom)):
+    for function in collectable_tests(tree):
+        if is_fixture(function) or own_nodes(function, (ast.Yield, ast.YieldFrom)):
             continue
         # The defect is returning *instead of* asserting — a test that cannot fail.
         # A test that asserts AND returns can fail, and its return value is a
@@ -505,9 +282,9 @@ def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
         # sitting under a handler that catches AssertionError is inert, and a
         # test whose only assertions are inert cannot fail — which is precisely
         # the population this sweep exists to count (#15195).
-        if _propagating_guards(function):
+        if propagating_guards(function):
             continue
-        for node in _own_nodes(function, (ast.Return,)):
+        for node in own_nodes(function, (ast.Return,)):
             value = node.value
             if value is None or (isinstance(value, ast.Constant) and value.value is None):
                 continue
@@ -515,76 +292,34 @@ def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
     return found
 
 
-def swallowed_assertions(source: str) -> list[tuple[str, int]]:
-    """``(test name, line)`` for every test holding an assertion that cannot fire.
-
-    The general form of the #15195 defect, independent of whether the function
-    also returns a value. Driven from source text for the same reason
-    ``offending_returns`` is: a detector only ever pointed at the live tree
-    cannot be distinguished from one that has stopped detecting.
-    """
-    return _swallowed_assertions(ast.parse(source))
-
-
-def _swallowed_assertions(tree: ast.Module) -> list[tuple[str, int]]:
-    found: list[tuple[str, int]] = []
-    for function in _collectable_tests(tree):
-        if _is_fixture(function):
-            continue
-        live = {id(node) for node in _propagating_guards(function)}
-        inert = [
-            node
-            for node in _own_nodes(function, (ast.Assert,))
-            if id(node) not in live
-        ]
-        if inert:
-            found.append((function.name, inert[0].lineno))
-    return found
-
-
 def _swallowed_by_tree() -> dict[str, list[str]]:
     counts: dict[str, list[str]] = {}
-    for module in _test_modules():
-        relative = module.relative_to(_REPO_ROOT)
-        for name, line in _swallowed_assertions(_parse_module(module)):
+    for module in test_modules():
+        relative = module.relative_to(REPO_ROOT)
+        for name, line in swallowed_assertions_in(parse_module(module)):
             counts.setdefault(relative.parts[0], []).append(f"{relative}:{line} {name}")
     return counts
 
 
 def _offenders_by_tree() -> dict[str, list[str]]:
     counts: dict[str, list[str]] = {}
-    for module in _test_modules():
-        relative = module.relative_to(_REPO_ROOT)
-        for name, line in _offending_returns(_parse_module(module)):
+    for module in test_modules():
+        relative = module.relative_to(REPO_ROOT)
+        for name, line in _offending_returns(parse_module(module)):
             counts.setdefault(relative.parts[0], []).append(f"{relative}:{line} {name}")
-    return counts
-
-
-def _test_functions_by_tree() -> dict[str, int]:
-    """Collectable test functions per top-level tree.
-
-    The presence half of the ratchet: a per-tree count, because the repo-wide
-    floors below cannot notice one tree's walk collapsing inside a population
-    of 27,000.
-    """
-    counts: dict[str, int] = {}
-    for module in _test_modules():
-        tree = module.relative_to(_REPO_ROOT).parts[0]
-        found = _collectable_tests(_parse_module(module))
-        counts[tree] = counts.get(tree, 0) + len(found)
     return counts
 
 
 def test_the_population_is_present_and_large_enough_to_mean_anything() -> None:
     """Floors on the subject, not on the findings. Zero of zero is not clean."""
-    modules = _test_modules()
+    modules = test_modules()
     assert len(modules) >= _MIN_MODULES, (
         f"only {len(modules)} modules match pytest's python_files "
-        f"{_pytest_option('python_files')} — expected at least {_MIN_MODULES}. "
+        f"{pytest_option('python_files')} — expected at least {_MIN_MODULES}. "
         "The sweep has stopped matching and would call every tree clean."
     )
     total = sum(
-        len(_collectable_tests(_parse_module(module)))
+        len(collectable_tests(parse_module(module)))
         for module in modules
     )
     assert total >= _MIN_TEST_FUNCTIONS, (
@@ -631,7 +366,7 @@ def test_the_known_offender_budgets_only_ever_shrink() -> None:
     the assertion below tells you the new figure to write down.
     """
     offenders = _offenders_by_tree()
-    populations = _test_functions_by_tree()
+    populations = test_functions_by_tree()
 
     collapsed = {
         tree: (populations.get(tree, 0), floor)
@@ -688,7 +423,7 @@ def test_no_test_smothers_its_own_assertions_under_a_swallowing_handler() -> Non
     ``raise`` in the handler — both are read as reporting, not swallowing.
     """
     swallowed = _swallowed_by_tree()
-    populations = _test_functions_by_tree()
+    populations = test_functions_by_tree()
 
     collapsed = {
         tree: (populations.get(tree, 0), floor)
@@ -740,129 +475,6 @@ def test_no_test_smothers_its_own_assertions_under_a_swallowing_handler() -> Non
     assert not spent, (
         "these trees are now BELOW their recorded budget (actual, budget): "
         f"{spent}. Lower the number here in the same commit."
-    )
-
-
-def test_an_assertion_under_a_swallowing_handler_does_not_count_as_protection() -> None:
-    """#15195, both directions — it must catch the swallow and spare the rest.
-
-    The second half matters more than the first. A guard that over-flags a
-    legitimate ``try``/``except`` gets switched off, and a switched-off guard is
-    worse than the blind spot this rule closes.
-    """
-    swallowing = (
-        "def test_a():\n"
-        "    try:\n"
-        "        assert 1 == 2, 'nope'\n"
-        "        return True\n"
-        "    except Exception:\n"
-        "        return False\n"
-    )
-    assert sorted(offending_returns(swallowing)) == [("test_a", 4), ("test_a", 6)], (
-        "an assert under `except Exception` is inert — the test cannot fail, "
-        "which is exactly this sweep's subject (#15195)"
-    )
-    assert swallowed_assertions(swallowing) == [("test_a", 3)]
-
-    for name, catcher in (
-        ("BaseException", "except BaseException:"),
-        ("AssertionError", "except AssertionError:"),
-        ("a bare except", "except:"),
-        ("a tuple naming Exception", "except (ValueError, Exception):"),
-        ("an aliased handler", "except Exception as exc:"),
-    ):
-        source = (
-            "def test_a():\n"
-            "    try:\n"
-            "        assert False\n"
-            "        return True\n"
-            f"    {catcher}\n"
-            "        return False\n"
-        )
-        assert offending_returns(source), f"{name} swallows AssertionError too"
-
-    # ---- the counter-cases: these must NOT be flagged --------------------
-    reraises = (
-        "def test_a():\n"
-        "    try:\n"
-        "        assert False\n"
-        "        return True\n"
-        "    except Exception:\n"
-        "        raise\n"
-    )
-    assert not offending_returns(reraises), "a handler that re-raises protects nothing away"
-    assert not swallowed_assertions(reraises)
-
-    specific = (
-        "def test_a():\n"
-        "    try:\n"
-        "        assert False\n"
-        "        return True\n"
-        "    except ValueError:\n"
-        "        return False\n"
-    )
-    assert not offending_returns(specific), (
-        "except ValueError does not catch AssertionError; flagging it would make "
-        "this guard something a reviewer switches off"
-    )
-    assert not swallowed_assertions(specific)
-
-    reports = (
-        "import pytest\n\n\n"
-        "def test_a():\n"
-        "    try:\n"
-        "        assert False\n"
-        "        return True\n"
-        "    except Exception as exc:\n"
-        "        pytest.fail(str(exc))\n"
-    )
-    assert not offending_returns(reports), "pytest.fail ends the test; it does not absorb it"
-    assert not swallowed_assertions(reports)
-
-    # Only the `try` body is covered by its own handlers.
-    for clause, body in (("else", "    else:\n"), ("finally", "    finally:\n")):
-        source = (
-            "def test_a():\n"
-            "    try:\n"
-            "        pass\n"
-            "    except Exception:\n"
-            "        pass\n"
-            f"{body}"
-            "        assert False\n"
-            "        return True\n"
-        )
-        assert not offending_returns(source), (
-            f"an assert in `{clause}` is not caught by that try's own handlers"
-        )
-
-    # Nesting: an inner handler that re-raises does not undo an outer swallow.
-    nested = (
-        "def test_a():\n"
-        "    try:\n"
-        "        try:\n"
-        "            assert False\n"
-        "        except ValueError:\n"
-        "            raise\n"
-        "        return True\n"
-        "    except Exception:\n"
-        "        return False\n"
-    )
-    assert offending_returns(nested), "the outer bare except still eats the AssertionError"
-
-    # Ownership is unchanged: a nested definition owns its own swallow.
-    helper = (
-        "def test_a():\n"
-        "    def helper():\n"
-        "        try:\n"
-        "            assert False\n"
-        "        except Exception:\n"
-        "            pass\n"
-        "\n"
-        "    assert helper() is None\n"
-        "    return True\n"
-    )
-    assert not offending_returns(helper), (
-        "the enclosing test's own assert is live; the helper's is the helper's"
     )
 
 
@@ -918,6 +530,33 @@ def test_the_detector_finds_a_planted_return_and_spares_the_legitimate_ones() ->
         "        return False\n"
     ), "a handler naming a non-assertion exception leaves the assert able to fire"
 
+    swallowing = (
+        "def test_a():\n"
+        "    try:\n"
+        "        assert 1 == 2, 'nope'\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        return False\n"
+    )
+    assert sorted(offending_returns(swallowing)) == [("test_a", 4), ("test_a", 6)], (
+        "an assert under `except Exception` is inert — the test cannot fail, "
+        "which is exactly this sweep's subject (#15195)"
+    )
+    for catcher in (
+        "except BaseException:",
+        "except AssertionError:",
+        "except:",
+        "except (ValueError, Exception):",
+        "except Exception as exc:",
+    ):
+        assert offending_returns(
+            swallowing.replace("except Exception:", catcher)
+        ), f"`{catcher}` swallows AssertionError too"
+    for handler in ("        raise\n", "        assert False\n"):
+        assert not offending_returns(
+            swallowing.replace("        return False\n", handler)
+        ), "a handler that hands the failure back on protects nothing away"
+
 
 def test_an_unparseable_swept_file_fails_loudly_instead_of_reading_as_clean() -> None:
     """The sweep is a denylist from the repo root, so it meets stray files.
@@ -926,19 +565,19 @@ def test_an_unparseable_swept_file_fails_loudly_instead_of_reading_as_clean() ->
     walk cleared, and dropping it silently is the under-reporting this guard
     exists to catch. It has to fail, name the file and say what to do about it.
 
-    The probe is written under a ``_SKIP``ped directory so no concurrently
+    The probe is written under a ``SKIP``ped directory so no concurrently
     running sweep can pick it up while it exists.
     """
-    scratch = _REPO_ROOT / "__pycache__"
+    scratch = REPO_ROOT / "__pycache__"
     scratch.mkdir(exist_ok=True)
     stray = scratch / "unparseable_probe_test.py"
     stray.write_text("from a-b.c import (\n", encoding="utf-8")
     try:
         with pytest.raises(AssertionError) as raised:
-            _parse_module(stray)
+            parse_module(stray)
     finally:
         stray.unlink()
 
     message = str(raised.value)
     assert "unparseable_probe_test.py" in message, "the failure must name the file"
-    assert "_SKIP" in message, "the failure must say how to exclude a file on purpose"
+    assert "SKIP" in message, "the failure must say how to exclude a file on purpose"

--- a/repo_tests/tests_that_return_instead_of_asserting_test.py
+++ b/repo_tests/tests_that_return_instead_of_asserting_test.py
@@ -67,6 +67,42 @@ Measured on this branch, each derived from the code rather than from a list:
 * a bare ``return`` and an explicit ``return None`` — pytest does not warn on
   either, because neither returns a value.
 
+WHEN AN ASSERT DOES NOT COUNT AS PROTECTION (#15195)
+----------------------------------------------------
+A test that asserts as well as returns is exempt, because it can still fail.
+That held only while an ``assert`` which is PRESENT was an ``assert`` which can
+FIRE, and for one very common shape it is not::
+
+    def test_thing():
+        try:
+            assert cache.get("k") == "v"
+            return True
+        except Exception:
+            return False
+
+``except Exception`` catches ``AssertionError``. The assertion is inert, the
+function returns on both branches, and the test cannot fail whichever way it
+goes — while reading as defended to a sweep that only looked for the node. Nine
+of the ten functions in #15189 were exactly this, and this guard passed over
+every one of them for as long as the file existed.
+
+So the exemption is now spent only on assertions that can reach pytest. An
+``assert`` or ``raise`` is discounted when it sits in the ``try`` body of a
+``try`` whose handler catches ``Exception``, ``BaseException`` or
+``AssertionError`` and neither re-raises nor calls a pytest outcome
+(``fail``/``exit``/``skip``/``xfail``). The rule is deliberately narrow in three
+directions, because a guard that over-flags is a guard somebody switches off:
+
+* a handler naming a specific non-assertion exception (``except ValueError``)
+  protects nothing away and is not counted;
+* ``else`` and ``finally`` clauses, and the handler bodies themselves, are not
+  covered by that try's own handlers, so assertions there stay live;
+* the ownership rule is unchanged — a nested helper's swallow is the helper's.
+
+The same machinery drives ``_SWALLOWED_ASSERTIONS``, a second down-only ceiling
+covering the general form: an inert assertion in a test that does NOT return a
+value. The ceiling on returns cannot see those, and there are nine of them.
+
 THE RATCHET
 -----------
 Keyed on the top-level tree, never on a filename: an exemption keyed on a path
@@ -182,12 +218,66 @@ _KNOWN_OFFENDERS = {
     # `test_migrated_files_import`, whose body was `pass` plus prints with no
     # assert at all, was ever counted (2 returns, lines 281 and 288).
     #
-    # So this guard is blind to an assert that cannot fire. That gap is #15195;
-    # it is not fixed here, and this number is the measured population under the
-    # rules as they stand today.
-    "autobot-backend": (71, 18000),
-    "autobot-infrastructure": (121, 250),
+    # So this guard is blind to an assert that cannot fire. That gap is #15195.
+    #
+    # 71 -> 86 and 121 -> 127 with #15195: A DELIBERATE RE-MEASUREMENT, NOT A
+    # RATCHET VIOLATION, AND THE ONLY ONE THIS FILE SANCTIONS.
+    #
+    # The ceilings above are down-only against a FIXED definition of the defect.
+    # #15195 changed the definition: an assertion neutralised by a handler that
+    # catches AssertionError no longer buys the assert/raise exemption, because
+    # such a test cannot fail — which is the whole subject of this sweep. The
+    # population did not grow; the detector stopped missing part of it. Nothing
+    # was written, nothing regressed, and no offending line is new.
+    #
+    # The distinction that keeps this from being a loophole: a re-baseline is
+    # legitimate only when the sweep is made STRICTER and the delta is
+    # enumerated. Both hold here. The 21 newly-counted returns are 8 functions
+    # in 3 files, every one of them pre-existing:
+    #
+    #   autobot-backend/config/config_consolidation_p2_test.py        11 returns
+    #     (test_config_consolidation — ten `try: assert…/except Exception:
+    #      return False` sections in one function)
+    #   autobot-backend/tests/integration/
+    #     test_causal_framework_integration.py                         4 returns
+    #     (four *_full_pipeline methods that catch AssertionError into a
+    #      scenario report and return it)
+    #   autobot-infrastructure/shared/scripts/test_configuration.py    6 returns
+    #     (three driver functions consumed by the module's own main())
+    #
+    # No previously-counted site stopped being counted (the base set is a strict
+    # subset of the new one, verified site-by-site), and no tree outside this
+    # dict gained an offender — the hard zero below is unmoved. Those 8 are
+    # reported, not converted, under #15189: two of the three files are large
+    # live-service drivers where unwrapping the swallow is its own piece of
+    # work, and half-converting a population is how a ratchet gets stuck.
+    #
+    # A number here may be raised again ONLY on the same terms: the detector got
+    # stricter, and the delta is enumerated in this comment. Fixing tests still
+    # requires no permission at all.
+    "autobot-backend": (86, 18000),
+    "autobot-infrastructure": (127, 250),
     "autobot-npu-worker": (7, 150),
+}
+
+# Test functions holding at least one assertion that cannot fire, per top-level
+# tree, paired with the same population floor as above (#15195).
+#
+# The sibling defect, and the one that made this file blind: an `assert` under a
+# handler catching Exception/BaseException/AssertionError. The ceiling above
+# only sees it when the function ALSO returns a value; this one sees it whether
+# or not it returns, which is what closes the general case. Nine functions
+# today, and every tree not named here is pinned at zero by derivation.
+#
+# Down-only, on the same terms as every other ceiling in this file: there is no
+# sanctioned route to raise one. Wrapping a test's own assertions in
+# `except Exception` is never the right thing to write — if the test is meant to
+# tolerate an error, catch the specific exception it tolerates; if it is meant
+# to report one, `pytest.fail(...)` or `raise` in the handler, both of which
+# this guard already recognises as reporting rather than swallowing.
+_SWALLOWED_ASSERTIONS = {
+    "autobot-backend": (6, 18000),
+    "autobot-infrastructure": (3, 250),
 }
 
 # Floors under the whole population. A sweep that has silently stopped matching
@@ -283,6 +373,103 @@ def _own_nodes(function: ast.AST, wanted: tuple[type, ...]) -> list[ast.AST]:
     return found
 
 
+# ---------------------------------------------------------------------------
+# Is an assertion able to fire? (#15195)
+#
+# The exemption below spares a test that asserts AND returns, on the reasoning
+# that such a test can still fail. That reasoning assumes an ``assert`` which is
+# PRESENT is an ``assert`` which can FIRE. Under a handler that catches
+# ``AssertionError``, it cannot: the assertion is inert, the test cannot fail
+# whichever way it goes, and the sweep built to find tests that cannot fail read
+# it as defended. Nine of the ten functions in #15189 had exactly this shape.
+#
+# So an assertion is counted as protective only when nothing lexically between
+# it and the function boundary would catch what it raises.
+# ---------------------------------------------------------------------------
+
+# Handlers that catch an AssertionError: a bare ``except:``, and any handler
+# naming one of these. ``Exception`` is the one that does the damage in
+# practice, because it is the one people write without meaning to catch a
+# failed assertion.
+_ASSERTION_CATCHING = frozenset({"Exception", "BaseException", "AssertionError"})
+
+# A handler that catches the assertion but turns it back into a verdict is NOT
+# swallowing it. ``raise`` re-raises, an ``assert`` in the handler re-checks,
+# and pytest's outcome calls end the test rather than let it report green.
+# ``skip``/``xfail`` are in the set deliberately: a skipped test is not a
+# passing test, and a guard that over-flags is a guard somebody switches off —
+# which would be worse than the blindness this rule removes.
+_OUTCOME_CALLS = frozenset({"fail", "exit", "skip", "xfail"})
+
+_TRY_NODES: tuple[type, ...] = (
+    (ast.Try, ast.TryStar) if hasattr(ast, "TryStar") else (ast.Try,)
+)
+
+
+def _catches_an_assertion(handler: ast.ExceptHandler) -> bool:
+    """Would this handler catch an ``AssertionError`` raised in the try body?"""
+    if handler.type is None:
+        return True
+    named = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    for node in named:
+        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
+        if name in _ASSERTION_CATCHING:
+            return True
+    return False
+
+
+def _reports_the_failure(handler: ast.ExceptHandler) -> bool:
+    """Does the handler hand the failure back on, rather than absorb it?"""
+    for node in _own_nodes(handler, (ast.Raise, ast.Assert, ast.Call)):
+        if isinstance(node, (ast.Raise, ast.Assert)):
+            return True
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", "")
+        if name in _OUTCOME_CALLS:
+            return True
+    return False
+
+
+def _swallows_assertions(node: ast.AST) -> bool:
+    """True when this ``try`` neutralises assertions made in its own body."""
+    return any(
+        _catches_an_assertion(handler) and not _reports_the_failure(handler)
+        for handler in getattr(node, "handlers", ())
+    )
+
+
+def _collect_guards(node: ast.AST, swallowed: bool, found: list[ast.AST]) -> None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+        return
+    if isinstance(node, (ast.Assert, ast.Raise)):
+        if not swallowed:
+            found.append(node)
+        return
+    if isinstance(node, _TRY_NODES):
+        inside = swallowed or _swallows_assertions(node)
+        for child in node.body:
+            _collect_guards(child, inside, found)
+        # ``else``, ``finally`` and the handler bodies are NOT covered by this
+        # try's own handlers — anything raised there propagates — so they keep
+        # whatever protection state the enclosing scope had.
+        for child in (*node.handlers, *node.orelse, *node.finalbody):
+            _collect_guards(child, swallowed, found)
+        return
+    for child in ast.iter_child_nodes(node):
+        _collect_guards(child, swallowed, found)
+
+
+def _propagating_guards(function: ast.AST) -> list[ast.AST]:
+    """``assert``/``raise`` owned by ``function`` that can actually reach pytest.
+
+    Same ownership rule as ``_own_nodes``: a nested definition owns its own.
+    """
+    found: list[ast.AST] = []
+    for child in ast.iter_child_nodes(function):
+        _collect_guards(child, False, found)
+    return found
+
+
 def _is_fixture(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     for decorator in function.decorator_list:
         node = decorator.func if isinstance(decorator, ast.Call) else decorator
@@ -313,7 +500,12 @@ def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
         # separate contract: several drivers in this repo sum truthiness over
         # `result = test_func()`, so a bare assert there leaves a passing test
         # counted as failed. Both are needed, and neither is an offence (#14920).
-        if _own_nodes(function, (ast.Assert, ast.Raise)):
+        #
+        # The exemption is spent only on assertions that can actually FIRE. One
+        # sitting under a handler that catches AssertionError is inert, and a
+        # test whose only assertions are inert cannot fail — which is precisely
+        # the population this sweep exists to count (#15195).
+        if _propagating_guards(function):
             continue
         for node in _own_nodes(function, (ast.Return,)):
             value = node.value
@@ -321,6 +513,42 @@ def _offending_returns(tree: ast.Module) -> list[tuple[str, int]]:
                 continue
             found.append((function.name, node.lineno))
     return found
+
+
+def swallowed_assertions(source: str) -> list[tuple[str, int]]:
+    """``(test name, line)`` for every test holding an assertion that cannot fire.
+
+    The general form of the #15195 defect, independent of whether the function
+    also returns a value. Driven from source text for the same reason
+    ``offending_returns`` is: a detector only ever pointed at the live tree
+    cannot be distinguished from one that has stopped detecting.
+    """
+    return _swallowed_assertions(ast.parse(source))
+
+
+def _swallowed_assertions(tree: ast.Module) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for function in _collectable_tests(tree):
+        if _is_fixture(function):
+            continue
+        live = {id(node) for node in _propagating_guards(function)}
+        inert = [
+            node
+            for node in _own_nodes(function, (ast.Assert,))
+            if id(node) not in live
+        ]
+        if inert:
+            found.append((function.name, inert[0].lineno))
+    return found
+
+
+def _swallowed_by_tree() -> dict[str, list[str]]:
+    counts: dict[str, list[str]] = {}
+    for module in _test_modules():
+        relative = module.relative_to(_REPO_ROOT)
+        for name, line in _swallowed_assertions(_parse_module(module)):
+            counts.setdefault(relative.parts[0], []).append(f"{relative}:{line} {name}")
+    return counts
 
 
 def _offenders_by_tree() -> dict[str, list[str]]:
@@ -445,6 +673,199 @@ def test_the_known_offender_budgets_only_ever_shrink() -> None:
     )
 
 
+def test_no_test_smothers_its_own_assertions_under_a_swallowing_handler() -> None:
+    """The general case of #15195, whether or not the function also returns.
+
+    A ``try`` whose handler catches ``Exception``/``BaseException``/
+    ``AssertionError`` and neither re-raises nor calls a pytest outcome absorbs
+    the ``AssertionError`` its own body raises. Every assertion in that body is
+    decoration: the test reports green on the failing branch and on the passing
+    one alike. Nine functions carry that shape today; every other tree is pinned
+    at zero by derivation, so the tenth fails on arrival.
+
+    Down-only, and no route up. If the test is meant to tolerate an error, name
+    the exception it tolerates; if it is meant to report one, ``pytest.fail`` or
+    ``raise`` in the handler — both are read as reporting, not swallowing.
+    """
+    swallowed = _swallowed_by_tree()
+    populations = _test_functions_by_tree()
+
+    collapsed = {
+        tree: (populations.get(tree, 0), floor)
+        for tree, (_, floor) in _SWALLOWED_ASSERTIONS.items()
+        if populations.get(tree, 0) < floor
+    }
+    assert not collapsed, (
+        "the sweep no longer finds the tests it is supposed to be scanning "
+        f"(found, floor): {collapsed}. Fix the sweep; do NOT lower these numbers."
+    )
+
+    surprises = {
+        tree: sites
+        for tree, sites in swallowed.items()
+        if tree not in _SWALLOWED_ASSERTIONS
+    }
+    detail = "\n".join(
+        f"  {tree}:\n    " + "\n    ".join(sorted(sites))
+        for tree, sites in sorted(surprises.items())
+    )
+    assert not surprises, (
+        "these tests assert inside a `try` whose handler swallows the "
+        f"AssertionError, in a tree that was clean:\n{detail}\n"
+        "The assertion cannot fire, so the test passes whichever way it goes. "
+        "Catch the specific exception the test tolerates, or re-raise / "
+        "pytest.fail in the handler (#15195)."
+    )
+
+    over = {
+        tree: (len(swallowed.get(tree, [])), budget)
+        for tree, (budget, _) in _SWALLOWED_ASSERTIONS.items()
+        if len(swallowed.get(tree, [])) > budget
+    }
+    assert not over, (
+        "these trees gained a test whose assertions cannot fire "
+        f"(actual, budget): {over}. The budgets are ceilings and there is no "
+        "route to raise one (#15195)."
+    )
+    drained = sorted(tree for tree in _SWALLOWED_ASSERTIONS if not swallowed.get(tree))
+    assert not drained, (
+        f"{drained} no longer smother any assertion — delete the entry from "
+        "_SWALLOWED_ASSERTIONS so the tree is pinned at zero by derivation."
+    )
+    spent = {
+        tree: (len(swallowed.get(tree, [])), budget)
+        for tree, (budget, _) in _SWALLOWED_ASSERTIONS.items()
+        if len(swallowed.get(tree, [])) < budget
+    }
+    assert not spent, (
+        "these trees are now BELOW their recorded budget (actual, budget): "
+        f"{spent}. Lower the number here in the same commit."
+    )
+
+
+def test_an_assertion_under_a_swallowing_handler_does_not_count_as_protection() -> None:
+    """#15195, both directions — it must catch the swallow and spare the rest.
+
+    The second half matters more than the first. A guard that over-flags a
+    legitimate ``try``/``except`` gets switched off, and a switched-off guard is
+    worse than the blind spot this rule closes.
+    """
+    swallowing = (
+        "def test_a():\n"
+        "    try:\n"
+        "        assert 1 == 2, 'nope'\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        return False\n"
+    )
+    assert sorted(offending_returns(swallowing)) == [("test_a", 4), ("test_a", 6)], (
+        "an assert under `except Exception` is inert — the test cannot fail, "
+        "which is exactly this sweep's subject (#15195)"
+    )
+    assert swallowed_assertions(swallowing) == [("test_a", 3)]
+
+    for name, catcher in (
+        ("BaseException", "except BaseException:"),
+        ("AssertionError", "except AssertionError:"),
+        ("a bare except", "except:"),
+        ("a tuple naming Exception", "except (ValueError, Exception):"),
+        ("an aliased handler", "except Exception as exc:"),
+    ):
+        source = (
+            "def test_a():\n"
+            "    try:\n"
+            "        assert False\n"
+            "        return True\n"
+            f"    {catcher}\n"
+            "        return False\n"
+        )
+        assert offending_returns(source), f"{name} swallows AssertionError too"
+
+    # ---- the counter-cases: these must NOT be flagged --------------------
+    reraises = (
+        "def test_a():\n"
+        "    try:\n"
+        "        assert False\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        raise\n"
+    )
+    assert not offending_returns(reraises), "a handler that re-raises protects nothing away"
+    assert not swallowed_assertions(reraises)
+
+    specific = (
+        "def test_a():\n"
+        "    try:\n"
+        "        assert False\n"
+        "        return True\n"
+        "    except ValueError:\n"
+        "        return False\n"
+    )
+    assert not offending_returns(specific), (
+        "except ValueError does not catch AssertionError; flagging it would make "
+        "this guard something a reviewer switches off"
+    )
+    assert not swallowed_assertions(specific)
+
+    reports = (
+        "import pytest\n\n\n"
+        "def test_a():\n"
+        "    try:\n"
+        "        assert False\n"
+        "        return True\n"
+        "    except Exception as exc:\n"
+        "        pytest.fail(str(exc))\n"
+    )
+    assert not offending_returns(reports), "pytest.fail ends the test; it does not absorb it"
+    assert not swallowed_assertions(reports)
+
+    # Only the `try` body is covered by its own handlers.
+    for clause, body in (("else", "    else:\n"), ("finally", "    finally:\n")):
+        source = (
+            "def test_a():\n"
+            "    try:\n"
+            "        pass\n"
+            "    except Exception:\n"
+            "        pass\n"
+            f"{body}"
+            "        assert False\n"
+            "        return True\n"
+        )
+        assert not offending_returns(source), (
+            f"an assert in `{clause}` is not caught by that try's own handlers"
+        )
+
+    # Nesting: an inner handler that re-raises does not undo an outer swallow.
+    nested = (
+        "def test_a():\n"
+        "    try:\n"
+        "        try:\n"
+        "            assert False\n"
+        "        except ValueError:\n"
+        "            raise\n"
+        "        return True\n"
+        "    except Exception:\n"
+        "        return False\n"
+    )
+    assert offending_returns(nested), "the outer bare except still eats the AssertionError"
+
+    # Ownership is unchanged: a nested definition owns its own swallow.
+    helper = (
+        "def test_a():\n"
+        "    def helper():\n"
+        "        try:\n"
+        "            assert False\n"
+        "        except Exception:\n"
+        "            pass\n"
+        "\n"
+        "    assert helper() is None\n"
+        "    return True\n"
+    )
+    assert not offending_returns(helper), (
+        "the enclosing test's own assert is live; the helper's is the helper's"
+    )
+
+
 def test_the_detector_finds_a_planted_return_and_spares_the_legitimate_ones() -> None:
     """Self-test. Every exclusion branch is exercised, not merely written down."""
     assert offending_returns("def test_a():\n    return False\n") == [("test_a", 2)]
@@ -482,6 +903,20 @@ def test_the_detector_finds_a_planted_return_and_spares_the_legitimate_ones() ->
     assert offending_returns(
         "def test_c():\n    return True\n"
     ), "a test whose return is its ONLY verdict is still an offence"
+
+    # #15195 narrowed that exemption to assertions which can actually fire. The
+    # driver shape it exists to protect must survive the narrowing, including
+    # when the driver guards itself against a specific error it tolerates —
+    # `except ValueError` does not catch an AssertionError, so the assert below
+    # still propagates and the return is still a separate driver contract.
+    assert not offending_returns(
+        "def test_a():\n"
+        "    try:\n"
+        "        assert True\n"
+        "        return True\n"
+        "    except ValueError:\n"
+        "        return False\n"
+    ), "a handler naming a non-assertion exception leaves the assert able to fire"
 
 
 def test_an_unparseable_swept_file_fails_loudly_instead_of_reading_as_clean() -> None:


### PR DESCRIPTION
Closes #15195
Refs #15189

## Thinking Path

`repo_tests/tests_that_return_instead_of_asserting_test.py` (#14920) is a fatal AST
sweep with a per-tree down-only ratchet. It skipped any test containing an `assert`
or `raise`, on the sound-sounding reasoning that such a test can still fail.

That reasoning silently assumes an assertion which is **present** is an assertion
which can **fire**. Under a handler catching `Exception`, `BaseException` or
`AssertionError`, it cannot — the `AssertionError` never leaves the function, both
branches return, and the test passes whichever way it goes. Which is precisely the
population this sweep exists to count. So the guard built to find tests that cannot
fail was blind to the family of tests that most convincingly cannot fail: the ones
that look defended.

#15189 is the consequence. Ten functions in one file had the shape; nine had
(inert) asserts, so this sweep attributed only **2** offending returns to the whole
module — both in the single function with no assert at all. Sweeping for siblings
before this landed would have used the blind detector, which is why #15195 goes first.

Two corrections to #15189's own framing, per the owner's comment on it:

* making pytest's `PytestReturnNotNoneWarning` fatal is useful but **insufficient
  alone** — it would have caught one of the ten, and it only ever sees tests that
  run (this AST sweep reaches modules nothing collects).
* closing the blind spot makes the measured population **rise**. That is a detector
  improvement, not a ratchet violation, and this PR says so at the constant rather
  than quietly absorbing it into a bigger ceiling.

## What Changed

Three files. The detector took the guard from 509 to 944 lines, past the repo's
600-line cap on a file that had never needed a `KNOWN_LARGE` exemption — so it is
split rather than grandfathered.

| File | Lines | Holds |
|---|---|---|
| `repo_tests/collected_test_model.py` *(new)* | 325 | pytest's collection model + the assertion-propagation analysis |
| `repo_tests/collected_test_model_test.py` *(new)* | 160 | the detector's unit cases, every branch |
| `repo_tests/tests_that_return_instead_of_asserting_test.py` | 583 | the sweep, both ratchets, both budget dicts |

The seam is one step wider than the detector alone, deliberately. The new
`_SWALLOWED_ASSERTIONS` guard needs the same "what would pytest collect" model as the
returns guard; extracting only the detector would have left a second copy of that
model to drift, which is exactly the failure behind #14927 (matched `python_classes`
by name, missed every `unittest.TestCase`) and #15018 (enumerated half of nothing).
Same shape as the neighbouring `uncollected_class_model.py` / `_test.py` pair. The
numbers stay with the guard that enforces them, not with the model.

**The rule.** An `assert`/`raise` is counted as protection only when it can reach
pytest. It is discounted when it sits in the **body** of a `try` whose handler
would catch an `AssertionError` and does not hand the failure back on.

*Swallowing* (assertion is inert) vs *protective* (assertion still fires):

| Handler | Verdict |
|---|---|
| `except Exception:` / `except BaseException:` / `except AssertionError:` / bare `except:` / a tuple naming any of them | swallowing |
| `except ValueError:` — any specific non-assertion exception | protective, not flagged |
| handler containing `raise` (bare re-raise or a new one) | protective |
| handler containing its own `assert` | protective |
| handler calling `pytest.fail` / `exit` / `skip` / `xfail` (or `self.fail`) | protective |
| assertions in `else`, `finally`, or a handler body | protective — that try's own handlers do not cover them |
| a nested helper's `try` | the helper's, not the test's — ownership rule unchanged |

Deliberately narrow in every one of those directions: a guard that over-flags a
legitimate `try`/`except` is a guard someone switches off, which would be worse than
the blindness being removed.

**Re-baseline, argued in the file.** `_KNOWN_OFFENDERS` 71 -> 86 (`autobot-backend`)
and 121 -> 127 (`autobot-infrastructure`); `autobot-npu-worker` unchanged at 7. The
comment at the constant states the terms under which a ceiling may be raised at all
— the sweep got *stricter* and the delta is *enumerated* — and enumerates it: 21
returns, 8 pre-existing functions, 3 files. No previously-counted site stopped being
counted (base set verified a strict subset of the new one), and no clean tree gained
an offender.

**A second ceiling, `_SWALLOWED_ASSERTIONS`.** The general form of the same defect —
an inert assertion in a test that does *not* return a value, which the returns
ceiling structurally cannot see. 6 functions in `autobot-backend`, 3 in
`autobot-infrastructure`; every other tree pinned at zero by derivation. Down-only,
no route up. This is #15195's fourth acceptance criterion, implemented as a guard
rather than left as a note.

**Self-tests.** A new `test_an_assertion_under_a_swallowing_handler_does_not_count_as_protection`
exercises five swallowing handler spellings and six counter-cases, so every branch of
the rule is proven by a synthetic case rather than by whatever the live tree happens
to contain.

Nothing in the swept population was converted — see *what is left*, below.

## Verification

`python3 -m pytest repo_tests/collected_test_model_test.py repo_tests/tests_that_return_instead_of_asserting_test.py -q`
-> **16 passed**. `repo_tests/python_file_size_ratchet_test.py` -> **31 passed** (the
cap that caught the unsplit file).

The split is a pure lift: no detection behaviour changed and no measured number moved
— `_KNOWN_OFFENDERS` 86/127/7 and `_SWALLOWED_ASSERTIONS` 6/3 are both enforced by
exact equality, so a silent shift could not pass. Both mutations below were re-run
against the split shape, not carried over.

**Contrast mutation.** A swallowing test planted in `autobot_shared/` (a tree with no
budget), then the guard run at base and at HEAD.

*Base guard, planted test* — passes, seeing nothing:

```
1 passed, 4 deselected in 10.69s
```

*This PR's guard, same planted test* — fails twice, once per ceiling:

```
E   AssertionError: these tests return a value instead of asserting, in a tree that was clean:
E       autobot_shared:
E         autobot_shared/mutation_probe_15195_test.py:11 test_probe_cache_round_trip
E         autobot_shared/mutation_probe_15195_test.py:9 test_probe_cache_round_trip
E   AssertionError: these tests assert inside a `try` whose handler swallows the
E   AssertionError, in a tree that was clean:
E       autobot_shared:
E         autobot_shared/mutation_probe_15195_test.py:8 test_probe_cache_round_trip
FAILED ...::test_no_tree_outside_the_known_set_has_a_test_that_returns_a_value
FAILED ...::test_no_test_smothers_its_own_assertions_under_a_swallowing_handler
2 failed, 5 deselected in 31.68s
```

Probe deleted and the guard file restored from a pristine copy, confirmed with
`diff -q` and `git status` (only the intended file modified).

**Counter-mutation.** Five legitimate shapes planted together in the same clean tree
— `except ValueError` + return, `except Exception: raise`, `except Exception:
pytest.fail(...)`, an assert in `finally`, and a `pytest.raises` block:

```
2 passed, 6 deselected in 39.41s
```

None is flagged. Probe deleted; `git status` clean afterwards.

**Sweep counts, before and after (#15189's criteria).**

| Sweep | Base | With this rule |
|---|---|---|
| Offending returns attributed by the guard | 199 (71 / 121 / 7) | **220** (86 / 127 / 7) |
| The swallowing shape — swallowed assert **and** a value return | 0 seen | **8 functions / 21 returns**, 3 files |
| Swallowed assertions in a test, return or not (general form) | not detectable | **9 functions**, 2 trees |
| The weaker form — any collected non-fixture test returning a value, raw | **250 return statements in 115 functions** (backend 105/55, infrastructure 132/51, npu-worker 13/9) | unchanged (raw) |
| Body is `pass` or only `print()` while the name claims a check | 0 | **0** |
| Sweep subject | 2,048 modules, 28,407 collected non-fixture test functions | unchanged |

Breadth check on the new rule, so "narrow" is measured rather than asserted: 582
collected tests contain a `try`; 237 handlers in them would catch an
`AssertionError`; 41 of those are read as *reporting* (15 `skip`, 9 `fail`, 9
`assert`, 8 `raise`); 196 are swallowing — yet only **9 tests** actually hold an
assertion inside such a body. The rule fires on the shape that matters and stays
silent on the rest.

**Exemption-list question from #15189, answered either way.**
`autobot-backend/cache/cache_consolidation_p4_test.py` was in **no** exemption, skip,
ignore or warning-filter list. `autobot-backend` is in `testpaths`; the file is under
neither `norecursedirs` nor any `--ignore` in `addopts`; and there is **no
`filterwarnings` section anywhere in the repo**. `PytestReturnNotNoneWarning` was
therefore emitted, unfiltered, and simply never fatal — the file was not suppressed,
it was scrolled past.

**The three files the re-baseline covers, not converted here.**

| File | Functions | Returns |
|---|---|---|
| `autobot-backend/config/config_consolidation_p2_test.py:17` | 1 (`test_config_consolidation`, ten `try/except Exception` sections in one async body) | 11 |
| `autobot-backend/tests/integration/test_causal_framework_integration.py:102,333,660,898` | 4 (`*_full_pipeline`, catch `AssertionError` into a scenario report and return it) | 4 |
| `autobot-infrastructure/shared/scripts/test_configuration.py:49,94,163` | 3 (driver functions consumed by the module's own `main()`) | 6 |

Plus `autobot-backend/config/config_migration_integration_test.py:87`
(`test_secrets_service_config_migration`, 1 inert assert, no value return) — visible
only to the new `_SWALLOWED_ASSERTIONS` ceiling.

Reported rather than half-converted, deliberately. Two of the three are large
live-service drivers (a 217-line async config driver and a 1,145-line causal harness)
where unwrapping the swallow is its own piece of work with its own failure surface —
the #15166 precedent for the same shape took a file from 499 to 236 lines. Converting
one of three would leave the ratchet stuck mid-population.

**mypy.** Not a risk here: the pre-commit and CI mypy hooks scope to
`^autobot_shared/` (strict) and `^(autobot-backend|autobot-slm-backend)/`
(informational). `repo_tests/` is in neither, so the extraction cannot expose the
lifted code to a stricter configuration than it had inline. No `# type: ignore` was
added anywhere.

**Not verified.** The local interpreter is below 90 of 206 declared dependency floors,
so a local pass carries no CI signal beyond this guard's own AST work — which needs no
imports. Whether the 8 functions above still pass once their swallow is unwrapped is
unknown and untested here; that is the point of leaving them.

## Model Used

Claude Opus 5 (1M context).