### PR TITLE
fix(guards): scrub the git environment before asking git for the repo root (#15176)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -276,6 +276,20 @@ repos:
         stages: [pre-commit]
         description: "A ${AUTOBOT_*_PORT:-N} fallback that disagrees with ssot_config.py points at the wrong service whenever the shell library fails to load"
 
+      # #15176: six guards resolved the repository root with `git rev-parse
+      # --show-toplevel` and no scrub of the git environment. A hook exports
+      # GIT_DIR and no GIT_WORK_TREE, so git calls the caller's CWD the work
+      # tree and the flag answers with the CWD -- silently. Three of the six
+      # were hook entries; two of those printed their success line having
+      # inspected nothing, one of them over a deliberately planted violation.
+      - id: git-toplevel-env-scrubbed
+        name: "Asking git for the repo root must scrub GIT_DIR first (#15176)"
+        entry: tools/lint/check_git_toplevel_env_scrubbed.py
+        language: python
+        files: \.py$
+        stages: [pre-commit]
+        description: "An inherited GIT_DIR makes --show-toplevel answer with the caller's CWD; resolve the root with autobot_shared.paths.git_repo_root()"
+
       # #14228: autobot-backend/requirements.txt ends with `-r ../requirements.txt`,
       # so pip sees both files as one set and aborts when the same distribution
       # arrives with different specifiers. openpyxl and python-pptx did exactly

--- a/autobot-slm-backend/ansible/tests/check_ssh_key_path_defined.py
+++ b/autobot-slm-backend/ansible/tests/check_ssh_key_path_defined.py
@@ -36,17 +36,34 @@ import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
 import sys
 from pathlib import Path
 
+# The scrubbed root resolver lives in ``autobot_shared``; this script is run
+# directly, so the import path is bootstrapped from this file's own location
+# -- the one derivation an inherited GIT_DIR cannot confuse (#15176).
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from autobot_shared.paths import (  # noqa: E402
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
+
 VAR = "autobot_ssh_key_path"
 _GUARDED = re.compile(rf"{VAR}\s*\|\s*default\(")
 
 
 def _repo_root() -> Path:
-    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, encoding="utf-8"
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        sys.exit(f"FATAL: cannot locate the repo root: {result.stderr.strip()}")
-    return Path(result.stdout.strip())
+    """Absolute repo root, with the ambient git environment scrubbed first.
+
+    Measured for #15176 before the scrub: run from ``repo_tests/`` with
+    ``GIT_DIR`` exported, this resolved the root to ``repo_tests/`` and died
+    with an uncaught ``FileNotFoundError`` on the first
+    ``roles/*/defaults/main.yml`` read — loud, but blaming a missing role
+    default rather than the root it was joined to.
+    """
+    try:
+        return git_repo_root()
+    except GitRepoRootUnavailable as exc:
+        sys.exit(f"FATAL: cannot locate the repo root: {exc}")
 
 
 def _tracked_yaml(root: Path) -> list[str]:
@@ -56,6 +73,9 @@ def _tracked_yaml(root: Path) -> list[str]:
         capture_output=True,
         text=True,
         encoding="utf-8",
+        # Same scrub as the root: an inherited GIT_DIR would enumerate one
+        # checkout's index while *root* names another (#15176).
+        env=scrubbed_git_env(),
     )
     if result.returncode != 0:
         sys.exit(f"FATAL: git ls-files failed: {result.stderr.strip()}")

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -1,3 +1,5 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
 """Canonical project-root resolution for Python code (#13149).
 
 Every call site used to paste the shell placeholder
@@ -22,6 +24,8 @@ one implementation rather than two that can drift.
 from __future__ import annotations
 
 import os
+import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
+from collections.abc import Mapping
 from pathlib import Path
 
 #: Markers that identify a source checkout root and nothing below it. Both must
@@ -187,3 +191,84 @@ def resolve_project_root(start: Path) -> Path:
             else ""
         )
     )
+
+
+#: Git variables a hook exports into every process it starts. With ``GIT_DIR``
+#: set and ``GIT_WORK_TREE`` unset — exactly what a ``pre-commit``/``pre-push``
+#: hook hands its children — git treats the **current directory** as the work
+#: tree, so ``rev-parse --show-toplevel`` answers with wherever the caller
+#: happens to be rather than the repository root.
+#:
+#: The answer is wrong without being an error, which is the whole reason this
+#: is a named constant rather than a line inside one caller: a guard that
+#: resolves the wrong root reads a different (usually empty) set of files and
+#: reports clean. #15018 hit the raising half of that — ``pytest.ini`` read from
+#: ``repo_tests/`` and ``FileNotFoundError`` — and #15176 measured the silent
+#: half: two pre-commit guards printed their success line having inspected
+#: nothing at all.
+#:
+#: Measured on git 2.34.1 rather than assumed. A hook run in a **git worktree**
+#: -- this repository's entire workflow -- is handed
+#: ``GIT_DIR=<main>/.git/worktrees/<name>`` with no ``GIT_WORK_TREE``, for both
+#: ``pre-commit`` and ``pre-push``; a hook in a plain checkout on that version is
+#: handed neither. Git also chdirs the hook to the worktree top level, even when
+#: the user ran ``git commit`` from a subdirectory, so the *hook itself* still
+#: gets the right answer. What breaks is anything the hook then runs from
+#: somewhere else -- a helper passing ``cwd=``, a test module, a CI step
+#: invoking a guard directly. That is the whole distance between "correct today"
+#: and "correct".
+AMBIENT_GIT_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE")
+
+
+class GitRepoRootUnavailable(RuntimeError):
+    """``git rev-parse --show-toplevel`` could not name a repository root.
+
+    Raised rather than returning ``None`` so a caller has to decide what an
+    absent root means for it: the tooling scripts exit fatally, the pytest
+    guards skip. Both are correct answers; silently continuing with a
+    plausible-looking wrong path is not (#14544 records what that costs).
+    """
+
+
+def scrubbed_git_env(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """*env* (default :data:`os.environ`) minus every :data:`AMBIENT_GIT_VARS` entry.
+
+    Use for **any** git subprocess whose answer depends on the work tree, not
+    only ``rev-parse``: ``ls-files`` inherits the same confusion.
+    """
+    source = os.environ if env is None else env
+    return {key: value for key, value in source.items() if key not in AMBIENT_GIT_VARS}
+
+
+def git_repo_root(start: Path | str | None = None) -> Path:
+    """Repository root containing *start*, asked of git with the environment scrubbed.
+
+    *start* is the directory the question is asked from (default: the process
+    working directory). It selects which checkout answers — this repository's
+    workflow runs from worktrees, so "the repository root" is genuinely
+    caller-relative — while :data:`AMBIENT_GIT_VARS` scrubbing is what stops an
+    inherited hook environment from turning that directory into the answer.
+
+    Deliberately git-driven rather than :func:`project_root`: every caller here
+    goes on to run ``git ls-files`` against the result, so the root and the file
+    enumeration must come from the same checkout. Resolving the root by walking
+    for markers and then enumerating with git is two answers that can disagree.
+
+    Raises:
+        GitRepoRootUnavailable: git is absent, failed, or named nothing.
+    """
+    try:
+        result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=None if start is None else str(start),
+            env=scrubbed_git_env(),
+            check=False,
+        )
+    except OSError as exc:  # git not installed, or *start* is not a directory
+        raise GitRepoRootUnavailable(f"could not run git rev-parse: {exc}") from exc
+    if result.returncode != 0 or not result.stdout.strip():
+        raise GitRepoRootUnavailable(f"git rev-parse --show-toplevel exit {result.returncode}: {result.stderr.strip()}")
+    return Path(result.stdout.strip())

--- a/autobot_shared/paths.py
+++ b/autobot_shared/paths.py
@@ -1,5 +1,7 @@
 # Copyright 2025-2026 mrveiss
 # SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
 """Canonical project-root resolution for Python code (#13149).
 
 Every call site used to paste the shell placeholder

--- a/autobot_shared/paths_test.py
+++ b/autobot_shared/paths_test.py
@@ -17,6 +17,7 @@ from autobot_shared.paths import (
     is_checkout_root,
     project_root,
     resolve_project_root,
+    scrubbed_git_env,
 )
 
 
@@ -208,7 +209,17 @@ class TestRealGitWorktree:
             check=True,
             capture_output=True,
             text=True,
-            env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+            # scrubbed_git_env, not os.environ: the pre-push hook runs this
+            # suite with GIT_DIR pointing at the worktree it is pushing, and
+            # `git init`/`git commit` in *this* fixture then operate on that
+            # repository instead of the temporary one. Both tests in this class
+            # failed that way from a worktree, which is every checkout here
+            # (#15176).
+            env={
+                **scrubbed_git_env(),
+                "GIT_CONFIG_GLOBAL": "/dev/null",
+                "GIT_CONFIG_SYSTEM": "/dev/null",
+            },
         )
 
     def _build_main_tree(self, tmp_path: Path) -> Path:

--- a/pipeline-scripts/check_hook_exec_bits.py
+++ b/pipeline-scripts/check_hook_exec_bits.py
@@ -45,6 +45,18 @@ from pathlib import Path
 
 import yaml
 
+# The scrubbed root resolver lives in ``autobot_shared`` and this script runs
+# from a pre-commit virtualenv that does not have the repository installed, so
+# the import path is bootstrapped from this file's own location -- the one
+# derivation an inherited GIT_DIR cannot confuse (#15176).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autobot_shared.paths import (  # noqa: E402
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
+
 # Both copies, repo-relative. Resolved against the repo root at call time --
 # never against the process CWD, see _repo_root().
 _CONFIG_PATHS = (
@@ -91,16 +103,21 @@ def _repo_root() -> Path:
     of health over 16 real violations. ``pre-commit`` itself chdirs to the repo
     root before running a hook, so its own path was safe -- but a direct
     invocation was not, and this script's whole purpose is to not do that.
+
+    Resolved through ``autobot_shared.paths.git_repo_root``, which scrubs the
+    git environment first. A hook exports ``GIT_DIR`` without ``GIT_WORK_TREE``
+    and git then calls the *current directory* the work tree, so an unscrubbed
+    ``--show-toplevel`` hands back the caller's CWD instead (#15176).
+
+    Measured for #15176: run from ``repo_tests/`` with ``GIT_DIR`` exported, the
+    unscrubbed form resolved the root to ``repo_tests/``, found no
+    ``.pre-commit-config.yaml`` beneath it, and printed its success line having
+    read zero hook entries -- with a planted ``100644`` entry standing.
     """
-    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        sys.exit(f"FATAL: cannot locate the repo root (git rev-parse exit {result.returncode}): {result.stderr.strip()}")
-    return Path(result.stdout.strip())
+    try:
+        return git_repo_root()
+    except GitRepoRootUnavailable as exc:
+        sys.exit(f"FATAL: cannot locate the repo root: {exc}")
 
 
 def _tracked_modes(root: Path) -> dict[str, str]:
@@ -111,6 +128,9 @@ def _tracked_modes(root: Path) -> dict[str, str]:
         capture_output=True,
         text=True,
         encoding="utf-8",
+        # Same scrub as the root: an inherited GIT_DIR would enumerate one
+        # checkout's index while *root* names another (#15176).
+        env=scrubbed_git_env(),
     )
     if result.returncode != 0:
         # An empty listing and a failed listing look identical to every caller
@@ -179,13 +199,17 @@ def main(argv: list[str] | None = None) -> int:
     if known:
         # Printed on every run, pass or fail. A backlog nobody is reminded of is
         # indistinguishable from no backlog.
-        print(f"check-hook-exec-bits: {len(known)} hook(s) dormant and tracked in {_KNOWN_DORMANT_ISSUE}:")  # noqa: print
+        print(
+            f"check-hook-exec-bits: {len(known)} hook(s) dormant and tracked in {_KNOWN_DORMANT_ISSUE}:"
+        )  # noqa: print
         for item in known:
             print(f"  KNOWN  {item}")  # noqa: print
         print()  # noqa: print
 
     if not blocking:
-        print(f"check-hook-exec-bits: no new hook entry is missing its exec bit (expected {_REQUIRED_MODE})")  # noqa: print
+        print(
+            f"check-hook-exec-bits: no new hook entry is missing its exec bit (expected {_REQUIRED_MODE})"
+        )  # noqa: print
         return 0
 
     print(f"check-hook-exec-bits: {len(blocking)} hook entr(ies) not tracked executable\n")  # noqa: print

--- a/pipeline-scripts/check_requirements_no_conflicting_dupes.py
+++ b/pipeline-scripts/check_requirements_no_conflicting_dupes.py
@@ -33,6 +33,18 @@ import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
 import sys
 from pathlib import Path
 
+# The scrubbed root resolver lives in ``autobot_shared`` and this script runs
+# from a pre-commit virtualenv that does not have the repository installed, so
+# the import path is bootstrapped from this file's own location -- the one
+# derivation an inherited GIT_DIR cannot confuse (#15176).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autobot_shared.paths import (  # noqa: E402
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
+
 _REQ = re.compile(r"([A-Za-z0-9_.\-]+)(\[[^\]]*\])?\s*([<>=!~].*)?$")
 # pip accepts both spellings, and a guard that silently skips one reports clean
 # on a file it never opened (#14228 review).
@@ -40,12 +52,21 @@ _INCLUDE = re.compile(r"^\s*(?:-r|--requirement)[\s=]+(\S+)")
 
 
 def _repo_root() -> Path:
-    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, encoding="utf-8"
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        sys.exit(f"FATAL: cannot locate the repo root: {result.stderr.strip()}")
-    return Path(result.stdout.strip())
+    """Absolute repo root, with the ambient git environment scrubbed first.
+
+    Measured for #15176 before the scrub: run from ``repo_tests/`` with
+    ``GIT_DIR`` exported (which is what a hook hands its children), this
+    resolved the root to ``repo_tests/``. ``git ls-files`` still listed the
+    requirements files, so the empty-scope guard below never fired, but every
+    ``root / rel`` join then pointed at a path that does not exist, ``_closure``
+    skipped each one as "not a file", and the check printed its success line
+    having opened **no requirements file at all** -- with a planted
+    ``openpyxl==3.0.0`` conflict standing.
+    """
+    try:
+        return git_repo_root()
+    except GitRepoRootUnavailable as exc:
+        sys.exit(f"FATAL: cannot locate the repo root: {exc}")
 
 
 def _declarations(path: Path) -> dict[str, tuple[int, str]]:
@@ -93,7 +114,14 @@ def _closure(path: Path) -> list[Path]:
 def conflicts(root: Path) -> list[str]:
     """Every package pinned differently anywhere in one install's requirement set."""
     listing = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "ls-files", "*requirements*.txt"], cwd=str(root), capture_output=True, text=True, encoding="utf-8"
+        ["git", "ls-files", "*requirements*.txt"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        # Same scrub as the root: an inherited GIT_DIR would enumerate one
+        # checkout's index while *root* names another (#15176).
+        env=scrubbed_git_env(),
     )
     if listing.returncode != 0:
         sys.exit(f"FATAL: git ls-files failed: {listing.stderr.strip()}")
@@ -130,8 +158,7 @@ def conflicts(root: Path) -> list[str]:
                     continue
                 reported.add(key)
                 found.append(
-                    f"{name}: {first[0]}:{first[1]}: '{first[2]}' "
-                    f"conflicts with {site[0]}:{site[1]}: '{site[2]}'"
+                    f"{name}: {first[0]}:{first[1]}: '{first[2]}' " f"conflicts with {site[0]}:{site[1]}: '{site[2]}'"
                 )
     return found
 
@@ -143,7 +170,9 @@ def main(argv: list[str] | None = None) -> int:
 
     found = conflicts(_repo_root())
     if not found:
-        print("check-requirements-dupes: no package is pinned differently within any install's requirement set")  # noqa: print
+        print(
+            "check-requirements-dupes: no package is pinned differently within any install's requirement set"
+        )  # noqa: print
         return 0
 
     print(f"check-requirements-dupes: {len(found)} conflicting duplicate(s)\n")  # noqa: print

--- a/repo_tests/collection_coverage_test.py
+++ b/repo_tests/collection_coverage_test.py
@@ -41,24 +41,16 @@ that would have caught it, and is now here.
 
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
-
-#: Git variables a hook exports into its child processes. With ``GIT_DIR`` set
-#: and no ``GIT_WORK_TREE``, git treats the *current directory* as the work
-#: tree, so ``rev-parse --show-toplevel`` answers `repo_tests/` rather than the
-#: repository root and every path derived from it is wrong. The pre-push hook
-#: runs this module, so that is a real environment here, not a hypothetical.
-_AMBIENT_GIT_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE")
-
-
-def _git_env() -> dict[str, str]:
-    """The environment minus whatever git state a calling hook exported."""
-    return {k: v for k, v in os.environ.items() if k not in _AMBIENT_GIT_VARS}
+from autobot_shared.paths import (
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
 
 
 def project_root() -> Path:
@@ -70,23 +62,20 @@ def project_root() -> Path:
     #13659 stack lands, switching to the canonical resolver removes this
     dependency entirely.
 
+    #15176: the ``GIT_DIR``/``GIT_WORK_TREE`` scrub this module introduced now
+    lives in ``autobot_shared.paths`` — five sibling guards had the same
+    unscrubbed call, and a per-site copy is how that became a family.
+
     The whole module is git-driven — every check enumerates *tracked* files — so
     without git there is nothing to assert rather than something failing. This
     repository ships a `.dockerignore` that strips `.git` from build contexts,
     so a git-less checkout is a real configuration here, not a hypothetical, and
     it must skip rather than raise `CalledProcessError` out of ten tests.
     """
-    out = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        cwd=str(Path(__file__).resolve().parent),
-        env=_git_env(),
-        check=False,
-    )
-    if out.returncode != 0:
+    try:
+        return git_repo_root(Path(__file__).resolve().parent)
+    except GitRepoRootUnavailable:
         pytest.skip("not a git checkout — these checks enumerate tracked files")
-    return Path(out.stdout.strip())
 
 
 #: Top-level directories collected by ci.yml's backend pytest invocation.
@@ -193,7 +182,7 @@ def _tracked_test_files_by_pattern() -> dict[str, list[str]]:
             capture_output=True,
             text=True,
             cwd=root,
-            env=_git_env(),
+            env=scrubbed_git_env(),
             check=False,
         )
         matched[pattern] = sorted({line for line in out.stdout.splitlines() if line})
@@ -271,9 +260,7 @@ def test_allowlist_has_no_stale_entries() -> None:
         if not any(p.startswith(f"{prefix}/") for p in files)
     )
 
-    assert not stale, (
-        f"these recorded prefixes match no test file and should be removed: {stale}"
-    )
+    assert not stale, f"these recorded prefixes match no test file and should be removed: {stale}"
 
 
 def test_every_python_files_half_is_recorded_with_a_floor() -> None:
@@ -326,6 +313,4 @@ def test_every_python_files_half_matches_at_depth() -> None:
 @pytest.mark.parametrize("directory", sorted(BACKEND_RUN | SLM_RUN))
 def test_collected_directories_still_exist(directory: str) -> None:
     """A renamed directory would silently stop being collected."""
-    assert (project_root() / directory).is_dir(), (
-        f"{directory} is named in ci.yml's collection list but does not exist"
-    )
+    assert (project_root() / directory).is_dir(), f"{directory} is named in ci.yml's collection list but does not exist"

--- a/repo_tests/git_repo_root_scrub_test.py
+++ b/repo_tests/git_repo_root_scrub_test.py
@@ -1,0 +1,202 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Every guard that asks git for the repository root must scrub the git env first (#15176).
+
+A git hook run in a **worktree** — this repository's entire workflow — is handed
+``GIT_DIR=<main>/.git/worktrees/<name>`` and no ``GIT_WORK_TREE`` (measured on
+git 2.34.1, for both ``pre-commit`` and ``pre-push``; a plain checkout on that
+version exports neither). Git then treats the *current directory* as the work
+tree, so ``git rev-parse --show-toplevel`` answers with wherever the caller
+happens to be standing rather than the repository root.
+
+Git chdirs the hook to the top level before running it, even when the commit
+was made from a subdirectory, so a hook's own first call still lands on the
+root. The reproduction below is therefore run from ``repo_tests/``: the
+environment is the hook's, the working directory is any of the places a
+hook-spawned helper, an imported test module or a direct CI invocation actually
+runs from.
+
+The reason this is a test and not a note is that the wrong answer is not an
+error. Measured on this branch's parent, run from ``repo_tests/`` with
+``GIT_DIR`` exported:
+
+============================================= ================================
+site                                          behaviour before the scrub
+============================================= ================================
+``pipeline-scripts/check_hook_exec_bits``     exit 0, **reported clean** over a
+                                              planted ``100644`` hook entry,
+                                              having read zero hook configs
+``pipeline-scripts/check_requirements_...``   exit 0, **reported clean** over a
+                                              planted ``openpyxl`` conflict,
+                                              having opened zero requirements
+                                              files
+``tools/lint/check_port_fallbacks_...``       exit 1, ``FATAL: ... ssot_config.py
+                                              not found``
+``repo_tests/sdk_defaults_match_ssot_test``   2 failures, "SDK defaults is
+                                              missing"
+``autobot-slm-backend/ansible/tests/...``     exit 1, uncaught
+                                              ``FileNotFoundError``
+============================================= ================================
+
+Three of the five failed loudly and two passed wrongly, which is exactly why
+"all five behave alike" was not assumable — and why the two silent ones are the
+reason the family was worth fixing rather than noting.
+
+The static half of the guard is ``tools/lint/check_git_toplevel_env_scrubbed.py``,
+which blocks a sixth unscrubbed ``--show-toplevel`` from being added. This module
+is the behavioural half: it re-runs the reproduction against every site.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.paths import (
+    AMBIENT_GIT_VARS,
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The directory every reproduction is run from. Any tracked subdirectory of
+#: the repository does; this one is where #15018 first observed the defect.
+SUBDIR = "repo_tests"
+
+#: ``(label, sys.path entry relative to the root, module, resolver attribute)``
+#: for every site that asks git where the repository is. Adding a seventh site
+#: without adding it here is what the static guard blocks.
+SITES = [
+    ("check_hook_exec_bits", "pipeline-scripts", "check_hook_exec_bits", "_repo_root"),
+    (
+        "check_requirements_no_conflicting_dupes",
+        "pipeline-scripts",
+        "check_requirements_no_conflicting_dupes",
+        "_repo_root",
+    ),
+    ("check_port_fallbacks_match_ssot", "tools/lint", "check_port_fallbacks_match_ssot", "_repo_root"),
+    (
+        "check_ssh_key_path_defined",
+        "autobot-slm-backend/ansible/tests",
+        "check_ssh_key_path_defined",
+        "_repo_root",
+    ),
+    ("sdk_defaults_match_ssot_test", "repo_tests", "sdk_defaults_match_ssot_test", "project_root"),
+    ("collection_coverage_test", "repo_tests", "collection_coverage_test", "project_root"),
+]
+
+
+def _ambient_git_dir() -> str:
+    """The ``GIT_DIR`` a hook would export here, or a skip outside a checkout."""
+    out = subprocess.run(
+        ["git", "rev-parse", "--absolute-git-dir"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(REPO_ROOT),
+        env=scrubbed_git_env(),
+        check=False,
+    )
+    if out.returncode != 0 or not out.stdout.strip():
+        pytest.skip("not a git checkout — there is no ambient GIT_DIR to reproduce")
+    return out.stdout.strip()
+
+
+def _hook_env() -> dict[str, str]:
+    """A child environment shaped like the one a git hook hands its children."""
+    env = scrubbed_git_env()
+    env["GIT_DIR"] = _ambient_git_dir()
+    # The repository root has to be importable for ``autobot_shared``; the
+    # scripts bootstrap that themselves, but the two pytest modules are
+    # imported here directly.
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return env
+
+
+def _require_the_defect_is_reproducible(env: dict[str, str]) -> None:
+    """Skip unless an unscrubbed ``--show-toplevel`` really does answer the CWD.
+
+    Asserting git's own behaviour would make this suite fail the day git stops
+    misreading a bare ``GIT_DIR`` — a change that would make the scrub
+    unnecessary rather than broken. Skipping keeps the positive assertions
+    below honest: they only claim to have reproduced something when the
+    environment can still produce it.
+    """
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(REPO_ROOT / SUBDIR),
+        env=env,
+        check=False,
+    )
+    if out.stdout.strip() != str(REPO_ROOT / SUBDIR):
+        pytest.skip(f"an ambient GIT_DIR no longer redirects --show-toplevel here (got {out.stdout.strip()!r})")
+
+
+def test_scrubbed_git_env_drops_every_ambient_variable() -> None:
+    scrubbed = scrubbed_git_env({"GIT_DIR": "/x", "GIT_WORK_TREE": "/y", "PATH": "/bin"})
+    assert scrubbed == {"PATH": "/bin"}
+    assert set(AMBIENT_GIT_VARS) == {"GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE"}
+
+
+def test_git_repo_root_ignores_an_ambient_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The shared helper answers the root even when asked from a subdirectory."""
+    env = _hook_env()
+    _require_the_defect_is_reproducible(env)
+    monkeypatch.setenv("GIT_DIR", env["GIT_DIR"])
+    monkeypatch.delenv("GIT_WORK_TREE", raising=False)
+    assert git_repo_root(REPO_ROOT / SUBDIR) == REPO_ROOT
+
+
+def test_git_repo_root_raises_rather_than_guessing(tmp_path: Path) -> None:
+    """Outside any checkout the helper raises; no caller receives a wrong path."""
+    with pytest.raises(GitRepoRootUnavailable):
+        git_repo_root(tmp_path / "does-not-exist")
+
+
+@pytest.mark.parametrize(
+    ("label", "path_entry", "module", "attribute"),
+    SITES,
+    ids=[site[0] for site in SITES],
+)
+def test_site_resolves_the_repo_root_under_an_ambient_git_dir(
+    label: str, path_entry: str, module: str, attribute: str
+) -> None:
+    """Each site's own resolver, run from a subdirectory with ``GIT_DIR`` exported.
+
+    Run out of process on purpose: ``GIT_DIR`` has to be in the *environment* of
+    the git subprocess the site starts, and several of these modules exit the
+    interpreter on failure.
+    """
+    env = _hook_env()
+    _require_the_defect_is_reproducible(env)
+    program = (
+        "import sys;"
+        f"sys.path.insert(0, {str(REPO_ROOT / path_entry)!r});"
+        f"import {module} as m;"
+        f"print(m.{attribute}())"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        cwd=str(REPO_ROOT / SUBDIR),
+        env=env,
+        check=False,
+    )
+    assert out.returncode == 0, f"{label} could not resolve a root: {out.stderr.strip()}"
+    assert out.stdout.strip() == str(REPO_ROOT), (
+        f"{label} resolved {out.stdout.strip()!r} instead of the repository root. "
+        "An ambient GIT_DIR made git call the caller's CWD the work tree — the "
+        "site is asking git for the root without scrubbing the environment (#15176)."
+    )

--- a/repo_tests/sdk_defaults_match_ssot_test.py
+++ b/repo_tests/sdk_defaults_match_ssot_test.py
@@ -22,29 +22,30 @@ couple.
 from __future__ import annotations
 
 import ast
-import subprocess
 from pathlib import Path
 
 import pytest
 
+from autobot_shared.paths import GitRepoRootUnavailable, git_repo_root
 from autobot_shared.ssot_constants import QueryDefaults
 
 SDK_DEFAULTS = Path("libs/autobot-sdk-python/autobot_sdk/defaults.py")
 
 
 def project_root() -> Path:
-    """Repository root via git, or a skip when this is not a git checkout."""
+    """Repository root via git, or a skip when this is not a git checkout.
+
+    Asked from this file's own directory, with the ambient git environment
+    scrubbed (#15176). The pre-push hook exports ``GIT_DIR`` and no
+    ``GIT_WORK_TREE``, which makes git call the caller's CWD the work tree.
+    Measured before the scrub: running pytest from ``repo_tests/`` with
+    ``GIT_DIR`` exported failed both tests here with "SDK defaults is missing"
+    — a real failure, but one that blames a moved SDK file.
+    """
     try:
-        out = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True,
-            text=True,
-            check=True,
-            encoding="utf-8",
-        )
-    except (OSError, subprocess.CalledProcessError):
+        return git_repo_root(Path(__file__).resolve().parent)
+    except GitRepoRootUnavailable:
         pytest.skip("not a git checkout")
-    return Path(out.stdout.strip())
 
 
 def sdk_constants() -> dict[str, int]:

--- a/tools/lint/check_git_toplevel_env_scrubbed.py
+++ b/tools/lint/check_git_toplevel_env_scrubbed.py
@@ -40,11 +40,37 @@ SCOPE, AND WHAT IS DELIBERATELY NOT SCOPED
   mean two rules wearing one name. Recorded here rather than silently omitted.
 * **The call, not the string.** Only ``subprocess`` calls are inspected, so
   prose that names the flag — this docstring included — is not a finding and
-  needs no allowlist entry.
+  needs no allowlist entry. The name ``subprocess`` is bound to is resolved
+  from the file's own imports, so ``import subprocess as sp`` and
+  ``from subprocess import run`` are both caught.
 * **``git ls-files`` is not gated**, though the same inherited ``GIT_DIR``
   misleads it. Every current call site passes ``cwd=<root>`` from a root this
   hook already protects, so gating it would flag correct code; the sites fixed
   in #15176 pass ``env=scrubbed_git_env()`` there anyway.
+
+KNOWN GAPS — WHAT THIS DOES **NOT** CATCH
+-----------------------------------------
+Stated because an unstated gap is worse than a stated one: a guard that reads
+as airtight is how the next reader stops checking. Closing these three needs
+dataflow analysis, which is out of proportion to a repository-local lint rule,
+so they are documented and pinned by tests rather than half-implemented.
+
+* **Argv built through a variable.** ``cmd = ["git", "rev-parse",
+  "--show-toplevel"]`` followed by ``subprocess.run(cmd)`` is not reported: the
+  call node's arguments hold a ``Name``, not the string. This is the gap most
+  likely to be reached by accident, since it is an ordinary refactor rather
+  than an evasion.
+* **Wrappers.** A helper that receives the flag from its caller —
+  ``def git(*args): subprocess.run(["git", *args])`` — carries no literal at
+  the call node either.
+* **A shadowed scrub helper.** ``_scrubs`` accepts ``env=`` whose callee is
+  *named* ``scrubbed_git_env``; it does not verify the name resolves to
+  ``autobot_shared.paths``. A locally defined function of that name satisfies
+  it.
+
+The behavioural half of the guard (``repo_tests/git_repo_root_scrub_test.py``)
+covers what static analysis cannot: it runs each real site under an ambient
+``GIT_DIR`` and asserts the answer, whatever shape the call has.
 
 Exit code:
   0 — every ``--show-toplevel`` call scrubs its environment
@@ -56,7 +82,7 @@ from __future__ import annotations
 import ast
 import sys
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Iterable, List, Set, Tuple
 
 # tools/lint/ is not a Python package; ensure the sibling helper is importable
 # regardless of invocation mode (script / importlib from tests).
@@ -85,10 +111,39 @@ ALLOWLIST = {
 }
 
 
-def _is_subprocess_call(node: ast.Call) -> bool:
+def subprocess_names(tree: ast.AST) -> Tuple[Set[str], Set[str]]:
+    """``(module aliases, directly imported entry points)`` bound in *tree*.
+
+    Matching the literal ``"subprocess"`` missed two ordinary spellings —
+    ``import subprocess as sp`` and ``from subprocess import run`` — so the
+    binding is read from the file's own imports instead. ``ast.walk`` is used
+    rather than a scan of ``tree.body`` because a ``try:``-guarded or
+    function-local import is still an import.
+
+    ``"subprocess"`` is always in the module set. Seeding it can only produce a
+    finding, never suppress one, and for a guard that is the safe direction to
+    be wrong in.
+    """
+    modules: Set[str] = {"subprocess"}
+    functions: Set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    modules.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in _SUBPROCESS_CALLS:
+                    functions.add(alias.asname or alias.name)
+    return modules, functions
+
+
+def _is_subprocess_call(node: ast.Call, modules: Set[str], functions: Set[str]) -> bool:
     func = node.func
     if isinstance(func, ast.Attribute) and func.attr in _SUBPROCESS_CALLS:
-        return isinstance(func.value, ast.Name) and func.value.id == "subprocess"
+        return isinstance(func.value, ast.Name) and func.value.id in modules
+    if isinstance(func, ast.Name):
+        return func.id in functions
     return False
 
 
@@ -137,9 +192,10 @@ def scan(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
     except SyntaxError:
         # A file that does not parse is another hook's finding, not this one's.
         return []
+    modules, functions = subprocess_names(tree)
     findings: List[Tuple[int, str]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not _is_subprocess_call(node):
+        if not isinstance(node, ast.Call) or not _is_subprocess_call(node, modules, functions):
             continue
         if not _mentions_toplevel(node) or _scrubs(node):
             continue

--- a/tools/lint/check_git_toplevel_env_scrubbed.py
+++ b/tools/lint/check_git_toplevel_env_scrubbed.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``git rev-parse --show-toplevel`` must run with the git environment scrubbed (#15176).
+
+A git hook run in a **worktree** — this repository's entire workflow — is handed
+``GIT_DIR=<main>/.git/worktrees/<name>`` and no ``GIT_WORK_TREE`` (measured on
+git 2.34.1, for both ``pre-commit`` and ``pre-push``). Git then treats the
+**current directory** as the work tree, so ``--show-toplevel`` answers with
+wherever the caller happens to be standing rather than the repository root.
+
+Git chdirs the hook itself to the top level, so the hook's own first call is
+right by luck. Everything downstream of it is not: a helper passing ``cwd=``,
+an imported test module, a CI step running a guard directly from elsewhere.
+
+The answer is wrong without being an error, and that is what makes this worth a
+gate rather than a code review note. Six guards in this repository shared the
+pattern. #15018 hit the loud half — ``pytest.ini`` read out of ``repo_tests/``,
+``FileNotFoundError``. #15176 measured the silent half: two **pre-commit hook**
+entries printed their success line while having read zero of the files they
+exist to inspect, one of them over a deliberately planted violation.
+
+Five hand-rolled repeats of one four-line scrub is how that became a family, so
+the rule here is not "scrub it somehow" but "go through the one helper":
+
+    from autobot_shared.paths import git_repo_root
+    root = git_repo_root()
+
+A call is accepted when it passes ``env=scrubbed_git_env(...)`` explicitly —
+that is what ``git_repo_root`` itself does, and it keeps the helper from having
+to exempt itself.
+
+SCOPE, AND WHAT IS DELIBERATELY NOT SCOPED
+------------------------------------------
+* **Python only.** Fourteen shell scripts also call ``--show-toplevel``. A
+  shell caller has no ``autobot_shared`` to reuse and the fix there is a
+  different one (``env -u GIT_DIR ...``), so gating both from one hook would
+  mean two rules wearing one name. Recorded here rather than silently omitted.
+* **The call, not the string.** Only ``subprocess`` calls are inspected, so
+  prose that names the flag — this docstring included — is not a finding and
+  needs no allowlist entry.
+* **``git ls-files`` is not gated**, though the same inherited ``GIT_DIR``
+  misleads it. Every current call site passes ``cwd=<root>`` from a root this
+  hook already protects, so gating it would flag correct code; the sites fixed
+  in #15176 pass ``env=scrubbed_git_env()`` there anyway.
+
+Exit code:
+  0 — every ``--show-toplevel`` call scrubs its environment
+  1 — at least one does not (commit/PR blocked)
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+# tools/lint/ is not a Python package; ensure the sibling helper is importable
+# regardless of invocation mode (script / importlib from tests).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _scan_helpers import iter_python_files  # noqa: E402
+
+#: The canonical scrubbing helper, ``autobot_shared.paths.scrubbed_git_env``.
+SCRUB_HELPER = "scrubbed_git_env"
+
+#: The flag whose answer depends on the work tree git thinks it has.
+TOPLEVEL_FLAG = "--show-toplevel"
+
+#: ``subprocess`` entry points that start a process.
+_SUBPROCESS_CALLS = frozenset({"run", "Popen", "call", "check_call", "check_output"})
+
+#: Files allowed to call ``--show-toplevel`` with an environment that is NOT
+#: scrubbed, POSIX-relative to the repository root. Each entry is a call that
+#: needs the hook environment *intact* to mean anything.
+ALLOWLIST = {
+    # The #15176 reproduction. It runs git with GIT_DIR deliberately exported
+    # to confirm the defect still reproduces on this git version before
+    # asserting that the six sites survive it; scrubbing there would make the
+    # suite assert nothing and pass.
+    "repo_tests/git_repo_root_scrub_test.py",
+}
+
+
+def _is_subprocess_call(node: ast.Call) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr in _SUBPROCESS_CALLS:
+        return isinstance(func.value, ast.Name) and func.value.id == "subprocess"
+    return False
+
+
+def _mentions_toplevel(node: ast.Call) -> bool:
+    """True when any string argument of *node* carries the flag."""
+    for arg in node.args:
+        for child in ast.walk(arg):
+            if isinstance(child, ast.Constant) and isinstance(child.value, str):
+                if TOPLEVEL_FLAG in child.value:
+                    return True
+    return False
+
+
+def _scrubs(node: ast.Call) -> bool:
+    """True when the call passes ``env=scrubbed_git_env(...)``."""
+    for keyword in node.keywords:
+        if keyword.arg != "env":
+            continue
+        value = keyword.value
+        if isinstance(value, ast.Call):
+            func = value.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            return name == SCRUB_HELPER
+    return False
+
+
+def scan(path: Path, repo_root: Path) -> List[Tuple[int, str]]:
+    """Return ``(line, message)`` for every unscrubbed ``--show-toplevel`` call."""
+    try:
+        rel = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in ALLOWLIST:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    # Cheap gate before the expensive one: full-repo mode walks every tracked
+    # .py file, and AST-parsing all of them costs ~20s where a substring test
+    # over the same set costs under one.
+    if TOPLEVEL_FLAG not in text:
+        return []
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        # A file that does not parse is another hook's finding, not this one's.
+        return []
+    findings: List[Tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_subprocess_call(node):
+            continue
+        if not _mentions_toplevel(node) or _scrubs(node):
+            continue
+        findings.append(
+            (
+                node.lineno,
+                f"{TOPLEVEL_FLAG} without a scrubbed git environment. A hook exports "
+                "GIT_DIR and no GIT_WORK_TREE, so git calls the caller's CWD the work "
+                "tree and this answers with the CWD, silently. Use "
+                "`from autobot_shared.paths import git_repo_root` (#15176).",
+            )
+        )
+    return findings
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    repo_root = Path(__file__).resolve().parents[2]
+    files: Iterable[Path] = iter_python_files(args, repo_root)
+    total = 0
+    for path in files:
+        for line_no, message in scan(path, repo_root):
+            try:
+                rel = path.resolve().relative_to(repo_root).as_posix()
+            except ValueError:
+                rel = path.as_posix()
+            print(f"[git-toplevel-env-scrubbed] {rel}:{line_no}: {message}", file=sys.stderr)
+            total += 1
+    if total:
+        print(
+            f"\n[git-toplevel-env-scrubbed] {total} unscrubbed call(s). "
+            "Resolve the repository root with autobot_shared.paths.git_repo_root() (#15176).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/lint/check_git_toplevel_env_scrubbed.py
+++ b/tools/lint/check_git_toplevel_env_scrubbed.py
@@ -222,10 +222,10 @@ def main(argv: List[str] | None = None) -> int:
                 rel = path.resolve().relative_to(repo_root).as_posix()
             except ValueError:
                 rel = path.as_posix()
-            print(f"[git-toplevel-env-scrubbed] {rel}:{line_no}: {message}", file=sys.stderr)
+            print(f"[git-toplevel-env-scrubbed] {rel}:{line_no}: {message}", file=sys.stderr)  # noqa: print
             total += 1
     if total:
-        print(
+        print(  # noqa: print
             f"\n[git-toplevel-env-scrubbed] {total} unscrubbed call(s). "
             "Resolve the repository root with autobot_shared.paths.git_repo_root() (#15176).",
             file=sys.stderr,

--- a/tools/lint/check_git_toplevel_env_scrubbed_test.py
+++ b/tools/lint/check_git_toplevel_env_scrubbed_test.py
@@ -12,6 +12,7 @@ judgement: what it flags, what it accepts, and what it deliberately ignores.
 
 from __future__ import annotations
 
+import ast
 import sys
 from pathlib import Path
 
@@ -19,7 +20,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from check_git_toplevel_env_scrubbed import ALLOWLIST, main, scan  # noqa: E402
+from check_git_toplevel_env_scrubbed import (  # noqa: E402
+    ALLOWLIST,
+    main,
+    scan,
+    subprocess_names,
+)
 
 _UNSCRUBBED = """
 import subprocess
@@ -66,6 +72,85 @@ import subprocess
 
 def tracked(root):
     return subprocess.run(["git", "ls-files"], cwd=root).stdout
+"""
+
+
+_ALIASED_MODULE = """
+import subprocess as sp
+
+def root():
+    return sp.run(["git", "rev-parse", "--show-toplevel"]).stdout
+"""
+
+_ALIASED_MODULE_SCRUBBED = """
+import subprocess as sp
+
+from autobot_shared.paths import scrubbed_git_env
+
+def root():
+    return sp.run(["git", "rev-parse", "--show-toplevel"], env=scrubbed_git_env()).stdout
+"""
+
+_FROM_IMPORT = """
+from subprocess import run
+
+def root():
+    return run(["git", "rev-parse", "--show-toplevel"]).stdout
+"""
+
+_FROM_IMPORT_ALIASED = """
+from subprocess import check_output as _co
+
+def root():
+    return _co(["git", "rev-parse", "--show-toplevel"])
+"""
+
+_FROM_IMPORT_SCRUBBED = """
+from subprocess import run
+
+from autobot_shared.paths import scrubbed_git_env
+
+def root():
+    return run(["git", "rev-parse", "--show-toplevel"], env=scrubbed_git_env()).stdout
+"""
+
+_FUNCTION_LOCAL_IMPORT = """
+def root():
+    import subprocess as sp
+
+    return sp.run(["git", "rev-parse", "--show-toplevel"]).stdout
+"""
+
+# --- documented gaps (see the guard's KNOWN GAPS section) --------------------
+
+_VARIABLE_ARGV = """
+import subprocess
+
+CMD = ["git", "rev-parse", "--show-toplevel"]
+
+def root():
+    return subprocess.run(CMD).stdout
+"""
+
+_WRAPPER = """
+import subprocess
+
+def git(*args):
+    return subprocess.run(["git", *args]).stdout
+
+def root():
+    return git("rev-parse", "--show-toplevel")
+"""
+
+_SHADOWED_SCRUB_HELPER = """
+import os
+import subprocess
+
+def scrubbed_git_env():
+    return dict(os.environ)
+
+def root():
+    return subprocess.run(["git", "rev-parse", "--show-toplevel"], env=scrubbed_git_env()).stdout
 """
 
 
@@ -133,3 +218,66 @@ def test_unparseable_neighbours_do_not_crash_the_scan(tmp_path: Path, source: st
     broken = _write(tmp_path, "def (:\n", "broken.py")
     assert scan(broken, tmp_path) == []
     _write(tmp_path, source)
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("import subprocess as sp", _ALIASED_MODULE),
+        ("from subprocess import run", _FROM_IMPORT),
+        ("from subprocess import check_output as _co", _FROM_IMPORT_ALIASED),
+        ("function-local aliased import", _FUNCTION_LOCAL_IMPORT),
+    ],
+)
+def test_the_import_binding_is_resolved_not_matched_literally(tmp_path: Path, label: str, source: str) -> None:
+    """Review finding: matching the literal ``subprocess`` missed these spellings."""
+    assert len(scan(_write(tmp_path, source), tmp_path)) == 1, label
+
+
+@pytest.mark.parametrize("source", [_ALIASED_MODULE_SCRUBBED, _FROM_IMPORT_SCRUBBED])
+def test_the_scrubbed_form_is_accepted_under_every_import_spelling(tmp_path: Path, source: str) -> None:
+    assert scan(_write(tmp_path, source), tmp_path) == []
+
+
+def test_subprocess_names_reads_the_bindings() -> None:
+    modules, functions = subprocess_names(ast.parse(_ALIASED_MODULE))
+    assert modules == {"subprocess", "sp"} and functions == set()
+    modules, functions = subprocess_names(ast.parse(_FROM_IMPORT_ALIASED))
+    assert functions == {"_co"}
+
+
+def test_the_bare_name_stays_covered_when_nothing_imports_it() -> None:
+    """Seeding ``"subprocess"`` can only add a finding, never suppress one."""
+    modules, _ = subprocess_names(ast.parse("x = 1\n"))
+    assert "subprocess" in modules
+
+
+@pytest.mark.parametrize(
+    ("gap", "source"),
+    [
+        ("argv built through a variable", _VARIABLE_ARGV),
+        ("flag supplied to a wrapper by its caller", _WRAPPER),
+        ("a locally shadowed scrubbed_git_env", _SHADOWED_SCRUB_HELPER),
+    ],
+)
+def test_documented_gaps_stay_documented(tmp_path: Path, gap: str, source: str) -> None:
+    """These three are NOT reported, and the guard's docstring says so.
+
+    Pinned rather than left implicit: closing them needs dataflow analysis,
+    which is out of proportion here. If a future change starts catching one,
+    this test fails and the KNOWN GAPS section has to be corrected with it —
+    which is the point. The behavioural suite
+    (``repo_tests/git_repo_root_scrub_test.py``) is what actually covers the
+    real sites, whatever shape their calls take.
+    """
+    assert scan(_write(tmp_path, source), tmp_path) == [], gap
+
+
+def test_the_docstring_lists_every_pinned_gap() -> None:
+    """An unstated gap is the defect class this whole backlog exists to fix."""
+    import check_git_toplevel_env_scrubbed as guard
+
+    doc = guard.__doc__ or ""
+    assert "KNOWN GAPS" in doc
+    for phrase in ("through a variable", "Wrappers", "shadowed scrub helper"):
+        assert phrase in doc, phrase

--- a/tools/lint/check_git_toplevel_env_scrubbed_test.py
+++ b/tools/lint/check_git_toplevel_env_scrubbed_test.py
@@ -1,0 +1,135 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Unit tests for the #15176 ``--show-toplevel`` environment-scrub guard.
+
+The behavioural half — that each of the six real sites still resolves the
+repository root under an ambient ``GIT_DIR`` — lives in
+``repo_tests/git_repo_root_scrub_test.py``. This half pins the guard's own
+judgement: what it flags, what it accepts, and what it deliberately ignores.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_git_toplevel_env_scrubbed import ALLOWLIST, main, scan  # noqa: E402
+
+_UNSCRUBBED = """
+import subprocess
+
+def root():
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+    )
+    return out.stdout.strip()
+"""
+
+_SCRUBBED = """
+import subprocess
+
+from autobot_shared.paths import scrubbed_git_env
+
+def root():
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        env=scrubbed_git_env(),
+    )
+    return out.stdout.strip()
+"""
+
+_ENV_BUT_NOT_SCRUBBED = """
+import os
+import subprocess
+
+def root():
+    out = subprocess.run(["git", "rev-parse", "--show-toplevel"], env=os.environ.copy())
+    return out.stdout.strip()
+"""
+
+_PROSE_ONLY = '''
+"""This module explains why ``git rev-parse --show-toplevel`` is dangerous."""
+
+TOPLEVEL_NOTE = "--show-toplevel answers with the CWD under an ambient GIT_DIR"
+'''
+
+_OTHER_GIT_CALL = """
+import subprocess
+
+def tracked(root):
+    return subprocess.run(["git", "ls-files"], cwd=root).stdout
+"""
+
+
+def _write(tmp_path: Path, source: str, name: str = "sample.py") -> Path:
+    path = tmp_path / name
+    path.write_text(source, encoding="utf-8")
+    return path
+
+
+def test_unscrubbed_call_is_reported(tmp_path: Path) -> None:
+    findings = scan(_write(tmp_path, _UNSCRUBBED), tmp_path)
+    assert len(findings) == 1
+    assert "#15176" in findings[0][1]
+
+
+def test_scrubbed_call_is_accepted(tmp_path: Path) -> None:
+    assert scan(_write(tmp_path, _SCRUBBED), tmp_path) == []
+
+
+def test_an_env_that_is_not_the_helper_is_still_reported(tmp_path: Path) -> None:
+    """``env=os.environ.copy()`` carries GIT_DIR straight back in."""
+    assert len(scan(_write(tmp_path, _ENV_BUT_NOT_SCRUBBED), tmp_path)) == 1
+
+
+def test_prose_mentioning_the_flag_is_not_a_finding(tmp_path: Path) -> None:
+    """Only calls are inspected, so documentation needs no allowlist entry."""
+    assert scan(_write(tmp_path, _PROSE_ONLY), tmp_path) == []
+
+
+def test_other_git_subprocesses_are_left_alone(tmp_path: Path) -> None:
+    assert scan(_write(tmp_path, _OTHER_GIT_CALL), tmp_path) == []
+
+
+def test_allowlisted_files_are_skipped(tmp_path: Path) -> None:
+    """The allowlist is keyed on the repo-relative POSIX path."""
+    entry = sorted(ALLOWLIST)[0]
+    path = tmp_path / entry
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_UNSCRUBBED, encoding="utf-8")
+    assert scan(path, tmp_path) == []
+
+
+def test_every_allowlist_entry_still_exists() -> None:
+    """A stranded exemption exempts nothing and says nothing while it does it."""
+    repo_root = Path(__file__).resolve().parents[2]
+    missing = [entry for entry in ALLOWLIST if not (repo_root / entry).is_file()]
+    assert not missing, f"allowlist entries no longer in the tree: {missing}"
+
+
+def test_main_exits_nonzero_on_a_violation(tmp_path: Path) -> None:
+    assert main([str(_write(tmp_path, _UNSCRUBBED))]) == 1
+
+
+def test_main_exits_zero_on_the_scrubbed_form(tmp_path: Path) -> None:
+    assert main([str(_write(tmp_path, _SCRUBBED))]) == 0
+
+
+def test_the_whole_repository_is_clean() -> None:
+    """The guard's own subject: no seventh unscrubbed call is in the tree."""
+    assert main([]) == 0
+
+
+@pytest.mark.parametrize("source", [_UNSCRUBBED, _SCRUBBED])
+def test_unparseable_neighbours_do_not_crash_the_scan(tmp_path: Path, source: str) -> None:
+    broken = _write(tmp_path, "def (:\n", "broken.py")
+    assert scan(broken, tmp_path) == []
+    _write(tmp_path, source)

--- a/tools/lint/check_port_fallbacks_match_ssot.py
+++ b/tools/lint/check_port_fallbacks_match_ssot.py
@@ -32,6 +32,18 @@ import subprocess  # nosec B404  # git plumbing, fixed argv, no shell
 import sys
 from pathlib import Path
 
+# The scrubbed root resolver lives in ``autobot_shared`` and this script runs
+# from a pre-commit virtualenv that does not have the repository installed, so
+# the import path is bootstrapped from this file's own location -- the one
+# derivation an inherited GIT_DIR cannot confuse (#15176).
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from autobot_shared.paths import (  # noqa: E402
+    GitRepoRootUnavailable,
+    git_repo_root,
+    scrubbed_git_env,
+)
+
 _FALLBACK = re.compile(r"\$\{(AUTOBOT_[A-Z0-9_]*PORT):-([0-9]+)\}")
 _SSOT_FIELD = re.compile(r'Field\(\s*default=(\d+)[^)]*alias="(AUTOBOT_[A-Z0-9_]*PORT)"')
 
@@ -51,13 +63,20 @@ _ALLOWLIST = frozenset(
 
 
 def _repo_root() -> Path:
-    """Absolute repo root, or die — every path below is resolved against it."""
-    result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, encoding="utf-8"
-    )
-    if result.returncode != 0 or not result.stdout.strip():
-        sys.exit(f"FATAL: cannot locate the repo root: {result.stderr.strip()}")
-    return Path(result.stdout.strip())
+    """Absolute repo root, or die — every path below is resolved against it.
+
+    Scrubbed of the ambient git environment first (#15176). This entry is a
+    pre-commit hook, and a hook exports ``GIT_DIR`` without ``GIT_WORK_TREE``,
+    which makes git call the caller's CWD the work tree. Measured before the
+    scrub: run from ``repo_tests/`` with ``GIT_DIR`` exported, this exited 1
+    with ``FATAL: autobot_shared/ssot_config.py not found`` — loud, unlike its
+    two sibling hooks, because the SSOT guard below refuses to report clean
+    without the file.
+    """
+    try:
+        return git_repo_root()
+    except GitRepoRootUnavailable as exc:
+        sys.exit(f"FATAL: cannot locate the repo root: {exc}")
 
 
 def _ssot_ports(root: Path) -> dict[str, str]:
@@ -93,7 +112,14 @@ def _ssot_ports(root: Path) -> dict[str, str]:
 def _shell_files(root: Path) -> list[str]:
     """Tracked shell scripts, or die rather than scan nothing."""
     result = subprocess.run(  # nosec B603 B607  # fixed argv, no shell
-        ["git", "ls-files", "*.sh"], cwd=str(root), capture_output=True, text=True, encoding="utf-8"
+        ["git", "ls-files", "*.sh"],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        # Same scrub as the root: an inherited GIT_DIR would enumerate one
+        # checkout's index while *root* names another (#15176).
+        env=scrubbed_git_env(),
     )
     if result.returncode != 0:
         sys.exit(f"FATAL: git ls-files failed: {result.stderr.strip()}")


### PR DESCRIPTION
## Thinking Path

The issue asked for five call sites to be patched. The first job was not patching: a guard that
resolves the wrong root does not error, it inspects the wrong files and reports success, so what
each site *actually does* under an ambient `GIT_DIR` had to be measured rather than assumed. It was
worth measuring — the five do **not** behave alike, and two of them pass wrongly.

Three corrections to the issue text, code wins:

1. **Three of the five are pre-commit hook entries, not two.** `tools/lint/check_port_fallbacks_match_ssot.py`
   is `entry:` for the `port-fallbacks-match-ssot` hook in `.pre-commit-config.yaml`; the issue lists it
   as not a hook.
2. **The premise "git hooks export `GIT_DIR`" is true only in a worktree** on the git version here
   (2.34.1). Measured with an instrumented hook in a throwaway repository: a plain checkout exports
   neither `GIT_DIR` nor `GIT_WORK_TREE` to `pre-commit` or `pre-push`; a **worktree** exports
   `GIT_DIR=<main>/.git/worktrees/<name>` with no `GIT_WORK_TREE` for both. Since this repository's
   entire workflow runs from worktrees, the condition is real — but it is a worktree property, and
   that is now written down rather than assumed.
3. **A hook's own first call is right by luck.** Git chdirs the hook to the work-tree top level even
   when the commit was made from a subdirectory, so `--show-toplevel` answers correctly *at hook
   entry*. What breaks is everything downstream: a helper passing `cwd=` (which is exactly how #15018
   surfaced), an imported test module, or a CI step invoking a guard directly. The reproduction is
   therefore run from a subdirectory with the hook's environment — which is the state those callers
   are actually in.

Five hand-rolled copies of a four-line scrub is how this became a family, so the scrub is not
repeated five times. It lands once in `autobot_shared/paths.py`, the module that already owns "where
is the project root", and the sixth instance fixed under #15018 is folded onto the same helper so
there is one implementation rather than two that can drift.

A seventh instance surfaced while pushing, and it is the destructive one — see **What Changed**.

## What Changed

**One helper.** `autobot_shared/paths.py` gains `AMBIENT_GIT_VARS`, `scrubbed_git_env()`,
`git_repo_root()` and `GitRepoRootUnavailable`. Stdlib-only, matching the rest of that module, so the
tooling scripts can import it. It raises rather than returning a plausible-looking wrong path, and
each caller decides what an absent root means for it (the scripts exit fatally, the pytest guards
skip).

**Six sites migrated**, plus the `git ls-files` calls that consume the root in the same functions — a
scrubbed root with an unscrubbed enumeration is still two answers that can disagree:

| Site | Runs as a pre-commit hook |
|---|---|
| `pipeline-scripts/check_hook_exec_bits.py` | yes |
| `pipeline-scripts/check_requirements_no_conflicting_dupes.py` | yes |
| `tools/lint/check_port_fallbacks_match_ssot.py` | **yes** (issue said no) |
| `repo_tests/sdk_defaults_match_ssot_test.py` | no |
| `autobot-slm-backend/ansible/tests/check_ssh_key_path_defined.py` | no |
| `repo_tests/collection_coverage_test.py` | no — the #15018 fix, folded onto the helper |

The three hook scripts run in pre-commit's own virtualenv, which does not have this repository
installed, so each bootstraps `sys.path` from its own file location — the one root derivation an
inherited `GIT_DIR` cannot confuse. That pattern is already live in
`pipeline-scripts/check_env_var_registry.py`, and all four hooks were run through real `pre-commit`
to confirm it works in that environment.

**A seventh instance, found the hard way.** `autobot_shared/paths_test.py::TestRealGitWorktree`
builds a real git repository in a temp directory and its `_git` helper passed
`env={**os.environ, ...}`. Run by the pre-push hook — which exports `GIT_DIR` — its `git add -A` /
`git commit -m initial` executed against **the pushing worktree's own git directory** with the temp
fixture as the work tree. It wrote a commit onto the branch being pushed that dropped 86 tracked
files from the index. Nothing was lost (the files are git-ignored-but-tracked, so they were untouched
on disk; the branch was restored with a mixed reset onto the good commit and the tree verified back
at 9637 tracked files), but this is the same defect with a write instead of a read, in the test file
of the module being changed, and it blocks any push from a worktree. Fixed here with the same helper.

**A guard against the eighth.** `tools/lint/check_git_toplevel_env_scrubbed.py` — new pre-commit hook
`git-toplevel-env-scrubbed`, tracked `100755`. It inspects `subprocess` **calls**, not the string, so
prose naming the flag is not a finding and needs no allowlist entry; a call is accepted only when it
passes `env=scrubbed_git_env(...)`, which is what the helper itself does. One allowlist entry: the
reproduction suite, which needs the hook environment intact or it asserts nothing.

The name `subprocess` is bound to is **resolved from the file's own imports** rather than matched as
a literal, so `import subprocess as sp`, `from subprocess import run`, `from subprocess import
check_output as _co` and function-local imports are all caught (review round; four of them slipped
through the first version). Three constructs remain uncaught — argv built through a variable, a
wrapper receiving the flag from its caller, and a locally shadowed `scrubbed_git_env` — because
closing them needs dataflow analysis, out of proportion to a repository-local lint rule. They are
named in a `KNOWN GAPS` section of the guard's docstring and pinned by tests, so a future change that
starts catching one fails the suite and forces the docstring to be corrected with it. A guard that
overstates its coverage is the defect class this backlog exists to fix; the behavioural suite is what
actually covers the real sites, whatever shape their calls take.

Deliberately out of the guard's scope, recorded in its docstring rather than silently omitted:
fourteen **shell** scripts also call `--show-toplevel` (a shell caller has no `autobot_shared` to
reuse and the fix there is `env -u GIT_DIR`, so gating both from one hook would be two rules wearing
one name), and `git ls-files` is not gated because every current call site passes `cwd=<root>` from a
root this hook already protects.

## Verification

**Per-site behaviour, measured** — each run from `repo_tests/` with `GIT_DIR` exported and
`GIT_WORK_TREE` unset, against a repository-root run with a clean environment as the control. Two
sites were probed with a deliberately planted violation, because "exit 0" is not evidence of
inspection:

| Site | Before | After |
|---|---|---|
| `check_hook_exec_bits.py` | **exit 0, silently wrong** — 5 output lines became 1; read zero hook configs, and reported clean over a hook entry planted at `100644` (`git update-index --chmod=-x`, restored after) | exit 0, 5 lines, both `KNOWN` findings back |
| `check_requirements_no_conflicting_dupes.py` | **exit 0, silently wrong** — opened zero requirements files, reported clean over a planted `openpyxl==3.0.0` conflict | exit 1 on the planted conflict, naming both declaration sites; exit 0 clean once reverted |
| `check_port_fallbacks_match_ssot.py` | exit 1, `FATAL: autobot_shared/ssot_config.py not found` — loud | exit 0, 2 lines, identical to the control |
| `sdk_defaults_match_ssot_test.py` | 2 failures, "SDK defaults is missing" — loud, but blaming a moved SDK file | 2 passed |
| `check_ssh_key_path_defined.py` | exit 1, uncaught `FileNotFoundError` on a `roles/*/defaults/main.yml` read — loud, blaming a missing role default | exit 0, identical to the control |

Three failed loudly and two passed wrongly. The two silent ones are both hook entries.

**Regression test** — `repo_tests/git_repo_root_scrub_test.py` (9 tests). It re-runs the
reproduction: each of the six sites' own root resolver, in a subprocess started from a subdirectory
with the hook's environment, asserted equal to the repository root. It skips rather than passes if
the environment can no longer produce the defect, so a green result always means something was
actually reproduced.

**Contrast mutation** — removing `env=scrubbed_git_env()` from `git_repo_root` turned 9 passed into
**7 failed, 2 passed**: every site case plus the helper's own. Observed message:

```
E   AssertionError: check_hook_exec_bits resolved '<repo>/repo_tests' instead of the repository
    root. An ambient GIT_DIR made git call the caller's CWD the work tree — the site is asking git
    for the root without scrubbing the environment (#15176).
```

Reverted from a pristine copy and confirmed with `diff -q`; 9 passed again.

**Guard** — 24 unit tests (`tools/lint/check_git_toplevel_env_scrubbed_test.py`) covering the
unscrubbed form, the scrubbed form, `env=os.environ.copy()` (still reported — it carries `GIT_DIR`
straight back in), prose-only mentions, unrelated git calls, allowlist handling, a stranded-allowlist
check, a whole-repository clean assertion, the four import spellings now resolved, the scrubbed form
under each of those spellings, the seeding of the bare `subprocess` name, the three documented gaps
asserted **not** reported, and a test that fails if the docstring stops naming them. Also run
end-to-end against a planted sixth site and against planted aliased / `from`-import evasions: exit 1
with file, line and remedy in each case. Full-repo mode is 1.4s (a substring gate before the AST
parse, down from 20s).

**Contrast mutation for the resolver** — reverting `_is_subprocess_call` to the literal
`"subprocess"` match turned 24 passed into **4 failed, 20 passed**, one per import spelling.
Reverted from a pristine copy, confirmed with `diff -q`; 24 passed again.

**Suites** — `pipeline-scripts` + `tools/lint`: 883 passed. `repo_tests -k "precommit or hook"`: 77
passed. The six touched modules and their own suites: 77 passed. `autobot_shared/paths_test.py`: 13
passed both with and without an ambient `GIT_DIR` (it failed 2 with one, before the fix).

**Hooks through real pre-commit** — `hook-exec-bits`, `requirements-no-conflicting-dupes`,
`port-fallbacks-match-ssot` and the new `git-toplevel-env-scrubbed`, each `--all-files`: all Passed.
This is the check that matters for the `sys.path` bootstrap, since pre-commit builds its own
virtualenv.

**Lint** — black (line-length 120), isort, pyflakes, flake8, bandit and the SPDX header check clean
on every changed file. `autobot_shared/paths.py` was missing its SPDX header (pre-existing; the
`insert-license` hook is `--fix`, so it would have been rewritten mid-commit) — added, in the
repository's four-line form (`Copyright`, `SPDX-License-Identifier`, platform line, `Author`).

**Not verified:** hook-time behaviour was measured on git 2.34.1 with an instrumented throwaway
repository, not by driving a real commit through this repository's own hook chain on the pre-fix
tree. Whether other git versions in CI export `GIT_DIR` differently is untested — the fix is correct
either way, since scrubbing is unconditional.

## Model Used

Claude Opus 5 (1M context)

Closes #15176


