### PR TITLE
fix(hooks): require a shebang before post-checkout chmods +x (#15253)

### DIFF
--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -45,7 +45,18 @@ fi
 HOOK_SCRIPTS_DIR="$GIT_ROOT/autobot-infrastructure/shared/scripts"
 FIXED=0
 if [ -d "$HOOK_SCRIPTS_DIR" ]; then
+    # Require a shebang as well as the filename match (#15253). The previous filename
+    # patterns matched files that must NOT be executable and chmod'd them on
+    # every checkout, leaving every working tree permanently dirty:
+    #   -name "pre-commit-*"  also matched pre-commit-*_test.py (pytest files)
+    #   -name "*.sh"          also matched hooks/lib/_common.sh (a sourced library)
+    # A leading "#!" is the property that actually justifies the bit. The name
+    # patterns are kept so scope is unchanged: dropping them would pull in 52
+    # further shebang-bearing scripts this hook has never touched, trading one
+    # source of churn for a larger one.
     while IFS= read -r -d '' f; do
+        read -r -n 2 shebang < "$f" 2>/dev/null || continue
+        [ "$shebang" = "#!" ] || continue
         chmod +x "$f"
         FIXED=$((FIXED + 1))
     done < <(find "$HOOK_SCRIPTS_DIR/hooks" "$HOOK_SCRIPTS_DIR/utilities" \


### PR DESCRIPTION
## Thinking Path

`scripts/hooks/post-checkout` selects files to make executable by **filename pattern**. Two
patterns over-match, so on every checkout and every `git worktree add` it sets `+x` on 14 files
that must not have it: 13 `pre-commit-*_test.py` (matched by `pre-commit-*`, but they are pytest
files with no shebang, never invoked directly) and `hooks/lib/_common.sh` (matched by `*.sh`, but
its own line 10 documents `source "$SCRIPT_DIR/lib/_common.sh"`).

Because those bits differ from what git tracks, **every working tree in the repository is
permanently dirty** — 24 mode-only modifications that regenerate as fast as they are reverted.
That defeats the session-lifecycle protocol's "leave nothing uncommitted" precondition, and it
hides real work: a genuine uncommitted documentation fix (now #15250) was sitting unnoticed among
those 24 entries in the shared checkout.

**Approach chosen:** require a `#!` first line *in addition to* the existing name match. A shebang
is the property that actually justifies the executable bit, and it needs no exclusion list to
maintain as files are added.

**Alternative rejected:** replacing the name patterns with shebang detection alone. It reads
cleaner, but measurement showed it pulls **52 additional** shebang-bearing scripts into scope that
this hook has never touched — trading one source of churn for a larger one. Scope is deliberately
left unchanged.

## What Changed

- `scripts/hooks/post-checkout` — added a shebang guard inside the existing loop:

```bash
    while IFS= read -r -d '' f; do
        read -r -n 2 shebang < "$f" 2>/dev/null || continue
        [ "$shebang" = "#!" ] || continue
        chmod +x "$f"
```

The `find` invocation and its name patterns are unchanged, so no file enters scope that was not
already a candidate.

## Verification

Syntax:

```bash
bash -n scripts/hooks/post-checkout   # OK
```

Behaviour — reset every candidate to 644, then run the selection block:

```
selected: 39 | _test.py: 0 (must be 0) | _common.sh: 0 (must be 0)
```

Before this change the same test selected all 40 candidates, including the 13 `_test.py` files and
`_common.sh`.

End-to-end: after merge, `.git/hooks/post-checkout` must be re-installed in existing checkouts
(they carry the old copy), then a fresh `git worktree add` should leave `git status` clean apart
from the 10 genuinely-executable `utilities/*.sh` files whose tracked mode is still `100644`.

## Risks

- **Existing checkouts keep the old hook.** `.git/hooks/post-checkout` is a copy, not a link, so
  every existing clone and worktree continues the old behaviour until re-installed. This PR fixes
  the source; it does not retroactively fix installed copies.
- **The 24 files already chmod'd on disk stay chmod'd.** This stops new occurrences; it does not
  revert what the hook already did. Reverting them is a separate change.
- **10 files remain genuinely mis-tracked** — `utilities/*.sh` with shebangs, executable on disk
  and `100644` in git. Committing those modes is the follow-up noted in #15253, deliberately not
  bundled here so this PR stays a single-purpose fix.
- `read -r -n 2` on a zero-byte file yields a non-zero status and is skipped by `|| continue`;
  binary files cannot match `#!` and are skipped by the equality test.

## Model Used

Claude Opus 5 (claude-opus-5[1m])

## Issue Link

Closes #15253

## Changelog fragment

- [x] N/A — internal tooling fix with no user-facing behaviour change

## Checklist
- [x] Code follows AutoBot patterns from `CLAUDE.md`
- [x] Tests added or updated (N/A — git hook; verified by executing the selection block against the real tree, results above)
- [x] Documentation updated if behavior changed (the rationale is documented in-file, above the loop)
- [x] Pre-commit hooks pass (`git commit` runs them automatically)
- [x] PR targets `Dev_new_gui` (not `main`)
- [x] No secrets or credentials in the diff