### PR TITLE
test(guard): make the with_error_handling guard scan the tree it claims (#15202)

### DIFF
--- a/repo_tests/with_error_handling_single_definition_test.py
+++ b/repo_tests/with_error_handling_single_definition_test.py
@@ -18,13 +18,70 @@ now-renamed ``with_default_on_error``) looking for ``FunctionDef``/
 the canonical decorator in ``decorators.py`` may define it; a second
 definition anywhere else — under any name that happens to collide — fails
 this test with the offending file:line, whether or not it is ever imported.
+
+WHAT "THE TRACKED TREE" MEANS HERE (#15202 item 1)
+--------------------------------------------------
+It used to mean ``autobot-backend/`` alone, while this docstring and
+``test_exactly_one_definition_exists_in_the_tracked_tree`` both said *tracked
+tree*. A fork landing in ``autobot_shared/``, ``autobot-slm-backend/``,
+``scripts/`` or ``tools/`` — all of which import from the backend and all of
+which are places a decorator plausibly gets copied to — was outside the scan
+while inside the claim. The scan was widened rather than the claim narrowed:
+the name collision #14191 is about is a *repository* property, and a fork one
+directory outside ``autobot-backend/`` is exactly as ambiguous at an import
+site as one inside it.
+
+"Tracked" is now literal. ``_tracked_sources`` walks from ``_REPO`` and then
+keeps only paths ``git ls-files`` reports, for two measured reasons:
+
+* The walk alone is checkout-dependent. In the mandated
+  ``<main-tree>/.worktrees/<branch>/`` layout the main checkout carries 2,911
+  untracked ``.py`` files under ``.claude/worktrees/`` and a fresh clone
+  carries none, so the population — and worse, the offender set — would depend
+  on which machine ran the guard. Someone's half-finished scratch fork of this
+  very decorator is not a defect in the tracked tree.
+* ``git ls-files`` alone would make most of ``_SKIP_PARTS`` unreachable and
+  would give up the directory pruning, which is load-bearing: the main
+  checkout holds 416,065 ``.py`` files under ``.worktrees/``.
+
+Measured: 3,099 sources, identical in the main checkout and in a fresh
+worktree.
+
+UNPARSEABLE IS AN UNKNOWN, NOT AN ABSENCE (#15202 item 3)
+----------------------------------------------------------
+``_defines_target`` used to catch ``SyntaxError``/``UnicodeDecodeError`` and
+return ``[]``, so a file too broken to parse contributed no definitions and the
+one-definition assertion passed straight over it. A half-committed fork is
+precisely the kind of file that does not parse, which made the swallow blindest
+where the guard most needed to see. #14975 settled the precedent the other way
+(a file the size gate could not read became a violation, not a pass) and PR
+#15249 applied it to a sibling repo guard.
+
+So ``_defines_target`` raises, ``_scan_for_definitions`` records the file in a
+second list, and ``test_no_tracked_source_is_unreadable_by_this_guard`` fails on
+it. ``_KNOWN_UNPARSEABLE`` is the down-only hatch and is **deliberately empty** —
+measured at 0 unreadable of 3,099 — so failing loudly costs nothing today, and
+an entry there would be an admission that a tracked source does not parse,
+which is its own defect.
+
+THE POPULATION FLOOR (#15202 item 4)
+-------------------------------------
+The floor exists so a filter that has started eating the tree fails as a defect
+in this file instead of reporting a clean codebase. It was ``> 100`` against
+2,308 real files — 23x slack, which only catches total collapse, while #15121
+was a filter eating the tree and a *partial* version of it would have sailed
+through. ``_SOURCE_FLOOR`` now sits just under the measured population, and
+``test_the_floor_has_not_decayed_into_slack`` caps how far the population may
+outgrow it so the slack cannot silently return.
 """
 
 from __future__ import annotations
 
 import ast
+import os
+import subprocess
 from pathlib import Path
-from typing import List, Set
+from typing import Dict, FrozenSet, List, Set, Tuple
 
 import pytest
 
@@ -42,36 +99,102 @@ _TARGET_NAME = "with_error_handling"
 # under any directory of that name. Same form as
 # `first_party_imports_resolve_test.py:33` and
 # `shell_lib_sources_resolve_test.py:58`.
+#
+# #15202 item 2: `.worktrees` was an unreachable entry while the scan root was
+# `autobot-backend/` -- no path relative to that root can carry it. Scanning
+# from `_REPO` (as #15121's AC1 specified) makes it reachable and load-bearing:
+# the main checkout keeps 85 worktrees holding 416,065 `.py` files directly
+# under `<repo>/.worktrees/`, each a full copy of this tree with its own
+# `decorators.py`. `test_a_worktrees_directory_under_the_scan_root_is_pruned`
+# pins that, so the entry can never go back to doing nothing unnoticed.
 _SKIP_PARTS = {"node_modules", ".worktrees", "tests", "__pycache__", "venv", ".venv"}
 
 # The one file allowed to define it. Anything else defining a function or
 # async function with this exact name is the fork this test exists to catch.
 _CANONICAL_DEFINER = (_BACKEND / "utils" / "error_boundaries" / "decorators.py").resolve()
 
+# Trees the widened scan must keep reaching. Narrowing the scan back to
+# `autobot-backend/` -- the #15202 item 1 regression -- empties these without
+# moving the floor much, so the floor alone would not catch it.
+_TREES_THAT_MUST_BE_SCANNED = ("autobot_shared", "autobot-slm-backend", "scripts", "tools")
+
+#: Population floor for the tracked scan. Measured at 3,099 sources; the floor
+#: sits 149 below that. For scale, the largest number of `.py` files deleted by
+#: any single merge in the last 300 first-parent commits is 3, so ordinary churn
+#: has ~50x headroom, while losing any one of the four trees above (217, 175,
+#: 55, 22 files) or any comparable subtree fails. RATCHET: raise it when the
+#: population genuinely grows; lower it only with a stated reason.
+_SOURCE_FLOOR = 2950
+
+#: How far the population may outgrow the floor before the floor is stale. The
+#: floor started at 100 against 2,308 files -- 23x slack -- which is how it
+#: stopped meaning anything. At 1.5x it can never decay that far again, while
+#: still allowing 43% growth before anyone has to touch it.
+_MAX_FLOOR_SLACK = 1.5
+
+#: Tracked sources that do not parse, and are therefore inspected blind. Empty
+#: on purpose: measured at 0 of 3,099. Down-only -- an entry here is a statement
+#: that a tracked source is syntactically broken, which is a defect to fix, not
+#: to waive. Same discipline as `KNOWN_UNPARSEABLE` in
+#: `test_module_path_anchors_15181_test.py` (PR #15249).
+_KNOWN_UNPARSEABLE: FrozenSet[str] = frozenset()
+
 
 def _production_sources(root: Path = _BACKEND) -> List[Path]:
-    """Backend .py files, excluding tests, node_modules and worktree copies.
+    """Non-test .py files under `root`, excluding `_SKIP_PARTS` directories.
 
     `root` is a parameter so the exclusion logic can be exercised against a
     fixture tree that itself lives under `.worktrees/` -- the arrangement this
     scan silently erased before #15121.
+
+    Pruning `dirnames` in place is the same rule as testing the parts of the
+    path relative to `root`, applied one level earlier: a directory whose name
+    is in `_SKIP_PARTS` is never descended into. Names *above* `root` are never
+    looked at, which is the prefix-invariance #15140 asked for, and the pruning
+    is what keeps a scan rooted at `_REPO` affordable in a checkout that holds
+    hundreds of thousands of worktree copies.
     """
     out: List[Path] = []
-    for path in root.rglob("*.py"):
-        if path.name.endswith("_test.py") or path.name.startswith("test_"):
-            continue
-        if any(part in _SKIP_PARTS for part in path.relative_to(root).parts):
-            continue
-        out.append(path)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in _SKIP_PARTS]
+        for name in filenames:
+            if not name.endswith(".py"):
+                continue
+            if name.endswith("_test.py") or name.startswith("test_"):
+                continue
+            out.append(Path(dirpath) / name)
     return out
 
 
+def _tracked_paths(root: Path = _REPO) -> Set[Path]:
+    """Absolute paths of every file git tracks under `root`."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {root / relative for relative in listing.split("\0") if relative}
+
+
+def _tracked_sources() -> List[Path]:
+    """Every tracked, non-test .py file in the repository -- the guard's real scan.
+
+    See "WHAT THE TRACKED TREE MEANS HERE" above for why both halves are here.
+    """
+    tracked = _tracked_paths()
+    return [path for path in _production_sources(_REPO) if path in tracked]
+
+
 def _defines_target(path: Path) -> List[int]:
-    """Return line numbers where `path` defines a (async) function named _TARGET_NAME."""
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except (SyntaxError, UnicodeDecodeError):
-        return []
+    """Line numbers where `path` defines a (async) function named _TARGET_NAME.
+
+    Raises rather than reporting an absence when the file cannot be read or
+    parsed (#15202 item 3). Callers that sweep many files use
+    `_scan_for_definitions`, which records the failure instead of dropping it.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
 
     lines = []
     for node in ast.walk(tree):
@@ -80,7 +203,32 @@ def _defines_target(path: Path) -> List[int]:
     return lines
 
 
-def test_the_scan_sees_the_tree_it_is_pointed_at():
+def _scan_for_definitions(sources: List[Path]) -> Tuple[Dict[Path, List[int]], List[Tuple[Path, str]]]:
+    """(definers, unreadable). A source that cannot be parsed lands in the second list."""
+    definers: Dict[Path, List[int]] = {}
+    unreadable: List[Tuple[Path, str]] = []
+    for path in sources:
+        try:
+            hits = _defines_target(path)
+        except (SyntaxError, UnicodeDecodeError, ValueError, OSError) as failure:
+            unreadable.append((path, f"{type(failure).__name__}: {failure}"))
+            continue
+        if hits:
+            definers[path.resolve()] = hits
+    return definers, unreadable
+
+
+@pytest.fixture(scope="module")
+def tracked_sources() -> List[Path]:
+    return _tracked_sources()
+
+
+@pytest.fixture(scope="module")
+def scan_result(tracked_sources) -> Tuple[Dict[Path, List[int]], List[Tuple[Path, str]]]:
+    return _scan_for_definitions(tracked_sources)
+
+
+def test_the_scan_sees_the_tree_it_is_pointed_at(tracked_sources):
     """A guard that skipped every file would report clean, not report a skip.
 
     Split out from the assertion below so the two failures read differently:
@@ -88,13 +236,41 @@ def test_the_scan_sees_the_tree_it_is_pointed_at():
     "with_error_handling vanished" is a defect in the code under guard. Before
     #15121 the first masqueraded as the second in every worktree checkout.
     """
-    sources = _production_sources()
-
-    assert len(sources) > 100, (
-        f"only {len(sources)} backend sources survived the exclusion filter — "
-        "the filter is eating the tree, so every assertion below is vacuous"
+    assert len(tracked_sources) >= _SOURCE_FLOOR, (
+        f"only {len(tracked_sources)} tracked sources survived the exclusion filter, "
+        f"below the recorded floor of {_SOURCE_FLOOR} — the filter is eating the tree, "
+        "so every assertion below is vacuous"
     )
-    assert _CANONICAL_DEFINER in {path.resolve() for path in sources}
+    assert _CANONICAL_DEFINER in {path.resolve() for path in tracked_sources}
+
+
+def test_the_floor_has_not_decayed_into_slack(tracked_sources):
+    """#15202 item 4: a floor far below the population stops catching anything.
+
+    The floor is only proportional while someone raises it. This caps the drift
+    at `_MAX_FLOOR_SLACK` so it cannot quietly return to the 23x it had.
+    """
+    ceiling = int(_SOURCE_FLOOR * _MAX_FLOOR_SLACK)
+    assert len(tracked_sources) <= ceiling, (
+        f"the tree has grown to {len(tracked_sources)} sources against a floor of "
+        f"{_SOURCE_FLOOR} — raise `_SOURCE_FLOOR` to just under the new population. "
+        "This is not a defect in the codebase; it is the floor going stale."
+    )
+
+
+@pytest.mark.parametrize("tree", _TREES_THAT_MUST_BE_SCANNED)
+def test_the_scan_reaches_every_tree_the_docstring_claims(tracked_sources, tree):
+    """#15202 item 1: the scan must cover what its name and docstring promise.
+
+    Pinned per tree rather than by count: narrowing the scan back to
+    `autobot-backend/` loses 787 of 3,099 sources, which the floor would catch,
+    but losing `scripts/` alone (22 files) it would not.
+    """
+    scanned = {path.relative_to(_REPO).parts[0] for path in tracked_sources}
+    assert tree in scanned, (
+        f"no source under {tree}/ reached the scan — the guard is back to inspecting "
+        "one tree while its name and docstring claim the tracked tree (#15202)"
+    )
 
 
 def _write_fixture_tree(root: Path) -> Path:
@@ -137,6 +313,29 @@ def test_a_checkout_under_worktrees_is_still_scanned(tmp_path):
     assert _defines_target(definer) == [1]
 
 
+def test_a_worktrees_directory_under_the_scan_root_is_pruned(tmp_path):
+    """#15202 item 2: the `.worktrees` entry must be able to match something.
+
+    Rooted at the repository (as #15121's AC1 specified) the entry is reachable
+    and load-bearing — the main checkout keeps whole copies of this tree under
+    `<repo>/.worktrees/`, each with its own `with_error_handling`. Fixture-based
+    rather than layout-dependent, so the entry stays pinned in a checkout that
+    happens to have no worktrees of its own.
+    """
+    root = tmp_path / "checkout"
+    definer = _write_fixture_tree(root / "autobot-backend")
+    fork = root / ".worktrees" / "issue-9999" / "autobot-backend" / "utils" / "error_boundaries"
+    fork.mkdir(parents=True)
+    (fork / "decorators.py").write_text(f"def {_TARGET_NAME}():\n    pass\n", encoding="utf-8")
+
+    scanned = _production_sources(root)
+
+    assert scanned == [definer], (
+        "a copy of the tree under .worktrees/ was scanned as if it were the tree — "
+        "every worktree in the mandated layout would report itself as a fork"
+    )
+
+
 @pytest.mark.parametrize("ancestor", sorted(_SKIP_PARTS))
 def test_an_excluded_name_above_the_scan_root_changes_nothing(tmp_path, ancestor):
     """#15140: the filter must be prefix-invariant for *every* skipped name.
@@ -163,12 +362,8 @@ def test_an_excluded_name_above_the_scan_root_changes_nothing(tmp_path, ancestor
     )
 
 
-def test_exactly_one_definition_exists_in_the_tracked_tree():
-    definers = {}
-    for path in _production_sources():
-        hits = _defines_target(path)
-        if hits:
-            definers[path.resolve()] = hits
+def test_exactly_one_definition_exists_in_the_tracked_tree(scan_result):
+    definers, _unreadable = scan_result
 
     assert definers, f"{_TARGET_NAME} vanished from its canonical module — this guard expects it to exist"
 
@@ -181,6 +376,55 @@ def test_exactly_one_definition_exists_in_the_tracked_tree():
         "shared name with different behaviour produced a wrong analysis in PR "
         "#14186."
     )
+
+
+def test_no_tracked_source_is_unreadable_by_this_guard(scan_result):
+    """#15202 item 3: an unparseable file is an unknown, not an absence."""
+    _definers, unreadable = scan_result
+    offenders = [
+        f"{path.relative_to(_REPO)}  ->  {reason}"
+        for path, reason in unreadable
+        if str(path.relative_to(_REPO)) not in _KNOWN_UNPARSEABLE
+    ]
+    assert not offenders, (
+        "These tracked sources could not be parsed, so this guard saw NONE of their "
+        f"definitions and scored them clean without reading them. A half-committed "
+        f"fork of {_TARGET_NAME} is exactly the kind of file that does not parse — "
+        "fix it, or add it to _KNOWN_UNPARSEABLE with a reason:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_unparseable_hatch_is_down_only_and_still_earned(scan_result):
+    _definers, unreadable = scan_result
+    still_unreadable = {str(path.relative_to(_REPO)) for path, _reason in unreadable}
+    stale = _KNOWN_UNPARSEABLE - still_unreadable
+    assert not stale, f"these sources parse again and must leave _KNOWN_UNPARSEABLE: {sorted(stale)}"
+    assert not _KNOWN_UNPARSEABLE, (
+        "_KNOWN_UNPARSEABLE was empty when this guard was written and is down-only. "
+        "A tracked source that does not parse is a defect to fix, not to list."
+    )
+
+
+def test_an_unparseable_source_is_recorded_rather_than_scored_clean(tmp_path):
+    """The swallow this replaced would have reported this fixture as definition-free.
+
+    The fixture carries a real definition *and* a syntax error, so it cannot
+    reach the `unreadable` list for want of anything to find: strip the broken
+    line and the same text yields exactly one definition.
+    """
+    broken = tmp_path / "fork.py"
+    broken.write_text(f"def {_TARGET_NAME}():\n    pass\ndef (\n", encoding="utf-8")
+    intact = tmp_path / "intact.py"
+    intact.write_text(f"def {_TARGET_NAME}():\n    pass\n", encoding="utf-8")
+
+    with pytest.raises(SyntaxError):
+        _defines_target(broken)
+    assert _defines_target(intact) == [1]
+
+    definers, unreadable = _scan_for_definitions([broken, intact])
+    assert list(definers) == [intact.resolve()]
+    assert [path for path, _reason in unreadable] == [broken]
+    assert unreadable[0][1].startswith("SyntaxError")
 
 
 def test_the_canonical_definer_defines_it_exactly_once():
@@ -200,9 +444,7 @@ def test_the_renamed_sibling_no_longer_shares_the_name():
     )
 
     tree = ast.parse(renamed_module.read_text(encoding="utf-8"))
-    defined = {
-        node.name for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    }
+    defined = {node.name for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))}
     assert "with_default_on_error" in defined, (
         f"{renamed_module.relative_to(_REPO)} lost with_default_on_error — "
         "never-delete: it must be renamed, not removed."


### PR DESCRIPTION
Closes #15202

## Thinking Path

Four gaps between what this guard's name, docstring and test names promise and what it checks. Taken one at a time, with the widening/narrowing choice made explicitly rather than by default.

**Item 1 — the scan was widened, not the claim narrowed.** `_production_sources()` enumerated `autobot-backend/` alone while the docstring and `test_exactly_one_definition_exists_in_the_tracked_tree` both said *tracked tree*. The name collision #14191 is about is a repository property: a fork in `autobot_shared/` is exactly as ambiguous at an import site as one inside the backend, and those trees import from the backend, so a copied decorator lands there first. Narrowing the claim would have been cheaper and would have left the real gap open.

"Tracked" is now literal — a walk from `_REPO` intersected with `git ls-files`. Both halves earn their place, measured:

* Walk alone is checkout-dependent. The main checkout carries **2,911 untracked `.py` files** under `.claude/worktrees/`; a fresh clone carries none. The population, and worse the offender set, would depend on which machine ran the guard, and someone's half-finished scratch fork of this decorator is not a defect in the tracked tree.
* `git ls-files` alone gives up the directory pruning, which is load-bearing: the main checkout holds **416,065 `.py` files** under `.worktrees/`.

Measured at **3,099 sources, identical in the main checkout and in a fresh worktree**.

**Item 2 — the `.worktrees` exclusion became reachable rather than being deleted.** The filter now runs from `_REPO`, which is what #15121's AC1 specified; the implementation had used `root`. At the repository root the entry is not merely reachable but load-bearing — the mandated layout puts whole copies of this tree, each with its own `decorators.py`, directly under `<repo>/.worktrees/`. Without it every worktree would report itself as a fork. `test_a_worktrees_directory_under_the_scan_root_is_pruned` pins it with a fixture rather than with the local layout, so the entry cannot go back to doing nothing unnoticed in a checkout that happens to have no worktrees.

The enumeration moved from `rglob` + a relative-parts test to `os.walk` with in-place `dirnames` pruning. Same rule applied one level earlier: a skipped directory is never descended into. Names *above* the root are still never examined, which is the prefix-invariance #15140 asked for, and the #15121/#15140 fixture tests are unchanged and still green.

**Item 3 — unparseable is an unknown, not an absence.** `_defines_target` caught `SyntaxError`/`UnicodeDecodeError` and returned `[]`, so a file too broken to parse contributed no definitions and the one-definition assertion passed over it. A half-committed fork is precisely the kind of file that does not parse, so the swallow was blindest where the guard most needed to see. Followed PR #15249, which hit this in a new guard and made it raise; #14975 is the older precedent, where a file the size gate could not read became a violation rather than a pass.

`_defines_target` now raises; `_scan_for_definitions` returns `(definers, unreadable)`; `test_no_tracked_source_is_unreadable_by_this_guard` fails on the second list. `_KNOWN_UNPARSEABLE` is the same down-only hatch and is **deliberately empty** — measured at **0 unreadable of 3,099** — and a test fails if it is non-empty, so an entry there has to be argued for.

**Item 4 — the floor is now proportional.** `> 100` against 2,308 files is 23x slack: it catches total collapse and nothing else, while #15121 *was* a filter eating the tree and a partial version of it would have sailed through. `_SOURCE_FLOOR = 2950` sits 149 under the measured 3,099. For scale, the largest number of `.py` files deleted by any single merge in the **last 300 first-parent commits is 3**, so ordinary churn has ~50x headroom while losing any comparable subtree fails.

A floor is only proportional while someone raises it, so `test_the_floor_has_not_decayed_into_slack` caps the drift at 1.5x (fires at 4,425 sources, +43% growth). That is deliberately wide — a band that fired on ordinary growth would be disabled the first time someone added files — but it makes the 23x slack unreachable in future.

The floor alone would not have caught item 1 regressing: narrowing back to `autobot-backend/` loses 787 sources and fails, but losing `scripts/` alone (22 files) would not. So `test_the_scan_reaches_every_tree_the_docstring_claims` pins `autobot_shared`, `autobot-slm-backend`, `scripts` and `tools` by name.

## What Changed

| File | Change |
|---|---|
| `repo_tests/with_error_handling_single_definition_test.py` | Scan widened to the tracked tree (`_tracked_sources` = pruning walk from `_REPO` ∩ `git ls-files`); enumeration moved to `os.walk` with `dirnames` pruning so `.worktrees` is reachable and load-bearing at the repo root; `_defines_target` raises instead of swallowing parse failures, with `_scan_for_definitions` recording unreadable files and an empty down-only `_KNOWN_UNPARSEABLE`; floor `> 100` → `>= 2950` plus a 1.5x staleness cap and a per-tree coverage check |

Tests: 11 → 20 collected. Five new (`test_the_floor_has_not_decayed_into_slack`, `test_the_scan_reaches_every_tree_the_docstring_claims` x4 params, `test_a_worktrees_directory_under_the_scan_root_is_pruned`, `test_no_tracked_source_is_unreadable_by_this_guard`, `test_the_unparseable_hatch_is_down_only_and_still_earned`, `test_an_unparseable_source_is_recorded_rather_than_scored_clean`). None removed. 451 lines, under the 600 ceiling.

## Verification

`20 passed` on the file; `72 passed` across it plus `python_file_size_ratchet_test.py`, `tests_that_return_instead_of_asserting_test.py` and `collection_coverage_test.py`. `black`, `isort` and `flake8` clean.

**Contrast mutation 1 — item 1, a fork planted in a second tree.** `autobot_shared/error_boundary_fork.py` defining `with_error_handling`, `git add`ed so it is tracked:

```
FAILED ...::test_exactly_one_definition_exists_in_the_tracked_tree
E   AssertionError: A second `with_error_handling` definition reappeared outside
    autobot-backend/utils/error_boundaries/decorators.py:
    {PosixPath('<repo>/autobot_shared/error_boundary_fork.py'): [4]}
```

The **pre-change file, same mutation: `11 passed`.** Reverted (`git rm --cached` + `rm`); index diffed clean against the recorded baseline.

**Contrast mutation 2 — item 3, an unparseable fork.** Same path, a real `with_error_handling` definition plus a trailing `def (`:

```
1 failed, 19 passed
FAILED ...::test_no_tracked_source_is_unreadable_by_this_guard
E   AssertionError: These tracked sources could not be parsed, so this guard saw NONE
    of their definitions and scored them clean without reading them...
E       autobot_shared/error_boundary_fork.py  ->  SyntaxError: invalid syntax (<unknown>, line 7)
```

The **pre-change file, same mutation: `11 passed`** — it did not even report the fork, let alone the breakage. Reverted, index clean.

**Contrast mutation 3 — item 4, a *partial* filter breakage.** `"services"` added to `_SKIP_PARTS`, which eats 458 of 3,099 sources (15%) and leaves the rest of the tree intact:

```
1 failed, 20 passed
FAILED ...::test_the_scan_sees_the_tree_it_is_pointed_at
E   AssertionError: only 2641 tracked sources survived the exclusion filter, below the
    recorded floor of 2950 — the filter is eating the tree, so every assertion below is vacuous
```

The **pre-change file with the same breakage: `12 passed`** — 2,308 backend sources minus its `services/` still cleared `> 100` by an order of magnitude. Reverted by the inverse `sed`, `_SKIP_PARTS` confirmed byte-identical to the original line, `20 passed` again.

**Counter-mutation — item 4, ordinary variation must not fire it.** Both directions, exercised on the index so nothing left the disk:

| Probe | Population | Result |
|---|---|---|
| 100 tracked `.py` files removed from the tree | 2,999 | `20 passed` — floor holds (largest real single-merge deletion in 300 commits: 3) |
| 400 new tracked `.py` files added | 3,499 | `20 passed` — staleness cap holds (fires at 4,425) |

Index restored and diffed byte-for-byte against the recorded baseline after each (`INDEX-RESTORED-OK`).

**What could not be verified here.** The local interpreter sits below 90 of 206 declared dependency floors (python 3.10.12), so a local pass carries less information than CI; the numbers above need CI to confirm. The 3,099 measurement was taken on this branch in two checkouts on one machine — CI runs a fresh clone, where the walk and the `git ls-files` intersection should agree exactly, but that has not been observed on a runner. `black --check` reports a pre-existing reformat in a region this PR does not touch (`{node.name for node in ...}` re-joined onto one line); it was applied so the commit is deterministic, and the local `black` warns that python 3.10 cannot run its py312 safety check.

## Model Used

Claude Opus 5 (1M context)
