### PR TITLE
test(sdk-guard): catch a None-defaulted query parameter no row exercises (#15187)

### DIFF
--- a/repo_tests/conftest.py
+++ b/repo_tests/conftest.py
@@ -1,0 +1,92 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``route_query_params``, shared by ``sdk_request_url_test.py`` and
+``sdk_request_signature_params_test.py`` (#15187).
+
+Lives here rather than in ``sdk_request_shared.py`` alongside the plain
+constants and functions those two files import: pytest finds a fixture by
+scanning ``conftest.py``, not by an import being referenced elsewhere as an
+expression, and the local ``autoflake`` pre-commit hook
+(``.pre-commit-config.yaml``, unscoped to ``repo_tests/``) removes any import
+it cannot see used that way. Importing a fixture by name into a second test
+module for reuse -- the usual way to share one without a ``conftest.py`` --
+would be stripped on the next commit; a fixture defined here needs no import
+in either test module at all.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from autobot_shared.api_routing import router_prefixes as routing
+from repo_tests.sdk_request_shared import _BACKEND, _BACKEND_API_ROOT
+
+#: Backend modules serving the paths ``SDK_REQUESTS`` (``sdk_request_shared.py``)
+#: names. Only these are imported, so the oracle costs one small app rather
+#: than the whole backend.
+#:
+#: This list cannot go stale unnoticed: the app built from it is asked for every
+#: path in ``SDK_REQUESTS``, so a module missing here shows up as a path the spec
+#: does not contain, and ``test_every_sdk_request_path_is_in_the_query_oracle``
+#: (``sdk_request_url_test.py``) fails naming it.
+SERVING_MODULES: tuple[str, ...] = (
+    "api.agent",
+    "api.agent_config",
+    "api.analytics",
+    "api.chat_sessions",
+    "api.knowledge",
+    "api.knowledge_search",
+)
+
+
+@pytest.fixture(scope="module")
+def route_query_params() -> dict[tuple[str, str], frozenset[str]]:
+    """``(METHOD, path template) -> declared query parameter names``.
+
+    Built through ``fastapi.openapi.utils.get_openapi`` on an app that mounts the
+    modules above exactly as ``app_factory`` mounts them -- ``/api`` + the prefix
+    ``initialization/router_registry`` gives that module. Deliberately **not** a
+    walk over ``router.routes``: from ``fastapi>=0.139`` ``include_router`` records
+    an opaque wrapper instead of copying the child's routes onto the parent, so a
+    flat walk finds almost nothing and every assertion over it passes vacuously.
+    CI pins 0.141.1 and a development checkout may resolve below 0.139, so a local
+    pass would prove nothing about the runner (#15091, #15093). ``get_openapi`` is
+    the view FastAPI itself serves ``/openapi.json`` from and answers the same on
+    both shapes.
+
+    The mount prefixes are read from the registry rather than written here, so a
+    router that moves is followed rather than silently mismatched.
+
+    ``scope="module"``: each test module that requests this fixture builds its
+    own copy (this file is now shared by two), rather than the one build the
+    single original file used to get -- a small, deliberate cost of the split.
+    """
+    registry = dict(routing.registry_entries(_BACKEND / "initialization" / "router_registry"))
+    assert registry, "the router registry parsed no entries -- the oracle below would have nothing to mount"
+
+    app = FastAPI()
+    for module_path in SERVING_MODULES:
+        assert module_path in registry, f"{module_path} is not mounted by initialization/router_registry"
+        app.include_router(
+            importlib.import_module(module_path).router, prefix=f"{_BACKEND_API_ROOT}{registry[module_path]}"
+        )
+
+    spec = get_openapi(title="sdk-request-oracle", version="1", routes=app.routes)
+    declared: dict[tuple[str, str], frozenset[str]] = {}
+    for path, operations in spec.get("paths", {}).items():
+        for verb, operation in operations.items():
+            names = {p["name"] for p in operation.get("parameters", []) if p.get("in") == "query"}
+            declared[(verb.upper(), path)] = frozenset(names)
+
+    assert declared, "the oracle enumerated no routes at all; every assertion below would pass vacuously"
+    assert any(names for names in declared.values()), (
+        "no route in the oracle declares a single query parameter. Either the mounted set is wrong or "
+        "the parameter extraction is -- an oracle where everything accepts nothing cannot detect a wrong name."
+    )
+    return declared

--- a/repo_tests/sdk_request_shared.py
+++ b/repo_tests/sdk_request_shared.py
@@ -1,0 +1,143 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""The pinned SDK request table and wire-capture harness shared by
+``sdk_request_url_test.py`` and ``sdk_request_signature_params_test.py``.
+
+Split out of ``sdk_request_url_test.py`` (#15187) once the signature-derived
+query-parameter guard pushed that file past the 600-line cap
+(``scripts/check_python_file_size.py``). ``SDK_REQUESTS`` is the single
+pinned list of every request the SDK can make; both files assert against it,
+and duplicating it would let the two copies drift -- exactly the failure
+mode #15119's guard exists to prevent. ``route_query_params`` stays in
+``conftest.py`` rather than here: it is a fixture, and the local
+``autoflake`` pre-commit hook (``.pre-commit-config.yaml``, unscoped to
+``repo_tests/``) strips an import it cannot see referenced as an expression,
+which is exactly how a fixture *reused* across test files (rather than
+defined by ``@pytest.fixture`` where pytest finds it) would be imported.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import httpx
+from autobot_sdk import AutoBot
+
+_REPO = Path(__file__).resolve().parents[1]
+_BACKEND = _REPO / "autobot-backend"
+_BASE = "http://backend.test:9999"
+
+# The BACKEND's API root, stated here independently of the SDK. If the oracle
+# in ``conftest.py`` read ``autobot_sdk.API_PREFIX`` instead, dropping the
+# prefix from the SDK would move the route table with it and every assertion
+# would still pass -- the mutation would have deleted its own detector.
+# ``sdk_request_url_test.py``'s ``test_the_api_root_is_the_one_the_application_factory_mounts``
+# anchors this constant to app_factory.py, and its
+# ``test_the_sdk_uses_the_backend_api_root`` anchors the SDK to it.
+_BACKEND_API_ROOT = "/api"
+
+
+async def _record(call) -> list[tuple[str, str, frozenset[str]]]:
+    """Run one SDK call against a transport that answers without dialling.
+
+    The third element is the set of query-parameter **names** actually put on the
+    wire. Read off ``request.url.params`` rather than off the method signature:
+    ``AutoBotClient.get()`` drops ``None`` values, so what a method accepts and
+    what it sends are two different sets and only the second one reaches a route.
+    """
+    seen: list[tuple[str, str, frozenset[str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, frozenset(request.url.params.keys())))
+        return httpx.Response(200, json={"success": True, "data": None, "status": "healthy"})
+
+    async with AutoBot(base_url=_BASE, token="t") as bot:
+        # Swap the transport in place so the real client construction, the real
+        # base-URL merge and the real resource paths are all exercised.
+        bot._client._transport = httpx.MockTransport(handler)
+        await call(bot)
+    return seen
+
+
+def _urls(call) -> list[tuple[str, str, frozenset[str]]]:
+    return asyncio.run(_record(call))
+
+
+# ``(name, coroutine, expected METHOD, expected full path)`` — one row per
+# request the SDK can make. Adding a resource method without a row here fails
+# ``test_every_sdk_request_is_covered`` in ``sdk_request_url_test.py``.
+SDK_REQUESTS = [
+    ("sessions.list", lambda b: b.sessions.list(scope="team", team_id="t1"), "GET", "/api/chat/sessions"),
+    ("sessions.get", lambda b: b.sessions.get("s1", page=2, per_page=10), "GET", "/api/chat/sessions/s1"),
+    ("sessions.create", lambda b: b.sessions.create(title="t"), "POST", "/api/chat/sessions"),
+    ("sessions.update", lambda b: b.sessions.update("s1", title="t"), "PUT", "/api/chat/sessions/s1"),
+    ("sessions.delete", lambda b: b.sessions.delete("s1"), "DELETE", "/api/chat/sessions/s1"),
+    ("agents.health", lambda b: b.agents.health(), "GET", "/api/agent/health/detailed"),
+    ("agents.get_config", lambda b: b.agents.get_config("a1"), "GET", "/api/agent_config/agents/a1"),
+    ("agents.set_model", lambda b: b.agents.set_model("a1", "m"), "POST", "/api/agent_config/agents/a1/model"),
+    ("agents.set_enabled_on", lambda b: b.agents.set_enabled("a1", True), "POST", "/api/agent_config/agents/a1/enable"),
+    (
+        "agents.set_enabled_off",
+        lambda b: b.agents.set_enabled("a1", False),
+        "POST",
+        "/api/agent_config/agents/a1/disable",
+    ),
+    ("agents.send_command", lambda b: b.agents.send_command("ls"), "POST", "/api/agent/execute_command"),
+    ("knowledge.stats", lambda b: b.knowledge.stats(), "GET", "/api/knowledge_base/stats"),
+    ("knowledge.add_text", lambda b: b.knowledge.add_text("x"), "POST", "/api/knowledge_base/add_text"),
+    ("knowledge.search", lambda b: b.knowledge.search("q"), "POST", "/api/knowledge_base/search"),
+    (
+        "knowledge.get_entries",
+        lambda b: b.knowledge.get_entries(limit=5, cursor="7", category="ops"),
+        "GET",
+        "/api/knowledge_base/entries",
+    ),
+    ("analytics.usage", lambda b: b.analytics.usage(), "GET", "/api/analytics/usage/statistics"),
+    ("analytics.performance", lambda b: b.analytics.performance(), "GET", "/api/analytics/performance/metrics"),
+]
+
+
+def _template_for(concrete: str, templates) -> str | None:
+    """The route template *concrete* fills in, or ``None``."""
+    for template in templates:
+        pattern = "/".join("[^/]+" if seg.startswith("{") else re.escape(seg) for seg in template.split("/"))
+        if re.fullmatch(pattern, concrete):
+            return template
+    return None
+
+
+def _assert_sent_params_are_accepted(name: str, verb: str, path: str, sent: frozenset[str], route_query_params) -> None:
+    """The comparison every query-parameter guard runs: a name the SDK puts on
+    the wire must be one the target route's own signature declares.
+
+    Factored out so ``sdk_request_signature_params_test.py``'s contrast
+    mutation exercises the exact logic the real per-row guard runs, rather
+    than a re-implementation of it that could drift out of step (#15187).
+    """
+    template = _template_for(path, {p for _verb, p in route_query_params})
+    assert template is not None, f"{name} requests {path}, which the oracle's mounted modules do not serve."
+    accepted = route_query_params[(verb, template)]
+
+    unknown = sent - accepted
+    assert not unknown, (
+        f"{name} sends {sorted(unknown)} to {verb} {template}, which declares "
+        f"{sorted(accepted) or 'no query parameters at all'}. FastAPI drops an undeclared parameter "
+        "without an error, so the caller's intent silently does not apply."
+    )
+
+
+#: Attribute each resource class hangs off ``AutoBot`` under -- ``bot.agents``,
+#: ``bot.knowledge`` and so on. Shared because both the coverage check in
+#: ``sdk_request_url_test.py`` and the signature probe in
+#: ``sdk_request_signature_params_test.py`` need to turn a resource class into
+#: the name a request row or a forced call addresses it by.
+_RESOURCE_ATTRS = {
+    "AgentsResource": "agents",
+    "AnalyticsResource": "analytics",
+    "KnowledgeResource": "knowledge",
+    "SessionsResource": "sessions",
+}

--- a/repo_tests/sdk_request_shared.py
+++ b/repo_tests/sdk_request_shared.py
@@ -16,6 +16,17 @@ mode #15119's guard exists to prevent. ``route_query_params`` stays in
 ``repo_tests/``) strips an import it cannot see referenced as an expression,
 which is exactly how a fixture *reused* across test files (rather than
 defined by ``@pytest.fixture`` where pytest finds it) would be imported.
+
+The mock base URL is NOT owned here either, for a sibling reason: the
+hardcoded-value hook's test-file exemption
+(``docs/developer/HARDCODING_PREVENTION.md``) is matched on filename, and
+this module's name matches none of ``test_*.py``/``*_test.py``. A literal
+that was allowed at its old address in ``sdk_request_url_test.py`` became a
+violation purely by moving here, with no line changed (#15187 review; the
+allowlist gap itself is filed separately, not fixed in this module). ``_urls``
+takes ``base`` as a required argument instead; each ``*_test.py`` module
+defines its own ``_BASE`` and rebinds ``_urls`` to a ``functools.partial``
+that supplies it, so every existing ``_urls(call)`` call site is unchanged.
 """
 
 from __future__ import annotations
@@ -29,7 +40,6 @@ from autobot_sdk import AutoBot
 
 _REPO = Path(__file__).resolve().parents[1]
 _BACKEND = _REPO / "autobot-backend"
-_BASE = "http://backend.test:9999"
 
 # The BACKEND's API root, stated here independently of the SDK. If the oracle
 # in ``conftest.py`` read ``autobot_sdk.API_PREFIX`` instead, dropping the
@@ -41,13 +51,16 @@ _BASE = "http://backend.test:9999"
 _BACKEND_API_ROOT = "/api"
 
 
-async def _record(call) -> list[tuple[str, str, frozenset[str]]]:
+async def _record(call, base: str) -> list[tuple[str, str, frozenset[str]]]:
     """Run one SDK call against a transport that answers without dialling.
 
     The third element is the set of query-parameter **names** actually put on the
     wire. Read off ``request.url.params`` rather than off the method signature:
     ``AutoBotClient.get()`` drops ``None`` values, so what a method accepts and
     what it sends are two different sets and only the second one reaches a route.
+
+    ``base`` is the caller's mock URL, not a literal owned here -- see the
+    module docstring for why.
     """
     seen: list[tuple[str, str, frozenset[str]]] = []
 
@@ -55,7 +68,7 @@ async def _record(call) -> list[tuple[str, str, frozenset[str]]]:
         seen.append((request.method, request.url.path, frozenset(request.url.params.keys())))
         return httpx.Response(200, json={"success": True, "data": None, "status": "healthy"})
 
-    async with AutoBot(base_url=_BASE, token="t") as bot:
+    async with AutoBot(base_url=base, token="t") as bot:
         # Swap the transport in place so the real client construction, the real
         # base-URL merge and the real resource paths are all exercised.
         bot._client._transport = httpx.MockTransport(handler)
@@ -63,8 +76,8 @@ async def _record(call) -> list[tuple[str, str, frozenset[str]]]:
     return seen
 
 
-def _urls(call) -> list[tuple[str, str, frozenset[str]]]:
-    return asyncio.run(_record(call))
+def _urls(call, base: str) -> list[tuple[str, str, frozenset[str]]]:
+    return asyncio.run(_record(call, base))
 
 
 # ``(name, coroutine, expected METHOD, expected full path)`` — one row per

--- a/repo_tests/sdk_request_signature_params_test.py
+++ b/repo_tests/sdk_request_signature_params_test.py
@@ -36,6 +36,7 @@ here so nobody assumes this file's coverage extends to that shape.
 
 from __future__ import annotations
 
+import functools
 import inspect
 import types
 import typing
@@ -44,7 +45,16 @@ from typing import Any
 import pytest
 from autobot_sdk import resources
 
-from repo_tests.sdk_request_shared import SDK_REQUESTS, _RESOURCE_ATTRS, _assert_sent_params_are_accepted, _urls
+from repo_tests.sdk_request_shared import SDK_REQUESTS, _RESOURCE_ATTRS, _assert_sent_params_are_accepted
+from repo_tests.sdk_request_shared import _urls as _shared_urls
+
+# Own mock base URL rather than importing one: sdk_request_shared.py cannot
+# hold this literal (see its module docstring -- the hardcoded-value hook's
+# test-file exemption is filename-matched, and that module's name does not
+# qualify). Rebinding ``_urls`` to a partial keeps every ``_urls(call)`` call
+# site below unchanged.
+_BASE = "http://backend.test:9999"
+_urls = functools.partial(_shared_urls, base=_BASE)
 
 
 def _dummy_value(annotation: Any) -> Any:

--- a/repo_tests/sdk_request_signature_params_test.py
+++ b/repo_tests/sdk_request_signature_params_test.py
@@ -1,0 +1,189 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Signature-derived query-parameter coverage (#15187).
+
+Split out of ``sdk_request_url_test.py`` once this section pushed that file
+past the 600-line cap (``scripts/check_python_file_size.py``). See that
+file's module docstring for the #15119/#15053 background; this one covers
+only the gap #15119's own guard left.
+
+That guard (``test_every_query_parameter_the_sdk_sends_exists_on_the_route``,
+in ``sdk_request_url_test.py``) only sees what a hand-written ``SDK_REQUESTS``
+row happens to pass. ``AutoBotClient.get()`` drops ``None`` values, so a query
+parameter defaulting to ``None`` that no row bothers to pass is never on the
+wire that guard observes -- and most optional SDK parameters default to
+``None``, so that is the common shape, not an edge case.
+
+The tests below force every parameter -- named straight off each resource
+method's own signature, independent of what any row does -- to a concrete
+value, so it reaches the wire and gets checked whether or not a row
+remembers it. A row is still required per parameter: an unexercised one is
+itself a failure below, so deriving the set from signatures does not trade
+one hole (a parameter no test sees) for another (a parameter this file
+claims coverage for but never actually calls through a public API surface).
+
+This does NOT close #15186's class of defect -- a parameter that *does*
+exist on the route signature but the handler never applies (``page`` on
+``/chat/sessions/{id}``). That is a behavioural gap, not a naming one: the
+parameter passes every check here because it is declared, so only a test
+that asserts two different values produce two different responses (as
+``test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next``
+in ``sdk_request_url_test.py`` does for the cursor) can catch it. Recorded
+here so nobody assumes this file's coverage extends to that shape.
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+import typing
+from typing import Any
+
+import pytest
+from autobot_sdk import resources
+
+from repo_tests.sdk_request_shared import SDK_REQUESTS, _RESOURCE_ATTRS, _assert_sent_params_are_accepted, _urls
+
+
+def _dummy_value(annotation: Any) -> Any:
+    """A concrete, non-``None`` stand-in for *annotation*.
+
+    Every optional parameter is forced to one of these rather than left at its
+    declared default, so a ``None``-defaulted parameter reaches the wire
+    exactly as it would for a caller who actually passes it. Only ``Optional``
+    (``X | None``) is unwrapped -- recursing into every generic's type args
+    would misread ``dict[str, Any]`` as a two-member union and hand back a
+    string where a dict was wanted.
+    """
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        for arg in typing.get_args(annotation):
+            if arg is not type(None):
+                return _dummy_value(arg)
+        return "x"
+    if annotation is bool:
+        return True
+    if annotation is int:
+        return 7
+    if annotation is float:
+        return 1.5
+    if annotation is dict or origin is dict:
+        # Truthy on purpose. Several call sites include an optional argument
+        # only under ``if param:``, so an empty dict would be dropped before
+        # it reached the wire — the parameter would read as "forced" while
+        # never actually being checked, which is the exact blindness this
+        # guard exists to remove (#15187 review).
+        return {"x": "x"}
+    return "x"
+
+
+def _forced_call(resource_attr: str, fn):
+    """A call to unbound method *fn*, bound to ``bot.<resource_attr>``, with
+    every parameter set to a concrete value.
+
+    ``inspect.signature`` names every parameter regardless of its default, so
+    this reaches parameters no ``SDK_REQUESTS`` row is obliged to pass.
+    ``**kwargs`` parameters are skipped: none in this SDK carry a query
+    parameter (every one forwards into a JSON body -- see the resource
+    docstrings), so there is no fixed name to force in the first place.
+    """
+    hints = typing.get_type_hints(fn)
+    kwargs: dict[str, Any] = {}
+    for pname, param in inspect.signature(fn).parameters.items():
+        if pname == "self" or param.kind is inspect.Parameter.VAR_KEYWORD:
+            continue
+        kwargs[pname] = _dummy_value(hints.get(pname, str))
+
+    async def call(bot):
+        resource = getattr(bot, resource_attr)
+        await fn(resource, **kwargs)
+
+    return call
+
+
+@pytest.fixture(scope="module")
+def signature_forced_requests() -> dict[str, tuple[str, str, frozenset[str]]]:
+    """``name -> (verb, path, query-parameter names)``, every optional
+    parameter forced to a value, derived from each resource method's own
+    signature rather than from what ``SDK_REQUESTS`` happens to exercise.
+    """
+    result: dict[str, tuple[str, str, frozenset[str]]] = {}
+    for cls in (
+        resources.AgentsResource,
+        resources.AnalyticsResource,
+        resources.KnowledgeResource,
+        resources.SessionsResource,
+    ):
+        attr = _RESOURCE_ATTRS[cls.__name__]
+        for method_name, fn in inspect.getmembers(cls, inspect.iscoroutinefunction):
+            if method_name.startswith("_"):
+                continue
+            verb, path, sent = _urls(_forced_call(attr, fn))[0]
+            result[f"{attr}.{method_name}"] = (verb, path, sent)
+    assert result, "no resource methods were probed -- the introspection broke, not the SDK"
+    return result
+
+
+def test_every_signature_forced_parameter_exists_on_the_route(signature_forced_requests, route_query_params):
+    """AC (#15187): does not depend on SDK_REQUESTS passing the parameter at
+    all -- forcing every optional argument reaches a ``None``-defaulted one
+    the pinned rows never exercise.
+    """
+    for name, (verb, path, sent) in signature_forced_requests.items():
+        if sent:
+            _assert_sent_params_are_accepted(name, verb, path, sent, route_query_params)
+
+
+#: SDK_REQUESTS row names that do not match their underlying method name 1:1
+#: -- two rows exercise the same ``set_enabled`` method with different args.
+_ROW_METHOD_ALIASES = {"set_enabled_on": "set_enabled", "set_enabled_off": "set_enabled"}
+
+
+def test_every_signature_derived_parameter_is_exercised_by_a_pinned_row(signature_forced_requests):
+    """AC (#15187): a parameter the signature can send but no row exercises is
+    a hole in coverage, not a pass -- deriving the set from signatures must
+    not excuse SDK_REQUESTS from exercising every name in it.
+    """
+    pinned: dict[str, frozenset[str]] = {}
+    for row_name, call, _method, _expected in SDK_REQUESTS:
+        attr, _, method = row_name.partition(".")
+        method = _ROW_METHOD_ALIASES.get(method, method)
+        _, _, sent = _urls(call)[0]
+        pinned[f"{attr}.{method}"] = pinned.get(f"{attr}.{method}", frozenset()) | sent
+
+    for name, (_verb, _path, forced) in signature_forced_requests.items():
+        missing = forced - pinned.get(name, frozenset())
+        assert not missing, (
+            f"{name} can send {sorted(missing)} once every optional parameter is forced, but no row in "
+            f"SDK_REQUESTS exercises it -- add one, or the route contract for it is checked by nothing (#15187)."
+        )
+
+
+def test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept(route_query_params):
+    """AC (#15187) contrast mutation: a ``None``-defaulted query parameter the
+    route does not accept, exercised by no row, must fail this guard; removing
+    it must pass again.
+
+    A synthetic method stands in for a resource file so the mutation does not
+    touch real source, but it is driven through the exact ``_forced_call`` /
+    ``_assert_sent_params_are_accepted`` pipeline the real guards use --
+    this proves the mechanism catches the shape #15119's AC4 named, not a
+    re-implementation of it.
+    """
+
+    class _Buggy:
+        async def get_entries(self, category: str | None = None, secret_offset: str | None = None) -> None:
+            await self._c.get("/knowledge_base/entries", category=category, secret_offset=secret_offset)
+
+    class _Fixed:
+        async def get_entries(self, category: str | None = None) -> None:
+            await self._c.get("/knowledge_base/entries", category=category)
+
+    verb, path, sent = _urls(_forced_call("knowledge", _Buggy.get_entries))[0]
+    with pytest.raises(AssertionError, match="secret_offset"):
+        _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)
+
+    verb, path, sent = _urls(_forced_call("knowledge", _Fixed.get_entries))[0]
+    _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -46,6 +46,7 @@ marker-carrying tests there, so an unmarked test under
 from __future__ import annotations
 
 import asyncio
+import functools
 import importlib.util
 import inspect
 import re
@@ -61,14 +62,21 @@ from autobot_shared.ssot_config import config
 from repo_tests.sdk_request_shared import (
     _BACKEND,
     _BACKEND_API_ROOT,
-    _BASE,
     _REPO,
     _RESOURCE_ATTRS,
     SDK_REQUESTS,
     _assert_sent_params_are_accepted,
     _template_for,
-    _urls,
 )
+from repo_tests.sdk_request_shared import _urls as _shared_urls
+
+# Own mock base URL rather than importing one: sdk_request_shared.py cannot
+# hold this literal (see its module docstring -- the hardcoded-value hook's
+# test-file exemption is filename-matched, and that module's name does not
+# qualify). Rebinding ``_urls`` to a partial keeps every ``_urls(call)`` call
+# site below unchanged.
+_BASE = "http://backend.test:9999"
+_urls = functools.partial(_shared_urls, base=_BASE)
 
 
 def _route_decorator_re():

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -27,14 +27,15 @@ that is not paginated, and both analytics methods sent a ``period`` neither rout
 takes. Response *shapes* are asserted next door in
 ``sdk_response_model_contract_test.py`` and ``sdk_response_parsing_test.py``.
 
-The #15119 checks above only see a parameter a ``SDK_REQUESTS`` row actually
-passes; ``AutoBotClient.get()`` drops ``None`` values, so a parameter
-defaulting to ``None`` that no row bothers to pass reaches neither this
-file's ``observed`` set nor a route that might reject it -- the common shape,
-since most optional parameters default to ``None`` (#15187). The
-"Signature-derived coverage" section forces every parameter, named straight
-off each resource method's own signature, so that gap does not depend on a
-row remembering it.
+The checks here only see a parameter a ``SDK_REQUESTS`` row actually passes; a
+parameter defaulting to ``None`` that no row bothers to pass reaches neither
+this file's ``observed`` set nor a route that might reject it (#15187). That
+gap is closed in ``sdk_request_signature_params_test.py``, split out once this
+file's own #15187 section pushed it past the 600-line cap
+(``scripts/check_python_file_size.py``). ``SDK_REQUESTS``, the wire-capture
+harness and the per-row comparison both files share live in
+``sdk_request_shared.py``; ``route_query_params`` is a fixture in
+``conftest.py``, visible to both without either importing it by name.
 
 This lives in ``repo_tests`` rather than beside the SDK deliberately: ci.yml's
 roots do not include ``libs``, and marker-tests.yml selects only
@@ -45,37 +46,29 @@ marker-carrying tests there, so an unmarked test under
 from __future__ import annotations
 
 import asyncio
-import importlib
 import importlib.util
 import inspect
 import re
 import sys
-import types
-import typing
 from pathlib import Path
-from typing import Any
 
 import httpx
 import pytest
 from autobot_sdk import API_PREFIX, AutoBot, api_path, default_base_url, resources
-from fastapi import FastAPI
-from fastapi.openapi.utils import get_openapi
 
 from autobot_shared.api_routing import router_prefixes as routing
 from autobot_shared.ssot_config import config
-
-_REPO = Path(__file__).resolve().parents[1]
-_BACKEND = _REPO / "autobot-backend"
-_BASE = "http://backend.test:9999"
-
-# The BACKEND's API root, stated here independently of the SDK. If the oracle
-# below read ``autobot_sdk.API_PREFIX`` instead, dropping the prefix from the
-# SDK would move the route table with it and every assertion would still pass
-# — the mutation would have deleted its own detector.
-# ``test_the_api_root_is_the_one_the_application_factory_mounts`` anchors this
-# constant to app_factory.py, and ``test_the_sdk_uses_the_backend_api_root``
-# anchors the SDK to it.
-_BACKEND_API_ROOT = "/api"
+from repo_tests.sdk_request_shared import (
+    _BACKEND,
+    _BACKEND_API_ROOT,
+    _BASE,
+    _REPO,
+    _RESOURCE_ATTRS,
+    SDK_REQUESTS,
+    _assert_sent_params_are_accepted,
+    _template_for,
+    _urls,
+)
 
 
 def _route_decorator_re():
@@ -138,66 +131,6 @@ def _matches_a_route(concrete: str, routes: set[str]) -> bool:
     return False
 
 
-async def _record(call) -> list[tuple[str, str, frozenset[str]]]:
-    """Run one SDK call against a transport that answers without dialling.
-
-    The third element is the set of query-parameter **names** actually put on the
-    wire. Read off ``request.url.params`` rather than off the method signature:
-    ``AutoBotClient.get()`` drops ``None`` values, so what a method accepts and
-    what it sends are two different sets and only the second one reaches a route.
-    """
-    seen: list[tuple[str, str, frozenset[str]]] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        seen.append((request.method, request.url.path, frozenset(request.url.params.keys())))
-        return httpx.Response(200, json={"success": True, "data": None, "status": "healthy"})
-
-    async with AutoBot(base_url=_BASE, token="t") as bot:
-        # Swap the transport in place so the real client construction, the real
-        # base-URL merge and the real resource paths are all exercised.
-        bot._client._transport = httpx.MockTransport(handler)
-        await call(bot)
-    return seen
-
-
-def _urls(call) -> list[tuple[str, str, frozenset[str]]]:
-    return asyncio.run(_record(call))
-
-
-# ``(name, coroutine, expected METHOD, expected full path)`` — one row per
-# request the SDK can make. Adding a resource method without a row here fails
-# ``test_every_sdk_request_is_covered`` below.
-SDK_REQUESTS = [
-    ("sessions.list", lambda b: b.sessions.list(scope="team", team_id="t1"), "GET", "/api/chat/sessions"),
-    ("sessions.get", lambda b: b.sessions.get("s1", page=2, per_page=10), "GET", "/api/chat/sessions/s1"),
-    ("sessions.create", lambda b: b.sessions.create(title="t"), "POST", "/api/chat/sessions"),
-    ("sessions.update", lambda b: b.sessions.update("s1", title="t"), "PUT", "/api/chat/sessions/s1"),
-    ("sessions.delete", lambda b: b.sessions.delete("s1"), "DELETE", "/api/chat/sessions/s1"),
-    ("agents.health", lambda b: b.agents.health(), "GET", "/api/agent/health/detailed"),
-    ("agents.get_config", lambda b: b.agents.get_config("a1"), "GET", "/api/agent_config/agents/a1"),
-    ("agents.set_model", lambda b: b.agents.set_model("a1", "m"), "POST", "/api/agent_config/agents/a1/model"),
-    ("agents.set_enabled_on", lambda b: b.agents.set_enabled("a1", True), "POST", "/api/agent_config/agents/a1/enable"),
-    (
-        "agents.set_enabled_off",
-        lambda b: b.agents.set_enabled("a1", False),
-        "POST",
-        "/api/agent_config/agents/a1/disable",
-    ),
-    ("agents.send_command", lambda b: b.agents.send_command("ls"), "POST", "/api/agent/execute_command"),
-    ("knowledge.stats", lambda b: b.knowledge.stats(), "GET", "/api/knowledge_base/stats"),
-    ("knowledge.add_text", lambda b: b.knowledge.add_text("x"), "POST", "/api/knowledge_base/add_text"),
-    ("knowledge.search", lambda b: b.knowledge.search("q"), "POST", "/api/knowledge_base/search"),
-    (
-        "knowledge.get_entries",
-        lambda b: b.knowledge.get_entries(limit=5, cursor="7", category="ops"),
-        "GET",
-        "/api/knowledge_base/entries",
-    ),
-    ("analytics.usage", lambda b: b.analytics.usage(), "GET", "/api/analytics/usage/statistics"),
-    ("analytics.performance", lambda b: b.analytics.performance(), "GET", "/api/analytics/performance/metrics"),
-]
-
-
 @pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
 def test_the_sdk_puts_the_expected_url_on_the_wire(name, call, method, expected):
     """Pin the exact method and path, not that some mock was called."""
@@ -221,79 +154,15 @@ def test_the_url_the_sdk_builds_names_a_route_the_backend_serves(name, call, met
 # Query parameters (#15119)
 # --------------------------------------------------------------------------
 
-#: Backend modules serving the paths above. Only these are imported, so the
-#: oracle costs one small app rather than the whole backend.
-#:
-#: This list cannot go stale unnoticed: the app built from it is asked for every
-#: path in ``SDK_REQUESTS``, so a module missing here shows up as a path the spec
-#: does not contain, and ``test_every_sdk_request_path_is_in_the_query_oracle``
-#: fails naming it.
-SERVING_MODULES: tuple[str, ...] = (
-    "api.agent",
-    "api.agent_config",
-    "api.analytics",
-    "api.chat_sessions",
-    "api.knowledge",
-    "api.knowledge_search",
-)
-
 #: Every query-parameter name the SDK can put on the wire, across all of
 #: ``SDK_REQUESTS``. Pinned rather than merely non-empty: a new parameter added to
 #: a resource method without a row exercising it would otherwise be sent by
 #: nothing here, and the subset assertion below would pass without ever seeing it.
+#:
+#: This is deliberately weaker than ``sdk_request_signature_params_test.py``'s
+#: coverage -- it only sees what a row here happens to pass -- but stays as a
+#: fast, no-oracle sanity check that a row was not simply deleted.
 SENT_QUERY_PARAMS = frozenset({"scope", "team_id", "page", "per_page", "limit", "cursor", "category"})
-
-
-@pytest.fixture(scope="module")
-def route_query_params() -> dict[tuple[str, str], frozenset[str]]:
-    """``(METHOD, path template) -> declared query parameter names``.
-
-    Built through ``fastapi.openapi.utils.get_openapi`` on an app that mounts the
-    modules above exactly as ``app_factory`` mounts them -- ``/api`` + the prefix
-    ``initialization/router_registry`` gives that module. Deliberately **not** a
-    walk over ``router.routes``: from ``fastapi>=0.139`` ``include_router`` records
-    an opaque wrapper instead of copying the child's routes onto the parent, so a
-    flat walk finds almost nothing and every assertion over it passes vacuously.
-    CI pins 0.141.1 and a development checkout may resolve below 0.139, so a local
-    pass would prove nothing about the runner (#15091, #15093). ``get_openapi`` is
-    the view FastAPI itself serves ``/openapi.json`` from and answers the same on
-    both shapes.
-
-    The mount prefixes are read from the registry rather than written here, so a
-    router that moves is followed rather than silently mismatched.
-    """
-    registry = dict(routing.registry_entries(_BACKEND / "initialization" / "router_registry"))
-    assert registry, "the router registry parsed no entries -- the oracle below would have nothing to mount"
-
-    app = FastAPI()
-    for module_path in SERVING_MODULES:
-        assert module_path in registry, f"{module_path} is not mounted by initialization/router_registry"
-        app.include_router(
-            importlib.import_module(module_path).router, prefix=f"{_BACKEND_API_ROOT}{registry[module_path]}"
-        )
-
-    spec = get_openapi(title="sdk-request-oracle", version="1", routes=app.routes)
-    declared: dict[tuple[str, str], frozenset[str]] = {}
-    for path, operations in spec.get("paths", {}).items():
-        for verb, operation in operations.items():
-            names = {p["name"] for p in operation.get("parameters", []) if p.get("in") == "query"}
-            declared[(verb.upper(), path)] = frozenset(names)
-
-    assert declared, "the oracle enumerated no routes at all; every assertion below would pass vacuously"
-    assert any(names for names in declared.values()), (
-        "no route in the oracle declares a single query parameter. Either the mounted set is wrong or "
-        "the parameter extraction is -- an oracle where everything accepts nothing cannot detect a wrong name."
-    )
-    return declared
-
-
-def _template_for(concrete: str, templates) -> str | None:
-    """The route template *concrete* fills in, or ``None``."""
-    for template in templates:
-        pattern = "/".join("[^/]+" if seg.startswith("{") else re.escape(seg) for seg in template.split("/"))
-        if re.fullmatch(pattern, concrete):
-            return template
-    return None
 
 
 def test_the_rows_above_exercise_every_query_parameter_the_sdk_can_send():
@@ -308,35 +177,17 @@ def test_the_rows_above_exercise_every_query_parameter_the_sdk_can_send():
 
 @pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
 def test_every_sdk_request_path_is_in_the_query_oracle(name, call, method, expected, route_query_params):
-    """Proves SERVING_MODULES is sufficient before anything is read out of the oracle."""
+    """Proves ``conftest.py``'s ``SERVING_MODULES`` is sufficient before anything
+    is read out of the oracle it builds.
+    """
     verb, wanted, _params = _urls(call)[0]
     template = _template_for(wanted, {path for _verb, path in route_query_params})
 
     assert template is not None, (
         f"{name} requests {wanted}, which the oracle's mounted modules do not serve. "
-        f"Add the module serving it to SERVING_MODULES."
+        f"Add the module serving it to conftest.py's SERVING_MODULES."
     )
     assert (verb, template) in route_query_params, f"{name} uses {verb} on {template}, which serves other verbs only"
-
-
-def _assert_sent_params_are_accepted(name: str, verb: str, path: str, sent: frozenset[str], route_query_params) -> None:
-    """The comparison every guard in this section runs: a name the SDK puts on
-    the wire must be one the target route's own signature declares.
-
-    Factored out so ``test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept``
-    below exercises the exact logic the real guards run, rather than a
-    re-implementation of it that could drift out of step (#15187).
-    """
-    template = _template_for(path, {p for _verb, p in route_query_params})
-    assert template is not None, f"{name} requests {path}, which the oracle's mounted modules do not serve."
-    accepted = route_query_params[(verb, template)]
-
-    unknown = sent - accepted
-    assert not unknown, (
-        f"{name} sends {sorted(unknown)} to {verb} {template}, which declares "
-        f"{sorted(accepted) or 'no query parameters at all'}. FastAPI drops an undeclared parameter "
-        "without an error, so the caller's intent silently does not apply."
-    )
 
 
 @pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
@@ -345,181 +196,12 @@ def test_every_query_parameter_the_sdk_sends_exists_on_the_route(name, call, met
 
     ``limit``/``offset`` on ``/chat/sessions``, ``offset`` on
     ``/knowledge_base/entries`` and ``period`` on both analytics routes each
-    failed this way -- sent on every call, ignored on every call.
+    failed this way -- sent on every call, ignored on every call. The
+    ``None``-defaulted-and-unexercised half of this same shape is guarded in
+    ``sdk_request_signature_params_test.py`` instead (#15187).
     """
     verb, wanted, sent = _urls(call)[0]
     _assert_sent_params_are_accepted(name, verb, wanted, sent, route_query_params)
-
-
-# --------------------------------------------------------------------------
-# Signature-derived coverage (#15187)
-#
-# The guard above only sees what a hand-written SDK_REQUESTS row happens to
-# pass. ``AutoBotClient.get()`` drops ``None`` values, so a query parameter
-# defaulting to ``None`` that no row bothers to pass is never on the wire this
-# file observes -- ``test_the_rows_above_exercise_every_query_parameter_the_sdk_can_send``
-# would not even notice it exists. Most optional parameters default to
-# ``None``, so that is the common shape, not an edge case.
-#
-# The tests below force every parameter -- named straight off each resource
-# method's own signature, independent of what any row does -- to a concrete
-# value, so it reaches the wire and gets checked whether or not a row
-# remembers it. A row is still required per parameter: an unexercised one is
-# itself a failure below, so deriving the set from signatures does not trade
-# one hole (a parameter no test sees) for another (a parameter this file
-# claims coverage for but never actually calls through a public API surface).
-#
-# This does NOT close #15186's class of defect -- a parameter that *does*
-# exist on the route signature but the handler never applies (``page`` on
-# ``/chat/sessions/{id}``). That is a behavioural gap, not a naming one: the
-# parameter passes every check here because it is declared, so only a test
-# that asserts two different values produce two different responses (as
-# ``test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next``
-# does for the cursor) can catch it. Recorded here so nobody assumes this
-# section's coverage extends to that shape.
-# --------------------------------------------------------------------------
-
-
-def _dummy_value(annotation: Any) -> Any:
-    """A concrete, non-``None`` stand-in for *annotation*.
-
-    Every optional parameter is forced to one of these rather than left at its
-    declared default, so a ``None``-defaulted parameter reaches the wire
-    exactly as it would for a caller who actually passes it. Only ``Optional``
-    (``X | None``) is unwrapped -- recursing into every generic's type args
-    would misread ``dict[str, Any]`` as a two-member union and hand back a
-    string where a dict was wanted.
-    """
-    origin = typing.get_origin(annotation)
-    if origin is typing.Union or origin is types.UnionType:
-        for arg in typing.get_args(annotation):
-            if arg is not type(None):
-                return _dummy_value(arg)
-        return "x"
-    if annotation is bool:
-        return True
-    if annotation is int:
-        return 7
-    if annotation is float:
-        return 1.5
-    if annotation is dict or origin is dict:
-        # Truthy on purpose. Several call sites include an optional argument
-        # only under ``if param:``, so an empty dict would be dropped before
-        # it reached the wire — the parameter would read as "forced" while
-        # never actually being checked, which is the exact blindness this
-        # guard exists to remove (#15187 review).
-        return {"x": "x"}
-    return "x"
-
-
-def _forced_call(resource_attr: str, fn):
-    """A call to unbound method *fn*, bound to ``bot.<resource_attr>``, with
-    every parameter set to a concrete value.
-
-    ``inspect.signature`` names every parameter regardless of its default, so
-    this reaches parameters no ``SDK_REQUESTS`` row is obliged to pass.
-    ``**kwargs`` parameters are skipped: none in this SDK carry a query
-    parameter (every one forwards into a JSON body -- see the resource
-    docstrings), so there is no fixed name to force in the first place.
-    """
-    hints = typing.get_type_hints(fn)
-    kwargs: dict[str, Any] = {}
-    for pname, param in inspect.signature(fn).parameters.items():
-        if pname == "self" or param.kind is inspect.Parameter.VAR_KEYWORD:
-            continue
-        kwargs[pname] = _dummy_value(hints.get(pname, str))
-
-    async def call(bot):
-        resource = getattr(bot, resource_attr)
-        await fn(resource, **kwargs)
-
-    return call
-
-
-@pytest.fixture(scope="module")
-def signature_forced_requests() -> dict[str, tuple[str, str, frozenset[str]]]:
-    """``name -> (verb, path, query-parameter names)``, every optional
-    parameter forced to a value, derived from each resource method's own
-    signature rather than from what ``SDK_REQUESTS`` happens to exercise.
-    """
-    result: dict[str, tuple[str, str, frozenset[str]]] = {}
-    for cls in (
-        resources.AgentsResource,
-        resources.AnalyticsResource,
-        resources.KnowledgeResource,
-        resources.SessionsResource,
-    ):
-        attr = _RESOURCE_ATTRS[cls.__name__]
-        for method_name, fn in inspect.getmembers(cls, inspect.iscoroutinefunction):
-            if method_name.startswith("_"):
-                continue
-            verb, path, sent = _urls(_forced_call(attr, fn))[0]
-            result[f"{attr}.{method_name}"] = (verb, path, sent)
-    assert result, "no resource methods were probed -- the introspection broke, not the SDK"
-    return result
-
-
-def test_every_signature_forced_parameter_exists_on_the_route(signature_forced_requests, route_query_params):
-    """AC (#15187): does not depend on SDK_REQUESTS passing the parameter at
-    all -- forcing every optional argument reaches a ``None``-defaulted one
-    the pinned rows never exercise.
-    """
-    for name, (verb, path, sent) in signature_forced_requests.items():
-        if sent:
-            _assert_sent_params_are_accepted(name, verb, path, sent, route_query_params)
-
-
-#: SDK_REQUESTS row names that do not match their underlying method name 1:1
-#: -- two rows exercise the same ``set_enabled`` method with different args.
-_ROW_METHOD_ALIASES = {"set_enabled_on": "set_enabled", "set_enabled_off": "set_enabled"}
-
-
-def test_every_signature_derived_parameter_is_exercised_by_a_pinned_row(signature_forced_requests):
-    """AC (#15187): a parameter the signature can send but no row exercises is
-    a hole in coverage, not a pass -- deriving the set from signatures must
-    not excuse SDK_REQUESTS from exercising every name in it.
-    """
-    pinned: dict[str, frozenset[str]] = {}
-    for row_name, call, _method, _expected in SDK_REQUESTS:
-        attr, _, method = row_name.partition(".")
-        method = _ROW_METHOD_ALIASES.get(method, method)
-        _, _, sent = _urls(call)[0]
-        pinned[f"{attr}.{method}"] = pinned.get(f"{attr}.{method}", frozenset()) | sent
-
-    for name, (_verb, _path, forced) in signature_forced_requests.items():
-        missing = forced - pinned.get(name, frozenset())
-        assert not missing, (
-            f"{name} can send {sorted(missing)} once every optional parameter is forced, but no row in "
-            f"SDK_REQUESTS exercises it -- add one, or the route contract for it is checked by nothing (#15187)."
-        )
-
-
-def test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept(route_query_params):
-    """AC (#15187) contrast mutation: a ``None``-defaulted query parameter the
-    route does not accept, exercised by no row, must fail this guard; removing
-    it must pass again.
-
-    A synthetic method stands in for a resource file so the mutation does not
-    touch real source, but it is driven through the exact ``_forced_call`` /
-    ``_assert_sent_params_are_accepted`` pipeline the real guards above use --
-    this proves the mechanism catches the shape #15119's AC4 named, not a
-    re-implementation of it.
-    """
-
-    class _Buggy:
-        async def get_entries(self, category: str | None = None, secret_offset: str | None = None) -> None:
-            await self._c.get("/knowledge_base/entries", category=category, secret_offset=secret_offset)
-
-    class _Fixed:
-        async def get_entries(self, category: str | None = None) -> None:
-            await self._c.get("/knowledge_base/entries", category=category)
-
-    verb, path, sent = _urls(_forced_call("knowledge", _Buggy.get_entries))[0]
-    with pytest.raises(AssertionError, match="secret_offset"):
-        _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)
-
-    verb, path, sent = _urls(_forced_call("knowledge", _Fixed.get_entries))[0]
-    _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)
 
 
 def test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next():
@@ -554,14 +236,6 @@ def test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next
     assert [e.key for e in first.entries] == ["k1"]
     assert [e.key for e in second.entries] == ["k2"], "the second page returned the first page's rows"
     assert second.has_more is False
-
-
-_RESOURCE_ATTRS = {
-    "AgentsResource": "agents",
-    "AnalyticsResource": "analytics",
-    "KnowledgeResource": "knowledge",
-    "SessionsResource": "sessions",
-}
 
 
 def test_every_sdk_request_is_covered():

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -27,6 +27,15 @@ that is not paginated, and both analytics methods sent a ``period`` neither rout
 takes. Response *shapes* are asserted next door in
 ``sdk_response_model_contract_test.py`` and ``sdk_response_parsing_test.py``.
 
+The #15119 checks above only see a parameter a ``SDK_REQUESTS`` row actually
+passes; ``AutoBotClient.get()`` drops ``None`` values, so a parameter
+defaulting to ``None`` that no row bothers to pass reaches neither this
+file's ``observed`` set nor a route that might reject it -- the common shape,
+since most optional parameters default to ``None`` (#15187). The
+"Signature-derived coverage" section forces every parameter, named straight
+off each resource method's own signature, so that gap does not depend on a
+row remembering it.
+
 This lives in ``repo_tests`` rather than beside the SDK deliberately: ci.yml's
 roots do not include ``libs``, and marker-tests.yml selects only
 marker-carrying tests there, so an unmarked test under
@@ -38,13 +47,17 @@ from __future__ import annotations
 import asyncio
 import importlib
 import importlib.util
+import inspect
 import re
 import sys
+import types
+import typing
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
-from autobot_sdk import API_PREFIX, AutoBot, api_path, default_base_url
+from autobot_sdk import API_PREFIX, AutoBot, api_path, default_base_url, resources
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
@@ -306,6 +319,26 @@ def test_every_sdk_request_path_is_in_the_query_oracle(name, call, method, expec
     assert (verb, template) in route_query_params, f"{name} uses {verb} on {template}, which serves other verbs only"
 
 
+def _assert_sent_params_are_accepted(name: str, verb: str, path: str, sent: frozenset[str], route_query_params) -> None:
+    """The comparison every guard in this section runs: a name the SDK puts on
+    the wire must be one the target route's own signature declares.
+
+    Factored out so ``test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept``
+    below exercises the exact logic the real guards run, rather than a
+    re-implementation of it that could drift out of step (#15187).
+    """
+    template = _template_for(path, {p for _verb, p in route_query_params})
+    assert template is not None, f"{name} requests {path}, which the oracle's mounted modules do not serve."
+    accepted = route_query_params[(verb, template)]
+
+    unknown = sent - accepted
+    assert not unknown, (
+        f"{name} sends {sorted(unknown)} to {verb} {template}, which declares "
+        f"{sorted(accepted) or 'no query parameters at all'}. FastAPI drops an undeclared parameter "
+        "without an error, so the caller's intent silently does not apply."
+    )
+
+
 @pytest.mark.parametrize("name,call,method,expected", SDK_REQUESTS, ids=[r[0] for r in SDK_REQUESTS])
 def test_every_query_parameter_the_sdk_sends_exists_on_the_route(name, call, method, expected, route_query_params):
     """AC (#15119): a parameter the route does not declare is dropped, and nothing said so.
@@ -315,15 +348,173 @@ def test_every_query_parameter_the_sdk_sends_exists_on_the_route(name, call, met
     failed this way -- sent on every call, ignored on every call.
     """
     verb, wanted, sent = _urls(call)[0]
-    template = _template_for(wanted, {path for _verb, path in route_query_params})
-    accepted = route_query_params[(verb, template)]
+    _assert_sent_params_are_accepted(name, verb, wanted, sent, route_query_params)
 
-    unknown = sent - accepted
-    assert not unknown, (
-        f"{name} sends {sorted(unknown)} to {verb} {template}, which declares "
-        f"{sorted(accepted) or 'no query parameters at all'}. FastAPI drops an undeclared parameter "
-        "without an error, so the caller's intent silently does not apply."
-    )
+
+# --------------------------------------------------------------------------
+# Signature-derived coverage (#15187)
+#
+# The guard above only sees what a hand-written SDK_REQUESTS row happens to
+# pass. ``AutoBotClient.get()`` drops ``None`` values, so a query parameter
+# defaulting to ``None`` that no row bothers to pass is never on the wire this
+# file observes -- ``test_the_rows_above_exercise_every_query_parameter_the_sdk_can_send``
+# would not even notice it exists. Most optional parameters default to
+# ``None``, so that is the common shape, not an edge case.
+#
+# The tests below force every parameter -- named straight off each resource
+# method's own signature, independent of what any row does -- to a concrete
+# value, so it reaches the wire and gets checked whether or not a row
+# remembers it. A row is still required per parameter: an unexercised one is
+# itself a failure below, so deriving the set from signatures does not trade
+# one hole (a parameter no test sees) for another (a parameter this file
+# claims coverage for but never actually calls through a public API surface).
+#
+# This does NOT close #15186's class of defect -- a parameter that *does*
+# exist on the route signature but the handler never applies (``page`` on
+# ``/chat/sessions/{id}``). That is a behavioural gap, not a naming one: the
+# parameter passes every check here because it is declared, so only a test
+# that asserts two different values produce two different responses (as
+# ``test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next``
+# does for the cursor) can catch it. Recorded here so nobody assumes this
+# section's coverage extends to that shape.
+# --------------------------------------------------------------------------
+
+
+def _dummy_value(annotation: Any) -> Any:
+    """A concrete, non-``None`` stand-in for *annotation*.
+
+    Every optional parameter is forced to one of these rather than left at its
+    declared default, so a ``None``-defaulted parameter reaches the wire
+    exactly as it would for a caller who actually passes it. Only ``Optional``
+    (``X | None``) is unwrapped -- recursing into every generic's type args
+    would misread ``dict[str, Any]`` as a two-member union and hand back a
+    string where a dict was wanted.
+    """
+    origin = typing.get_origin(annotation)
+    if origin is typing.Union or origin is types.UnionType:
+        for arg in typing.get_args(annotation):
+            if arg is not type(None):
+                return _dummy_value(arg)
+        return "x"
+    if annotation is bool:
+        return True
+    if annotation is int:
+        return 7
+    if annotation is float:
+        return 1.5
+    if annotation is dict or origin is dict:
+        return {}
+    return "x"
+
+
+def _forced_call(resource_attr: str, fn):
+    """A call to unbound method *fn*, bound to ``bot.<resource_attr>``, with
+    every parameter set to a concrete value.
+
+    ``inspect.signature`` names every parameter regardless of its default, so
+    this reaches parameters no ``SDK_REQUESTS`` row is obliged to pass.
+    ``**kwargs`` parameters are skipped: none in this SDK carry a query
+    parameter (every one forwards into a JSON body -- see the resource
+    docstrings), so there is no fixed name to force in the first place.
+    """
+    hints = typing.get_type_hints(fn)
+    kwargs: dict[str, Any] = {}
+    for pname, param in inspect.signature(fn).parameters.items():
+        if pname == "self" or param.kind is inspect.Parameter.VAR_KEYWORD:
+            continue
+        kwargs[pname] = _dummy_value(hints.get(pname, str))
+
+    async def call(bot):
+        resource = getattr(bot, resource_attr)
+        await fn(resource, **kwargs)
+
+    return call
+
+
+@pytest.fixture(scope="module")
+def signature_forced_requests() -> dict[str, tuple[str, str, frozenset[str]]]:
+    """``name -> (verb, path, query-parameter names)``, every optional
+    parameter forced to a value, derived from each resource method's own
+    signature rather than from what ``SDK_REQUESTS`` happens to exercise.
+    """
+    result: dict[str, tuple[str, str, frozenset[str]]] = {}
+    for cls in (
+        resources.AgentsResource,
+        resources.AnalyticsResource,
+        resources.KnowledgeResource,
+        resources.SessionsResource,
+    ):
+        attr = _RESOURCE_ATTRS[cls.__name__]
+        for method_name, fn in inspect.getmembers(cls, inspect.iscoroutinefunction):
+            if method_name.startswith("_"):
+                continue
+            verb, path, sent = _urls(_forced_call(attr, fn))[0]
+            result[f"{attr}.{method_name}"] = (verb, path, sent)
+    assert result, "no resource methods were probed -- the introspection broke, not the SDK"
+    return result
+
+
+def test_every_signature_forced_parameter_exists_on_the_route(signature_forced_requests, route_query_params):
+    """AC (#15187): does not depend on SDK_REQUESTS passing the parameter at
+    all -- forcing every optional argument reaches a ``None``-defaulted one
+    the pinned rows never exercise.
+    """
+    for name, (verb, path, sent) in signature_forced_requests.items():
+        if sent:
+            _assert_sent_params_are_accepted(name, verb, path, sent, route_query_params)
+
+
+#: SDK_REQUESTS row names that do not match their underlying method name 1:1
+#: -- two rows exercise the same ``set_enabled`` method with different args.
+_ROW_METHOD_ALIASES = {"set_enabled_on": "set_enabled", "set_enabled_off": "set_enabled"}
+
+
+def test_every_signature_derived_parameter_is_exercised_by_a_pinned_row(signature_forced_requests):
+    """AC (#15187): a parameter the signature can send but no row exercises is
+    a hole in coverage, not a pass -- deriving the set from signatures must
+    not excuse SDK_REQUESTS from exercising every name in it.
+    """
+    pinned: dict[str, frozenset[str]] = {}
+    for row_name, call, _method, _expected in SDK_REQUESTS:
+        attr, _, method = row_name.partition(".")
+        method = _ROW_METHOD_ALIASES.get(method, method)
+        _, _, sent = _urls(call)[0]
+        pinned[f"{attr}.{method}"] = pinned.get(f"{attr}.{method}", frozenset()) | sent
+
+    for name, (_verb, _path, forced) in signature_forced_requests.items():
+        missing = forced - pinned.get(name, frozenset())
+        assert not missing, (
+            f"{name} can send {sorted(missing)} once every optional parameter is forced, but no row in "
+            f"SDK_REQUESTS exercises it -- add one, or the route contract for it is checked by nothing (#15187)."
+        )
+
+
+def test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept(route_query_params):
+    """AC (#15187) contrast mutation: a ``None``-defaulted query parameter the
+    route does not accept, exercised by no row, must fail this guard; removing
+    it must pass again.
+
+    A synthetic method stands in for a resource file so the mutation does not
+    touch real source, but it is driven through the exact ``_forced_call`` /
+    ``_assert_sent_params_are_accepted`` pipeline the real guards above use --
+    this proves the mechanism catches the shape #15119's AC4 named, not a
+    re-implementation of it.
+    """
+
+    class _Buggy:
+        async def get_entries(self, category: str | None = None, secret_offset: str | None = None) -> None:
+            await self._c.get("/knowledge_base/entries", category=category, secret_offset=secret_offset)
+
+    class _Fixed:
+        async def get_entries(self, category: str | None = None) -> None:
+            await self._c.get("/knowledge_base/entries", category=category)
+
+    verb, path, sent = _urls(_forced_call("knowledge", _Buggy.get_entries))[0]
+    with pytest.raises(AssertionError, match="secret_offset"):
+        _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)
+
+    verb, path, sent = _urls(_forced_call("knowledge", _Fixed.get_entries))[0]
+    _assert_sent_params_are_accepted("knowledge.get_entries", verb, path, sent, route_query_params)
 
 
 def test_pagination_advances_when_the_cursor_from_one_page_is_passed_to_the_next():
@@ -370,10 +561,6 @@ _RESOURCE_ATTRS = {
 
 def test_every_sdk_request_is_covered():
     """A new resource method must arrive with a URL row above, or this fails."""
-    import inspect
-
-    from autobot_sdk import resources
-
     declared = {
         f"{_RESOURCE_ATTRS[cls.__name__]}.{name}"
         for cls in (

--- a/repo_tests/sdk_request_url_test.py
+++ b/repo_tests/sdk_request_url_test.py
@@ -403,7 +403,12 @@ def _dummy_value(annotation: Any) -> Any:
     if annotation is float:
         return 1.5
     if annotation is dict or origin is dict:
-        return {}
+        # Truthy on purpose. Several call sites include an optional argument
+        # only under ``if param:``, so an empty dict would be dropped before
+        # it reached the wire — the parameter would read as "forced" while
+        # never actually being checked, which is the exact blindness this
+        # guard exists to remove (#15187 review).
+        return {"x": "x"}
     return "x"
 
 


### PR DESCRIPTION
## Thinking Path

#15119 asked for a guard that fails CI the next time an SDK method sends a
query parameter its route does not accept. `repo_tests/sdk_request_url_test.py`
delivers that guard for the three methods the issue named (PR #15137,
merged as `fc3a93aa4`) — but the owner's closure verification on #15119 found
AC4 only partially met: `test_the_rows_above_exercise_every_query_parameter_the_sdk_can_send`
derives its expected parameter set from `SENT_QUERY_PARAMS`, a set pinned by
what the `SDK_REQUESTS` rows actually put on the wire, not from the SDK's own
method signatures. `AutoBotClient.get()` drops `None` values
(`libs/autobot-sdk-python/autobot_sdk/client.py:117`), so a parameter
defaulting to `None` that no row bothers to pass never reaches the wire this
file observes — the guard passes even though a real caller who *does* pass it
sends a parameter FastAPI silently ignores. That gap was filed as #15187
because most optional SDK parameters default to `None`, so it is the common
shape, not an edge case.

This PR is #15187's whole scope. #15119 itself needs no further code change —
the three methods it named are already fixed — it stays open only pending
this issue, per the owner's comment on it.

## What Changed

`repo_tests/sdk_request_url_test.py`:

- `_dummy_value` / `_forced_call`: introspect a resource method's own
  signature (`inspect.signature` + `typing.get_type_hints`) and force every
  parameter — regardless of its default — to a concrete, non-`None` value.
  `**kwargs` parameters are skipped: none in this SDK carry a query parameter,
  every one forwards into a JSON body.
- `signature_forced_requests` fixture: runs every async resource method this
  way and records `(verb, path, query-parameter names)` per method, driven
  through the same `httpx.MockTransport` harness the existing guards use.
- `test_every_signature_forced_parameter_exists_on_the_route`: the AC4 check
  itself — a signature-forced parameter must exist on the route it targets,
  independent of whether any `SDK_REQUESTS` row happens to pass it.
- `test_every_signature_derived_parameter_is_exercised_by_a_pinned_row`: the
  companion check #15187's AC2 asked for — a signature can send a parameter
  no row exercises is itself a failure, so deriving the set from signatures
  does not trade the original hole for "coverage" nothing ever actually
  calls through.
- `test_the_guard_flags_a_none_defaulted_parameter_the_route_does_not_accept`:
  the AC3 contrast mutation. A synthetic method with a `None`-defaulted,
  route-rejected, row-unexercised parameter is driven through the exact
  `_forced_call` / `_assert_sent_params_are_accepted` pipeline the real
  guards use (factored out of the existing per-row test rather than
  reimplemented) and shown to fail; the same check on the fixed shape passes.
- `_assert_sent_params_are_accepted`: the existing per-row test's comparison,
  factored into a shared helper so the contrast test exercises the real
  mechanism rather than a copy of it.
- Module docstring and an inline note record why this does **not** close
  #15186's defect class: a parameter the route *does* declare but the handler
  never applies passes every check here because it is declared — that needs
  a behavioural test (asserting two different values produce two different
  responses), not a name-existence check.

## Verification

- `git push` ran the repo's pre-push hook, which executes pytest on this file
  directly: `[pre-push OK] pytest: all relevant tests pass`.
- Traced every SDK resource method's actual `self._c.get(...)` call sites
  (`libs/autobot-sdk-python/autobot_sdk/resources/{agents,analytics,knowledge,sessions}.py`)
  to confirm only `sessions.list`, `sessions.get` and `knowledge.get_entries`
  forward keyword arguments into a GET call — the new signature-forced tests
  reduce to a no-op (empty query-parameter set) everywhere else, so they do
  not silently assert nothing.
- `api-wiring` (the blocking route-table gate) checks URL shape, not query
  parameters, so it could not have caught this class — the `repo_tests` guard
  this PR strengthens is the only line of defence for it.

Closes #15187

## Model Used

Claude Opus 5 (1M context)