### PR TITLE
test-guard(repo_tests): count the tests that run nothing, and unwrap four that could not fail (#15189)

### DIFF
--- a/autobot-backend/config/config_migration_integration_test.py
+++ b/autobot-backend/config/config_migration_integration_test.py
@@ -85,25 +85,23 @@ class TestConfigurationMigration:
         assert test_config.get("redis.password") == "test-password"
 
     def test_secrets_service_config_migration(self):
-        """Test that secrets service uses centralized configuration"""
-        # Create test config with security settings
+        """The secrets service reads its key from centralized configuration.
+
+        Two things are checked here and both can now fail. ``patch`` raises
+        AttributeError if ``services.secrets_service`` has no ``config_manager``
+        seam to substitute, which is the migration this test is named for; the
+        assertion then verifies the value the service would read back through
+        it.
+
+        Both used to sit under ``except Exception: pass``. That catches
+        AssertionError, so the assertion was inert and the test passed whichever
+        way it went — the #15189 shape, found by the #15195 sweep.
+        """
         test_config = ConfigManager()
         test_config.set("security.secrets_key", "test_secrets_key")
 
-        # Mock the config manager import
         with patch("services.secrets_service.config_manager", test_config):
-            pass
-
-            # Create secrets service - should use config for key
-            # Note: This might still try to create actual encryption, so we test carefully
-            try:
-                # Just test that config is accessible
-                secrets_key = test_config.get("security.secrets_key")
-                assert secrets_key == "test_secrets_key"
-            except Exception:
-                # If initialization fails, that's OK for this test
-                # We're just testing that config access works
-                pass
+            assert test_config.get("security.secrets_key") == "test_secrets_key"
 
     def test_config_environment_variable_priorities(self):
         """Env-var override is ConfigRegistry's job, via the AUTOBOT_ prefix.

--- a/autobot-infrastructure/shared/scripts/test_configuration.py
+++ b/autobot-infrastructure/shared/scripts/test_configuration.py
@@ -6,6 +6,19 @@
 """
 Configuration Validation and Testing Script
 Tests centralized configuration system and validates all config values
+
+#15189: ``test_config_values``, ``test_config_manager`` and
+``test_config_validation`` each wrapped their assertions in
+``try: ... except Exception: return False``. ``except Exception`` catches
+``AssertionError``, so every assertion in those three was inert — the function
+returned on both branches and reported the same verdict whichever way it went.
+The wrappers are gone and the assertions now propagate.
+
+The driver contract is unchanged, because ``main()`` below already wraps every
+call in its own ``try/except`` and records a crash as a failed test. The only
+difference is that a broken assertion is now one of the things it records,
+instead of being converted to a quiet ``False`` at the point it fired — and the
+traceback names the assertion rather than being discarded.
 """
 
 import logging
@@ -50,76 +63,68 @@ def test_config_values():
     """Test configuration values are properly loaded"""
     logger.info("Testing configuration values...")
 
-    try:
-        from config import (
-            API_BASE_URL,
-            API_TIMEOUT,
-            OLLAMA_URL,
-            REDIS_URL,
-            VNC_CONTAINER_PORT,
-            VNC_DISPLAY_PORT,
-            get_vnc_direct_url,
-            get_vnc_display_port,
-        )
+    from config import (
+        API_BASE_URL,
+        API_TIMEOUT,
+        OLLAMA_URL,
+        REDIS_URL,
+        VNC_CONTAINER_PORT,
+        VNC_DISPLAY_PORT,
+        get_vnc_direct_url,
+        get_vnc_display_port,
+    )
 
-        # Test basic values
-        assert API_BASE_URL.startswith("http"), "API_BASE_URL should start with http"
-        assert REDIS_URL.startswith("redis"), "REDIS_URL should start with redis"
-        assert OLLAMA_URL.startswith("http"), "OLLAMA_URL should start with http"
-        assert isinstance(API_TIMEOUT, int), "API_TIMEOUT should be integer"
+    # Test basic values
+    assert API_BASE_URL.startswith("http"), "API_BASE_URL should start with http"
+    assert REDIS_URL.startswith("redis"), "REDIS_URL should start with redis"
+    assert OLLAMA_URL.startswith("http"), "OLLAMA_URL should start with http"
+    assert isinstance(API_TIMEOUT, int), "API_TIMEOUT should be integer"
 
-        # Test VNC configuration
-        vnc_port = get_vnc_display_port()
-        vnc_url = get_vnc_direct_url()
-        assert isinstance(vnc_port, int), "VNC port should be integer"
-        assert vnc_url.startswith("vnc://"), "VNC URL should start with vnc://"
-        assert vnc_port in [
-            VNC_DISPLAY_PORT,
-            VNC_CONTAINER_PORT,
-        ], "VNC port should be valid option"
+    # Test VNC configuration
+    vnc_port = get_vnc_display_port()
+    vnc_url = get_vnc_direct_url()
+    assert isinstance(vnc_port, int), "VNC port should be integer"
+    assert vnc_url.startswith("vnc://"), "VNC URL should start with vnc://"
+    assert vnc_port in [
+        VNC_DISPLAY_PORT,
+        VNC_CONTAINER_PORT,
+    ], "VNC port should be valid option"
 
-        logger.info("   API_BASE_URL: %s", API_BASE_URL)
-        logger.info("   REDIS_URL: %s", REDIS_URL)
-        logger.info("   OLLAMA_URL: %s", OLLAMA_URL)
-        logger.info("   API_TIMEOUT: %dms", API_TIMEOUT)
-        logger.info("   VNC_PORT (intelligent): %d", vnc_port)
-        logger.info("   VNC_URL: %s", vnc_url)
+    logger.info("   API_BASE_URL: %s", API_BASE_URL)
+    logger.info("   REDIS_URL: %s", REDIS_URL)
+    logger.info("   OLLAMA_URL: %s", OLLAMA_URL)
+    logger.info("   API_TIMEOUT: %dms", API_TIMEOUT)
+    logger.info("   VNC_PORT (intelligent): %d", vnc_port)
+    logger.info("   VNC_URL: %s", vnc_url)
 
-        return True
-    except Exception as e:
-        logger.error("   Configuration value validation failed: %s", e)
-        return False
+    return True
 
 
 def test_config_manager():
     """Test configuration manager functionality"""
     logger.info("Testing configuration manager...")
 
-    try:
-        from config import config
+    from config import config
 
-        # Test basic operations
-        backend_config = config.get("backend", {})
-        llm_config = config.get_llm_config()
-        redis_config = config.get_redis_config()
+    # Test basic operations
+    backend_config = config.get("backend", {})
+    llm_config = config.get_llm_config()
+    redis_config = config.get_redis_config()
 
-        assert isinstance(backend_config, dict), "Backend config should be dict"
-        assert isinstance(llm_config, dict), "LLM config should be dict"
-        assert isinstance(redis_config, dict), "Redis config should be dict"
+    assert isinstance(backend_config, dict), "Backend config should be dict"
+    assert isinstance(llm_config, dict), "LLM config should be dict"
+    assert isinstance(redis_config, dict), "Redis config should be dict"
 
-        # Test nested access
-        nested_value = config.get_nested("backend.server_host", "default")
-        assert nested_value is not None, "Nested config access should work"
+    # Test nested access
+    nested_value = config.get_nested("backend.server_host", "default")
+    assert nested_value is not None, "Nested config access should work"
 
-        logger.info("   Configuration manager operational")
-        logger.info("   Backend config keys: %d", len(backend_config))
-        logger.info("   LLM config keys: %d", len(llm_config))
-        logger.info("   Redis config keys: %d", len(redis_config))
+    logger.info("   Configuration manager operational")
+    logger.info("   Backend config keys: %d", len(backend_config))
+    logger.info("   LLM config keys: %d", len(llm_config))
+    logger.info("   Redis config keys: %d", len(redis_config))
 
-        return True
-    except Exception as e:
-        logger.error("   Configuration manager test failed: %s", e)
-        return False
+    return True
 
 
 def test_environment_overrides():
@@ -164,31 +169,27 @@ def test_config_validation():
     """Test configuration validation functionality"""
     logger.info("Testing configuration validation...")
 
-    try:
-        from config import config
+    from config import config
 
-        validation_result = config.validate_config()
+    validation_result = config.validate_config()
 
-        assert isinstance(validation_result, dict), "Validation should return dict"
-        assert "config_loaded" in validation_result, "Should include config_loaded status"
+    assert isinstance(validation_result, dict), "Validation should return dict"
+    assert "config_loaded" in validation_result, "Should include config_loaded status"
 
-        logger.info("   Configuration validation operational")
-        logger.info(
-            "   Validation status: %s",
-            validation_result.get("config_loaded", "unknown"),
-        )
+    logger.info("   Configuration validation operational")
+    logger.info(
+        "   Validation status: %s",
+        validation_result.get("config_loaded", "unknown"),
+    )
 
-        if validation_result.get("issues"):
-            logger.warning("   Configuration issues found: %d", len(validation_result["issues"]))
-            for issue in validation_result["issues"][:3]:  # Show first 3 issues
-                logger.warning("      - %s", issue)
-        else:
-            logger.info("   No configuration issues found")
+    if validation_result.get("issues"):
+        logger.warning("   Configuration issues found: %d", len(validation_result["issues"]))
+        for issue in validation_result["issues"][:3]:  # Show first 3 issues
+            logger.warning("      - %s", issue)
+    else:
+        logger.info("   No configuration issues found")
 
-        return True
-    except Exception as e:
-        logger.error("   Configuration validation test failed: %s", e)
-        return False
+    return True
 
 
 def test_config_performance():

--- a/repo_tests/collected_test_model.py
+++ b/repo_tests/collected_test_model.py
@@ -16,6 +16,11 @@ execution:
 * **Can this test fail?** ``propagating_guards`` answers whether an ``assert``
   or ``raise`` in a collected test can actually reach pytest, which is a
   different question from whether one is written down (#15195, below).
+* **Does this test run anything?** ``empty_bodies`` answers whether a collected
+  test's body is entirely no-ops — ``pass``, ``...``, a docstring, ``print()``
+  — which neither of the ceilings driven from here can see, because such a test
+  returns no verdict to discard and holds no assertion to discount (#15189,
+  below).
 
 Split out of ``tests_that_return_instead_of_asserting_test.py`` when a second
 guard needed the same model. Two copies of "what pytest collects" would drift,
@@ -323,3 +328,77 @@ def test_functions_by_tree() -> dict[str, int]:
         found = collectable_tests(parse_module(module))
         counts[tree] = counts.get(tree, 0) + len(found)
     return counts
+
+
+# ---------------------------------------------------------------------------
+# Does this test execute anything at all? (#15189)
+#
+# The third shape, and the one neither ceiling above can see. A test with no
+# `return` and no `assert` is invisible to both — there is no returned verdict
+# to discard and no inert assertion to discount — yet a body of `pass` plus a
+# docstring claiming a check is the same defect in its purest form: a green
+# tile for work never done. `test_migrated_files_import` in #15189 was exactly
+# this, six `print()` calls announcing six successful imports with the `import`
+# statements stripped out, and it reported success for all six.
+#
+# The rule is deliberately the narrowest one that catches it: EVERY statement
+# in the body is a no-op. A body that calls anything at all is out of scope,
+# because "it does not raise" is a real, if thin, assertion and flagging it
+# would make this guard the kind somebody switches off.
+# ---------------------------------------------------------------------------
+
+# Decorators that declare the test is not expected to run or not expected to
+# pass. An empty body under one of those is honest rather than misleading, so
+# it is not this guard's subject.
+DECLARED_NOT_RUNNING = frozenset({"skip", "skipif", "xfail"})
+
+
+def is_declared_not_running(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    for decorator in function.decorator_list:
+        node = decorator.func if isinstance(decorator, ast.Call) else decorator
+        name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
+        if name in DECLARED_NOT_RUNNING:
+            return True
+    return False
+
+
+def does_nothing(statement: ast.stmt) -> bool:
+    """True for a statement that cannot observe, change or check anything.
+
+    ``pass``, ``...``, a bare string (docstring, or a comment written as one)
+    and ``print(...)`` — the four ways a body can be written out in full and
+    still run no check. ``print`` is matched only as a bare name: an attribute
+    call such as ``reporter.print(...)`` is somebody's method and may do work.
+    """
+    if isinstance(statement, ast.Pass):
+        return True
+    if not isinstance(statement, ast.Expr):
+        return False
+    value = statement.value
+    if isinstance(value, ast.Constant):
+        return True
+    return (
+        isinstance(value, ast.Call)
+        and isinstance(value.func, ast.Name)
+        and value.func.id == "print"
+    )
+
+
+def empty_bodies(source: str) -> list[tuple[str, int]]:
+    """``(test name, line)`` for every collected test that executes nothing.
+
+    Source-driven for the same reason ``swallowed_assertions`` is: a detector
+    only ever pointed at the live tree cannot be told apart from one that has
+    stopped detecting.
+    """
+    return empty_bodies_in(ast.parse(source))
+
+
+def empty_bodies_in(tree: ast.Module) -> list[tuple[str, int]]:
+    found: list[tuple[str, int]] = []
+    for function in collectable_tests(tree):
+        if is_fixture(function) or is_declared_not_running(function):
+            continue
+        if all(does_nothing(statement) for statement in function.body):
+            found.append((function.name, function.lineno))
+    return found

--- a/repo_tests/tests_that_execute_nothing_test.py
+++ b/repo_tests/tests_that_execute_nothing_test.py
@@ -1,0 +1,233 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""A collected test whose body runs nothing still reports green (#15189).
+
+The third shape in the #15189 family, and the only one neither of this
+repository's existing ceilings can see::
+
+    def test_migrated_files_import():
+        \"\"\"All six migrated modules import successfully.\"\"\"
+        pass
+        print("✅ services.chat_service imports")
+        print("✅ services.rag_service imports")
+        ...
+
+That function was real, in ``autobot-backend/cache/cache_consolidation_p4_test.py``
+before #15166 fixed it. Its ``import`` statements had been stripped at some
+point and nothing noticed, because there was nothing left to notice: it
+asserted six imports, performed none, and printed six successes.
+
+WHY THE OTHER TWO GUARDS CANNOT SEE THIS
+----------------------------------------
+``repo_tests/tests_that_return_instead_of_asserting_test.py`` counts a returned
+verdict pytest discards — this shape returns nothing. Its ``_SWALLOWED_ASSERTIONS``
+companion counts an assertion neutralised by a handler that catches
+``AssertionError`` (#15195) — this shape holds no assertion to neutralise. Both
+are ceilings on a written-down thing that does not work; this one is a ceiling
+on nothing being written down at all, which is why it needs its own sweep
+rather than another number in that file.
+
+WHAT COUNTS, AND HOW NARROWLY
+-----------------------------
+Every statement in the body is a no-op: ``pass``, ``...``, a bare string
+(docstring, or a comment written as one), or ``print(...)`` as a bare name.
+``does_nothing`` in ``repo_tests/collected_test_model`` carries the rule.
+
+The narrowness is the point, in three directions, because a guard that
+over-flags is a guard somebody switches off:
+
+* **one statement that calls something and the function is out of scope.** A
+  test that only calls its subject is a thin test, but "it does not raise" is a
+  real assertion and this guard has no business flagging it.
+* ``reporter.print(...)`` is somebody's method, not the builtin. Only a bare
+  ``print`` name is a no-op.
+* a test carrying ``@pytest.mark.skip``/``skipif``/``xfail`` is **declaring**
+  that it does not run or is not expected to pass. An empty body under one of
+  those is honest, and honesty is not this guard's subject.
+
+THE RATCHET
+-----------
+Keyed on the top-level tree, never on a filename — an exemption keyed on a path
+is stranded by the first rename. Every tree not named below is pinned at zero
+by derivation, so the twelfth fails on arrival in any of the other trees with
+nobody maintaining a list.
+
+Down-only, and no route up, on the same terms as the sibling guard. There is
+nothing an author could be trying to express with an empty test body that a
+real body does not express better; if the check genuinely cannot be written
+yet, ``@pytest.mark.skip(reason=...)`` says so out loud and this guard steps
+aside for it. Lowering a number needs no permission at all — fix a test and the
+assertion below prints the new figure.
+
+Each entry also carries a floor on its tree's own test population, for the
+reason every baseline guard in ``repo_tests`` carries one: a walk that quietly
+stops matching finds nothing, and finding nothing is indistinguishable from
+finished work. The collapse is checked before the count, and it fails telling
+the reader to fix the sweep rather than to write the zero down.
+"""
+
+from __future__ import annotations
+
+from repo_tests.collected_test_model import (
+    REPO_ROOT,
+    empty_bodies,
+    empty_bodies_in,
+    parse_module,
+    test_functions_by_tree,
+    test_modules,
+)
+
+# Measured on this branch, per top-level tree:
+#   tree: (test functions with an empty body that must not be exceeded,
+#          test functions that must STILL be found in that tree)
+#
+# Eleven today, in three files, every one a placeholder whose docstring names a
+# check its body does not perform:
+#
+#   autobot-backend/config/timeout_configuration_test.py            2
+#     ("would require importing KnowledgeBase")
+#   autobot-backend/services/rag_integration_test.py                5
+#     (TestAPIEndpoints — "would require FastAPI TestClient integration")
+#   autobot-backend/tests/api/test_knowledge_grounding.py           4
+#     ("Endpoint test structure")
+#
+# All eleven are reported rather than converted under #15189: each needs a real
+# integration test written against a live endpoint or a real KnowledgeBase, and
+# half-converting a population is how a ratchet gets stuck. None is decorated
+# with skip or xfail — all eleven run, and all eleven report green.
+_EMPTY_BODIED = {
+    "autobot-backend": (11, 18000),
+}
+
+
+def _empty_by_tree() -> dict[str, list[str]]:
+    counts: dict[str, list[str]] = {}
+    for module in test_modules():
+        relative = module.relative_to(REPO_ROOT)
+        for name, line in empty_bodies_in(parse_module(module)):
+            counts.setdefault(relative.parts[0], []).append(f"{relative}:{line} {name}")
+    return counts
+
+
+def _collapsed(populations: dict[str, int]) -> dict[str, tuple[int, int]]:
+    return {
+        tree: (populations.get(tree, 0), floor)
+        for tree, (_, floor) in _EMPTY_BODIED.items()
+        if populations.get(tree, 0) < floor
+    }
+
+
+def test_no_tree_outside_the_known_set_has_a_test_that_executes_nothing() -> None:
+    """The hard zero, derived — no list of clean trees to go stale."""
+    populations = test_functions_by_tree()
+    collapsed = _collapsed(populations)
+    assert not collapsed, (
+        "the sweep no longer finds the tests it is supposed to be scanning "
+        f"(found, floor): {collapsed}. The zero below is therefore meaningless — "
+        "a scan that finds nothing reports every tree clean. Fix the sweep."
+    )
+
+    empty = _empty_by_tree()
+    surprises = {tree: sites for tree, sites in empty.items() if tree not in _EMPTY_BODIED}
+    detail = "\n".join(
+        f"  {tree}:\n    " + "\n    ".join(sorted(sites))
+        for tree, sites in sorted(surprises.items())
+    )
+    assert not surprises, (
+        "these collected tests execute nothing at all — every statement in the "
+        f"body is `pass`, `...`, a docstring or `print()` — in a tree that was "
+        f"clean:\n{detail}\n"
+        "pytest reports each of them green, so the suite counts a check nobody "
+        "wrote. Write the body, or say out loud that it is not written with "
+        "`@pytest.mark.skip(reason=...)` (#15189)."
+    )
+
+
+def test_the_empty_bodied_budgets_only_ever_shrink() -> None:
+    """Ratchet, both directions — a recorded shrink is locked in (#14498)."""
+    populations = test_functions_by_tree()
+    collapsed = _collapsed(populations)
+    assert not collapsed, (
+        "the sweep no longer finds the tests it is supposed to be scanning "
+        f"(found, floor): {collapsed}. Fix the sweep; do NOT lower these numbers."
+    )
+
+    empty = _empty_by_tree()
+    over = {
+        tree: (len(empty.get(tree, [])), budget)
+        for tree, (budget, _) in _EMPTY_BODIED.items()
+        if len(empty.get(tree, [])) > budget
+    }
+    assert not over, (
+        "these trees gained a test with nothing in its body "
+        f"(actual, budget): {over}. The budgets are ceilings and there is no "
+        "route to raise one — write the body, or mark the test skipped with a "
+        "reason (#15189)."
+    )
+    drained = sorted(tree for tree in _EMPTY_BODIED if not empty.get(tree))
+    assert not drained, (
+        f"{drained} no longer contain an empty-bodied test — delete the entry "
+        "from _EMPTY_BODIED so the tree is pinned at zero by derivation. A "
+        "budget left behind after the work is done is spendable, and it will "
+        "be spent."
+    )
+    spent = {
+        tree: (len(empty.get(tree, [])), budget)
+        for tree, (budget, _) in _EMPTY_BODIED.items()
+        if len(empty.get(tree, [])) < budget
+    }
+    assert not spent, (
+        "these trees are now BELOW their recorded budget (actual, budget): "
+        f"{spent}. Lower the number here in the same commit, or the tests a fix "
+        "removed can be spent back inside a stale tolerance."
+    )
+
+
+def test_the_detector_finds_an_empty_body_and_spares_a_real_one() -> None:
+    """Self-test. Every branch is exercised, not merely described above.
+
+    The second half is the one that matters most: this guard is worth having
+    only if it leaves real tests alone, because an over-flagging guard is a
+    guard somebody switches off, and that is worse than the blindness.
+    """
+    assert empty_bodies("def test_a():\n    pass\n") == [("test_a", 1)]
+    assert empty_bodies('def test_a():\n    """Checks the thing."""\n') == [("test_a", 1)]
+    assert empty_bodies("def test_a():\n    ...\n") == [("test_a", 1)]
+    assert empty_bodies('def test_a():\n    print("✅ imports fine")\n') == [("test_a", 1)]
+    assert empty_bodies(
+        'def test_a():\n    """Doc."""\n    pass\n    print("✅ six imports")\n'
+    ) == [("test_a", 1)], "the #15189 shape itself: docstring, pass, and prints"
+    assert empty_bodies("class TestX:\n    def test_a(self):\n        pass\n")
+    assert empty_bodies("async def test_a():\n    pass\n") == [("test_a", 1)]
+
+    # Spared, and each for a different reason.
+    assert not empty_bodies(
+        "def test_a():\n    subject()\n"
+    ), "a call is a real check — it can raise, which is a thin assertion but a real one"
+    assert not empty_bodies(
+        "def test_a():\n    assert subject()\n"
+    ), "an assertion is a body"
+    assert not empty_bodies(
+        'def test_a():\n    """Doc."""\n    reporter.print("x")\n'
+    ), "an attribute call is somebody's method, not the no-op builtin"
+    assert not empty_bodies(
+        "def test_a():\n    with pytest.raises(ValueError):\n        subject()\n"
+    ), "a with-block runs its body"
+    assert not empty_bodies(
+        "def test_a():\n    return True\n"
+    ), "a returning test is the sibling guard's subject, not this one's"
+    assert not empty_bodies(
+        "import pytest\n\n\n@pytest.fixture\ndef test_a():\n    pass\n"
+    ), "a fixture that yields nothing is still a fixture"
+    assert not empty_bodies(
+        "class Helper:\n    def test_a(self):\n        pass\n"
+    ), "pytest does not collect a method of a non-Test class"
+    for marker in ("skip", 'skipif(True, reason="x")', "xfail"):
+        assert not empty_bodies(
+            f"import pytest\n\n\n@pytest.mark.{marker}\ndef test_a():\n    pass\n"
+        ), f"`{marker}` declares the test does not run — that is honest, not misleading"
+    assert empty_bodies(
+        "import pytest\n\n\n@pytest.mark.asyncio\nasync def test_a():\n    pass\n"
+    ), "an unrelated marker does not excuse an empty body — asyncio still runs it"

--- a/repo_tests/tests_that_return_instead_of_asserting_test.py
+++ b/repo_tests/tests_that_return_instead_of_asserting_test.py
@@ -225,8 +225,14 @@ _KNOWN_OFFENDERS = {
     # A number here may be raised again ONLY on the same terms: the detector got
     # stricter, and the delta is enumerated in this comment. Fixing tests still
     # requires no permission at all.
+    # 127 -> 121 with #15189: the three swallowing driver functions in
+    # shared/scripts/test_configuration.py lost their `except Exception:
+    # return False` wrappers, so their assertions propagate. Each still returns
+    # True for the module's own main(), but a test with a LIVE assertion is
+    # exempt by the rule above — removing six swallowed returns from this
+    # ceiling took nothing away from what is enforced.
     "autobot-backend": (86, 18000),
-    "autobot-infrastructure": (127, 250),
+    "autobot-infrastructure": (121, 250),
     "autobot-npu-worker": (7, 150),
 }
 
@@ -245,9 +251,19 @@ _KNOWN_OFFENDERS = {
 # tolerate an error, catch the specific exception it tolerates; if it is meant
 # to report one, `pytest.fail(...)` or `raise` in the handler, both of which
 # this guard already recognises as reporting rather than swallowing.
+#
+# 9 -> 5 with #15189, and `autobot-infrastructure` deleted rather than left at
+# zero: three driver functions in shared/scripts/test_configuration.py and
+# `test_secrets_service_config_migration` in autobot-backend/config/
+# config_migration_integration_test.py were unwrapped, and every assertion each
+# one holds now reaches pytest. The five that remain are named in #15189 and
+# left deliberately: config/config_consolidation_p2_test.py (one 200-line
+# driver function) and four scenario-report methods in tests/integration/
+# test_causal_framework_integration.py that catch AssertionError into a
+# dataclass an aggregator consumes. Both need the restructuring #15166 did for
+# the sibling file, not an unwrap.
 _SWALLOWED_ASSERTIONS = {
-    "autobot-backend": (6, 18000),
-    "autobot-infrastructure": (3, 250),
+    "autobot-backend": (5, 18000),
 }
 
 # Floors under the whole population. A sweep that has silently stopped matching


### PR DESCRIPTION
## Thinking Path

#15189 asked for three sweeps. Running them was only possible after #15195 landed as `c5306fe85`, because until then the AST guard treated an `assert` that was *present* as one that could *fire* — so nine of the ten functions that started this issue read as defended.

The merged detector was read first and **called, not re-implemented**. `repo_tests/collected_test_model` already owns "what pytest collects" and "can this assertion fire"; the third sweep is a third question asked of the same model, so it is a new function in that module rather than a second AST walk. Re-implementing the walk is how #14927 and #15018 happened.

The third shape needed a definition narrow enough to survive contact with 27,000 tests. The rule chosen is the strictest one that still catches `test_migrated_files_import`: **every** statement in the body is a no-op — `pass`, `...`, a bare string, or a bare-name `print(...)`. One statement that calls anything and the function is out of scope, because "it does not raise" is a thin assertion but a real one. A test declaring `@pytest.mark.skip`/`skipif`/`xfail` is honest about not running and is not the subject. An over-flagging guard gets switched off, which is worse than the blindness.

Counts were taken before anything was touched, and only the cheap, unambiguous conversions were made. What was left is named below with the reason.

## What Changed

**Sweep counts, measured on this branch before any fix:**

| Sweep | Detector | Before | After |
|---|---|---|---|
| 1 — assert neutralised by a swallowing handler | `swallowed_assertions_in` (#15195) | **9** functions / 5 files / 2 trees | **5** |
| 2 — test returns a value instead of asserting | `_offending_returns` (#14920) | **220** returns / 3 trees | **214** |
| 3 — test body executes nothing | *new*, `empty_bodies_in` | **11** functions / 3 files / 1 tree | 11 (ratcheted) |

Per tree — sweep 1 before: `autobot-backend` 6, `autobot-infrastructure` 3. Sweep 2 before: `autobot-backend` 86, `autobot-infrastructure` 127, `autobot-npu-worker` 7. Sweep 3: `autobot-backend` 11, every other tree zero.

**New detector.** `repo_tests/collected_test_model.py` gains `does_nothing`, `is_declared_not_running`, `empty_bodies` and `empty_bodies_in`. No ratchet and no budget, matching the module's existing contract.

**New guard.** `repo_tests/tests_that_execute_nothing_test.py` — a per-tree down-only ratchet pinned at the measured 11, every other tree pinned at zero by derivation, a population floor so a collapsed walk cannot read as a drained tree, and a self-test that exercises every flagging branch **and** every sparing branch.

**Four tests converted**, each of which now holds an assertion that reaches pytest:

* `autobot-backend/config/config_migration_integration_test.py:87` `test_secrets_service_config_migration` — assertions moved out from under `except Exception: pass`.
* `autobot-infrastructure/shared/scripts/test_configuration.py` — `test_config_values`, `test_config_manager`, `test_config_validation` lost their `try: … except Exception: return False` wrappers. The driver contract is unchanged: `main()` already wraps every call in its own handler and records a crash as a failed test, so the verdict is identical and the traceback is no longer discarded.

**Ratchets lowered, never raised.** `_SWALLOWED_ASSERTIONS`: `autobot-backend` 6 → 5, and `autobot-infrastructure` **deleted** rather than left at zero. `_KNOWN_OFFENDERS["autobot-infrastructure"]`: 127 → 121 — those six returns stopped being counted because the assertions beside them became live, which is the guard's own exemption rule, not a weakening of it. `tests_that_return_instead_of_asserting_test.py` finishes at **599** lines, under `MAX_LINES = 600`, with no `KNOWN_LARGE` entry added.

**Left deliberately, and why.** Five swallowing sites remain: `autobot-backend/config/config_consolidation_p2_test.py:202` (one 200-line function with ten `try/assert/except` sections — the same restructuring #15166 did for its sibling `cache_consolidation_p4_test.py`, and its own piece of work), and four `*_full_pipeline` methods at `autobot-backend/tests/integration/test_causal_framework_integration.py:152,394,707,937` that catch `AssertionError` into a scenario dataclass a report aggregator consumes. All eleven empty-bodied tests remain: each needs a real integration test written against a live endpoint or a real `KnowledgeBase`. Half-converting a population is how a ratchet gets stuck, so all sixteen are recorded under a down-only ceiling instead.

## Verification

**Guards, after the change** — `repo_tests/tests_that_return_instead_of_asserting_test.py`, `repo_tests/tests_that_execute_nothing_test.py`, `repo_tests/collected_test_model_test.py`: 21 passed. `repo_tests/python_file_size_ratchet_test.py`: 31 passed.

**Contrast mutation 1 — the converted test now fails when its subject breaks.** `ConfigManager.set` was mutated to store the wrong value, then reverted from a pristine copy confirmed with `diff -q`:

| Subject | Test | Result |
|---|---|---|
| unmutated | converted | `1 passed` |
| **mutated** | **converted** | `1 failed` — `AssertionError: assert 'MUTATED' == 'test_secrets_key'` |
| **mutated** | original (swallowing) | **`1 passed`** |

The third row is the point: the same broken subject, and the pre-fix test reports green.

**Contrast mutation 2 — the driver's swallow was hiding a real break.** Same file, run directly:

* before: `7 passed, 7 warnings` (every one a `PytestReturnNotNoneWarning`)
* after: `3 failed, 4 passed`

The three failures are pre-existing and are recorded as a finding below, not introduced here.

**Contrast mutation 3 — the new guard catches the shape.** A planted `def test_planted_empty_body(): pass` + `print("✅ subject verified")` in `autobot_shared/` (a tree pinned at zero by derivation) fails the guard by name:

```
E   autobot_shared/planted_probe_15189_test.py:1 test_planted_empty_body
E   assert not {'autobot_shared': [...]}
1 failed, 4 passed
```

**Counter-mutation — the guards spare legitimate code.** A probe file in the same clean tree holding a `try/except ValueError` that `pytest.skip`s, a `try/except Exception` that re-raises, a thin smoke test that only calls its subject, and a `@pytest.mark.skip` test with an empty body: **13 passed**, nothing flagged by either guard. The same shapes are pinned as synthetic cases in the new guard's self-test, so the sparing branches are proven rather than described.

**AC 6 — was `cache_consolidation_p4_test.py` ever exempted?** No, and nothing suppressed the warning either. It appears in no skip, ignore or exemption list anywhere in the repository; its only two mentions outside itself are a path mapping in `scripts/migrate_tests.py:161` and a historical note in the ratchet. `pytest.ini` has **no `filterwarnings` section at all**, its `norecursedirs` covers only VCS and build directories, and `addopts` ignores only `autobot-slm-backend/ansible` and `autobot-npu-worker/resources`. The warning was emitted into a green run for its whole life and nothing was configured to catch it.

**What could not be verified.** Every run above is local, on an interpreter **90 of 206 declared dependency floors below CI** — the suite prints that banner itself. These runs demonstrate the *shape* of each guard and each fix; CI is the authority on whether they pass where they ship. The AC asking to "show CI fails" on a reintroduced swallowing test is met only to the extent that the planted probe fails the guard locally; no deliberately-red commit was pushed to prove it in CI. `filterwarnings = error::pytest.PytestReturnNotNoneWarning` remains off, correctly: 214 returns are still in the tree, and 121 of them are in a tree no pytest invocation collects, so the config would report clean while more than half the population sat outside its reach.

**Feasibility of detecting the third shape:** confirmed and cheap. 74 lines in the shared model, driven off the collection model that already existed, and the population is 11 in a single tree. The reason it was never measured is that nobody had asked the question, not that it was hard.

## Model Used

Claude Opus 5 (1M context)

Refs #15189 — not `Closes`. Two criteria are short: the contrast mutation is demonstrated locally rather than as an observed CI failure, and the sixteen remaining sites (5 swallowing + 11 empty-bodied) are measured and ratcheted down-only rather than converted.
