### PR TITLE
security(chat): tell a degraded log_only from a chosen one in the decision record (#15159)

### DIFF
--- a/autobot-backend/api/chat_sessions_enforcement_degrade_test.py
+++ b/autobot-backend/api/chat_sessions_enforcement_degrade_test.py
@@ -21,6 +21,12 @@ directly. That cannot see two things this file exists for:
 
 The enforced case is here for the same reason: without it, "the degraded case
 was not refused" would be satisfied by a harness incapable of refusing anything.
+
+#15159 added the last section: the two ways of arriving at `log_only` produced
+byte-identical decision records, separated only by the warning the section above
+asserts. A log line is what a human greps; the record is what code reads, and an
+audit trail or a #14010 AC4 measurement reads the record. Those tests assert on
+the record the route was handed, never on log output.
 """
 
 from __future__ import annotations
@@ -29,6 +35,7 @@ import contextlib
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -40,7 +47,13 @@ OWNER = "alice"
 INTRUDER = "bob"
 SESSION_ID = "alices-chat"
 EXPORT_PATH = f"/chat/sessions/{SESSION_ID}/export"
-LOGGER_NAME = "security.session_ownership"
+#: The ownership decision's own warnings. The mode resolver moved to
+#: `security/enforcement_mode.py` with #15159, so the degrade warnings are
+#: emitted under that name while the access decision still warns under the
+#: validator's. Both are the ownership decision talking; filtering to one alone
+#: would silently drop half the evidence.
+LOGGER_NAMES = ("security.session_ownership", "security.enforcement_mode")
+LOGGER_NAME = LOGGER_NAMES[0]
 
 
 class _Spy:
@@ -49,6 +62,13 @@ class _Spy:
     def __init__(self):
         self.owner_lookups = 0
         self.violations = 0
+        self.decisions: list[dict] = []
+
+    @property
+    def decision(self) -> dict:
+        """The single decision record this request produced."""
+        assert len(self.decisions) == 1, f"expected exactly one ownership decision, got {len(self.decisions)}"
+        return self.decisions[0]
 
 
 @contextlib.contextmanager
@@ -73,6 +93,19 @@ def _real_dependency(flags, spy: _Spy):
     def _violation(_self, *_args, **_kwargs):
         spy.violations += 1
 
+    real_validate = SessionOwnershipValidator.validate_ownership
+
+    async def _validate(self, session_id, request):
+        """Passthrough that records what the route was handed.
+
+        The real method runs unchanged — this observes the decision, it does not
+        make one — so the allow/deny assertions and the record assertions are
+        reading the same single execution.
+        """
+        result = await real_validate(self, session_id, request)
+        spy.decisions.append(result)
+        return result
+
     auth = MagicMock()
     auth.enable_auth = True
 
@@ -86,6 +119,7 @@ def _real_dependency(flags, spy: _Spy):
             patch.object(SessionOwnershipValidator, "_is_org_admin_access", AsyncMock(return_value=False))
         )
         stack.enter_context(patch.object(SessionOwnershipValidator, "_audit_log_violation", _violation))
+        stack.enter_context(patch.object(SessionOwnershipValidator, "validate_ownership", _validate))
         stack.enter_context(
             patch.object(SessionOwnershipValidator, "_record_violation_metrics", AsyncMock(return_value=None))
         )
@@ -109,7 +143,7 @@ def _ownership_warnings(caplog):
     downstream of the decision (a stubbed Redis, a missing session file) would
     otherwise make "a deliberate disabled logs no warning" impossible to state.
     """
-    return [r for r in caplog.records if r.levelno >= logging.WARNING and r.name == LOGGER_NAME]
+    return [r for r in caplog.records if r.levelno >= logging.WARNING and r.name in LOGGER_NAMES]
 
 
 def _flags_returning(mode: EnforcementMode):
@@ -151,7 +185,7 @@ class TestAFailedFlagsServiceDoesNotSkipTheCheck:
 
     def test_the_degrade_is_audible_from_a_real_request(self, caplog):
         spy = _Spy()
-        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        with caplog.at_level(logging.WARNING):
             with _real_dependency(RuntimeError("flag store unreachable"), spy) as client:
                 client.get(EXPORT_PATH)
 
@@ -169,7 +203,7 @@ class TestADeliberateDisabledStaysDistinguishableAtTheRoute:
 
     def test_it_skips_the_lookup_and_logs_no_warning(self, caplog):
         spy = _Spy()
-        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+        with caplog.at_level(logging.WARNING):
             with _real_dependency(_flags_returning(EnforcementMode.DISABLED), spy) as client:
                 response = client.get(EXPORT_PATH)
 
@@ -178,4 +212,121 @@ class TestADeliberateDisabledStaysDistinguishableAtTheRoute:
         assert not _ownership_warnings(caplog), (
             "a deliberate 'disabled' now warns like an outage does; the two states are no longer "
             "tellable apart from the logs of a real request"
+        )
+
+
+#: How each way of arriving at an enforcement mode is wired into the harness,
+#: keyed by what an operator would call it. Enumerated rather than repeated in
+#: each test so a fifth resolution cannot be added without a line here.
+RESOLUTIONS: dict[str, object] = {
+    "chosen log_only": _flags_returning(EnforcementMode.LOG_ONLY),
+    "degraded log_only": RuntimeError("flag store unreachable"),
+    "deliberate disabled": _flags_returning(EnforcementMode.DISABLED),
+    "enforced": _flags_returning(EnforcementMode.ENFORCED),
+}
+
+#: What each resolution did *before* #15159, pinned as data: the HTTP status a
+#: non-owner got, and whether the ownership lookup ran. #15159 changes what the
+#: decision records and nothing about what it does, so every one of these has to
+#: still hold afterwards.
+PRE_15159_BEHAVIOUR: dict[str, tuple[bool, int]] = {
+    # name: (refused with 403, ownership lookups)
+    "chosen log_only": (False, 1),
+    "degraded log_only": (False, 1),
+    "deliberate disabled": (False, 0),
+    "enforced": (True, 1),
+}
+
+
+class TestAllowDenyIsUnchangedByTheMarker:
+    """The boundary #15159 must not cross.
+
+    `log_only` means allow-and-audit, deliberately: denying on a degraded read
+    would turn a flag blip into a platform-wide read outage (#14010, owner
+    ruling). Adding a marker to the record is only safe if the record is all it
+    adds, so the outcome of every resolution is pinned here as data rather than
+    left to be re-derived per test.
+    """
+
+    def test_the_behaviour_table_covers_every_resolution(self):
+        """A table that drifts from the enumeration stops covering a case silently."""
+        assert RESOLUTIONS, "the resolution enumeration is empty; the tests below assert nothing"
+        assert set(RESOLUTIONS) == set(PRE_15159_BEHAVIOUR), (
+            "a resolution has no pinned pre-#15159 behaviour; add it deliberately rather than "
+            "letting it drop out of the invariance check"
+        )
+
+    @pytest.mark.parametrize("resolution", list(RESOLUTIONS))
+    def test_each_resolution_allows_or_denies_exactly_as_it_did(self, resolution):
+        refuses, expected_lookups = PRE_15159_BEHAVIOUR[resolution]
+        spy = _Spy()
+
+        with _real_dependency(RESOLUTIONS[resolution], spy) as client:
+            response = client.get(EXPORT_PATH)
+
+        assert response.status_code != 404, "the export route did not resolve; a 404 fakes every outcome here"
+        assert (response.status_code == 403) is refuses, (
+            f"'{resolution}' now {'allows' if refuses else 'refuses'} a non-owner where it "
+            f"{'refused' if refuses else 'allowed'} before — #15159 may only change what the decision records"
+        )
+        assert spy.owner_lookups == expected_lookups, (
+            f"'{resolution}' changed whether the ownership lookup runs " f"({spy.owner_lookups} vs {expected_lookups})"
+        )
+
+
+class TestTheDecisionRecordSeparatesADegradedLogOnlyFromAChosenOne:
+    """#15159 itself, asserted on the record and never on log output.
+
+    The log is the weak distinguisher this issue exists to replace: a side effect
+    on another stream, invisible to an audit record, a metric, or the #14010 AC4
+    measurement that has to know whether the window it counted was healthy.
+    """
+
+    def _decision_for(self, resolution: str) -> dict:
+        spy = _Spy()
+        with _real_dependency(RESOLUTIONS[resolution], spy) as client:
+            response = client.get(EXPORT_PATH)
+        assert response.status_code != 404, "the export route did not resolve"
+        return spy.decision
+
+    def test_a_chosen_log_only_reports_the_plain_reason(self):
+        decision = self._decision_for("chosen log_only")
+
+        assert decision["reason"] == "log_only_mode"
+        assert decision["enforcement_degraded"] is False
+
+    def test_a_degraded_log_only_is_marked_as_degraded(self):
+        decision = self._decision_for("degraded log_only")
+
+        assert decision["enforcement_degraded"] is True, (
+            "a log_only reached because the flag store could not be read reports itself as a chosen "
+            "posture — an AC4 measurement cannot exclude the outage window"
+        )
+        assert decision["reason"] != "log_only_mode"
+        assert "degraded" in decision["reason"]
+
+    def test_the_two_log_only_reasons_do_not_converge(self):
+        """The decisive assertion: same mode, same outcome, different provenance."""
+        chosen = self._decision_for("chosen log_only")
+        degraded = self._decision_for("degraded log_only")
+
+        assert chosen["authorized"] is degraded["authorized"] is True, "the two must still behave identically"
+        assert chosen["reason"] != degraded["reason"], (
+            "a never-seeded install and a flag-store outage produce the same decision record again; "
+            "nothing in the record says which population a log_only violation belongs to (#15159)"
+        )
+
+    def test_the_marker_takes_both_values_and_is_not_a_constant(self):
+        """A field that exists and never varies distinguishes nothing.
+
+        Wiring the marker in but never setting it would leave every assertion
+        that only checks its presence green. This one fails on that mutation.
+        """
+        observed = {
+            self._decision_for(name)["enforcement_degraded"] for name in ("chosen log_only", "degraded log_only")
+        }
+
+        assert observed == {True, False}, (
+            f"the degraded marker only ever took {observed!r} — it is present but inert, and the two "
+            "log_only states are still indistinguishable in the record"
         )

--- a/autobot-backend/security/enforcement_mode.py
+++ b/autobot-backend/security/enforcement_mode.py
@@ -1,0 +1,129 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Resolve the ownership enforcement mode, and record *how* it was resolved (#15159).
+
+The mode alone is not enough to describe a decision. ``log_only`` is reached two
+ways -- an operator (or an unseeded install) sitting in it deliberately, and a
+flag store that could not be read at all -- and until #15159 the two produced
+byte-identical decision records. The only thing separating them was a
+``logger.warning`` emitted here at resolution time: a side effect on another
+stream, not a property of the decision. Anything reading the decision (audit
+records, metrics, an operator asking why a request was allowed) saw
+``log_only_mode`` for both.
+
+That matters because a ``log_only`` window is how the blast radius of flipping
+to ``enforced`` gets sized (#14010 AC4). If part of that window was an outage,
+the violations counted are of a different population, and nothing in the record
+said which.
+
+So resolution returns :class:`ResolvedEnforcementMode` -- the mode *and* whether
+it was determined or degraded to -- and the consumer stamps that onto the record
+it emits. What the mode *does* is untouched: ``log_only`` remains allow-and-audit
+in both cases, deliberately, because denying on a degraded read would turn a flag
+blip into a platform-wide read outage (#14010, owner ruling). This module changes
+what a decision **records**, never what it **does**.
+
+Split into its own module rather than added to ``session_ownership.py`` for the
+same reason ``endpoint_enforcement.py`` was: that file is grandfathered in the
+down-only file-size ratchet and may not grow. Mode resolution and its degradation
+handling is the cohesive unit, and it is what the marker is a property of.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from fastapi import Request
+
+from autobot_shared.logging_manager import get_logger
+from security.endpoint_enforcement import effective_enforcement_mode
+from services.feature_flags import EnforcementModeUnavailable
+
+logger = get_logger(__name__)
+
+
+# What an *undetermined* enforcement mode degrades to (#14010). Deliberately not
+# "disabled": an unreachable flag store must not read as "authorization is off".
+# log_only keeps every check running and every violation recorded without
+# changing what requests succeed, so an outage is loud in the logs and metrics
+# instead of silently permissive. Choosing the *default* posture when the flag is
+# simply unset is a separate decision and is untouched here.
+DEGRADED_ENFORCEMENT_MODE = "log_only"
+
+#: Appended to a decision ``reason`` when the mode was degraded to rather than
+#: chosen. A suffix, not a separate field name, so every existing consumer that
+#: matches a reason exactly (e.g. ``api/chat.py``'s ``legacy_migration`` check)
+#: keeps behaving identically while a new consumer can tell the two apart.
+DEGRADED_REASON_SUFFIX = "_degraded"
+
+
+@dataclass(frozen=True)
+class ResolvedEnforcementMode:
+    """An enforcement mode together with the provenance of that answer.
+
+    *degraded* is True only when the mode could not be determined and this module
+    substituted :data:`DEGRADED_ENFORCEMENT_MODE`. A mode read successfully from
+    the flag store is never degraded, including when that read returns
+    ``log_only``.
+    """
+
+    mode: str
+    degraded: bool = False
+
+    def reason(self, chosen_reason: str) -> str:
+        """*chosen_reason*, marked if this mode was degraded to rather than chosen.
+
+        Callers pass the reason they would have emitted anyway, so a decision
+        record never has to know the suffix convention.
+        """
+        return f"{chosen_reason}{DEGRADED_REASON_SUFFIX}" if self.degraded else chosen_reason
+
+
+async def resolve_enforcement_mode(feature_flags) -> ResolvedEnforcementMode:
+    """The global enforcement mode, or the degraded substitute when it is undeterminable.
+
+    Every route out of here that is not a successful read is marked ``degraded``,
+    so no failure can reach a decision record disguised as a policy choice.
+    """
+    if not feature_flags:
+        # No flags service means `get_feature_flags()` failed at
+        # construction — an infrastructure fault, not a policy decision.
+        logger.warning(
+            "Ownership enforcement mode is UNDETERMINED (no feature-flags service); "
+            "degrading to log_only. Checks still run and violations are recorded. "
+            "This is not a deliberate 'disabled' (#14010)."
+        )
+        return ResolvedEnforcementMode(DEGRADED_ENFORCEMENT_MODE, degraded=True)
+
+    try:
+        mode_enum = await feature_flags.get_enforcement_mode()
+        return ResolvedEnforcementMode(mode_enum.value)
+    except EnforcementModeUnavailable as exc:
+        logger.warning(
+            "Ownership enforcement mode is UNDETERMINED (%s); degrading to log_only. "
+            "Checks still run and violations are recorded. This is not a deliberate "
+            "'disabled' (#14010).",
+            exc,
+        )
+        return ResolvedEnforcementMode(DEGRADED_ENFORCEMENT_MODE, degraded=True)
+    except Exception as e:
+        # Anything unexpected is still a failure to determine policy, so it
+        # degrades the same way rather than silently disabling every check.
+        logger.warning(
+            "Ownership enforcement mode could not be resolved (%s); degrading to log_only (#14010).",
+            e,
+        )
+        return ResolvedEnforcementMode(DEGRADED_ENFORCEMENT_MODE, degraded=True)
+
+
+async def resolve_enforcement_mode_for_request(feature_flags, request: Request) -> ResolvedEnforcementMode:
+    """Global mode, tightened by any stricter per-endpoint override (#15086).
+
+    An override can only make the mode stricter, never weaker, so it can move a
+    degraded ``log_only`` up to ``enforced`` -- but it cannot make the *resolution*
+    any less degraded, and ``degraded`` is carried through unchanged.
+    """
+    resolved = await resolve_enforcement_mode(feature_flags)
+    return replace(resolved, mode=await effective_enforcement_mode(feature_flags, resolved.mode, request))

--- a/autobot-backend/security/session_ownership.py
+++ b/autobot-backend/security/session_ownership.py
@@ -22,8 +22,11 @@ from fastapi import HTTPException, Request
 from auth_middleware import get_auth_middleware
 from autobot_shared.logging_manager import get_logger
 from autobot_shared.ssot_constants import TTL_30_DAYS
-from security.endpoint_enforcement import effective_enforcement_mode
-from services.feature_flags import EnforcementModeUnavailable
+from security.enforcement_mode import (
+    ResolvedEnforcementMode,
+    resolve_enforcement_mode,
+    resolve_enforcement_mode_for_request,
+)
 
 logger = get_logger(__name__)
 
@@ -54,15 +57,6 @@ def build_owner_metadata(user_data: "dict | None", team_id: str | None = None) -
     if team_id:
         metadata["team_id"] = team_id
     return metadata
-
-
-# What an *undetermined* enforcement mode degrades to (#14010). Deliberately not
-# "disabled": an unreachable flag store must not read as "authorization is off".
-# log_only keeps every check running and every violation recorded without
-# changing what requests succeed, so an outage is loud in the logs and metrics
-# instead of silently permissive. Choosing the *default* posture when the flag is
-# simply unset is a separate decision and is untouched here.
-DEGRADED_ENFORCEMENT_MODE = "log_only"
 
 
 class SessionOwnershipValidator:
@@ -244,48 +238,19 @@ class SessionOwnershipValidator:
 
         return user_data
 
-    async def _get_enforcement_mode(self) -> str:
+    async def _get_enforcement_mode(self) -> ResolvedEnforcementMode:
+        """The global enforcement mode, with whether it was determined or degraded to.
+
+        Issue #281 extracted this helper; #15159 moved its body to
+        ``security/enforcement_mode.py`` and widened the answer from a bare mode
+        string to the mode plus its provenance, so a decision record can say
+        which of the two ``log_only`` states produced it.
         """
-        Get enforcement mode from feature flags with safe default.
+        return await resolve_enforcement_mode(self.feature_flags)
 
-        Issue #281: Extracted helper for enforcement mode retrieval.
-
-        Returns:
-            Enforcement mode string: "disabled", "log_only", or "enforced"
-        """
-        if not self.feature_flags:
-            # No flags service means `get_feature_flags()` failed at
-            # construction — an infrastructure fault, not a policy decision.
-            logger.warning(
-                "Ownership enforcement mode is UNDETERMINED (no feature-flags service); "
-                "degrading to log_only. Checks still run and violations are recorded. "
-                "This is not a deliberate 'disabled' (#14010)."
-            )
-            return DEGRADED_ENFORCEMENT_MODE
-
-        try:
-            mode_enum = await self.feature_flags.get_enforcement_mode()
-            return mode_enum.value
-        except EnforcementModeUnavailable as exc:
-            logger.warning(
-                "Ownership enforcement mode is UNDETERMINED (%s); degrading to log_only. "
-                "Checks still run and violations are recorded. This is not a deliberate "
-                "'disabled' (#14010).",
-                exc,
-            )
-            return DEGRADED_ENFORCEMENT_MODE
-        except Exception as e:
-            # Anything unexpected is still a failure to determine policy, so it
-            # degrades the same way rather than silently disabling every check.
-            logger.warning(
-                "Ownership enforcement mode could not be resolved (%s); degrading to log_only (#14010).",
-                e,
-            )
-            return DEGRADED_ENFORCEMENT_MODE
-
-    async def _get_enforcement_mode_for_request(self, request: Request) -> str:
+    async def _get_enforcement_mode_for_request(self, request: Request) -> ResolvedEnforcementMode:
         """Global mode, tightened by any stricter per-endpoint override (#15086)."""
-        return await effective_enforcement_mode(self.feature_flags, await self._get_enforcement_mode(), request)
+        return await resolve_enforcement_mode_for_request(self.feature_flags, request)
 
     def _audit_log_violation(
         self,
@@ -391,12 +356,13 @@ class SessionOwnershipValidator:
         stored_owner: str,
         user_data: Dict,
         request: Request,
-        enforcement_mode: str,
+        enforcement: ResolvedEnforcementMode,
     ) -> Dict:
         """Handle ownership mismatch with org admin bypass.
 
         Helper for validate_ownership (#684).
         """
+        enforcement_mode = enforcement.mode
         # Issue #684: Org admins can access any session in their org
         if await self._is_org_admin_access(user_data, session_id):
             logger.info(
@@ -432,7 +398,7 @@ class SessionOwnershipValidator:
             stored_owner,
             user_data,
             request,
-            enforcement_mode,
+            enforcement,
         )
 
     async def _is_org_admin_access(self, user_data: Dict, session_id: str) -> bool:
@@ -454,12 +420,18 @@ class SessionOwnershipValidator:
         stored_owner: str,
         user_data: Dict,
         request: Request,
-        enforcement_mode: str,
+        enforcement: ResolvedEnforcementMode,
     ) -> Dict:
         """
         Handle unauthorized access attempt based on enforcement mode.
 
         Issue #281: Extracted helper for unauthorized access handling.
+
+        The allowed-anyway record carries the resolution's provenance (#15159): a
+        ``log_only`` reached because the flag store could not be read reports a
+        distinct ``reason`` from one an operator is sitting in, so a #14010 AC4
+        measurement can exclude violations counted during an outage. It changes
+        nothing about which requests are allowed.
 
         Args:
             username: User attempting access
@@ -467,7 +439,7 @@ class SessionOwnershipValidator:
             stored_owner: Actual owner of session
             user_data: Authenticated user data
             request: FastAPI request object
-            enforcement_mode: Current enforcement mode
+            enforcement: Current enforcement mode and how it was resolved
 
         Returns:
             Dict with authorization result (for log_only mode)
@@ -475,6 +447,7 @@ class SessionOwnershipValidator:
         Raises:
             HTTPException: 403 if enforced mode
         """
+        enforcement_mode = enforcement.mode
         logger.warning(
             f"[{enforcement_mode.upper()} MODE] Unauthorized access: "
             f"user {username} tried to access session {session_id[:8]}... owned by {stored_owner}"
@@ -493,7 +466,8 @@ class SessionOwnershipValidator:
             return {
                 "authorized": True,
                 "user_data": user_data,
-                "reason": "log_only_mode",
+                "reason": enforcement.reason("log_only_mode"),
+                "enforcement_degraded": enforcement.degraded,
                 "violation_logged": True,
                 "actual_owner": stored_owner,
             }
@@ -595,7 +569,7 @@ class SessionOwnershipValidator:
         username: str,
         user_data: Dict,
         request: Request,
-        enforcement_mode: str,
+        enforcement: ResolvedEnforcementMode,
     ) -> Dict:
         """Helper for validate_ownership. Ref: #1088.
 
@@ -610,11 +584,12 @@ class SessionOwnershipValidator:
             username: Authenticated username
             user_data: Authenticated user data dict
             request: FastAPI request object
-            enforcement_mode: Current enforcement mode string
+            enforcement: Current enforcement mode and how it was resolved
 
         Returns:
             Dict with authorization result and user data
         """
+        enforcement_mode = enforcement.mode
         stored_owner = await self.get_session_owner(session_id)
 
         if not stored_owner:
@@ -624,7 +599,7 @@ class SessionOwnershipValidator:
 
         if stored_owner != username:
             return await self._check_ownership_mismatch(
-                username, session_id, stored_owner, user_data, request, enforcement_mode
+                username, session_id, stored_owner, user_data, request, enforcement
             )
 
         logger.debug(
@@ -658,13 +633,13 @@ class SessionOwnershipValidator:
         """
         user_data = self._get_authenticated_user(session_id, request)
         username = user_data["username"]
-        enforcement_mode = await self._get_enforcement_mode_for_request(request)
+        enforcement = await self._get_enforcement_mode_for_request(request)
 
-        fast_path_result = await self._resolve_fast_paths(session_id, user_data, enforcement_mode)
+        fast_path_result = await self._resolve_fast_paths(session_id, user_data, enforcement.mode)
         if fast_path_result is not None:
             return fast_path_result
 
-        return await self._resolve_ownership(session_id, username, user_data, request, enforcement_mode)
+        return await self._resolve_ownership(session_id, username, user_data, request, enforcement)
 
     async def get_user_sessions(self, username: str) -> list[str]:
         """

--- a/autobot-backend/security/session_ownership_endpoint_enforcement_test.py
+++ b/autobot-backend/security/session_ownership_endpoint_enforcement_test.py
@@ -147,7 +147,8 @@ class TestAnEndpointWithNoOverrideIsUnchanged:
         without_request = await validator._get_enforcement_mode()
         with_request = await validator._get_enforcement_mode_for_request(_request())
 
-        assert without_request == with_request == "log_only"
+        assert without_request.mode == with_request.mode == "log_only"
+        assert without_request.degraded is with_request.degraded is False
 
 
 class TestPrecedenceInTheDisagreementCase:

--- a/autobot-backend/security/session_ownership_enforcement_mode_test.py
+++ b/autobot-backend/security/session_ownership_enforcement_mode_test.py
@@ -34,7 +34,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from security.session_ownership import DEGRADED_ENFORCEMENT_MODE, SessionOwnershipValidator
+from security.enforcement_mode import DEGRADED_ENFORCEMENT_MODE
+from security.session_ownership import SessionOwnershipValidator
 from services.feature_flags import EnforcementMode, EnforcementModeUnavailable
 
 
@@ -64,14 +65,20 @@ class TestAPolicyDecisionIsUnchanged:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("mode", [EnforcementMode.DISABLED, EnforcementMode.LOG_ONLY, EnforcementMode.ENFORCED])
     async def test_a_resolved_mode_is_returned_verbatim(self, mode):
-        assert await _validator(_flags_returning(mode))._get_enforcement_mode() == mode.value
+        resolved = await _validator(_flags_returning(mode))._get_enforcement_mode()
+
+        assert resolved.mode == mode.value
+        assert resolved.degraded is False, (
+            f"a {mode.value!r} read successfully from the flag store was marked degraded — "
+            "a chosen posture must never be reported as an outage (#15159)"
+        )
 
     @pytest.mark.asyncio
     async def test_a_deliberate_disabled_still_disables(self):
         """The operator's own choice is still honoured — this is not a posture change."""
         validator = _validator(_flags_returning(EnforcementMode.DISABLED))
 
-        assert await validator._get_enforcement_mode() == "disabled"
+        assert (await validator._get_enforcement_mode()).mode == "disabled"
 
 
 class TestAnUndeterminedModeDoesNotDisableEnforcement:
@@ -81,24 +88,29 @@ class TestAnUndeterminedModeDoesNotDisableEnforcement:
     async def test_an_unreadable_mode_degrades_to_log_only(self):
         validator = _validator(_flags_raising(EnforcementModeUnavailable("redis down")))
 
-        mode = await validator._get_enforcement_mode()
+        resolved = await validator._get_enforcement_mode()
 
-        assert mode == DEGRADED_ENFORCEMENT_MODE == "log_only"
-        assert mode != "disabled", "an unreachable flag store was read as 'authorization is off' — the #14010 defect"
+        assert resolved.mode == DEGRADED_ENFORCEMENT_MODE == "log_only"
+        assert (
+            resolved.mode != "disabled"
+        ), "an unreachable flag store was read as 'authorization is off' — the #14010 defect"
+        assert resolved.degraded is True, "the degraded resolution is not marked as one (#15159)"
 
     @pytest.mark.asyncio
     async def test_a_missing_flags_service_degrades_to_log_only(self):
         """`feature_flags=None` means construction failed, not that policy is off."""
-        mode = await _validator(None)._get_enforcement_mode()
+        resolved = await _validator(None)._get_enforcement_mode()
 
-        assert mode == DEGRADED_ENFORCEMENT_MODE
-        assert mode != "disabled"
+        assert resolved.mode == DEGRADED_ENFORCEMENT_MODE
+        assert resolved.mode != "disabled"
+        assert resolved.degraded is True
 
     @pytest.mark.asyncio
     async def test_an_unexpected_error_degrades_rather_than_disabling(self):
-        mode = await _validator(_flags_raising(RuntimeError("boom")))._get_enforcement_mode()
+        resolved = await _validator(_flags_raising(RuntimeError("boom")))._get_enforcement_mode()
 
-        assert mode == DEGRADED_ENFORCEMENT_MODE
+        assert resolved.mode == DEGRADED_ENFORCEMENT_MODE
+        assert resolved.degraded is True
 
     @pytest.mark.asyncio
     async def test_the_degrade_is_audible(self, caplog):
@@ -177,7 +189,10 @@ class TestTheDegradedModeStillRunsAndRecordsTheCheck:
 
         # Allowed — log_only does not block, so no request that works today breaks.
         assert result["authorized"] is True
-        assert result["reason"] == "log_only_mode"
+        # The mode is log_only; #15159 marks *this* log_only as one it degraded
+        # into rather than one anybody chose. What it does is unchanged.
+        assert result["reason"] == "log_only_mode_degraded"
+        assert result["enforcement_degraded"] is True
         assert result["actual_owner"] == "alice"
 
         # ...but the check ran and the violation was recorded. Under the pre-fix
@@ -247,6 +262,12 @@ UNDETERMINED_ROUTE_NAMES = frozenset(
 )
 
 
+#: Where the resolver's own warnings are emitted. It moved out of
+#: ``security.session_ownership`` into its own module with #15159; caplog has to
+#: follow it, or every log assertion below silently captures nothing and passes.
+RESOLVER_LOGGER = "security.enforcement_mode"
+
+
 def _validator_for_route(route: str):
     """A validator wired for one of :data:`UNDETERMINED_ROUTES`."""
     failure = UNDETERMINED_ROUTES[route]
@@ -261,7 +282,7 @@ async def _records_from(validator, caplog) -> list[logging.LogRecord]:
     could not tell "logged nothing" from "logged the same thing one level down".
     """
     caplog.clear()
-    with caplog.at_level(logging.DEBUG, logger="security.session_ownership"):
+    with caplog.at_level(logging.DEBUG, logger=RESOLVER_LOGGER):
         await validator._get_enforcement_mode()
     return list(caplog.records)
 

--- a/autobot-backend/security/session_ownership_expiry_test.py
+++ b/autobot-backend/security/session_ownership_expiry_test.py
@@ -24,6 +24,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from security.enforcement_mode import ResolvedEnforcementMode
 from security.session_ownership import SessionOwnershipValidator
 
 _ALICE = "alice"
@@ -51,7 +52,7 @@ async def _resolve(validator, username):
         username=username,
         user_data={"username": username},
         request=MagicMock(),
-        enforcement_mode="enforced",
+        enforcement=ResolvedEnforcementMode("enforced"),
     )
 
 

--- a/docs/developer/THREAT_MODEL.md
+++ b/docs/developer/THREAT_MODEL.md
@@ -43,8 +43,8 @@ not an auth boundary — the caller is logged in — so a missing check reads as
 endpoint.
 
 **Canonical enforcement:** [`autobot-backend/security/session_ownership.py`](../../autobot-backend/security/session_ownership.py)
-— `build_owner_metadata` (:31) the one owner stamper · `validate_session_ownership` (:800)
-the one read-side gate · `validate_ownership` (:638).
+— `build_owner_metadata` (:34) the one owner stamper · `validate_session_ownership` (:775)
+the one read-side gate · `validate_ownership` (:613).
 
 **Invariants**
 
@@ -53,13 +53,20 @@ the one read-side gate · `validate_ownership` (:638).
 - Owner identity is `metadata.owner` = **username**, never a user id. A diff comparing
   against `user_id` is comparing the wrong field.
 - Redis is a TTL cache; the session file's `metadata.owner` is the record of truth. An absent
-  Redis record means "not cached", never "unowned" — `_owner_when_cache_is_empty` (:565) asks
+  Redis record means "not cached", never "unowned" — `_owner_when_cache_is_empty` (:539) asks
   disk first and rehydrates **for the real owner, never for the caller** (#14018).
-- Undetermined enforcement policy degrades to `DEGRADED_ENFORCEMENT_MODE` (:65), never to
-  `disabled`: checks still run and violations are still recorded (#14010). A new `except`
-  that returns `"disabled"` is a fail-open.
-- Only two legitimate fast-path bypasses exist — `_resolve_fast_paths` (:506): global auth
-  disabled, and enforcement explicitly `disabled`. A third one added in a diff is a finding.
+- Undetermined enforcement policy degrades, in
+  [`security/enforcement_mode.py`](../../autobot-backend/security/enforcement_mode.py), to
+  `DEGRADED_ENFORCEMENT_MODE` (:53) and never to `disabled`: checks still run and violations
+  are still recorded (#14010). A new `except` that returns `"disabled"` is a fail-open.
+- A resolution that degraded stays marked `degraded` (:73), so a `log_only` decision record
+  says which of the two `log_only` states produced it (#15159). It marks the record only —
+  `log_only` is allow-and-audit in both, deliberately. A degraded route reporting the chosen
+  `reason` is a finding.
+- Only two legitimate fast-path bypasses exist, in
+  [`security/session_ownership.py`](../../autobot-backend/security/session_ownership.py) —
+  `_resolve_fast_paths` (:480): global auth disabled, and enforcement explicitly `disabled`.
+  A third one added in a diff is a finding.
 - Creating over an existing session id is a 409, identical for "owned by someone else" and
   "no recorded owner" — a 403 on the first would confirm who owns it (#14012).
 

--- a/repo_tests/python_file_size_ratchet_baseline.py
+++ b/repo_tests/python_file_size_ratchet_baseline.py
@@ -323,7 +323,7 @@ RATCHET_BASELINE: dict[str, int] = {
     "autobot-backend/security/input_validator.py": 607,
     "autobot-backend/security/prompt_injection_detector.py": 747,
     "autobot-backend/security/security_edge_cases_test.py": 638,
-    "autobot-backend/security/session_ownership.py": 858,
+    "autobot-backend/security/session_ownership.py": 833,
     "autobot-backend/security/threat_detection_refactor_test.py": 880,
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,

--- a/scripts/python_file_size_known_large.py
+++ b/scripts/python_file_size_known_large.py
@@ -318,7 +318,7 @@ KNOWN_LARGE: dict[str, int] = {
     "autobot-backend/security/input_validator.py": 607,
     "autobot-backend/security/prompt_injection_detector.py": 747,
     "autobot-backend/security/security_edge_cases_test.py": 638,
-    "autobot-backend/security/session_ownership.py": 858,
+    "autobot-backend/security/session_ownership.py": 833,
     "autobot-backend/security/threat_detection_refactor_test.py": 880,
     "autobot-backend/security/threat_intelligence.py": 771,
     "autobot-backend/security_layer.py": 767,


### PR DESCRIPTION
## Thinking Path

After #14865 fixed the fail-open and #15155 fixed the unset-key default, two very
different states converged in the ownership decision record: an install sitting
in `log_only` deliberately, and one whose flag store could not be read at all.
Both resolved to `log_only` and both emitted `"reason": "log_only_mode"`. The
only thing separating them was a `logger.warning` at the moment the mode was
resolved — a side effect on another stream, not a property of the decision.
Anything reading the decision (an audit record, a metric, an operator asking why
a request was allowed) saw the same thing for both.

That is what makes #14010's AC4 measurement unsound: a `log_only` window is how
the blast radius of flipping to `enforced` gets sized, and if part of that window
was an outage the violations counted are of a different population, with nothing
in the record saying which.

**The boundary.** The owner has ruled that `log_only` means allow-and-audit,
deliberately, because denying on a degraded read would turn a flag blip into a
platform-wide read outage (#14010, 2026-08-26). So this changes what a decision
**records** and nothing about what it **does**. That invariant is pinned as a
test, not as a claim — see Verification.

**Why an extraction came first.** `session_ownership.py` was grandfathered at
exactly 858 lines in the down-only file-size ratchet: zero headroom, and the
marker needs the room. Mode resolution and its degradation handling is the
cohesive unit and is exactly what the marker is a property of, so it moved to its
own module — the same split `endpoint_enforcement.py` got, for the same reason.
The ceiling is **lowered** to the file's new size in this commit, never raised.

## What Changed

**New — `autobot-backend/security/enforcement_mode.py` (129 lines):** the body of
`SessionOwnershipValidator._get_enforcement_mode`, the `DEGRADED_ENFORCEMENT_MODE`
constant and the per-endpoint-override wrapper, lifted out whole. Resolution now
returns `ResolvedEnforcementMode(mode, degraded)` instead of a bare string: every
route that could not determine the mode is marked `degraded`, and a mode read
successfully from the flag store never is. An endpoint override can still tighten
a degraded `log_only` up to `enforced`; it cannot make the resolution any less
degraded, and the flag is carried through unchanged.

**`autobot-backend/security/session_ownership.py` (858 → 833):** the two resolver
methods become delegations; the resolution travels down the mismatch path as one
value instead of a bare mode string; the allowed-anyway record gains
`enforcement_degraded` and a `reason` of `log_only_mode_degraded` in place of
`log_only_mode` when the mode was degraded to rather than chosen.

The suffix is applied through `ResolvedEnforcementMode.reason()` so a consumer
matching a reason exactly (`api/chat.py`'s `legacy_migration` check) keeps
behaving identically. `enforcement_degraded` is added only to the `log_only`
violation record, where it can take both values — not to records where it would
be a constant.

**Docs — `docs/developer/THREAT_MODEL.md`.** The trust-boundary reference landed by #15218 (#15217) cites symbols in `session_ownership.py` by `file:line`, and `repo_tests/threat_model_anchors_resolve_test.py` verifies each citation still points at the symbol it names. Moving the file from 858 to 833 lines shifted them. All seven citations into the two modules were re-derived from the file at this head — not shifted by the delta, since the extraction removed lines in the middle and added lines at the top, so no two symbols moved by the same amount:

| symbol | before | after |
|---|---|---|
| `build_owner_metadata` | `session_ownership.py:31` | `session_ownership.py:34` |
| `_resolve_fast_paths` | `session_ownership.py:506` | `session_ownership.py:480` |
| `_owner_when_cache_is_empty` | `session_ownership.py:565` | `session_ownership.py:539` |
| `validate_ownership` | `session_ownership.py:638` | `session_ownership.py:613` |
| `validate_session_ownership` | `session_ownership.py:800` | `session_ownership.py:775` |
| `DEGRADED_ENFORCEMENT_MODE` | `session_ownership.py:65` | **`enforcement_mode.py:53`** |
| `degraded` | - (new) | `enforcement_mode.py:73` |

`DEGRADED_ENFORCEMENT_MODE` is the one that changed **modules**, so its path moved, not just its number. The anchor grammar carries the file forward from the last link seen, so the new link sits on the same line as its own anchor and the `session_ownership.py` link is re-established before `_resolve_fast_paths` — a path-only fix without that would have silently re-pointed the fast-path anchor at the wrong module. The invariant list also gains the #15159 rule itself, stated so that a degraded route reporting the chosen `reason` reads as a finding, and so that "records only, never denies" is on the page a security review starts from.

**Ratchet, lowered in the same commit:** `scripts/python_file_size_known_large.py`
and `repo_tests/python_file_size_ratchet_baseline.py`, `858 → 833` in both. The
entry stays (833 is still over 600); the new module needs none.

## Verification

**The decisive mutation.** Collapsed the degraded reason back onto the chosen one
(`ResolvedEnforcementMode.reason()` returns `chosen_reason` unconditionally).
3 tests fail, 29 pass:

```
AssertionError: a never-seeded install and a flag-store outage produce the same
decision record again; nothing in the record says which population a log_only
violation belongs to (#15159)
  assert 'log_only_mode' != 'log_only_mode'
```

Reverted from the index and re-verified by checksum.

**The inert-fix mutation.** Made the marker present but never set (`degraded=True`
dropped from all three degraded routes, so the field exists on every record and is
always `False`). 7 tests fail, including the one written for exactly this:

```
AssertionError: the degraded marker only ever took {False} — it is present but
inert, and the two log_only states are still indistinguishable in the record
```

Reverted from the index and re-verified by checksum.

**Behaviour invariance — the criterion that proves the boundary held.**
`TestAllowDenyIsUnchangedByTheMarker` pins the pre-change outcome of all four
resolutions as data (403-or-not, and whether the ownership lookup ran) and drives
each through a real request:

```
test_the_behaviour_table_covers_every_resolution               PASSED
test_each_resolution_allows_or_denies_exactly_as_it_did[chosen log_only]      PASSED
test_each_resolution_allows_or_denies_exactly_as_it_did[degraded log_only]    PASSED
test_each_resolution_allows_or_denies_exactly_as_it_did[deliberate disabled]  PASSED
test_each_resolution_allows_or_denies_exactly_as_it_did[enforced]             PASSED
```

Allow/deny is unchanged for every input, in both the chosen and the degraded case.

**Route-level, on the record and never on the log.** The new tests live in the
existing route harness, which mounts the real router and the real
`validate_session_ownership` dependency and stubs only the leaves. The decision
is observed by a passthrough around `validate_ownership`, so the allow/deny
assertions and the record assertions read the same single execution. Every case
asserts the status is not 404, so no refusal can pass for want of a route.

**Tests:** 90 passed across the six suites touching this code directly (the two
ownership enforcement suites, the expiry and endpoint-override suites, and the two
chat session/save ownership suites), and 374 passed / 1 skipped / 2 xfailed over
the whole security tree plus the chat ownership suites under CI's marker filter.

**Types:** mypy over the changed files reports the identical six pre-existing
errors before and after (`build_owner_metadata` × 4, the `str | None` owner
argument, the redis await) and none in the new module. No `# type: ignore` added.

**Doc anchors:** `repo_tests/threat_model_anchors_resolve_test.py` — 35 passed (2 failed before the fix). Every anchor into both modules was then re-read independently of the guard and lands on a real definition, not a docstring or a comment that merely contains the identifier. No other file in the repo cites `session_ownership.py` by line number.

**Ratchet:** `repo_tests/python_file_size_ratchet_test.py` — 31 passed.

**Not verified locally:** the runner is below 90 of 206 declared dependency floors
(python 3.10 vs the declared set), so a local pass carries limited information —
CI is the gate. `autobot-backend/security/enterprise/threat_detection/test_learner.py`
fails to collect on this interpreter, unchanged from base and unrelated.

## Model Used

Claude Opus 5 (1M context)

## Note for #15217's owner

Line-based citations break on every edit to a cited file. The guard makes that loud rather than silent, which is the right trade — but it asks the work of the wrong side: the doc already carries the symbol name, so the guard could locate the definition itself and fail with *"cites `build_owner_metadata` at :31, it is at :34"* instead of *"that line reads ..."*. That turns a re-derivation into a one-character edit and removes the class of mistake this fix had to be careful to avoid (arithmetic-shifting a number instead of looking it up). Feasible and small — the parser and the identifier extraction already exist. Not done here; flagging it only.

Closes #15159
Refs #14010, #14865, #15155, #15158.