### PR TITLE
fix(tests): recover the terminal route dump's lost include_router prefix from the static mount graph (#15126)

### DIFF
--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -182,7 +182,9 @@ def terminal_tools_include_prefix() -> str:
     """
     backend_root = Path(__file__).resolve().parents[1]
     graph = build_graph(backend_root)
-    edges = [e for e in graph.edges if e.parent == "api.terminal:admin_router" and e.child == "api.terminal_tools:router"]
+    edges = [
+        e for e in graph.edges if e.parent == "api.terminal:admin_router" and e.child == "api.terminal_tools:router"
+    ]
     assert edges, (
         "the api.terminal:admin_router -> api.terminal_tools:router mount "
         "(api/terminal.py:198) was not found in the static mount graph -- "

--- a/autobot-backend/api/terminal_router_dependency_wiring_test.py
+++ b/autobot-backend/api/terminal_router_dependency_wiring_test.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 
+from autobot_shared.api_routing.mount_graph import build_graph
+
 # --- clean-interpreter route/dependency enumeration (#14998, #15087) ---
 #
 # Every structural gate assertion below reads from this, never from an
@@ -167,6 +169,35 @@ def terminal_route_spec() -> dict:
     return {r["path"]: r["dependencies"] for r in routes}
 
 
+@pytest.fixture(scope="session")
+def terminal_tools_include_prefix() -> str:
+    """The literal ``prefix=`` argument at ``api/terminal.py:198``, read from
+    source rather than guessed at (#15126).
+
+    ``_walk`` above cannot recover this: the value is consumed by
+    ``include_router`` and never lands on a public attribute of the deferred
+    wrapper it leaves behind (see ``mount_graph.py``'s module docstring for the
+    one, private, unstable place it *does* land). The static mount graph reads
+    the call site itself, so it means the same thing on every FastAPI shape.
+    """
+    backend_root = Path(__file__).resolve().parents[1]
+    graph = build_graph(backend_root)
+    edges = [e for e in graph.edges if e.parent == "api.terminal:admin_router" and e.child == "api.terminal_tools:router"]
+    assert edges, (
+        "the api.terminal:admin_router -> api.terminal_tools:router mount "
+        "(api/terminal.py:198) was not found in the static mount graph -- "
+        "either the site moved or discovery regressed"
+    )
+    assert len(edges) == 1, f"expected exactly one such mount, found {len(edges)}: {edges}"
+    prefix = edges[0].prefix
+    assert prefix == "/terminal", (
+        f"api/terminal.py:198's include-time prefix resolved to {prefix!r}, not "
+        "'/terminal' -- either the literal argument at that call site changed, "
+        "or Mount.prefix extraction regressed"
+    )
+    return prefix
+
+
 class TestTerminalRouterDependencyWiring:
     """Structural proof of the fix: the admin dependency moved off the WS
     routes and stayed on the HTTP ones. This is the assertion #14998 itself
@@ -221,60 +252,63 @@ class TestTerminalRouteDumpIsComplete:
     naming only its own symptom.
     """
 
-    #: One route per nesting level: ``(needle, match_by_suffix, owner)``.
-    #:
-    #: The third is matched by **suffix**, for the reason
-    #: ``test_a_dumped_path_only_ever_loses_its_include_prefix`` below states
-    #: and pins: the dump cannot recover an include-time ``prefix=`` under a
-    #: deferring fastapi, so this route is ``/terminal/package-managers`` on
-    #: the eager local version (#15091) and ``/package-managers`` in CI (job
-    #: 98211256874). The suffix is unique within the dump and identical on
-    #: both, so the level stays pinned without this guard depending on the one
-    #: part of the dump that is version-sensitive.
+    #: One route per nesting level: ``(needle, owner)``. The third level
+    #: (``api.terminal_tools``' router) has its own test below rather than a
+    #: parametrize entry here, because it needs
+    #: ``terminal_tools_include_prefix`` to match exactly instead of by suffix
+    #: (#15126).
     _LEVELS = (
-        ("/ws/{session_id}", False, "router -- declared directly, present even without flattening"),
-        ("/", False, "admin_router -- included into router at the end of api/terminal.py"),
-        ("/package-managers", True, "api.terminal_tools' router -- included into admin_router"),
+        ("/ws/{session_id}", "router -- declared directly, present even without flattening"),
+        ("/", "admin_router -- included into router at the end of api/terminal.py"),
     )
 
-    @pytest.mark.parametrize("needle,by_suffix,owner", _LEVELS)
-    def test_the_dump_reaches_every_nesting_level(self, terminal_route_spec, needle, by_suffix, owner):
-        found = [p for p in terminal_route_spec if (p.endswith(needle) if by_suffix else p == needle)]
-        assert found, (
-            f"the dump holds no route {'ending in' if by_suffix else 'at'} {needle}. "
-            f"That route is owned by {owner}, so the walk never reached that "
-            "inclusion at all -- a dropped include prefix would still leave the "
-            "suffix, so this is absence, not truncation. Every dependency "
-            "assertion in this module sweeps that shortened surface.\n"
+    @pytest.mark.parametrize("needle,owner", _LEVELS)
+    def test_the_dump_reaches_every_nesting_level(self, terminal_route_spec, needle, owner):
+        assert needle in terminal_route_spec, (
+            f"the dump holds no route at {needle}. That route is owned by "
+            f"{owner}, so the walk never reached that inclusion at all. Every "
+            "dependency assertion in this module sweeps that shortened surface.\n"
+            f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
+        )
+
+    def test_the_dump_reaches_the_third_nesting_level(self, terminal_route_spec, terminal_tools_include_prefix):
+        """``api.terminal_tools``' router, included into ``admin_router``, three deep.
+
+        Matched exactly rather than by suffix (#15126): either the dump already
+        holds the full served path (eager fastapi, #15091), or it holds that
+        path with exactly the statically-derived include-time prefix removed
+        (deferred fastapi, #15093) -- never merely "ends with".
+        """
+        served = "/terminal/package-managers"
+        short = served[len(terminal_tools_include_prefix) :]
+        assert served in terminal_route_spec or short in terminal_route_spec, (
+            f"the dump holds neither {served!r} nor {short!r}. api.terminal_tools' "
+            "router, included into admin_router, was never reached.\n"
             f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
         )
 
 
-class TestTerminalRouteDumpPathFidelity:
-    """What the dump's paths do and do not mean (#15126).
+class TestTerminalRouteDumpPathReconstruction:
+    """The dump's path, plus the statically-derived include-time prefix, equals
+    the served path -- proven, not merely bounded as a limit (#15126).
 
     ``api/terminal.py:198`` is ``admin_router.include_router(tools_router,
     prefix="/terminal")``, and ``api.terminal_tools``' router carries no
     ``prefix`` of its own -- so that ``/terminal`` is purely the **include-time
-    ``prefix=`` argument**. #15112 separates that term from the one it was
-    being conflated with and states of it: "nothing recovers these from the
-    deferred shape". The *including router's own* ``.prefix`` is the other
-    term, and it is recoverable -- it simply is not the one in play here.
+    ``prefix=`` argument**. #15112 separated that term from the *including
+    router's own* ``.prefix`` (recoverable from the route objects on every
+    FastAPI shape) and found the include-time one unrecoverable through any
+    *public* route attribute. It is not gone -- ``mount_graph.py``'s module
+    docstring names the private, unstable attribute that does carry it, and why
+    depending on that would be a worse bet than reading the call site.
 
-    So this dump reports those four routes unprefixed in CI and prefixed on the
-    eager fastapi this repo resolves locally. Rather than let that trip a test
-    up again, it is asserted: a dumped path is never *wrong*, only ever missing
-    a leading include prefix. That holds on both versions, fails if the walk
-    ever starts inventing paths, and is the honest statement of the limit.
-
-    The stronger test -- build the expected full paths from a static mount
-    graph, which *can* see the include site, and compare -- is gated on #15112
-    (`autobot_shared/api_routing/`, open at the time of writing). It already
-    carries the piece needed: ``router_prefixes.include_router_prefixes()``
-    returns ``(router_name, prefix)`` from source, and that PR proposes
-    surfacing it as a ``prefix`` field on ``Mount``. Consume that when it
-    lands; do not write a private copy of it in the meantime (#15093). This
-    class and the suffix match above are what it replaces (#15126).
+    ``terminal_tools_include_prefix`` reads that literal from source, so it
+    means the same thing on both FastAPI shapes. Reconstructing the served path
+    from it and asserting equality is strictly stronger than the suffix-tolerant
+    check this class replaces (formerly ``TestTerminalRouteDumpPathFidelity``):
+    a suffix match cannot distinguish a correctly-recovered prefix from a
+    coincidentally-matching one, and this can, because the prefix it checks
+    against is independently derived rather than assumed.
     """
 
     #: The paths the application actually serves for the tool routes. Not an
@@ -289,15 +323,21 @@ class TestTerminalRouteDumpPathFidelity:
     )
 
     @pytest.mark.parametrize("served", _SERVED_TOOL_PATHS)
-    def test_a_dumped_path_only_ever_loses_its_include_prefix(self, terminal_route_spec, served):
-        matches = [p for p in terminal_route_spec if served.endswith(p) and p != "/"]
+    def test_dump_path_reconstructs_to_the_served_path(
+        self, terminal_route_spec, terminal_tools_include_prefix, served
+    ):
+        short = served[len(terminal_tools_include_prefix) :]
+        candidates = {served, short}
+        matches = [p for p in terminal_route_spec if p in candidates]
         assert matches, (
-            f"{served} is served by the application but nothing in the dump is "
-            "even a trailing part of it. The walk is not merely dropping the "
-            f"include prefix from api/terminal.py:198 -- it has lost the route.\n"
+            f"{served} is served by the application, but the dump holds neither "
+            f"it nor {short!r} ({terminal_tools_include_prefix!r} + {short!r} "
+            f"should equal {served!r}).\n"
             f"dump held {len(terminal_route_spec)} route(s): {sorted(terminal_route_spec)}"
         )
         assert len(matches) == 1, f"{served} matched more than one dumped path, so neither identifies it: {matches}"
+        recovered = terminal_tools_include_prefix + matches[0] if matches[0] == short else matches[0]
+        assert recovered == served, f"reconstructed {recovered!r} does not equal the served path {served!r}"
 
 
 def _dump_routes_main() -> None:
@@ -355,31 +395,38 @@ def _dump_routes_main() -> None:
 
         Under fastapi 0.141.1 neither ``include_router`` nor mounting an app
         flattens eagerly: both leave a wrapper whose ``.original_router`` holds
-        the real routes, and whose own path is ``None``. Same idiom the repo
-        already uses in ``llc/tests/test_roles_routes_registered.py``,
-        ``api/codebase_analytics/endpoints/impact_endpoint_test.py`` and
-        ``api/self_capabilities_integration_test.py`` -- copied here rather than
-        invented, though the fact that four files now carry it by hand is its
-        own problem.
+        the real routes, and whose own path is ``None``. This was one of four
+        hand-rolled copies of that idiom; #15112 replaced the other three
+        (``llc/tests/test_roles_routes_registered.py``,
+        ``api/codebase_analytics/endpoints/impact_endpoint_test.py``,
+        ``api/self_capabilities_integration_test.py``) with the shared
+        ``autobot_shared.api_routing.router_routes`` traversal and left this one
+        in place deliberately, gated on this issue (#15126).
 
-        **The reconstructed prefix is not trustworthy, and a caller must not
-        key an assertion on one.** Two different terms both read as "prefix"
-        and only one of them survives deferral (#15112): the *including
-        router's own* ``.prefix`` stays on the parent object and is
-        recoverable, while an include-time ``prefix=`` **argument** is consumed
-        at include time and left nowhere -- ``sub_prefix`` then resolves empty
-        and the path comes back short. ``api/terminal.py:198`` uses the second
-        kind, so CI job 98211256874 dumped ``/package-managers`` for a route
-        the application serves at ``/terminal/package-managers``, while the
-        eager fastapi this repo resolves locally (#15091) dumps it prefixed.
+        **This function's reconstructed prefix is still not trustworthy on its
+        own, and a caller must not key an assertion on one without the help
+        below.** Two different terms both read as "prefix" and only one of
+        them survives deferral (#15112): the *including router's own*
+        ``.prefix`` stays on the parent object and is recoverable, while an
+        include-time ``prefix=`` **argument** is consumed at include time and
+        is not exposed on any *public* attribute of the wrapper this function
+        reads -- ``sub_prefix`` then resolves empty and the path comes back
+        short. (It is not gone outright: verified against fastapi 0.141.1's own
+        ``routing.py``, the private ``_IncludedRouter.include_context.prefix``
+        carries the combined value. That is an internal, underscore-prefixed
+        pair with no cross-version stability guarantee, so nothing here reads
+        it -- see ``mount_graph.py`` for the same finding stated once, not
+        copied.) ``api/terminal.py:198`` uses the include-time kind, so CI job
+        98211256874 dumped ``/package-managers`` for a route the application
+        serves at ``/terminal/package-managers``, while the eager fastapi this
+        repo resolves locally (#15091) dumps it prefixed.
 
-        Nothing in this module reads a prefixed path -- the routes it asserts
-        on are all included without one -- and
-        ``TestTerminalRouteDumpPathFidelity`` pins the limit rather than
-        leaving the next reader to trip over it. Filed as #15126; the static
-        mount graph that *can* see the include site is #15112. Do not patch
-        this by guessing at a wrapper attribute, and do not fork a private
-        copy of that graph (#15093). Match by a unique suffix until it lands.
+        Nothing in this module reads a *raw* prefixed path from ``_walk`` alone
+        for that reason. ``TestTerminalRouteDumpPathReconstruction`` below
+        supplies the missing piece from the static mount graph
+        (``mount_graph.Mount.prefix``, read straight from
+        ``api/terminal.py:198``) instead of guessing at a wrapper attribute or
+        forking a private copy of that graph (#15093).
         """
         found = []
         for route in getattr(container, "routes", []) or []:

--- a/autobot_shared/api_routing/mount_graph.py
+++ b/autobot_shared/api_routing/mount_graph.py
@@ -20,14 +20,21 @@ report a human reads to judge it. This is the single copy.
 
 ## Why static
 
-Under ``fastapi>=0.139`` ``include_router`` defers: neither the include-time
-``prefix=`` nor an include-time ``dependencies=`` list is recoverable from the
-route objects afterwards (#15093, and see
-``autobot_shared/api_routing/router_routes.py`` for the runtime half). A
-development checkout may resolve a lower FastAPI where some of it *is* readable
-(#15091), so a runtime-introspection guard would mean one thing locally and
-another in CI — worse than no guard. Parsing the registration sites is
-version-independent, which is the property both consumers need.
+Under ``fastapi>=0.139`` ``include_router`` defers, and neither the include-time
+``prefix=`` nor an include-time ``dependencies=`` list is recoverable through
+the *public* route objects afterwards (#15093, and see
+``autobot_shared/api_routing/router_routes.py`` for the runtime half). Correction
+(#15126, verified against fastapi 0.141.1's own ``routing.py``): the prefix is
+not actually gone -- ``_IncludedRouter.include_context.prefix`` carries the
+combined value -- it is only unreachable from the *public* surface every
+runtime consumer here reads. Depending on that private, underscore-prefixed
+pair would mean trusting an implementation detail with no stability guarantee
+across a version bump, which is a worse bet than the deferral itself. A
+development checkout may resolve a lower FastAPI where some of it *is* publicly
+readable (#15091), so a runtime-introspection guard would mean one thing
+locally and another in CI regardless — worse than no guard. Parsing the
+registration sites is version-independent, which is the property both
+consumers need.
 
 ## What it cannot see
 
@@ -105,6 +112,14 @@ class Mount:
     child: str
     guards: FrozenSet[str]
     site: str
+    #: The literal ``prefix=`` argument at *this* ``include_router`` call, or
+    #: ``None`` when absent or not a plain string literal (#15126) -- the
+    #: include-time term #15093 found unreadable from the route objects after
+    #: the fact (see ``router_routes.py``). A registry-entry edge always leaves
+    #: this ``None``: ``app_factory`` mounts those with a computed
+    #: ``prefix=f"/api{prefix}"``, not a literal at the call site. ``None`` and
+    #: ``""`` are distinct, matching ``router_prefixes.apirouter_prefix``.
+    prefix: Optional[str] = None
 
 
 @dataclass
@@ -242,6 +257,17 @@ def _call_kwarg(call: ast.Call, name: str) -> ast.AST | None:
     for keyword in call.keywords:
         if keyword.arg == name:
             return keyword.value
+    return None
+
+
+def _string_literal(node: ast.AST | None) -> str | None:
+    """*node*'s value if it is a plain string constant, else ``None``.
+
+    An f-string or a name reference is real but not statically resolvable here;
+    treated the same as "no ``prefix=``" rather than guessed at (#15126).
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
     return None
 
 
@@ -450,7 +476,8 @@ class ModuleScan:
                 if parent_expr not in {"app", "application", "self.app"}:
                     self.unresolved.append(f"{site} parent={parent_expr or '<expr>'}")
             guards = _guards_from_keyword(_call_kwarg(node, "dependencies") or ast.List(elts=[]))
-            self.edges.append(Mount(parent=parent, child=child, guards=guards, site=site))
+            prefix = _string_literal(_call_kwarg(node, "prefix"))
+            self.edges.append(Mount(parent=parent, child=child, guards=guards, site=site, prefix=prefix))
 
 
 # --- registry entries -------------------------------------------------------

--- a/repo_tests/router_routes_traversal_test.py
+++ b/repo_tests/router_routes_traversal_test.py
@@ -52,11 +52,19 @@ being fixed).
   pinned by ``autobot_shared/api_routing/router_routes_test.py``, which asserts
   against a real ``APIRouter`` on whatever FastAPI is installed.
 * **An include-time ``prefix=`` or ``dependencies=``.** Neither is recoverable
-  from the deferred shape by any introspection — that is why
+  from the deferred shape through any *public* route attribute -- that is why
   ``api/terminal_tools.py`` carries its gate on its own ``APIRouter(...)``
   constructor, where ``repo_tests/router_mount_parity_test.py`` can read it, and
   why ``api/terminal_websocket_route_test.py`` proves its gate behaviourally with
-  a real request instead.
+  a real request instead. (Correction, #15126: the prefix specifically is not
+  gone -- fastapi 0.141.1's private ``_IncludedRouter.include_context.prefix``
+  carries it -- only unreachable from the stable surface anything here should
+  depend on; see ``mount_graph.py`` for the one place that says so.)
+* **Whether a reconstructed path is correct.** This guard's premise is the
+  deferred-shape *zero-routes* hazard -- a read that silently finds nothing. A
+  read that resolves and finds real routes but drops an include-time prefix,
+  producing a route that is wrong rather than absent, is a different defect
+  (#15126) and outside what this guard checks for, resolved or not.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Thinking Path

**Mechanism, confirmed against fastapi 0.141.1's own source (the version CI resolves, and the latest release as of this PR — downloaded and read, not installed or executed).** `autobot-backend/api/terminal_router_dependency_wiring_test.py:432-436`'s `_walk`:

```python
for route in getattr(container, "routes", []) or []:
    original = getattr(route, "original_router", None)
    if original is not None:
        sub_prefix = getattr(route, "prefix", "") or getattr(original, "prefix", "") or ""
```

`fastapi.routing.include_router` (0.141.1) appends `_IncludedRouter(original_router=router, include_context=include_context)` where `include_context.prefix = parent_router.prefix + prefix` (the combined value, `routing.py:1287,1326`). `_IncludedRouter` is a plain `@dataclass` with no `__getattr__` and no `prefix` field of its own (`routing.py:1586-1599`), so `getattr(route, "prefix", "")` returns `""`. `original` is `tools_router` (`api/terminal_tools.py:44`, `APIRouter(tags=..., dependencies=...)`, no `prefix=` of its own), so `getattr(original, "prefix", "")` is also `""`. Both terms in the `or` chain resolve empty, and `admin_router.include_router(tools_router, prefix="/terminal")` at **`api/terminal.py:198`** is lost.

**The issue body's diagnosis is right about the mechanism but overstates the conclusion.** #15112 and this issue both say the include-time prefix "is not recoverable" / "left nowhere". That's wrong in the literal sense: `route.include_context.prefix` **does** hold `"/terminal"` — it's a private, underscore-prefixed attribute pair (`_IncludedRouter`, `_RouterIncludeContext`) with no FastAPI stability guarantee, not a value that vanished. I corrected this in the three places that made the stronger claim (`mount_graph.py`'s "Why static" section, `terminal_router_dependency_wiring_test.py`'s `_walk` docstring, `router_routes_traversal_test.py`'s "what this does NOT catch" list) to say "not recoverable through any *public* attribute" and record the private one that does carry it, and why depending on it would be a worse bet than the deferral itself (no cross-version guarantee vs. reading the call site with AST, which means the same thing on every FastAPI shape). This doesn't change the prescribed fix — the static mount graph remains correct regardless — but the blanket "impossible" claim was inaccurate and is now precise.

**Consumers of this specific dump**, checked one by one:
- Only `terminal_router_dependency_wiring_test.py` itself consumes `_dump_routes_main`'s output (`grep` for `_dump_routes_main`/`_run_terminal_route_dump` across the repo returns this file plus one docstring cross-reference in `terminal_websocket_route_test.py`, not a code path).
- `scripts/audit_api_wiring.py` (the required `api-wiring` gate), named as a candidate in the issue, turns out **not** to be a consumer of this dump at all: its blocking path (`.github/workflows/api-wiring.yml`) runs `--dump-openapi` then `--openapi`, which calls `app.openapi()` — FastAPI's own, publicly-supported route resolver, which correctly applies `include_context.path_for()` internally and is unaffected by this bug. Its fallback static mode (`backend_paths_static`, used only without `--openapi`) reads `router_prefixes.include_router_prefixes()`, a source-level regex scan, also unaffected. `api-wiring`'s "normalise path segments to `{p}`" behaviour (`norm_path`) is unrelated to this defect — it only touches `{param}`-style segments, not a missing literal prefix — so it neither masked nor was exposed to this bug; api-wiring simply never touches the buggy dump.
- The three other hand-rolled copies the issue names (`llc/tests/test_roles_routes_registered.py`, `api/codebase_analytics/endpoints/impact_endpoint_test.py`, `api/self_capabilities_integration_test.py`) were already migrated by #15112 to `router_routes.effective_routes()` or `get_openapi()`. **Count of additional gaps found: zero.** None of their assertions cross an include-time `prefix=` argument — `test_roles_routes_registered.py` only relies on `llc_router`'s own constructor `.prefix` (the recoverable term), and the other two assert membership/registration, not a reconstructed prefixed path.
- `repo_tests/router_routes_traversal_test.py` (#15093/#15112's guard) **is** structurally blind to `_walk`'s read — `getattr(container, "routes", [])` where `container` is a function parameter, the documented "attribute chain rooted in a local variable" blind spot, bounded by `test_unresolved_routes_reads_stay_bounded`. This is a pre-existing, already-documented, already-bounded limitation, not a new gap. More importantly, even a perfect resolver wouldn't have caught #15126: that guard's premise is the *zero-routes* hazard (a read that silently finds nothing); this defect is a read that finds real routes but reconstructs a *wrong* (unprefixed) path, which is outside its scope by design. No new issue filed — the limit is already tracked in-repo and the guard was never meant to answer this question.

**The test (AC1).** `terminal_tools_include_prefix` (new session fixture) runs `mount_graph.build_graph()` over `autobot-backend/`, finds the `api.terminal:admin_router -> api.terminal_tools:router` edge, and asserts its `Mount.prefix == "/terminal"` — reading `api/terminal.py:198`'s literal argument, independent of which FastAPI is installed. `TestTerminalRouteDumpPathReconstruction` (replacing `TestTerminalRouteDumpPathFidelity`) then, for each of the four served tool paths, checks that either the dump already holds the full path (eager fastapi locally) or holds the path with exactly that statically-derived prefix stripped (deferred fastapi in CI), and asserts the reconstruction is exactly equal to the served path — not merely a suffix match.

**Mutation, confirmed by reading (not executing).** Removing `prefix="/terminal"` from `api/terminal.py:198` (mirroring the class of defect this issue is about) makes `_call_kwarg(node, "prefix")` return `None`, so `_string_literal(None)` returns `None`, so the new `Mount.prefix` is `None`. `terminal_tools_include_prefix`'s `assert prefix == "/terminal"` then fails immediately and by name, before any downstream test even runs — this is the "a test that would fail if the prefix were dropped again" the issue asks for, and it fails for the right reason (the site's literal argument, not an unrelated dump artifact).

## What Changed

- `autobot_shared/api_routing/mount_graph.py` — `Mount` gained a `prefix: Optional[str] = None` field, populated in `_collect_include_calls` from the include_router call's own literal `prefix=` argument via a new `_string_literal()` helper (dynamic/non-literal values stay `None`, matching `router_prefixes.apirouter_prefix`'s `None`-vs-`""` convention). Registry-mounted edges always leave it `None` (documented: `app_factory` computes `prefix=f"/api{prefix}"`, not a literal at that call site). Corrected the "Why static" section's overclaim about the prefix being unrecoverable (see Thinking Path).
- `autobot-backend/api/terminal_router_dependency_wiring_test.py` — new `terminal_tools_include_prefix` fixture; `TestTerminalRouteDumpIsComplete._LEVELS` dropped its suffix-tolerant third entry in favour of a dedicated `test_the_dump_reaches_the_third_nesting_level`; `TestTerminalRouteDumpPathFidelity` replaced by `TestTerminalRouteDumpPathReconstruction`, which proves the reconstruction instead of bounding the limit; `_walk`'s docstring updated to reflect that #15112 migrated the other three hand-rolled copies and to record the private-attribute correction.
- `repo_tests/router_routes_traversal_test.py` — docstring-only correction of the same overclaim, plus an explicit note that this guard's premise (zero routes) is a different question from path-reconstruction correctness (#15126).

No file exceeds 600 lines (`mount_graph.py`: 595; `terminal_router_dependency_wiring_test.py`: 465; `router_routes_traversal_test.py`: 432). No `KNOWN_LARGE` entry touched.

## Verification

- `python3 -m ast` parses all three touched files cleanly.
- Manual AST trace against `api/terminal.py` (imports → `admin_router = APIRouter(...)` at :175 → `admin_router.include_router(tools_router, prefix="/terminal")` at :198, with `tools_router` bound via `from api.terminal_tools import router as tools_router`) confirms `_collect_include_calls` resolves `parent="api.terminal:admin_router"`, `child="api.terminal_tools:router"`, `prefix="/terminal"` — matching what `terminal_tools_include_prefix` asserts.
- The repo's pre-push hook ran pytest on both touched test files against this repo's locally-resolved fastapi (0.135.2, eager shape) and passed: `[pre-push OK] pytest: all relevant tests pass` for `autobot-backend/api/terminal_router_dependency_wiring_test.py` and `repo_tests/router_routes_traversal_test.py`.
- CI will additionally exercise the deferred shape (fastapi 0.141.1), which is the shape this fix targets and could not be run locally.

## Model Used

Claude Opus 5 (1M context)

Closes #15126