### PR TITLE
fix(test): make four SSOT tests run and give Redis connectivity a real assertion (#15181, #15182)

### DIFF
--- a/autobot-infrastructure/shared/tests/integration/test_architecture_compliance.py
+++ b/autobot-infrastructure/shared/tests/integration/test_architecture_compliance.py
@@ -13,6 +13,7 @@ This replaces manual architecture fix scripts with automated validation.
 
 import socket
 import sys
+import uuid
 from pathlib import Path
 
 import pytest
@@ -162,14 +163,80 @@ class TestRedisConnection:
 
     @pytest.mark.integration
     def test_redis_connectivity(self):
-        """Test that Redis is accessible at configured host"""
+        """Redis serves commands on the SSOT-configured endpoint, in the SSOT-allocated DB.
+
+        #15182: this called ``client.ping()`` and then asserted ``assert True``,
+        skipping on ``ConnectionError``. There was no input under which it failed:
+        with Redis it passed asserting nothing, without Redis it skipped. #15182 put
+        it at 1 of the 8 tests the marker run selected from this tree; re-measured on
+        this branch the selection is 19 (16 passed, 3 skipped, 17 deselected of 36
+        collected), #15161 having restored the collection the earlier figure was taken
+        under. Either way a whole test of this directory's signal was a constant.
+
+        WHAT THIS TEST IS FOR, decided: not "a socket opened", but "the canonical
+        accessor hands back a client wired to the parameters the SSOT declares, and
+        that client serves commands". Three claims, each asserted separately so a
+        failure names which one broke:
+
+        1. ``get_redis_client()`` returns a client at all. It is documented to return
+           ``None`` when Redis is disabled or the connection fails inside the manager,
+           and the old body would have raised ``AttributeError`` on that path rather
+           than reporting it.
+        2. The pool's host and port are the ones ``unified_config_manager`` declares,
+           and its ``db`` is the number ``redis-databases.yaml`` allocates to the named
+           database ``main`` — the same mapping ``test_redis_db_ssot.py`` guards
+           (#15181). A client that connects to something other than the configured
+           endpoint is exactly the failure "connectivity" is assumed to cover.
+        3. A set/get/delete round-trip. A PING handshake proves reachability; it does
+           not prove the pool serves commands against the selected database.
+
+        NO SKIP, deliberately. ``marker-tests.yml`` is the only workflow that selects
+        ``integration``, and it provisions ``redis:7-alpine`` as a service container
+        with a ``redis-cli ping`` health gate, so Redis is not optional where this test
+        runs. An unreachable Redis there is the condition this test exists to report,
+        not a reason to withhold a verdict — a skip converts the one real failure mode
+        into a non-result. The ``except`` below is kept only to turn a transport error
+        into a named failure instead of a bare traceback; it does not carry the value,
+        which is why it does not interpolate the endpoint it dialled.
+        """
+        from autobot_shared.redis_management.types import DATABASE_MAPPING
+
+        expected = unified_config_manager.get_redis_config()
+        expected_db = DATABASE_MAPPING["main"]
+
         try:
             # Use canonical get_redis_client() pattern for consistency
             client = get_redis_client(async_client=False, database="main")
-            client.ping()
-            assert True, "Redis connection successful"
-        except (redis.ConnectionError, socket.timeout) as e:
-            pytest.skip(f"Redis not available (expected in CI): {e}")
+            assert client is not None, (
+                "get_redis_client(database='main') returned None — Redis is disabled, "
+                "or the connection failed inside the canonical accessor"
+            )
+
+            params = client.connection_pool.connection_kwargs
+            assert params.get("host") == expected.get(
+                "host"
+            ), "Redis pool host is not the one unified_config_manager declares"
+            assert params.get("port") == expected.get(
+                "port"
+            ), "Redis pool port is not the one unified_config_manager declares"
+            assert params.get("db") == expected_db, (
+                f"Redis pool selected db {params.get('db')} for database='main'; "
+                f"redis-databases.yaml allocates db {expected_db}"
+            )
+
+            assert client.ping() is True, "Redis PING did not return True"
+
+            probe_key = f"autobot:test:architecture-compliance:{uuid.uuid4().hex}"
+            try:
+                client.set(probe_key, "reachable")
+                assert client.get(probe_key) in (
+                    "reachable",
+                    b"reachable",
+                ), "Redis round-trip returned a different value than was written"
+            finally:
+                client.delete(probe_key)
+        except (redis.ConnectionError, redis.TimeoutError, socket.timeout) as e:
+            pytest.fail(f"Redis unreachable on the SSOT-configured endpoint: {type(e).__name__}: {e}")
 
     @pytest.mark.integration
     def test_redis_timeout_configuration(self):

--- a/autobot-infrastructure/shared/tests/test_redis_db_ssot.py
+++ b/autobot-infrastructure/shared/tests/test_redis_db_ssot.py
@@ -18,12 +18,29 @@ import yaml
 
 def _load_yaml_mapping() -> dict:
     """Load DB name→number from redis-databases.yaml."""
-    yaml_path = Path(__file__).resolve().parents[2] / "config" / "redis-databases.yaml"
+    # #15181: this read `parents[2]`, one level too high — `autobot-infrastructure/`
+    # rather than `autobot-infrastructure/shared/`. No checkout has ever had a
+    # `redis-databases.yaml` there, so the assert below fired inside the fixture and
+    # all four tests in this file ERRORED at setup instead of running. They had never
+    # executed once. `parents[0]` is this `tests/` directory and `parents[1]` is
+    # `shared/`, which is the directory `config/redis-databases.yaml` actually sits in.
+    #
+    # Kept as an assert rather than letting `open()` raise: a missing SSOT file must
+    # read as "this test could not run", not as an empty mapping that every assertion
+    # below would pass over vacuously. `repo_tests/test_module_path_anchors_15181_test.py`
+    # now fails on any test module whose `Path(__file__)`-anchored data file is absent,
+    # so the next one is caught when it is written rather than by inspection.
+    yaml_path = Path(__file__).resolve().parents[1] / "config" / "redis-databases.yaml"
     assert yaml_path.exists(), f"SSOT file not found: {yaml_path}"
     with open(yaml_path, "r", encoding="utf-8") as f:
         data = yaml.safe_load(f)
-    databases = data.get("redis_databases", {})
-    return {name: cfg["db"] for name, cfg in databases.items() if "db" in cfg}
+    databases = (data or {}).get("redis_databases", {})
+    mapping = {name: cfg["db"] for name, cfg in databases.items() if "db" in cfg}
+    # Every test below iterates this mapping, so an empty one would pass all four
+    # while comparing nothing — the same vacuous-green as the `assert True` in
+    # #15182. Asserted here so a renamed or emptied YAML section is a failure.
+    assert mapping, f"{yaml_path.name} declares no `redis_databases` entries carrying a `db` number"
+    return mapping
 
 
 @pytest.fixture()

--- a/repo_tests/test_module_path_anchors_15181_test.py
+++ b/repo_tests/test_module_path_anchors_15181_test.py
@@ -42,6 +42,24 @@ WHAT IS DELIBERATELY NOT CHECKED, AND WHY
   false failures that train people to add allowlist entries.
 * ``os.path.dirname(__file__)`` chains. None exist in a test module today; the
   ``Path`` form is the one the codebase uses and the one the defect appeared in.
+
+UNPARSEABLE IS AN UNKNOWN, NOT AN ABSENCE
+-----------------------------------------
+This sweep's whole claim is that it PARSES rather than imports, so it reaches
+modules hidden behind a collection error. A module too broken to parse is
+therefore the case most likely to be hiding a bad anchor — and it is the one case
+a ``except SyntaxError: return []`` would silently score as clean, contributing
+zero anchors and passing. That is #15202 item 3 reproduced inside the guard
+written to answer it, and #14975 already settled the precedent the other way: a
+file the size gate could not read became a violation, not a pass.
+
+So ``_file_anchors`` raises and ``_sweep`` records the module in a second list,
+which ``test_no_test_module_is_unreadable_by_the_sweep`` fails on. Measured on
+the branch that added this file: 0 unreadable of 1995 modules, so failing loudly
+costs nothing today. ``KNOWN_UNPARSEABLE`` exists as the same down-only escape
+hatch as ``KNOWN_UNRESOLVED`` and is deliberately empty — an entry there is a
+statement that a tracked test module does not parse, which is a defect in its own
+right and has to be argued for at the site.
 """
 
 from __future__ import annotations
@@ -60,7 +78,9 @@ DATA_SUFFIXES = frozenset(
     {".yaml", ".yml", ".json", ".toml", ".ini", ".cfg", ".txt", ".csv", ".sql", ".env", ".md", ".xml", ".sh", ".py"}
 )
 
-SKIP_DIR_PARTS = frozenset({".git", "node_modules", ".venv", "venv", "__pycache__", "scripts", "dist", "build"})
+SKIP_DIR_PARTS = frozenset(
+    {".git", ".worktrees", "node_modules", ".venv", "venv", "__pycache__", "scripts", "dist", "build"}
+)
 
 #: Floor on the swept population. The failure mode a path guard has is not a false
 #: failure but a silent shrink to nothing — an extractor that stops matching reports
@@ -79,6 +99,12 @@ MIN_SWEPT_EXPRESSIONS = 100
 #:   is the repository root. It is inert today only because the enclosing
 #:   ``_import_func`` discards the spec it just built and returns ``None``.
 KNOWN_UNRESOLVED = frozenset({"autobot-backend/tests/unit/test_agents_status_pg_optional.py"})
+
+#: Test modules that do not parse and are therefore swept blind. Empty on purpose:
+#: measured at 0 of 1995 on the branch that added this file. Same down-only
+#: discipline as ``KNOWN_UNRESOLVED`` — an entry here is an admission that a tracked
+#: test module is syntactically broken, which is its own defect, not a waiver.
+KNOWN_UNPARSEABLE: frozenset[str] = frozenset()
 
 
 def _anchor_levels(node: ast.AST) -> int | None:
@@ -141,21 +167,28 @@ def _outermost_divisions(tree: ast.AST) -> list[ast.BinOp]:
 
 
 def _test_modules(root: Path) -> list[Path]:
-    """Every module pytest would treat as a test file, plus conftest."""
+    """Every module pytest would treat as a test file, plus conftest.
+
+    Skipped parts are matched RELATIVE to the root, never against the absolute
+    path. All work here happens inside ``.worktrees/<branch>/``, so matching the
+    absolute path would let the root's own location skip the entire sweep — which
+    it did, silently, the first time ``.worktrees`` was added to the set.
+    """
     return sorted(
         path
         for path in root.rglob("*.py")
-        if not SKIP_DIR_PARTS.intersection(path.parts)
+        if not SKIP_DIR_PARTS.intersection(path.relative_to(root).parts)
         and (path.name.startswith("test_") or path.name.endswith("_test.py") or path.name == "conftest.py")
     )
 
 
 def _file_anchors(module: Path) -> list[tuple[int, str, Path]]:
-    """(lineno, expression-as-written, resolved path) for each anchored data file."""
-    try:
-        tree = ast.parse(module.read_text(encoding="utf-8"))
-    except (SyntaxError, UnicodeDecodeError):
-        return []
+    """(lineno, expression-as-written, resolved path) for each anchored data file.
+
+    Raises rather than returning ``[]`` when the module cannot be read. See
+    ``UNPARSEABLE IS AN UNKNOWN, NOT AN ABSENCE`` in the module docstring.
+    """
+    tree = ast.parse(module.read_text(encoding="utf-8"))
     found: list[tuple[int, str, Path]] = []
     for division in _outermost_divisions(tree):
         peeled = _literal_segments(division)
@@ -172,13 +205,33 @@ def _file_anchors(module: Path) -> list[tuple[int, str, Path]]:
     return found
 
 
-def _sweep(root: Path) -> list[tuple[Path, int, str, Path]]:
-    return [(module, *anchor) for module in _test_modules(root) for anchor in _file_anchors(module)]
+def _sweep(root: Path) -> tuple[list[tuple[Path, int, str, Path]], list[tuple[Path, str]]]:
+    """(anchors, unreadable). A module that cannot be parsed lands in the second list."""
+    anchors: list[tuple[Path, int, str, Path]] = []
+    unreadable: list[tuple[Path, str]] = []
+    for module in _test_modules(root):
+        try:
+            found = _file_anchors(module)
+        except (SyntaxError, UnicodeDecodeError, ValueError, OSError) as failure:
+            unreadable.append((module, f"{type(failure).__name__}: {failure}"))
+            continue
+        anchors.extend((module, *anchor) for anchor in found)
+    return anchors, unreadable
 
 
 @pytest.fixture(scope="module")
-def swept() -> list[tuple[Path, int, str, Path]]:
+def sweep_result() -> tuple[list[tuple[Path, int, str, Path]], list[tuple[Path, str]]]:
     return _sweep(project_root())
+
+
+@pytest.fixture(scope="module")
+def swept(sweep_result) -> list[tuple[Path, int, str, Path]]:
+    return sweep_result[0]
+
+
+@pytest.fixture(scope="module")
+def unreadable(sweep_result) -> list[tuple[Path, str]]:
+    return sweep_result[1]
 
 
 class TestEveryAnchoredDataFileExists:
@@ -225,6 +278,34 @@ class TestEveryAnchoredDataFileExists:
         stale = KNOWN_UNRESOLVED - still_missing
         assert not stale, f"these entries are fixed and must be removed from KNOWN_UNRESOLVED: {sorted(stale)}"
         assert len(KNOWN_UNRESOLVED) <= 1, "KNOWN_UNRESOLVED is a down-only ratchet; a new defect is fixed, not listed"
+
+
+class TestAModuleTheSweepCannotReadIsNotClean:
+    """#15202 item 3: an unparseable file is an unknown, not an absence."""
+
+    def test_no_test_module_is_unreadable_by_the_sweep(self, unreadable) -> None:
+        root = project_root()
+        offenders = [
+            f"{module.relative_to(root)}  ->  {reason}"
+            for module, reason in unreadable
+            if str(module.relative_to(root)) not in KNOWN_UNPARSEABLE
+        ]
+        assert not offenders, (
+            "These test modules could not be parsed, so this sweep saw NONE of their "
+            "path anchors and scored them clean without reading them. A file too broken "
+            "to parse is the one most likely to be hiding a bad anchor — fix it, or add "
+            "it to KNOWN_UNPARSEABLE with a reason:\n  " + "\n  ".join(offenders)
+        )
+
+    def test_the_unparseable_set_is_down_only_and_still_earned(self, unreadable) -> None:
+        root = project_root()
+        still_unreadable = {str(module.relative_to(root)) for module, _reason in unreadable}
+        stale = KNOWN_UNPARSEABLE - still_unreadable
+        assert not stale, f"these modules parse again and must leave KNOWN_UNPARSEABLE: {sorted(stale)}"
+        assert not KNOWN_UNPARSEABLE, (
+            "KNOWN_UNPARSEABLE was empty when this guard was written and is down-only. "
+            "A tracked test module that does not parse is a defect to fix, not to list."
+        )
 
 
 class TestTheExtractorItself:
@@ -276,6 +357,34 @@ class TestTheExtractorItself:
             encoding="utf-8",
         )
         assert [anchor[2].exists() for anchor in _file_anchors(module)] == [False]
+
+    def test_an_unparseable_module_raises_rather_than_reporting_no_anchors(self, tmp_path: Path) -> None:
+        """The behaviour chosen for #15202 item 3, pinned rather than described.
+
+        The fixture carries a real anchor so the assertion cannot pass for the
+        trivial reason that there was nothing to find: the SAME text parses to one
+        anchor once the syntax error is removed.
+        """
+        anchored = 'GOOD = Path(__file__).parent / "data.yaml"\n'
+        module = tmp_path / "test_broken.py"
+
+        module.write_text("from pathlib import Path\n" + anchored + "def oops(:\n", encoding="utf-8")
+        with pytest.raises(SyntaxError):
+            _file_anchors(module)
+
+        module.write_text("from pathlib import Path\n" + anchored, encoding="utf-8")
+        assert len(_file_anchors(module)) == 1, "the fixture must contribute an anchor when it parses"
+
+    def test_the_sweep_records_an_unparseable_module_instead_of_dropping_it(self, tmp_path: Path) -> None:
+        """End to end: a broken module reaches the `unreadable` list, not the floor."""
+        module = tmp_path / "test_broken.py"
+        module.write_text("def oops(:\n", encoding="utf-8")
+
+        anchors, unreadable = _sweep(tmp_path)
+
+        assert anchors == []
+        assert [entry[0] for entry in unreadable] == [module]
+        assert unreadable[0][1].startswith("SyntaxError")
 
     def test_a_chain_is_counted_once_not_per_link(self) -> None:
         tree = ast.parse('Path(__file__).parent / "a" / "b" / "c.yaml"')

--- a/repo_tests/test_module_path_anchors_15181_test.py
+++ b/repo_tests/test_module_path_anchors_15181_test.py
@@ -1,0 +1,282 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15181: a test module's ``Path(__file__)``-anchored data file must be there.
+
+``autobot-infrastructure/shared/tests/test_redis_db_ssot.py`` resolved its SSOT
+YAML with ``parents[2]`` where ``parents[1]`` is the file's directory-of-record.
+The anchor was one level too high for the whole life of the file, so its fixture
+asserted on a path no checkout has ever had and all four tests ERRORED at setup.
+They had never executed once, and nothing said so: an error at fixture setup in a
+tree that no routine invocation collects is indistinguishable from silence.
+
+That is the third defect of this exact shape found in that one directory (#15161
+repointed a conftest at a module that had moved and a directory that does not
+exist; #15182 covered the vacuous assertion filed alongside this). Three is not
+evidence there are only three, which is why this sweep is repository-wide rather
+than scoped to the file that prompted it.
+
+WHAT IS CHECKED
+---------------
+Every ``test_*.py`` / ``*_test.py`` / ``conftest.py`` on disk is parsed. Any
+expression of the form ``Path(__file__)[.resolve()][.parent... | .parents[N]] /
+"literal" / ...`` whose final segment names a FILE (it carries one of the
+suffixes below) is resolved and must exist.
+
+Reached by parsing, not by running: a module behind a collection error, excluded
+by a marker, or in a tree no workflow names is swept exactly like any other. That
+matters here specifically — this defect class lives where nothing runs.
+
+WHAT IS DELIBERATELY NOT CHECKED, AND WHY
+-----------------------------------------
+* Directory anchors (a final segment with no suffix). Tests legitimately build
+  output and scratch directories that do not exist until something writes them —
+  ``scripts/test_first_remediation.py:32`` names ``.worktrees``, which lives
+  outside the checkout by design. Requiring those to exist would be wrong.
+* Anything under a ``scripts/`` directory. Those modules are named ``test_*`` but
+  are operator utilities, not collected tests; they probe for absent paths on
+  purpose and branch on ``.exists()``.
+* Expressions with a non-literal segment (an f-string, a variable, a ``tmp_path``
+  fixture). Their value is not knowable statically, and guessing would produce
+  false failures that train people to add allowlist entries.
+* ``os.path.dirname(__file__)`` chains. None exist in a test module today; the
+  ``Path`` form is the one the codebase uses and the one the defect appeared in.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from autobot_shared.paths import project_root
+
+#: Final segments with one of these suffixes name a file that must be on disk.
+#: A segment with any other suffix, or none, is treated as a directory and skipped
+#: — see "WHAT IS DELIBERATELY NOT CHECKED" above.
+DATA_SUFFIXES = frozenset(
+    {".yaml", ".yml", ".json", ".toml", ".ini", ".cfg", ".txt", ".csv", ".sql", ".env", ".md", ".xml", ".sh", ".py"}
+)
+
+SKIP_DIR_PARTS = frozenset({".git", "node_modules", ".venv", "venv", "__pycache__", "scripts", "dist", "build"})
+
+#: Floor on the swept population. The failure mode a path guard has is not a false
+#: failure but a silent shrink to nothing — an extractor that stops matching reports
+#: a clean tree. Measured at 111 on the branch that added this file. RATCHET: raise
+#: it when the population genuinely grows; lower it only with a stated reason.
+MIN_SWEPT_EXPRESSIONS = 100
+
+#: Anchors that are already wrong on this branch and are NOT fixed here, because
+#: they sit outside #15181's scope. Each is a real defect of the same shape, found
+#: by this guard's first run and reported rather than absorbed. Remove an entry
+#: when its site is fixed; never add one to make a new failure pass.
+#:
+#: * ``autobot-backend/tests/unit/test_agents_status_pg_optional.py:54`` builds
+#:   ``parents[3] / "api" / "agent_org.py"``. The module is at
+#:   ``autobot-backend/api/agent_org.py``, which is ``parents[2]``; ``parents[3]``
+#:   is the repository root. It is inert today only because the enclosing
+#:   ``_import_func`` discards the spec it just built and returns ``None``.
+KNOWN_UNRESOLVED = frozenset({"autobot-backend/tests/unit/test_agents_status_pg_optional.py"})
+
+
+def _anchor_levels(node: ast.AST) -> int | None:
+    """Directories up from the module file, or None if not a ``Path(__file__)`` anchor."""
+    levels = 0
+    while True:
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Attribute) and node.value.attr == "parents":
+            index = node.slice
+            if not (isinstance(index, ast.Constant) and isinstance(index.value, int)):
+                return None
+            levels += index.value + 1
+            node = node.value.value
+        elif isinstance(node, ast.Attribute) and node.attr == "parent":
+            levels += 1
+            node = node.value
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "resolve":
+            node = node.func.value
+        elif _is_path_of_file(node):
+            return levels
+        else:
+            return None
+
+
+def _is_path_of_file(node: ast.AST) -> bool:
+    """True for the literal expression ``Path(__file__)``."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Path"
+        and len(node.args) == 1
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "__file__"
+    )
+
+
+def _literal_segments(node: ast.BinOp) -> tuple[ast.AST, list[str]] | None:
+    """Peel ``base / "a" / "b"`` into its base and its literal segments."""
+    segments: list[str] = []
+    while isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        if not (isinstance(node.right, ast.Constant) and isinstance(node.right.value, str)):
+            return None
+        segments.append(node.right.value)
+        node = node.left
+    segments.reverse()
+    return node, segments
+
+
+def _outermost_divisions(tree: ast.AST) -> list[ast.BinOp]:
+    """Every ``/`` chain, counted once at its outermost node rather than per link."""
+    nested = {
+        id(node.left)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div) and isinstance(node.left, ast.BinOp)
+    }
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div) and id(node) not in nested
+    ]
+
+
+def _test_modules(root: Path) -> list[Path]:
+    """Every module pytest would treat as a test file, plus conftest."""
+    return sorted(
+        path
+        for path in root.rglob("*.py")
+        if not SKIP_DIR_PARTS.intersection(path.parts)
+        and (path.name.startswith("test_") or path.name.endswith("_test.py") or path.name == "conftest.py")
+    )
+
+
+def _file_anchors(module: Path) -> list[tuple[int, str, Path]]:
+    """(lineno, expression-as-written, resolved path) for each anchored data file."""
+    try:
+        tree = ast.parse(module.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    found: list[tuple[int, str, Path]] = []
+    for division in _outermost_divisions(tree):
+        peeled = _literal_segments(division)
+        if peeled is None:
+            continue
+        base, segments = peeled
+        levels = _anchor_levels(base)
+        if levels is None or not segments or Path(segments[-1]).suffix not in DATA_SUFFIXES:
+            continue
+        anchor = module.resolve()
+        for _ in range(levels):
+            anchor = anchor.parent
+        found.append((division.lineno, "/".join(segments), anchor.joinpath(*segments)))
+    return found
+
+
+def _sweep(root: Path) -> list[tuple[Path, int, str, Path]]:
+    return [(module, *anchor) for module in _test_modules(root) for anchor in _file_anchors(module)]
+
+
+@pytest.fixture(scope="module")
+def swept() -> list[tuple[Path, int, str, Path]]:
+    return _sweep(project_root())
+
+
+class TestEveryAnchoredDataFileExists:
+    def test_no_test_module_anchors_a_data_file_that_is_not_there(self, swept) -> None:
+        root = project_root()
+        missing = [
+            f"{module.relative_to(root)}:{line}  ->  {resolved}"
+            for module, line, _expr, resolved in swept
+            if not resolved.exists() and str(module.relative_to(root)) not in KNOWN_UNRESOLVED
+        ]
+        assert not missing, (
+            "These test modules resolve a data file that does not exist. A fixture that "
+            "cannot find its data errors at setup, which reads as silence in a tree "
+            "nothing routinely collects (#15181):\n  " + "\n  ".join(missing)
+        )
+
+    def test_the_swept_population_has_not_collapsed(self, swept) -> None:
+        """A guard that matches nothing reports a clean tree. Assert it still matches."""
+        assert len(swept) >= MIN_SWEPT_EXPRESSIONS, (
+            f"only {len(swept)} anchored data-file expressions were found, below the "
+            f"recorded floor of {MIN_SWEPT_EXPRESSIONS} — the extractor has probably "
+            "stopped matching rather than the codebase having shrunk"
+        )
+
+    def test_the_issue_15181_site_is_swept_and_resolves(self, swept) -> None:
+        """The originating file, asserted by name so the sweep cannot lose it."""
+        root = project_root()
+        site = "autobot-infrastructure/shared/tests/test_redis_db_ssot.py"
+        hits = [entry for entry in swept if str(entry[0].relative_to(root)) == site]
+        assert len(hits) == 1, f"{site} contributes {len(hits)} anchored data files to the sweep, expected 1"
+        assert hits[0][3].exists(), f"{site} still resolves to a missing file: {hits[0][3]}"
+        assert hits[0][3].name == "redis-databases.yaml"
+
+    def test_the_grandfathered_set_is_down_only(self, swept) -> None:
+        """Every allowlisted module must still be swept, and still be broken.
+
+        An entry that no longer fails is an entry to delete — otherwise the set
+        grows into a place to hide new defects.
+        """
+        root = project_root()
+        still_missing = {
+            str(module.relative_to(root)) for module, _line, _expr, resolved in swept if not resolved.exists()
+        }
+        stale = KNOWN_UNRESOLVED - still_missing
+        assert not stale, f"these entries are fixed and must be removed from KNOWN_UNRESOLVED: {sorted(stale)}"
+        assert len(KNOWN_UNRESOLVED) <= 1, "KNOWN_UNRESOLVED is a down-only ratchet; a new defect is fixed, not listed"
+
+
+class TestTheExtractorItself:
+    """The sweep above is only worth its floor if the extractor reads real syntax."""
+
+    @pytest.mark.parametrize(
+        "expression,levels",
+        [
+            ('Path(__file__).parent / "a.yaml"', 1),
+            ('Path(__file__).parent.parent / "a.yaml"', 2),
+            ('Path(__file__).resolve().parents[0] / "a.yaml"', 1),
+            ('Path(__file__).resolve().parents[1] / "a.yaml"', 2),
+            ('Path(__file__).resolve().parents[2] / "config" / "a.yaml"', 3),
+        ],
+    )
+    def test_each_anchor_spelling_resolves_to_the_right_depth(self, expression: str, levels: int) -> None:
+        division = ast.parse(expression, mode="eval").body
+        peeled = _literal_segments(division)
+        assert peeled is not None
+        assert _anchor_levels(peeled[0]) == levels
+
+    def test_a_non_literal_segment_is_not_guessed_at(self) -> None:
+        division = ast.parse('Path(__file__).parent / name / "a.yaml"', mode="eval").body
+        assert _literal_segments(division) is None
+
+    def test_an_anchor_that_is_not_the_module_file_is_ignored(self) -> None:
+        division = ast.parse('Path(cwd).parent / "a.yaml"', mode="eval").body
+        peeled = _literal_segments(division)
+        assert peeled is not None
+        assert _anchor_levels(peeled[0]) is None
+
+    def test_the_15181_anchor_off_by_one_is_detectable(self, tmp_path: Path) -> None:
+        """The mutation, asserted rather than described: parents[2] must not resolve."""
+        module = tmp_path / "shared" / "tests" / "test_probe.py"
+        module.parent.mkdir(parents=True)
+        (tmp_path / "shared" / "config").mkdir(parents=True)
+        (tmp_path / "shared" / "config" / "redis-databases.yaml").write_text("{}\n", encoding="utf-8")
+
+        module.write_text(
+            "from pathlib import Path\n"
+            'GOOD = Path(__file__).resolve().parents[1] / "config" / "redis-databases.yaml"\n',
+            encoding="utf-8",
+        )
+        assert [anchor[2].exists() for anchor in _file_anchors(module)] == [True]
+
+        module.write_text(
+            "from pathlib import Path\n"
+            'BAD = Path(__file__).resolve().parents[2] / "config" / "redis-databases.yaml"\n',
+            encoding="utf-8",
+        )
+        assert [anchor[2].exists() for anchor in _file_anchors(module)] == [False]
+
+    def test_a_chain_is_counted_once_not_per_link(self) -> None:
+        tree = ast.parse('Path(__file__).parent / "a" / "b" / "c.yaml"')
+        assert len(_outermost_divisions(tree)) == 1


### PR DESCRIPTION
Closes #15181, #15182

## Thinking Path

Two defects in one directory, both of the same shape: a test that reports something other than what it claims.

**#15181** — `test_redis_db_ssot.py` resolved its SSOT YAML with `parents[2]`. The module sits at `autobot-infrastructure/shared/tests/`, so `parents[0]` is `tests/` and `parents[1]` is `shared/` — the directory `config/redis-databases.yaml` is actually in. `parents[2]` is `autobot-infrastructure/`, which has never held that file in any checkout. The fixture's own `assert yaml_path.exists()` therefore fired on every run and all four tests ERRORED at setup. They had never executed once.

Fixing the anchor is one line. The question worth answering is what happens next, so the four were run and their behaviour is stated below rather than assumed. A second, quieter hazard was fixed while there: `_load_yaml_mapping` returned `{}` if the `redis_databases` key were ever renamed, and every one of the four tests iterates that mapping — so a renamed section would have converted four comparisons into four vacuous passes, the same defect as #15182 in a different disguise. The loader now asserts the mapping is non-empty.

**#15182** — `test_redis_connectivity` called `client.ping()` and then `assert True`, skipping on `ConnectionError`. Deciding what it is for came first: not "a socket opened", but "the canonical accessor hands back a client wired to the parameters the SSOT declares, and that client serves commands". Those are three separate claims and they are now three separate assertions, so a failure names which one broke.

The skip is gone. `marker-tests.yml` is the only workflow that selects `integration`, and it provisions `redis:7-alpine` as a service container behind a `redis-cli ping` health gate. Redis is not optional where this test runs, so an unreachable Redis there is the condition the test exists to report, not a reason to withhold a verdict. The `except` is kept only to turn a transport error into a named failure rather than a bare traceback.

The mutation surfaced something the issue did not predict, and it is worth recording: `get_redis_client()` catches `ConnectionError` internally and returns `None`. The old `except redis.ConnectionError` at this call site was therefore **unreachable** — against a dead port the old test did not skip, it raised `AttributeError: 'NoneType' object has no attribute 'ping'`. The skip that was being reconsidered had been dead code the whole time, and the test's only non-pass outcome was an uninformative traceback. That is why `client is not None` is asserted first.

Three defects of this shape have now been found in this one directory (#15161, #15181, #15182), which is not evidence there are only three. Hence the guard, and hence it is repository-wide rather than scoped to the file that prompted it.

## What Changed

| File | Change |
|---|---|
| `autobot-infrastructure/shared/tests/test_redis_db_ssot.py` | `parents[2]` → `parents[1]`; loader asserts the YAML mapping is non-empty; the anchor is documented at the site |
| `autobot-infrastructure/shared/tests/integration/test_architecture_compliance.py` | `test_redis_connectivity` rewritten: client-not-None, pool host/port against `unified_config_manager`, pool `db` against the `redis-databases.yaml` allocation for `main`, `ping() is True`, and a set/get/delete round-trip. `pytest.skip` → `pytest.fail` |
| `repo_tests/test_module_path_anchors_15181_test.py` | New guard (#15181 AC4). AST sweep of every `test_*.py` / `*_test.py` / `conftest.py` on disk for `Path(__file__)`-anchored data files that do not exist |

**Review follow-up (`0cbb5a66c`).** The guard originally caught `SyntaxError` and returned `[]`, so a module too broken to parse contributed zero anchors and swept clean — #15202 item 3 reproduced inside the guard written to answer it, and worst precisely here, since parsing-not-importing is this sweep's whole stated advantage. Behaviour chosen: **fail loudly**, following #14975 (a file the size gate could not read became a violation, not a pass). `_file_anchors` now raises; `_sweep` returns `(anchors, unreadable)` and `test_no_test_module_is_unreadable_by_the_sweep` fails on the second list. `KNOWN_UNPARSEABLE` is the same down-only hatch as `KNOWN_UNRESOLVED` and is **deliberately empty** — measured at **0 unreadable of 1995 modules**, so failing loudly costs nothing today, and an entry there would be an admission that a tracked test module does not parse.

Adding `.worktrees` to `SKIP_DIR_PARTS` (also asked for) surfaced a second defect in the same line: parts were matched against the **absolute** path, so a root under `.worktrees/` — where all work here happens — skipped every file and swept nothing. The population floor caught it immediately. Parts are now matched relative to the root.

The guard reaches modules by parsing, not by running, so a module behind a collection error, deselected by a marker, or in a tree no workflow names is swept like any other — which is exactly where this defect class lives. It carries a population floor (100, measured at 111) so it cannot silently shrink to nothing, self-tests for the extractor including the `parents[2]` off-by-one, and a down-only `KNOWN_UNRESOLVED` set holding the one same-shape defect found outside these issues' scope.

**What the four tests do once they run.** All four pass, against 15 real database entries — not a vacuous set:

| Test | Asserts |
|---|---|
| `test_fallback_matches_yaml` | `_FALLBACK_MAPPING` is identical to the YAML |
| `test_database_mapping_contains_yaml_entries` | every YAML name is in `DATABASE_MAPPING` at the same number |
| `test_no_unknown_canonical_entries` | `DATABASE_MAPPING` invents no name absent from the YAML and not a declared alias |
| `test_redis_database_enum_values_match_yaml` | each `RedisDatabase` member's value matches the YAML for its lowercased name |

## Verification

**Before / after, `autobot-infrastructure/shared/tests/test_redis_db_ssot.py`** — collected is not executed, so both are given:

```
BEFORE:  collected 4 items ... 4 errors in 0.22s
         ERROR ...::test_fallback_matches_yaml - AssertionError: SSOT file not found:
               <root>/autobot-infrastructure/config/redis-databases.yaml
         (same for the other three)   -> 4 collected, 0 executed

AFTER:   collected 4 items ... 4 passed in 0.07s   -> 4 collected, 4 executed
```

**Whole tree, same invocation, before and after:**

```
BEFORE:  7 failed, 22 passed, 3 skipped, 4 errors   (36 collected)
AFTER:   7 failed, 26 passed, 3 skipped             (36 collected)
```

The 7 failures are pre-existing, untouched by this PR, and carry no marker — see Out of scope.

**The marker-selected set** (`-m "integration or slow or distributed or performance"`, what `marker-tests.yml` runs) is green before and after — `16 passed, 3 skipped, 17 deselected`. The difference is that one of those 16 now asserts six things instead of a literal.

**Contrast mutation 1 — #15181, the wrong anchor restored:**

```
$ sed -i 's/parents\[1\]/parents[2]/' .../test_redis_db_ssot.py
$ pytest .../test_redis_db_ssot.py
4 errors in 0.16s
ERROR ...::test_fallback_matches_yaml
ERROR ...::test_database_mapping_contains_yaml_entries
ERROR ...::test_no_unknown_canonical_entries
ERROR ...::test_redis_database_enum_values_match_yaml

$ pytest repo_tests/test_module_path_anchors_15181_test.py
FAILED ...::test_no_test_module_anchors_a_data_file_that_is_not_there
E  AssertionError: These test modules resolve a data file that does not exist...
E    autobot-infrastructure/shared/tests/test_redis_db_ssot.py:33 -> .../autobot-infrastructure/config/redis-databases.yaml
FAILED ...::test_the_issue_15181_site_is_swept_and_resolves
```

Reverted from a pristine copy and confirmed with `diff -q` (`SSOT-RESTORED-OK`); 4 passed again.

**Contrast mutation 2 — #15182, a port nothing listens on** (`AUTOBOT_REDIS_PORT` moves both the client and the expectation together, so it is reachability that changes, not the comparison):

```
$ AUTOBOT_REDIS_PORT=<dead> pytest ...::test_redis_connectivity
1 failed
E  AssertionError: get_redis_client(database='main') returned None — Redis is disabled,
   or the connection failed inside the canonical accessor
WARNING ...connection_manager: Failed to get sync Redis client for database 'main':
   Error 111 connecting to <endpoint>. Connection refused.
```

Fails, does not skip. The same mutation against the **old** body, for contrast:

```
E  AttributeError: 'NoneType' object has no attribute 'ping'
```

— a failure, but an uninformative one reached by a path the `except`/`skip` never saw. Restored from a pristine copy, `diff -q` clean, live-Redis run green.

**Contrast mutation 3 — the swallow restored** (`except (SyntaxError, UnicodeDecodeError): return []` put back):

```
FAILED ...::TestTheExtractorItself::test_an_unparseable_module_raises_rather_than_reporting_no_anchors
FAILED ...::TestTheExtractorItself::test_the_sweep_records_an_unparseable_module_instead_of_dropping_it
2 failed, 15 passed
```

Both new tests use a deliberately unparseable fixture that also carries a real anchor, so neither can pass for want of anything to find: the same text parses to exactly one anchor once the syntax error is removed. Restored from a pristine copy, `diff -q` clean; sweep re-measured unchanged at 1995 modules / 111 expressions / 1 unresolved / 0 unreadable.

**Guard:** `17 passed` on its own; `62 passed` across `python_file_size_ratchet_test.py`, `tests_that_return_instead_of_asserting_test.py`, `collection_coverage_test.py`, `marker_suite_root_coverage_test.py`. `black`, `isort` and `flake8` clean on all three files (the one `E501` in `test_architecture_compliance.py:59` is pre-existing and outside the diff).

**Sweep 1 — `parents[N]` anchors resolving to nothing.** Repository-wide over every `test_*.py` / `*_test.py` / `conftest.py`, `scripts/` excluded: **111 anchored data-file expressions, 1 unresolved** after this fix (it is the grandfathered entry, listed below). Scoped to `autobot-infrastructure/shared/tests/` alone: **0 unresolved** after the fix, 1 before. Directory-valued anchors are deliberately not required to exist — tests legitimately name output and scratch directories.

**Sweep 2 — assertion-free tests in this tree.** Of the **36 tests pytest collects** from `autobot-infrastructure/shared/tests/`: **1** could not fail by assertion before this PR (`test_redis_connectivity`), **0** after. A further **13** `test_*`-named functions in that tree have no assertion but are collected by nothing — 10 in `comprehensive_test_suite.py`, 2 in `results/comprehensive_testing_20250909_150149/system_assessment_report.py`, and `conftest.py:104 test_data_dir`, which is a fixture that merely happens to be named like a test. Those filenames match no `python_files` pattern; that is #15178's population, not this PR's.

**What could not be verified here.** The local interpreter sits below 90 of 206 declared dependency floors (python 3.10.12), so a local pass carries less information than CI — the numbers above need CI to confirm. The marker workflow itself has no cron (withheld under #13286) and could not be exercised; the claim that its `redis:7-alpine` service makes Redis non-optional is read from `marker-tests.yml`, not observed on a run. The round-trip assertion was exercised against a local Redis, not against that service container.

## Model Used

Claude Opus 5 (1M context)

