### PR TITLE
docs(research): NVIDIA Warp source analysis and AutoBot comparison (#15184)

### DIFF
--- a/docs/research/nvidia-warp.md
+++ b/docs/research/nvidia-warp.md
@@ -1,0 +1,334 @@
+---
+title: "Research: NVIDIA Warp"
+created: 2026-08-28
+reviewed: 2026-08-28
+status: current
+tags:
+  - research
+  - accelerators
+---
+
+# Research: NVIDIA Warp
+
+- **Source:** https://github.com/NVIDIA/warp
+- **Fetched:** 2026-08-28
+- **Phase:** 1 (Source Analysis) — Phase 2 gated on user approval
+
+---
+
+## Source Analysis: NVIDIA Warp (`warp-lang`)
+
+### What It Is
+
+Warp is NVIDIA's open-source Python framework for GPU-accelerated **simulation, robotics
+and spatial computing**. It takes ordinary-looking Python functions decorated with
+`@wp.kernel` and JIT-compiles them to native CPU code or CUDA PTX, so a numerical kernel
+is authored once in Python and executed as compiled machine code. It is mature and
+heavily used: ~7k stars, 601 forks, 7,215 commits on `main`, ~280 open issues, Apache-2.0,
+shipped as pre-built wheels (`pip install warp-lang`), Python 3.10+. Its centre of gravity
+is physics (particles, SPH, DEM, FEM, fluids), geometry (meshes, marching cubes, BVH ray
+casting) and *differentiable* simulation feeding PyTorch/JAX/Paddle — not general
+application or agent workloads.
+
+### Architecture & Key Patterns
+
+- **Source-to-source JIT, not a tracing runtime.** `warp/_src/codegen.py` (342 KB) walks
+  the Python AST of a decorated function and emits C++/CUDA. `warp/_src/context.py`
+  (682 KB) is the runtime: module registry, device management, launch, caching.
+- **Module as the compilation unit.** "All kernels belonging to a Python module are
+  runtime compiled into dynamic libraries and PTX" (`docs/user_guide/programming_model.rst`).
+  Compilation is triggered lazily on first launch and cached on disk, so the second run of
+  a process pays no compile cost.
+- **Mandatory static typing at the boundary.** Kernel parameters must carry annotations
+  (`pos: wp.array[wp.vec3]`) — the annotations *are* the codegen contract. Warp's own
+  `__init__.pyi` is 340 KB of generated stubs; `warp/_src/builtins.py` is 640 KB, i.e. the
+  builtin surface is machine-generated from one declarative table rather than hand-written.
+- **Two execution models on the same kernel syntax:** default SIMT (one logical thread per
+  grid point, `wp.tid()`), and cooperative *tile* programming for block-level algorithms.
+- **Explicit dual-scope API.** "Python scope" (configure, allocate, launch) and "kernel
+  scope" (the compiled subset) are documented as distinct API surfaces, with a documented
+  overlap set. The split is a first-class concept, not an accident.
+- **Differentiability as a codegen pass.** Adjoint/backward kernels are generated
+  alongside forward ones; `warp/_src/tape.py` (53 KB) records launches for replay,
+  `warp/_src/autograd.py` (51 KB) drives it.
+- **Interop by protocol first, bridge second** (`docs/user_guide/interoperability.rst`):
+  `__array_interface__` / `__cuda_array_interface__` for zero-copy with anything, DLPack as
+  the universal fallback, and dedicated `wp.to_torch`/`from_torch`, JAX and Paddle bridges
+  only where gradients must survive the crossing ("DLPack does not carry gradient
+  information").
+
+### Notable Implementation Details
+
+- **Compile once, cache on disk, keyed by module.** The lazy per-module compile + on-disk
+  kernel cache is the pattern that makes a JIT tolerable in an interactive Python process.
+  The documented failure mode is instructive: the cache directory is *not* multi-process
+  safe (`docs/user_guide/limitations.rst`).
+- **Generated API surface.** 640 KB of builtins and 340 KB of `.pyi` stubs are generated,
+  not authored — one source table produces the C++ intrinsic, the Python binding, the type
+  stub and the docs entry. This is how they keep hundreds of math builtins consistent.
+- **Honest, exhaustive limitation ledger.** `limitations.rst` enumerates precisely what
+  breaks — no lambdas, comprehensions, exceptions, recursion, `eval`, lists/dicts/sets, no
+  strings into kernels; `%` follows C++11 dividend-sign semantics, not Python's; variables
+  declared in an `if` block leak into the enclosing scope with undefined values. This is a
+  DSL that *looks* like Python and deliberately is not, and they say so plainly.
+- **Stream-synchronisation is documented as a correctness contract**, not a performance
+  note: `wp.from_dlpack()` synchronises, while raw PyCapsule construction does not and
+  pushes ordering correctness onto the caller.
+
+### Strengths
+
+- Enormous performance leverage from a small syntactic ask — a million-particle N-body
+  step is ~20 lines of annotated Python.
+- Differentiability is structural (generated adjoints), not bolted on via tracing.
+- First-class, well-reasoned interop with the ML ecosystem.
+- Exceptionally candid documentation of its own sharp edges.
+- Real maturity: prebuilt wheels, wide platform matrix, active NVIDIA maintenance.
+
+### Weaknesses / Limitations
+
+- **CUDA-or-nothing for acceleration.** No Metal, no ROCm, no Intel NPU/oneAPI path.
+  macOS and every non-NVIDIA machine fall back to CPU.
+- **The Python subset is narrow** and the divergences are silent (scope leakage, modulus
+  semantics) — code that runs correctly in Python can compile and behave differently.
+- **Kernel cache is not multi-process safe**; forked children cannot reuse a parent CUDA
+  context. Both are hostile to a worker-pool server architecture.
+- **Toolchain weight.** Building from source pulls NVIDIA libmathdx under a separate,
+  non-Apache licence.
+- Arrays capped at four dimensions, no complex numbers, no struct inheritance or generic
+  members.
+
+### Visible vs Hidden Metrics
+
+**Visible (advertised):**
+- 1M-particle gravity simulation in ~20 lines — self-reported, but structurally credible.
+- 7k stars / 601 forks / 7.2k commits — independently verifiable, genuine maturity signal.
+- Differentiable kernels interoperating with PyTorch, JAX, Paddle — verifiable from the
+  interop docs and dedicated bridge modules.
+- Apache-2.0, `pip install` prebuilt wheels — verifiable.
+
+**Hidden (costs an adopter inherits):**
+- **A second language in your codebase.** Kernel scope is a typed, non-Python DSL wearing
+  Python syntax. Every contributor must learn which constructs silently change meaning.
+- **NVIDIA lock-in.** Adopting Warp for anything on the hot path means an NVIDIA GPU is a
+  hard requirement, or you silently take the CPU fallback.
+- **Compile latency and cache operations.** First-launch compilation, a disk cache to
+  invalidate and size, and a documented multi-process cache hazard — real ops load for any
+  server that forks workers.
+- **Debuggability collapse.** No exceptions inside kernels; failures surface as wrong
+  numbers or device faults, not tracebacks.
+- **Version coupling** to CUDA driver/toolkit across the deployment fleet.
+
+**Weighing:**
+For NVIDIA-GPU numerical workloads — physics, FEM, differentiable simulation — the visible
+wins are so large (orders of magnitude, not percentages) that the hidden costs are simply
+the price of entry, and the honest limitation docs make that price legible up front.
+
+For anything else, the hidden metrics veto it. A workload that is I/O-bound, orchestration-
+bound, or LLM-inference-bound gains nothing from kernel JIT while inheriting the full cost:
+a DSL, an NVIDIA dependency, a compile cache, and a debugging regression. The multi-process
+cache limitation specifically penalises exactly the forked-worker server topology that
+backend platforms use. Warp is a correct choice for a narrow, well-marked domain and a poor
+one immediately outside it.
+
+**Relevance caveat for AutoBot:** Warp's *domain* (GPU physics simulation) has no overlap
+with AutoBot's, and its accelerator target (CUDA) is not AutoBot's (Intel NPU / OpenVINO).
+Any adoptable value is in its *engineering patterns* — generated API surfaces from one
+declarative table, lazy compile-and-cache keyed by content hash, protocol-first interop,
+and the exhaustive published limitation ledger — not in its code.
+
+---
+
+## AutoBot Comparison: NVIDIA Warp → AutoBot
+
+Scope: Warp's *engineering patterns*, not its code. Its domain (GPU physics) and target
+(CUDA) do not intersect AutoBot's (agent orchestration, Intel NPU / OpenVINO). Every item
+below was audited against actual AutoBot source before being placed.
+
+### What We Can Adopt
+
+**1. Compiled-model disk cache on the ONNX Runtime OpenVINO EP path**
+
+- *Warp pattern:* compile lazily on first launch, cache the artefact on disk, so only the
+  first process ever pays the compile cost.
+- *Already-exists audit:* `autobot-backend/code_embedding_generator.py:177-178` already does
+  this — `core.compile_model(ov_model, target_device, {"CACHE_DIR": OPENVINO_CACHE_DIR})`
+  (#10601 / #10623), asserted by `code_embedding_generator_test.py:79-82`. The mechanism is
+  also proven working in-repo by
+  `autobot-npu-worker/openvino/openvino_validation_test.py:139-155` and `:302-311`.
+  **But** `grep -rn cache_dir autobot-npu-worker/` returns *only* those test hits: the
+  Windows NPU worker's provider options at
+  `autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py:618-623` set
+  `device_type`, `precision`, `enable_opencl_throttling` and `num_of_threads` — and no
+  `cache_dir`.
+- *Missing delta:* the Windows worker recompiles its model to an NPU blob on **every**
+  process start. The same fix that landed on the backend path never reached the worker path.
+- *Visible benefit:* removes NPU compile time from every worker cold start; the slow step in
+  OpenVINO NPU startup is exactly this compilation.
+- *Hidden cost:* a cache directory on an end-user Windows machine to size and evict, plus a
+  stale-blob failure mode when the model file or the NPU driver changes under an unchanged
+  cache key.
+- *Verdict:* **adopt-with-conditions** — key the cache directory by model identity + OpenVINO
+  version so a driver or model upgrade cannot serve a stale blob, and bound its size. The
+  hidden cost is small and bounded; the visible win is on every single worker start.
+- *Effort:* trivial (the option) → moderate (keying + eviction + a test mirroring
+  `code_embedding_generator_test.py:79-82`).
+
+**2. Buffer-protocol transport for embedding vectors, instead of JSON number lists**
+
+- *Warp pattern:* protocol-first interop (`__array_interface__` /
+  `__cuda_array_interface__`, DLPack) with bespoke bridges reserved for the one case a
+  protocol cannot carry (gradients).
+- *Already-exists audit:* `npu_worker.py:885` returns `embedding.tolist()`;
+  `autobot-npu-worker/workers/worker_node.py:178-189` likewise returns `.tolist()`. No
+  `tobytes`, `np.frombuffer` or base64 path exists in `autobot-npu-worker/workers/` or
+  `core/` — every vector crosses the backend↔worker boundary as JSON decimal text.
+- *Missing delta:* a raw-buffer payload (bytes + dtype + shape) instead of decimal text.
+- *Visible benefit:* a float32 vector as JSON text is several times the bytes of its raw
+  buffer, plus parse cost on both ends.
+- *Hidden cost:* binary payloads are opaque in logs and in the message bus; it needs an
+  explicit versioned dtype/shape/endianness contract, and it changes a wire contract between
+  the backend and a separately-deployed Windows executable — i.e. a deploy-skew hazard on a
+  component that already carries a sync obligation
+  (`docs/developer/ARCHITECTURE_EXCEPTIONS.md`, Windows NPU Worker entry, #5438).
+- *Verdict:* **adopt-with-conditions, measure first.** Serialization is only worth changing
+  if it is material next to NPU inference time for a realistic batch. Unmeasured, the
+  deploy-skew hidden cost outweighs an unquantified visible win.
+- *Effort:* moderate.
+
+**3. A published behavioural-limitation ledger**
+
+- *Warp pattern:* `docs/user_guide/limitations.rst` states plainly where the system's
+  behaviour silently diverges from what a caller would assume.
+- *Already-exists audit:* `docs/developer/ARCHITECTURE_EXCEPTIONS.md` (10,470 bytes) is the
+  nearest thing and is a *different artefact* — it records intentional deviations plus their
+  sync obligation (e.g. the standalone Windows Redis client, #5438; `gpu_vector_search.py`
+  client type, #5800). It answers "why does this diverge from canonical" not "what will
+  behave differently than you expect when you call it". No file in `docs/developer/`
+  (~200 docs listed) fills the second role.
+- *Missing delta:* the caller-facing "surprising behaviour" register.
+- *Visible benefit:* fewer rediscovered sharp edges.
+- *Hidden cost:* one more hand-maintained doc in an already large `docs/developer/`; a stale
+  behavioural ledger is actively worse than none, because it is trusted.
+- *Verdict:* **rejected-by-hidden-metrics as a hand-written doc.** Adopt only if each entry
+  is anchored to a test or a CI gate that fails when the stated limitation stops being true —
+  the way `verify:types` gates the generated API surface. Without that anchor the maintenance
+  burden exceeds the benefit.
+- *Effort:* significant (if done with anchors), trivial-and-not-worth-it otherwise.
+
+### What We Already Do Better
+
+- **Generated API surface *with* a drift gate.** Warp generates a 340 KB `__init__.pyi` and
+  640 KB of builtins from a declarative source — the same pattern AutoBot uses via
+  `openapi-typescript` (`autobot-frontend/package.json:47` → `src/types/generated/api.ts`).
+  AutoBot goes further: `verify:types` (package.json:48) plus three CI workflows
+  (`frontend-test.yml:125-128`, `verify-generated-types.yml`, `auto-fix-generated-types.yml`)
+  fail the build when the committed artefact drifts from the live schema. Warp publishes no
+  equivalent freshness gate on its generated stubs. **Generation without a drift gate is the
+  weaker half of the pattern, and we already have both halves.**
+- **Multi-process safety.** Warp documents two unfixed hazards: its kernel cache directory
+  conflicts across processes, and a forked child cannot reuse the parent's CUDA context
+  (`limitations.rst`). AutoBot *solves* the second rather than documenting it —
+  `autobot-backend/code_intelligence/shared/process_offload.py:114-119` forces
+  `multiprocessing.get_context("spawn")` with the reasoning stated inline — and sidesteps the
+  first: the backend runs single-worker (`docker/slm/Dockerfile:90` `--workers 1`) and
+  `CodeEmbeddingGenerator` is an in-process `async_lazy_singleton`
+  (`code_embedding_generator.py:470-476`), so nothing forks into the OpenVINO cache.
+- **Configuration as a registered SSOT.** `AUTOBOT_OPENVINO_CACHE_DIR` is an `EnvVarSpec`
+  with type, default, description and component (`autobot_shared/env_registry_ai.py:53-64`).
+  Warp's configuration is module-level globals in `warp/config.py`.
+
+### Gaps & Opportunities
+
+Prioritised by impact, audited only:
+
+1. **P1 — NPU worker has no compiled-model cache** (`npu_worker.py:618-623`). The fix already
+   exists one directory away on the backend path and is covered by passing tests. This is a
+   dropped-delta gap, not a new capability: #10601/#10623 fixed one of two call sites.
+2. **P2 — `AUTOBOT_OPENVINO_CACHE_DIR` defaults to a relative path** (`data/openvino_cache`,
+   `env_registry_ai.py:57`), and the spec's own description concedes it is "Relative to the
+   working directory unless given as an absolute path". A systemd unit and a developer shell
+   with different CWDs silently maintain two separate caches and neither warms the other —
+   the cache appears configured while never hitting. Resolve to an absolute path at load.
+3. **P3 — embedding wire format** (item 2 above): benchmark before changing anything.
+
+### Specific Code/Files Affected
+
+| File | Change |
+|---|---|
+| `autobot-npu-worker/resources/windows-npu-worker/app/npu_worker.py:618-623` | Add `cache_dir` to `openvino_options`, keyed by model id + OpenVINO version |
+| `autobot-npu-worker/resources/windows-npu-worker/app/` (new test) | Assert the EP options carry `cache_dir`, mirroring `code_embedding_generator_test.py:79-82` |
+| `autobot_shared/env_registry_ai.py:53-64` | Resolve `AUTOBOT_OPENVINO_CACHE_DIR` to an absolute path at load; keep the env-var name |
+| `autobot-backend/code_embedding_generator.py:177-178` | Consume the resolved absolute path instead of the raw relative default |
+| `autobot-npu-worker/workers/worker_node.py:178-189`, `npu_worker.py:885` | Only if the P3 benchmark justifies it: buffer payload behind a versioned format flag |
+
+**Bottom line:** Warp contributes no code and no architecture to AutoBot. It contributes one
+concrete finding — the compiled-model cache that landed on the backend path and never reached
+the NPU worker path — and one confirmation, that AutoBot's generate-plus-gate and
+spawn-not-fork discipline are ahead of a well-regarded NVIDIA project on the same problems.
+
+---
+
+## Correction: AutoBot is dual-target (Intel NPU **and** CUDA)
+
+The Phase 1/Phase 2 framing above scoped Warp out partly on "CUDA is not AutoBot's
+accelerator". That premise is wrong. AutoBot targets both, and the development host is an
+NVIDIA GPU.
+
+**Host evidence (this machine, 2026-08-28):**
+`nvidia-smi` → `NVIDIA GeForce RTX 4070 Laptop GPU, driver 610.47, 8188 MiB, compute cap 8.9`.
+`nvcc` is not on PATH (driver present, toolkit absent — sufficient for prebuilt PTX wheels).
+
+**CUDA surface audited in-repo:** `requirements-gpu.txt` (vllm, torch 2.13.0, torchvision),
+`autobot-backend/utils/semantic_chunker_gpu.py` (explicitly "GPU Optimized for RTX 4070" —
+FP16, TF32, cuDNN benchmark, kernel warmup, memory pool, #5363),
+`autobot-backend/utils/gpu_vector_search.py` (FAISS-GPU hybrid, #387),
+`autobot-backend/hardware_acceleration.py`, `ai_hardware_accelerator.py`,
+`utils/gpu_acceleration_optimizer.py`, `llm_shared/optimization/{flash_attention,kv_cache,
+attention_backend}.py`, `llm_shared/providers/vllm.py`, plus `CUDAExecutionProvider` in the
+NPU worker's provider chain (`npu_worker.py:632-633`).
+
+### Revised verdict on Warp
+
+CUDA-only acceleration is **not** a lock-out for AutoBot. The reason to decline Warp is
+narrower and stands on its own: **AutoBot's GPU work is library-served, not
+kernel-authored.** Embedding compute goes through torch/cuDNN (`semantic_chunker_gpu.py`),
+similarity search through FAISS (`gpu_vector_search.py`), generation through vLLM. Warp pays
+off only for numerical kernels *no library provides* — the physics/geometry loops it was
+built for. Nothing in the audited surface is that shape. Adopting it would add a second CUDA
+toolchain beside torch's, onto an install path that is already the fragile part (see G3).
+
+**Verdict: rejected — no kernel-authored workload, not "wrong accelerator".** Revisit only if
+a custom hot numerical loop appears that torch cannot express efficiently.
+
+### CUDA-path findings (audited, higher value than the Warp comparison)
+
+**G1 (#15163) — the FAISS-GPU path is unreachable on every automated install.**
+`gpu_vector_search.py:44-52` sets `FAISS_GPU_AVAILABLE` from
+`hasattr(faiss, "StandardGpuResources")`. `requirements.txt:47` pins `faiss-cpu>=1.15.0`,
+under which that attribute does not exist. `faiss-gpu` appears nowhere installable —
+`requirements.txt:46` is a *comment*: "For GPU acceleration: conda install -c conda-forge
+faiss-gpu". `requirements-gpu.txt` contains only vllm/torch/torchvision. So
+`FAISS_GPU_AVAILABLE` is always `False`, `use_gpu` at `:174` is always falsy, and the backend
+always lands on `SearchBackend.FAISS_CPU` (`:189-191`). The "10-100x speedup" of #387 is
+unwired, not broken — the code is complete and the dependency is never installed.
+
+**G2 (#15164) — GPU FAISS is additionally hard-disabled under WSL.**
+`gpu_vector_search.py:172-177`: `use_gpu = ... and not is_wsl`, with the rationale "GPU
+operations can hang in WSL". This development host *is* WSL2 (`microsoft-standard-WSL2`) with
+a working CUDA driver, so the guard fires here regardless of G1. CUDA-on-WSL2 is supported by
+current drivers; the blanket disable looks like a stale workaround that needs re-validation
+rather than permanent residence.
+
+**G3 (#15162) — CUDA torch is coupled to the vLLM flag, so a GPU host without vLLM gets CPU torch.**
+`autobot-slm-backend/ansible/roles/backend/tasks/main.yml:916-918` installs
+`requirements-gpu.txt` only `when: backend_vllm_enabled and backend_gpu_available`, and
+`defaults/main.yml:172` sets `backend_vllm_enabled: false`. On an NVIDIA host that does not
+opt into in-process vLLM, `torch` stays the CPU build from `autobot-backend/requirements.txt:45`
+— and `semantic_chunker_gpu.py`, written specifically for this RTX 4070, runs its FP16/TF32
+path against a torch that has no CUDA. Two independent capabilities are gated behind one
+flag; the GPU-torch install should gate on `backend_gpu_available` alone.
+
+**Priority:** G3 (silent capability loss on every non-vLLM GPU deploy) > G1 (a complete
+feature that never activates) > G2 (a guard that needs evidence, not removal-on-sight).
+
+**Filed:** #15162 (G3), #15163 (G1), #15164 (G2) — 2026-08-28.


### PR DESCRIPTION
## Thinking Path

A `/research` run analysed [NVIDIA Warp](https://github.com/NVIDIA/warp) as a candidate for
AutoBot. The conclusion was **not to adopt it**: AutoBot's GPU work is library-served
(torch/cuDNN, FAISS, vLLM) rather than kernel-authored, so a kernel JIT has nothing to attach to.

A rejection is worth recording for the same reason an adoption is — without the document, the
same evaluation gets repeated by the next person who notices Warp. The alternative considered was
leaving the analysis in session scratch, which loses it entirely.

The lasting value was the CUDA-path audit the research triggered, which produced #15162, #15163,
#15164, #15180 and #15226 under umbrella #15184.

## What Changed

- Added `docs/research/nvidia-warp.md` (334 lines) — Phase 1 source analysis and Phase 2
  comparison against AutoBot, including the visible-vs-hidden-metrics weighing and the
  rejected-alternative reasoning.
- The file carries YAML front matter (`title`, `created`, `reviewed`, `status`), making it the
  first document in `docs/research/` to meet the timestamp standard recorded on #15190 and #15214.
  The other 13 documents there carry prose dates or none.

## Verification

Documentation only; no code paths touched.

```bash
git show --stat HEAD          # exactly one file, 334 insertions
head -9 docs/research/nvidia-warp.md   # front matter present and well-formed
```

The claims in the document were verified against the codebase when written — the file:line
references it cites (`gpu_vector_search.py`, `semantic_chunker_gpu.py`, `ssot_config.py`,
`ansible/roles/backend/defaults/main.yml`) are the evidence behind the five issues it produced.

## Risks

None identified. Documentation-only addition of a new file; nothing imports it, no build step
consumes it, no existing content is modified.

The filename is deliberately **unprefixed** (`nvidia-warp.md`, not `RES_nvidia-warp.md`). #15190's
`RES_` convention is decided but unimplemented, and the folder holds 13 unprefixed files —
committing the single prefixed one now would create a third state. The migration renames all 14
together.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Related #15184

## Changelog fragment

- [x] N/A — documentation-only change, per the template's stated exemption for docs-only work

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — documentation only)
- [x] Documentation updated if behavior changed (this PR *is* the documentation; no behaviour changed)
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff