### PR TITLE
canonical(secrets): close two vault-seam gaps and add the resolution-path guard that would have caught them

### DIFF
--- a/autobot-backend/agent_loop/search/registry.py
+++ b/autobot-backend/agent_loop/search/registry.py
@@ -102,23 +102,31 @@ def _populate_default_providers(registry: SearchProviderRegistry) -> None:
     from agent_loop.search.brave_provider import BraveSearchProvider
     from agent_loop.search.searxng_provider import SearXNGSearchProvider
     from autobot_shared.ssot_config import config
+    from services.provider_key_vault import resolve_provider_key
 
-    searxng_url = getattr(config, "searxng_instance_url", "")
+    # Credentials/URL resolve through the vault seam (env wins; else System
+    # vault, #15267) -- the same treatment llm_shared.provider_registry
+    # already gives its seven LLM provider keys.
+    searxng_url = resolve_provider_key("SEARXNG_INSTANCE_URL", getattr(config, "searxng_instance_url", ""))
     if searxng_url:
         registry.register(
             SearXNGSearchProvider(
                 settings={
                     "instance_url": searxng_url,
-                    "basic_auth_user": getattr(config, "searxng_basic_auth_user", ""),
-                    "basic_auth_pass": getattr(config, "searxng_basic_auth_pass", ""),
-                    "token": getattr(config, "searxng_token", ""),
+                    "basic_auth_user": resolve_provider_key(
+                        "SEARXNG_BASIC_AUTH_USER", getattr(config, "searxng_basic_auth_user", "")
+                    ),
+                    "basic_auth_pass": resolve_provider_key(
+                        "SEARXNG_BASIC_AUTH_PASS", getattr(config, "searxng_basic_auth_pass", "")
+                    ),
+                    "token": resolve_provider_key("SEARXNG_TOKEN", getattr(config, "searxng_token", "")),
                 }
             )
         )
     else:
         logger.debug("SEARXNG_INSTANCE_URL not set — SearXNG search provider not registered")
 
-    brave_key = getattr(config, "brave_search_api_key", "")
+    brave_key = resolve_provider_key("BRAVE_SEARCH_API_KEY", getattr(config, "brave_search_api_key", ""))
     if brave_key:
         registry.register(BraveSearchProvider(settings={"api_key": brave_key}))
     else:

--- a/autobot-backend/agent_loop/search/registry_test.py
+++ b/autobot-backend/agent_loop/search/registry_test.py
@@ -1,0 +1,104 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Web-search provider credentials resolve through the vault seam (#15267).
+
+Mirrors ``llm_shared/tests/test_provider_registry_key_coverage.py``'s spy technique:
+monkeypatch ``resolve_provider_key`` to record every name it is asked for (never
+touching a real vault or network), then run the registry's real population function.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_loop.search.registry import SearchProviderRegistry, _populate_default_providers
+
+_SEARCH_KEY_NAMES = {
+    "SEARXNG_INSTANCE_URL",
+    "SEARXNG_BASIC_AUTH_USER",
+    "SEARXNG_BASIC_AUTH_PASS",
+    "SEARXNG_TOKEN",
+    "BRAVE_SEARCH_API_KEY",
+}
+
+
+@pytest.fixture
+def asked_names(monkeypatch) -> list[str]:
+    """Run the registry build, recording every credential name it resolves.
+
+    The spy returns ``""`` for every name so no provider actually registers --
+    the assertion is about which names are *asked for*, not what a real vault
+    or env would return.
+    """
+    import services.provider_key_vault as vault_mod
+
+    asked: list[str] = []
+
+    def _spy(name: str, fallback: str = "") -> str:
+        asked.append(name)
+        return ""
+
+    monkeypatch.setattr(vault_mod, "resolve_provider_key", _spy)
+    _populate_default_providers(SearchProviderRegistry())
+    return asked
+
+
+def test_the_spy_saw_the_registry_run(asked_names: list[str]) -> None:
+    """Guard the guard: an empty recording would satisfy every assertion below."""
+    assert asked_names, "_populate_default_providers resolved no keys at all"
+
+
+def test_every_search_credential_resolves_through_the_vault_seam(asked_names: list[str]) -> None:
+    """Every name #15267 lists as evidence must be asked for via resolve_provider_key."""
+    missing = _SEARCH_KEY_NAMES - set(asked_names)
+    assert not missing, f"declared search credentials never resolved at runtime: {missing}"
+
+
+def test_env_var_wins_over_the_vault(monkeypatch) -> None:
+    """Dual-read, env-first: an Ansible-provisioned deployment is unaffected."""
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(vault_mod, "_hydrated_keys", {"BRAVE_SEARCH_API_KEY": "vault-value"})
+    monkeypatch.setattr(config, "brave_search_api_key", "env-value", raising=False)
+
+    registry = SearchProviderRegistry()
+    _populate_default_providers(registry)
+
+    provider = registry.get_provider("brave")
+    assert provider is not None
+    assert provider.api_key == "env-value"
+
+
+def test_vault_only_credential_still_registers_the_provider(monkeypatch) -> None:
+    """A key captured only via the wizard (no env var) still resolves and registers."""
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import config
+
+    monkeypatch.setattr(vault_mod, "_hydrated_keys", {"BRAVE_SEARCH_API_KEY": "vault-only-value"})
+    monkeypatch.setattr(config, "brave_search_api_key", "", raising=False)
+
+    registry = SearchProviderRegistry()
+    _populate_default_providers(registry)
+
+    provider = registry.get_provider("brave")
+    assert provider is not None
+    assert provider.api_key == "vault-only-value"
+
+
+def test_a_resolve_failure_degrades_to_no_provider_never_an_exception(monkeypatch) -> None:
+    """The registry's never-raise contract: nothing here may propagate an exception."""
+    import services.provider_key_vault as vault_mod
+
+    def _boom(name: str, fallback: str = "") -> str:
+        raise RuntimeError("simulated vault outage")
+
+    monkeypatch.setattr(vault_mod, "resolve_provider_key", _boom)
+
+    from autobot_shared.credential_gated_registry import gated_registry_singleton
+
+    accessor = gated_registry_singleton(SearchProviderRegistry, _populate_default_providers)
+    registry = accessor()  # must not raise -- population failures are caught and logged
+    assert registry is not None

--- a/autobot-backend/agent_loop/search/registry_test.py
+++ b/autobot-backend/agent_loop/search/registry_test.py
@@ -28,9 +28,11 @@ _SEARCH_KEY_NAMES = {
 def asked_names(monkeypatch) -> list[str]:
     """Run the registry build, recording every credential name it resolves.
 
-    The spy returns ``""`` for every name so no provider actually registers --
-    the assertion is about which names are *asked for*, not what a real vault
-    or env would return.
+    The spy returns a non-empty placeholder (never a real credential shape) for
+    every name so SEARXNG_INSTANCE_URL resolves truthy and the registry's own
+    ``if searxng_url:`` gate does not short-circuit before asking for the
+    basic-auth user/pass/token nested inside it -- the assertion is about which
+    names are *asked for*, not what a real vault or env would return.
     """
     import services.provider_key_vault as vault_mod
 
@@ -38,7 +40,7 @@ def asked_names(monkeypatch) -> list[str]:
 
     def _spy(name: str, fallback: str = "") -> str:
         asked.append(name)
-        return ""
+        return "placeholder"
 
     monkeypatch.setattr(vault_mod, "resolve_provider_key", _spy)
     _populate_default_providers(SearchProviderRegistry())

--- a/autobot-backend/llm_shared/provider_registry.py
+++ b/autobot-backend/llm_shared/provider_registry.py
@@ -620,8 +620,10 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("MISTRAL_API_KEY not set — Mistral provider not registered")
 
-    # HuggingFace — registered when HF token is present
-    hf_token = config.hf_token or config.huggingface_api_token
+    # HuggingFace — HF token, reused below as the Nous Portal fallback (env wins; else vault, #15268).
+    hf_token = resolve_provider_key("HF_TOKEN", config.hf_token) or resolve_provider_key(
+        "HUGGINGFACE_API_TOKEN", config.huggingface_api_token
+    )
     if hf_token:
         hf_provider = HuggingFaceProvider(settings={"api_token": hf_token})
         registry.register(hf_provider)
@@ -662,10 +664,8 @@ def _populate_default_providers(registry: ProviderRegistry) -> None:
     else:
         logger.debug("OPENROUTER_API_KEY not set — OpenRouter provider not registered")
 
-    # Nous Portal — registered when API key is present (Issue #4341; env wins else vault, #10088 Task 7)
-    nous_key = (
-        resolve_provider_key("NOUS_API_KEY", config.nous_api_key) or config.hf_token or config.huggingface_api_token
-    )
+    # Nous Portal — registered when API key is present (Issue #4341; env wins else vault, #10088 Task 7).
+    nous_key = resolve_provider_key("NOUS_API_KEY", config.nous_api_key) or hf_token
     if nous_key:
         try:
             nous_provider = NousPortalProvider(

--- a/autobot-backend/llm_shared/tests/test_hf_nous_precedence.py
+++ b/autobot-backend/llm_shared/tests/test_hf_nous_precedence.py
@@ -1,0 +1,93 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""HF_TOKEN / HUGGINGFACE_API_TOKEN now resolve through the vault seam (#15268).
+
+Both were previously read as a bare ``config.hf_token or config.huggingface_api_token``
+fallback in two places -- the HuggingFace provider's own registration, and the Nous
+Portal provider's fallback chain. This proves both are now members of the
+vault-resolved key set, both call sites route through ``resolve_provider_key``, and
+the three-tier precedence for Nous Portal (``NOUS_API_KEY`` > ``HF_TOKEN`` >
+``HUGGINGFACE_API_TOKEN``) is unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from llm_shared import provider_registry
+from llm_shared.provider_registry import ProviderRegistry
+from services.provider_key_vault import LLM_PROVIDER_KEY_NAMES
+
+
+def test_hf_token_names_are_members_of_the_vault_resolved_key_set() -> None:
+    assert {"HF_TOKEN", "HUGGINGFACE_API_TOKEN"} <= LLM_PROVIDER_KEY_NAMES
+
+
+@pytest.fixture
+def resolved(monkeypatch):
+    """Spy on resolve_provider_key: records every name asked for, and answers each
+    call from a per-test override map (env-unset default: falls through to the
+    ``fallback`` argument the call site passed, exactly like the real function)."""
+    import services.provider_key_vault as vault_mod
+
+    answers: dict[str, str] = {}
+    asked: list[str] = []
+
+    def _spy(name: str, fallback: str = "") -> str:
+        asked.append(name)
+        return answers.get(name, fallback)
+
+    monkeypatch.setattr(vault_mod, "resolve_provider_key", _spy)
+    return answers, asked
+
+
+def _populated_registry() -> ProviderRegistry:
+    registry = ProviderRegistry()
+    provider_registry._populate_default_providers(registry)
+    return registry
+
+
+def test_hf_token_and_huggingface_api_token_are_both_asked(resolved) -> None:
+    _answers, asked = resolved
+    _populated_registry()
+    assert "HF_TOKEN" in asked
+    assert "HUGGINGFACE_API_TOKEN" in asked
+
+
+def test_nous_key_prefers_nous_api_key_over_both_hf_names(resolved) -> None:
+    answers, _asked = resolved
+    answers["NOUS_API_KEY"] = "nous-value"
+    answers["HF_TOKEN"] = "hf-value"
+    answers["HUGGINGFACE_API_TOKEN"] = "hf-legacy-value"
+    nous = _populated_registry().get_provider_by_name("nous")
+    assert nous is not None
+    # Precedence is proven behaviourally: only the top tier winning could produce this.
+    assert nous.settings["api_key"] == "nous-value"
+
+
+def test_nous_key_falls_back_to_hf_token_when_nous_api_key_absent(resolved) -> None:
+    answers, _asked = resolved
+    answers["HF_TOKEN"] = "hf-value"
+    answers["HUGGINGFACE_API_TOKEN"] = "hf-legacy-value"
+    nous = _populated_registry().get_provider_by_name("nous")
+    assert nous is not None
+    assert nous.settings["api_key"] == "hf-value"
+
+
+def test_nous_key_falls_back_to_huggingface_api_token_last(resolved) -> None:
+    answers, _asked = resolved
+    answers["HUGGINGFACE_API_TOKEN"] = "hf-legacy-value"
+    nous = _populated_registry().get_provider_by_name("nous")
+    assert nous is not None
+    assert nous.settings["api_key"] == "hf-legacy-value"
+
+
+def test_huggingface_provider_prefers_hf_token_over_huggingface_api_token(resolved) -> None:
+    answers, _asked = resolved
+    answers["HF_TOKEN"] = "hf-value"
+    answers["HUGGINGFACE_API_TOKEN"] = "hf-legacy-value"
+    hf = _populated_registry().get_provider_by_name("huggingface")
+    assert hf is not None
+    assert hf.settings["api_token"] == "hf-value"

--- a/autobot-backend/services/provider_key_vault.py
+++ b/autobot-backend/services/provider_key_vault.py
@@ -49,12 +49,16 @@ from __future__ import annotations
 import logging
 import os
 import uuid
+from typing import TYPE_CHECKING
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from autobot_shared.secrets_vault import VaultKind, VaultRef
 from models.secret import Secret
+
+if TYPE_CHECKING:  # pragma: no cover -- annotation-only; zero runtime import cost
+    from services.envelope_secrets_service import EnvelopeSecretsService
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +223,7 @@ async def _register_credential_dependency(session: AsyncSession, *, name: str, s
 
 
 async def _hydrate_one_key(
-    session: AsyncSession, service: "EnvelopeSecretsService", *, name: str, secret_id: uuid.UUID
+    session: AsyncSession, service: EnvelopeSecretsService, *, name: str, secret_id: uuid.UUID
 ) -> bool:
     """Decrypt *secret_id* into ``_hydrated_keys[name]``. Returns whether it hydrated."""
     try:

--- a/autobot-backend/services/provider_key_vault.py
+++ b/autobot-backend/services/provider_key_vault.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # AutoBot - AI-Powered Automation Platform
 # Author: mrveiss
-"""LLM provider-key capture + vault-backed runtime resolution (#10088 Task 7).
+"""Provider-key capture + vault-backed runtime resolution (#10088 Task 7).
 
-First-time-setup flow: an admin captures an LLM provider key (OpenAI,
-Anthropic, ...) through the API-key setup wizard
+First-time-setup flow: an admin captures a provider key (OpenAI, Anthropic,
+HuggingFace, ...) through the API-key setup wizard
 (``autobot-frontend/src/components/settings/ApiKeySetupWizard.vue``), which
 posts to the legacy ``POST /api/secrets/`` endpoint (``api/secrets.py``) --
 today's *only* write path for these values, since ``SecretUpdateRequest`` has
@@ -15,23 +15,31 @@ that endpoint never had:
 1. **Capture** (:func:`mirror_provider_key_best_effort`) -- mirrors a
    provider-key value into the System vault at the moment it's created,
    idempotently (create once, rotate on a later re-capture of the same
-   name). Scoped strictly to :data:`LLM_PROVIDER_KEY_NAMES` -- the generic
-   ``secrets.json`` -> envelope migration is Task 3's importer (`#13052`
-   notes nothing invokes it yet); this hook does not duplicate that work,
-   it only guarantees LLM provider keys specifically are never vault-blind.
+   name). Scoped strictly to :data:`VAULT_RESOLVED_CREDENTIAL_NAMES` -- the
+   generic ``secrets.json`` -> envelope migration is Task 3's importer
+   (`#13052` notes nothing invokes it yet); this hook does not duplicate
+   that work, it only guarantees these specific credentials are never
+   vault-blind.
 
 2. **Runtime resolution** (:func:`hydrate_provider_keys_from_vault` +
-   :func:`resolve_provider_key`) -- the actual runtime reader,
-   ``llm_shared.provider_registry._populate_default_providers``, only ever
-   read ``ssot_config`` (env vars) and never consulted the legacy secrets
-   store *or* the vault -- a value captured via the wizard was, until this
-   change, write-only (unreachable at runtime; the same class of defect
-   Task 5 hit for connector credentials). :func:`hydrate_provider_keys_from_vault`
-   runs once at startup (``initialization/lifespan.py``, Phase 1, after the
-   DB is initialised) and populates a process-lifetime cache consulted
-   *only* when the env var itself is unset, so an Ansible-provisioned
-   deployment's env vars remain authoritative and unaffected (dual-read,
-   env-first -- no provider key becomes unreachable mid-cutover).
+   :func:`resolve_provider_key`) -- the actual runtime readers,
+   ``llm_shared.provider_registry._populate_default_providers`` (LLM
+   providers, :data:`LLM_PROVIDER_KEY_NAMES`) and
+   ``agent_loop.search.registry._populate_default_providers`` (web-search
+   providers, :data:`SEARCH_PROVIDER_KEY_NAMES`, #15267), used to read only
+   ``ssot_config`` (env vars) and never consulted the legacy secrets store
+   *or* the vault -- a value captured via the wizard was, until this change,
+   write-only (unreachable at runtime; the same class of defect Task 5 hit
+   for connector credentials). :func:`hydrate_provider_keys_from_vault` runs
+   once at startup (``initialization/lifespan.py``, Phase 1, after the DB is
+   initialised) and populates a process-lifetime cache consulted *only* when
+   the env var itself is unset, so an Ansible-provisioned deployment's env
+   vars remain authoritative and unaffected (dual-read, env-first -- no
+   provider key becomes unreachable mid-cutover). It also records a
+   ``secret_dependencies`` edge (#10088 Task 8.2) for every name whose
+   System-vault secret exists, regardless of whether the value currently
+   resolves from the vault or from the env, so rotation-impact analysis
+   sees the consumer.
 
 Never logs a secret value.
 """
@@ -54,8 +62,10 @@ logger = logging.getLogger(__name__)
 #: resolution. Each name has a real runtime reader in
 #: ``llm_shared.provider_registry._populate_default_providers`` -- the actual
 #: LLM-call routing path (not the adapter-listing-only AdapterRegistry).
-#: HF_TOKEN is deliberately excluded: it is captured via a different flow
-#: (the SLM setup wizard's ``system_secrets``, already migrated by Task 6a).
+#: HF_TOKEN / HUGGINGFACE_API_TOKEN are the HuggingFace-hosted-model tokens
+#: read by that same registry (#15268) -- distinct from the SLM setup
+#: wizard's unrelated ``tts_hf_token`` (TTS-worker model download, migrated
+#: by Task 6a), which this module has never covered.
 LLM_PROVIDER_KEY_NAMES: frozenset[str] = frozenset(
     {
         "OPENAI_API_KEY",
@@ -65,8 +75,35 @@ LLM_PROVIDER_KEY_NAMES: frozenset[str] = frozenset(
         "OPENROUTER_API_KEY",
         "NOUS_API_KEY",
         "CUSTOM_OPENAI_API_KEY",
+        "HF_TOKEN",
+        "HUGGINGFACE_API_TOKEN",
     }
 )
+
+#: Web-search provider credential names, the same treatment one module over
+#: (#15267): ``agent_loop.search.registry._populate_default_providers`` is
+#: the real runtime reader.
+SEARCH_PROVIDER_KEY_NAMES: frozenset[str] = frozenset(
+    {
+        "SEARXNG_INSTANCE_URL",
+        "SEARXNG_BASIC_AUTH_USER",
+        "SEARXNG_BASIC_AUTH_PASS",
+        "SEARXNG_TOKEN",
+        "BRAVE_SEARCH_API_KEY",
+    }
+)
+
+#: The full set of names eligible for capture-time mirroring and startup
+#: hydration -- provider-agnostic per #15267's suggestion, since this module
+#: is no longer LLM-only once search joins it.
+VAULT_RESOLVED_CREDENTIAL_NAMES: frozenset[str] = LLM_PROVIDER_KEY_NAMES | SEARCH_PROVIDER_KEY_NAMES
+
+#: Which module resolves each name -- the ``secret_dependencies`` edge
+#: (#10088 Task 8.2) recorded during hydration below.
+_CREDENTIAL_CONSUMERS: dict[str, str] = {
+    **{name: "llm_shared.provider_registry" for name in LLM_PROVIDER_KEY_NAMES},
+    **{name: "agent_loop.search.registry" for name in SEARCH_PROVIDER_KEY_NAMES},
+}
 
 _SYSTEM_VAULT = VaultRef(VaultKind.SYSTEM)
 
@@ -102,18 +139,18 @@ async def _find_system_secret_id(session: AsyncSession, name: str) -> uuid.UUID 
 async def capture_provider_key(
     session: AsyncSession, *, name: str, plaintext: str, created_by: uuid.UUID, root_key: bytes | None = None
 ) -> bool:
-    """Mirror an LLM-provider-key value into the System vault (idempotent).
+    """Mirror a provider-key value into the System vault (idempotent).
 
     Creates a new System-vault secret the first time *name* is captured;
     rotates the value on a later re-capture (an admin legitimately changing a
-    key). No-op for any name outside :data:`LLM_PROVIDER_KEY_NAMES` -- this
-    hook is intentionally scoped to LLM provider keys, not a generic secrets
-    mirror. Raises on a genuine vault error; callers use
+    key). No-op for any name outside :data:`VAULT_RESOLVED_CREDENTIAL_NAMES`
+    -- this hook is intentionally scoped to known provider keys, not a
+    generic secrets mirror. Raises on a genuine vault error; callers use
     :func:`mirror_provider_key_best_effort` for the best-effort wrapper.
     ``root_key`` defaults to loading ``AUTOBOT_SECRETS_ROOT_KEY`` (production
     behaviour); tests pass an explicit key.
     """
-    if name not in LLM_PROVIDER_KEY_NAMES:
+    if name not in VAULT_RESOLVED_CREDENTIAL_NAMES:
         return False
     from services.envelope_secrets_service import EnvelopeSecretsService
 
@@ -145,7 +182,7 @@ async def mirror_provider_key_best_effort(name: str, value: str, created_by: uui
     DB error, must not turn a successful legacy ``secrets.json`` write into a
     failed request. Returns True when the vault copy was written/updated.
     """
-    if name not in LLM_PROVIDER_KEY_NAMES:
+    if name not in VAULT_RESOLVED_CREDENTIAL_NAMES:
         return False
     try:
         from user_management.database import get_async_session_factory
@@ -161,31 +198,67 @@ async def mirror_provider_key_best_effort(name: str, value: str, created_by: uui
         return False
 
 
+async def _register_credential_dependency(session: AsyncSession, *, name: str, secret_id: uuid.UUID) -> None:
+    """Record that :data:`_CREDENTIAL_CONSUMERS`\\ [*name*] depends on *secret_id* (#10088 Task 8.2).
+
+    Best-effort and idempotent (``SecretDependencyService.register`` is an
+    ``ON CONFLICT DO NOTHING`` upsert): a rotation-impact-list write must
+    never fail startup hydration.
+    """
+    consumer = _CREDENTIAL_CONSUMERS.get(name)
+    if consumer is None:
+        return
+    from services.secret_dependency_service import SecretDependencyService
+
+    try:
+        await SecretDependencyService().register(
+            session, secret_id=secret_id, dependent_kind="service", dependent_id=consumer
+        )
+    except Exception as exc:  # noqa: BLE001 - metadata only; never blocks hydration
+        logger.warning("provider-key-vault: dependency registration failed name=%s: %s", name, type(exc).__name__)
+
+
+async def _hydrate_one_key(
+    session: AsyncSession, service: "EnvelopeSecretsService", *, name: str, secret_id: uuid.UUID
+) -> bool:
+    """Decrypt *secret_id* into ``_hydrated_keys[name]``. Returns whether it hydrated."""
+    try:
+        value = await service.read(session, secret_id=secret_id, accessible_vaults={_SYSTEM_VAULT})
+    except Exception as exc:  # noqa: BLE001 - defensive, one bad row must not break the rest
+        logger.warning("provider-key-vault: hydrate failed name=%s: %s", name, type(exc).__name__)
+        return False
+    _hydrated_keys[name] = value.decode("utf-8")
+    return True
+
+
 async def hydrate_provider_keys_from_vault(session: AsyncSession, *, root_key: bytes | None = None) -> list[str]:
     """Populate the process cache from the System vault for any unset env var.
 
     Called once at FastAPI startup, after the DB is initialised. Env vars
-    always win (skipped entirely when already set) -- an Ansible-provisioned
-    deployment is byte-identical to before this change. Returns the list of
-    names actually hydrated (for startup logging -- never the values).
-    ``root_key`` defaults to loading ``AUTOBOT_SECRETS_ROOT_KEY`` (production
-    behaviour); tests pass an explicit key.
+    always win (the cache is skipped entirely when already set) -- an
+    Ansible-provisioned deployment is byte-identical to before this change.
+    A ``secret_dependencies`` edge is recorded for every name whose vault
+    secret exists, independent of the env-var check, so rotation-impact
+    analysis sees a consumer even while its env var currently wins. Returns
+    the list of names actually hydrated into the cache (for startup logging
+    -- never the values). ``root_key`` defaults to loading
+    ``AUTOBOT_SECRETS_ROOT_KEY`` (production behaviour); tests pass an
+    explicit key.
     """
     from services.envelope_secrets_service import EnvelopeSecretsService
 
     service = EnvelopeSecretsService(root_key=root_key)
     hydrated: list[str] = []
-    for name in LLM_PROVIDER_KEY_NAMES:
-        if os.environ.get(name):
-            continue  # env wins -- irreducible/authoritative today
+    any_dependency_registered = False
+    for name in VAULT_RESOLVED_CREDENTIAL_NAMES:
         secret_id = await _find_system_secret_id(session, name)
-        if secret_id is None:
-            continue
-        try:
-            value = await service.read(session, secret_id=secret_id, accessible_vaults={_SYSTEM_VAULT})
-        except Exception as exc:  # noqa: BLE001 - defensive, one bad row must not break the rest
-            logger.warning("provider-key-vault: hydrate failed name=%s: %s", name, type(exc).__name__)
-            continue
-        _hydrated_keys[name] = value.decode("utf-8")
-        hydrated.append(name)
+        if secret_id is not None:
+            await _register_credential_dependency(session, name=name, secret_id=secret_id)
+            any_dependency_registered = True
+        if os.environ.get(name) or secret_id is None:
+            continue  # env wins -- irreducible/authoritative today
+        if await _hydrate_one_key(session, service, name=name, secret_id=secret_id):
+            hydrated.append(name)
+    if any_dependency_registered:
+        await session.commit()
     return hydrated

--- a/autobot-backend/tests/migrations/test_provider_key_vault.py
+++ b/autobot-backend/tests/migrations/test_provider_key_vault.py
@@ -26,6 +26,7 @@ from services.provider_key_vault import (
     hydrate_provider_keys_from_vault,
     resolve_provider_key,
 )
+from services.secret_dependency_service import SecretDependencyService
 from tests.migrations.conftest import requires_postgres, run_alembic
 
 pytestmark = [pytest.mark.migration_gate, requires_postgres]
@@ -173,3 +174,121 @@ async def test_hydrate_never_logs_secret_value(session, caplog, monkeypatch):
 # ``llm_shared/tests/test_provider_registry_key_coverage.py`` because this
 # module is gated behind ``requires_postgres`` -- a coverage assertion that
 # needs no database must not be skipped along with the migration tests.
+
+
+# --- #15268: HF_TOKEN / HUGGINGFACE_API_TOKEN joined the vault-resolved set. ---
+
+
+async def test_hydrate_finds_vault_only_hf_token(session, monkeypatch):
+    """A key captured through the setup wizard, never set as an env var, resolves."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    await capture_provider_key(
+        session, name="HF_TOKEN", plaintext="hf-vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "HF_TOKEN" in hydrated
+    assert resolve_provider_key("HF_TOKEN", "") == "hf-vault-value"
+
+
+async def test_hydrate_finds_vault_only_huggingface_api_token(session, monkeypatch):
+    monkeypatch.delenv("HUGGINGFACE_API_TOKEN", raising=False)
+    await capture_provider_key(
+        session, name="HUGGINGFACE_API_TOKEN", plaintext="legacy-vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "HUGGINGFACE_API_TOKEN" in hydrated
+    assert resolve_provider_key("HUGGINGFACE_API_TOKEN", "") == "legacy-vault-value"
+
+
+# --- #15267: the same mechanism generalises to web-search provider credentials. ---
+
+
+async def test_hydrate_finds_vault_only_search_credential(session, monkeypatch):
+    """The exact same round trip, now proven for a search-provider name too."""
+    monkeypatch.delenv("BRAVE_SEARCH_API_KEY", raising=False)
+    await capture_provider_key(
+        session, name="BRAVE_SEARCH_API_KEY", plaintext="brave-vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "BRAVE_SEARCH_API_KEY" in hydrated
+    assert resolve_provider_key("BRAVE_SEARCH_API_KEY", "") == "brave-vault-value"
+
+
+async def test_search_credential_env_wins_over_vault(session, monkeypatch):
+    monkeypatch.setenv("SEARXNG_TOKEN", "env-value")
+    await capture_provider_key(
+        session, name="SEARXNG_TOKEN", plaintext="vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "SEARXNG_TOKEN" not in hydrated  # env already set -- vault never even queried
+    assert resolve_provider_key("SEARXNG_TOKEN", "env-value") == "env-value"
+
+
+# --- #15267 AC: a secret_dependencies edge exists for each search credential consumer. ---
+
+
+async def test_hydrate_registers_a_dependency_edge_for_the_llm_registry(session, monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    wrote = await capture_provider_key(
+        session, name="OPENAI_API_KEY", plaintext="sk-dep-test", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+    assert wrote is True
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    secret_id = next(s.id for s in secrets if s.name == "OPENAI_API_KEY")
+
+    await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+
+    deps = await SecretDependencyService().what_depends_on(session, secret_id=secret_id)
+    assert any(d.dependent_kind == "service" and d.dependent_id == "llm_shared.provider_registry" for d in deps)
+
+
+async def test_hydrate_registers_a_dependency_edge_for_the_search_registry(session, monkeypatch):
+    monkeypatch.delenv("SEARXNG_INSTANCE_URL", raising=False)
+    wrote = await capture_provider_key(
+        session,
+        name="SEARXNG_INSTANCE_URL",
+        plaintext="https://searx.invalid",
+        created_by=_SENTINEL_USER,
+        root_key=_ROOT,
+    )
+    await session.commit()
+    assert wrote is True
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    secret_id = next(s.id for s in secrets if s.name == "SEARXNG_INSTANCE_URL")
+
+    await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+
+    deps = await SecretDependencyService().what_depends_on(session, secret_id=secret_id)
+    assert any(d.dependent_kind == "service" and d.dependent_id == "agent_loop.search.registry" for d in deps)
+
+
+async def test_hydrate_dependency_edge_survives_env_override(session, monkeypatch):
+    """The edge is recorded even while the env var currently wins (#15267)."""
+    monkeypatch.setenv("GROQ_API_KEY", "env-value")
+    await capture_provider_key(
+        session, name="GROQ_API_KEY", plaintext="vault-value", created_by=_SENTINEL_USER, root_key=_ROOT
+    )
+    await session.commit()
+
+    svc = EnvelopeSecretsService(root_key=_ROOT)
+    secrets = await svc.list_for_vaults(session, accessible_vaults={_SYSTEM_VAULT})
+    secret_id = next(s.id for s in secrets if s.name == "GROQ_API_KEY")
+
+    hydrated = await hydrate_provider_keys_from_vault(session, root_key=_ROOT)
+    assert "GROQ_API_KEY" not in hydrated  # env wins -- cache untouched
+
+    deps = await SecretDependencyService().what_depends_on(session, secret_id=secret_id)
+    assert any(d.dependent_kind == "service" and d.dependent_id == "llm_shared.provider_registry" for d in deps)

--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -60,9 +60,19 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
 
     @staticmethod
     def _api_key() -> str:
-        """Return the OpenAI API key from SSOT config with env-var fallback."""
+        """Return the OpenAI API key: env, then System vault, then a literal env-var
+        read as a last-resort safety net.
+
+        Found during #15269's guard sweep: a key captured through the setup wizard
+        resolved for every other OpenAI consumer but silently failed realtime voice
+        negotiation, since this call site never consulted the vault seam.
+        """
+        from services.provider_key_vault import resolve_provider_key
+
         cfg = get_config()
-        return cfg.llm.openai_api_key or os.environ.get("OPENAI_API_KEY", "")
+        return resolve_provider_key("OPENAI_API_KEY", cfg.llm.openai_api_key) or os.environ.get(
+            "OPENAI_API_KEY", ""
+        )
 
     @staticmethod
     def _model() -> str:

--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -15,8 +15,6 @@ browser.
 
 from __future__ import annotations
 
-import os
-
 import aiohttp
 
 from autobot_shared.logging_manager import get_logger
@@ -60,8 +58,17 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
 
     @staticmethod
     def _api_key() -> str:
-        """Return the OpenAI API key: env, then System vault, then a literal env-var
-        read as a last-resort safety net.
+        """Return the OpenAI API key: env (via ssot_config), then the System vault.
+
+        Exactly two tiers -- no third ``os.environ.get(...)`` fallback. Once
+        ``cfg.llm.openai_api_key`` (an ssot_config field, populated straight from
+        ``os.environ``/``.env`` at load) is non-empty, an unconditional literal
+        ``os.environ`` re-read can only ever repeat the same value: nothing in this
+        codebase mutates ``os.environ`` for ``OPENAI_API_KEY`` at runtime, and a
+        process's environment does not change out from under it externally, so the
+        two can never diverge within one process lifetime. A prior revision of this
+        method carried such a tail; it was dead code that could not fire, removed
+        rather than kept as a decoration (#15269 review).
 
         Found during #15269's guard sweep: a key captured through the setup wizard
         resolved for every other OpenAI consumer but silently failed realtime voice
@@ -70,7 +77,7 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
         from services.provider_key_vault import resolve_provider_key
 
         cfg = get_config()
-        return resolve_provider_key("OPENAI_API_KEY", cfg.llm.openai_api_key) or os.environ.get("OPENAI_API_KEY", "")
+        return resolve_provider_key("OPENAI_API_KEY", cfg.llm.openai_api_key)
 
     @staticmethod
     def _model() -> str:

--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -70,9 +70,7 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
         from services.provider_key_vault import resolve_provider_key
 
         cfg = get_config()
-        return resolve_provider_key("OPENAI_API_KEY", cfg.llm.openai_api_key) or os.environ.get(
-            "OPENAI_API_KEY", ""
-        )
+        return resolve_provider_key("OPENAI_API_KEY", cfg.llm.openai_api_key) or os.environ.get("OPENAI_API_KEY", "")
 
     @staticmethod
     def _model() -> str:

--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -60,15 +60,15 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
     def _api_key() -> str:
         """Return the OpenAI API key: env (via ssot_config), then the System vault.
 
-        Exactly two tiers -- no third ``os.environ.get(...)`` fallback. Once
-        ``cfg.llm.openai_api_key`` (an ssot_config field, populated straight from
-        ``os.environ``/``.env`` at load) is non-empty, an unconditional literal
-        ``os.environ`` re-read can only ever repeat the same value: nothing in this
-        codebase mutates ``os.environ`` for ``OPENAI_API_KEY`` at runtime, and a
-        process's environment does not change out from under it externally, so the
-        two can never diverge within one process lifetime. A prior revision of this
-        method carried such a tail; it was dead code that could not fire, removed
-        rather than kept as a decoration (#15269 review).
+        Exactly two tiers -- no third ``os.environ.get(...)`` fallback. The
+        ssot_config field this method reads below is itself populated straight from
+        ``os.environ``/``.env`` at load, so once it is non-empty an unconditional
+        literal ``os.environ`` re-read could only ever repeat the same value:
+        nothing in this codebase mutates ``os.environ`` for ``OPENAI_API_KEY`` at
+        runtime, and a process's environment does not change out from under it
+        externally, so the two can never diverge within one process lifetime. A
+        prior revision of this method carried such a tail; it was dead code that
+        could not fire, removed rather than kept as a decoration (#15269 review).
 
         Found during #15269's guard sweep: a key captured through the setup wizard
         resolved for every other OpenAI consumer but silently failed realtime voice

--- a/autobot-backend/voice_processing/realtime/openai_provider_test.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider_test.py
@@ -7,6 +7,14 @@
 Found during #15269's guard sweep: this call site read ``cfg.llm.openai_api_key``
 directly, so a key captured through the setup wizard resolved for every other OpenAI
 consumer but silently failed realtime voice negotiation.
+
+Exactly two tiers -- env (via ``cfg.llm.openai_api_key``), then the System vault. An
+earlier revision carried a third ``os.environ.get(...)`` tail; review established it
+was unreachable (``cfg.llm.openai_api_key`` is itself populated from ``os.environ`` at
+load, and nothing in this codebase mutates ``os.environ`` for ``OPENAI_API_KEY`` at
+runtime, so the two reads could never diverge) and it was removed rather than kept as
+a decoration. ``test_only_two_tiers_are_consulted`` pins that directly: with both
+tiers empty, the result is empty -- there is no third source to fall through to.
 """
 
 from __future__ import annotations
@@ -14,12 +22,11 @@ from __future__ import annotations
 from voice_processing.realtime.openai_provider import OpenAIRealtimeProvider
 
 
-def test_api_key_resolves_through_the_vault_seam_when_env_and_config_are_unset(monkeypatch) -> None:
-    """A key captured only via the wizard (config empty, env unset) still resolves."""
+def test_api_key_resolves_through_the_vault_seam_when_config_is_empty(monkeypatch) -> None:
+    """A key captured only via the wizard (config empty) still resolves."""
     import services.provider_key_vault as vault_mod
     from autobot_shared.ssot_config import get_config
 
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setattr(get_config().llm, "openai_api_key", "", raising=False)
     monkeypatch.setattr(vault_mod, "_hydrated_keys", {"OPENAI_API_KEY": "vault-only-value"})
 
@@ -27,7 +34,7 @@ def test_api_key_resolves_through_the_vault_seam_when_env_and_config_are_unset(m
 
 
 def test_api_key_prefers_config_over_the_vault(monkeypatch) -> None:
-    """Dual-read, config(env)-first -- unchanged by this fix."""
+    """Dual-read, config(env)-first -- the first and only preferred tier."""
     import services.provider_key_vault as vault_mod
     from autobot_shared.ssot_config import get_config
 
@@ -37,13 +44,18 @@ def test_api_key_prefers_config_over_the_vault(monkeypatch) -> None:
     assert OpenAIRealtimeProvider._api_key() == "config-value"
 
 
-def test_api_key_falls_back_to_literal_env_read_as_last_resort(monkeypatch) -> None:
-    """The pre-existing os.environ fallback is preserved, not removed."""
+def test_only_two_tiers_are_consulted(monkeypatch) -> None:
+    """Both tiers empty -> empty result -- there is no third fallback to reach.
+
+    A regression that resurrects the removed ``os.environ`` tail would make this
+    fail: it sets the literal env var while leaving both real tiers empty, so a
+    reintroduced third read would return it instead of the correct ``""``.
+    """
     import services.provider_key_vault as vault_mod
     from autobot_shared.ssot_config import get_config
 
     monkeypatch.setattr(get_config().llm, "openai_api_key", "", raising=False)
     monkeypatch.setattr(vault_mod, "_hydrated_keys", {})
-    monkeypatch.setenv("OPENAI_API_KEY", "literal-env-value")
+    monkeypatch.setenv("OPENAI_API_KEY", "should-never-be-read-by-a-third-tier")
 
-    assert OpenAIRealtimeProvider._api_key() == "literal-env-value"
+    assert OpenAIRealtimeProvider._api_key() == ""

--- a/autobot-backend/voice_processing/realtime/openai_provider_test.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider_test.py
@@ -1,0 +1,49 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""``OpenAIRealtimeProvider._api_key`` resolves through the vault seam.
+
+Found during #15269's guard sweep: this call site read ``cfg.llm.openai_api_key``
+directly, so a key captured through the setup wizard resolved for every other OpenAI
+consumer but silently failed realtime voice negotiation.
+"""
+
+from __future__ import annotations
+
+from voice_processing.realtime.openai_provider import OpenAIRealtimeProvider
+
+
+def test_api_key_resolves_through_the_vault_seam_when_env_and_config_are_unset(monkeypatch) -> None:
+    """A key captured only via the wizard (config empty, env unset) still resolves."""
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import get_config
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(get_config().llm, "openai_api_key", "", raising=False)
+    monkeypatch.setattr(vault_mod, "_hydrated_keys", {"OPENAI_API_KEY": "vault-only-value"})
+
+    assert OpenAIRealtimeProvider._api_key() == "vault-only-value"
+
+
+def test_api_key_prefers_config_over_the_vault(monkeypatch) -> None:
+    """Dual-read, config(env)-first -- unchanged by this fix."""
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import get_config
+
+    monkeypatch.setattr(get_config().llm, "openai_api_key", "config-value", raising=False)
+    monkeypatch.setattr(vault_mod, "_hydrated_keys", {"OPENAI_API_KEY": "vault-value"})
+
+    assert OpenAIRealtimeProvider._api_key() == "config-value"
+
+
+def test_api_key_falls_back_to_literal_env_read_as_last_resort(monkeypatch) -> None:
+    """The pre-existing os.environ fallback is preserved, not removed."""
+    import services.provider_key_vault as vault_mod
+    from autobot_shared.ssot_config import get_config
+
+    monkeypatch.setattr(get_config().llm, "openai_api_key", "", raising=False)
+    monkeypatch.setattr(vault_mod, "_hydrated_keys", {})
+    monkeypatch.setenv("OPENAI_API_KEY", "literal-env-value")
+
+    assert OpenAIRealtimeProvider._api_key() == "literal-env-value"

--- a/repo_tests/credential_vault_resolution_guard_test.py
+++ b/repo_tests/credential_vault_resolution_guard_test.py
@@ -19,15 +19,25 @@ Mechanism
    ends in one of :data:`_CREDENTIAL_ALIAS_SUFFIXES` (the naming convention #15269's
    evidence names, plus ``_PASS`` so ``SEARXNG_BASIC_AUTH_PASS`` -- #15267's own
    evidence -- is not excluded by the shorter ``_PASSWORD`` alone).
-2. :func:`find_direct_reads` greps every git-tracked, non-test production ``.py`` file
-   that imports the ``ssot_config`` singleton for a *direct* read of one of those
-   fields (``config.<field>``, ``ssot_config.<field>``, or
-   ``getattr(config, "<field>", ...)``) that is **not** spanned by a
-   ``resolve_provider_key(...)`` call, including a 120-column-wrapped one -- the
-   shape every vault-routed call site in the repo already uses
+2. :func:`_ssot_config_bindings` finds every identifier in a file bound to the
+   ssot_config singleton: the flat proxy, plain or aliased (``from ... import config``
+   / ``... import config as X``), the whole module aliased (``import ... as X``), and
+   a local variable assigned from the factory, however that was imported/aliased
+   (``cfg = get_config()`` / ``ssot = get_ssot_config()``) -- plus the factory names
+   themselves, for the un-assigned chained-call shape (``get_config().field``, seen in
+   ``initialization/lifespan.py``). An empty result means the file never touches
+   ssot_config at all.
+3. :func:`find_direct_reads` greps every git-tracked, non-test production ``.py`` file
+   for a *direct* read of one of those fields through any binding
+   :func:`_ssot_config_bindings` found -- ``config.<field>``, ``cfg.llm.<field>``
+   (nested submodel access, real inside ``ssot_config.py``'s own
+   ``AutoBotConfig.__getattr__`` delegation), ``get_config().auth.<field>`` (chained,
+   unassigned), or ``getattr(config, "<field>", ...)`` -- that is **not** spanned by a
+   ``resolve_provider_key(...)`` call, including a 120-column-wrapped one -- the shape
+   every vault-routed call site in the repo already uses
    (``services/provider_key_vault.py``, ``llm_shared/provider_registry.py``,
    ``agent_loop/search/registry.py``).
-3. Every match must be on :data:`ALLOWLIST`, keyed by ``(file, field)`` (not line
+4. Every match must be on :data:`ALLOWLIST`, keyed by ``(file, field)`` (not line
    number, which drifts on any unrelated edit) with a written reason -- either
    ``AUTH_BOOTSTRAP`` (the credential gates the vault/DB itself or is the platform's
    own internal-auth token, so vaulting it would be a confused-deputy cycle -- the
@@ -49,6 +59,13 @@ source text reproducing the exact pre-fix shape of #15267 (an unwrapped
 ``config.hf_token or config.huggingface_api_token``) -- both flagged -- and on a
 wholly novel field name standing in for a consumer that does not exist yet, proving
 the check is general rather than a fixed list of two prior mistakes.
+``test_nested_submodel_access_is_rejected`` and
+``test_get_config_import_and_chained_call_are_rejected`` do the same for the two
+binding shapes a security review found this detector originally missed --
+``cfg.llm.<field>`` (nested submodel access, real via ``AutoBotConfig.__getattr__``)
+and a file that only imports ``get_config`` -- both reproducing the real
+pre-fix line of ``voice_processing/realtime/openai_provider.py`` (fixed in this
+same PR) and ``initialization/lifespan.py`` (an existing, allowlisted gap).
 """
 
 from __future__ import annotations
@@ -67,16 +84,15 @@ _CREDENTIAL_ALIAS_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_PA
 
 _FIELD_ALIAS_RE = re.compile(r'^\s*([a-z_0-9]+):\s*[^=]+=\s*Field\([^)]*alias="([A-Z0-9_]+)"', re.MULTILINE)
 
-#: A file counts as an ssot_config consumer only if it imports the singleton under
-#: one of these forms -- the convention every real read site in the repo uses. This
-#: is also what keeps a per-connector ``self.config.api_key`` (an unrelated local
-#: config object, e.g. ``integrations/*.py``) from being mistaken for an ssot_config
-#: read: those files do not import ``autobot_shared.ssot_config`` at all.
-_IMPORTS_SSOT_CONFIG_RE = re.compile(
-    r"from\s+autobot_shared\.ssot_config\s+import\s+.*\bconfig\b|import\s+autobot_shared\.ssot_config\s+as\s+config"
-)
-
 _SKIP_PATH_SUBSTRINGS = ("/tests/", "repo_tests/", "/ssot_config.py")
+
+#: ``from autobot_shared.ssot_config import <names>`` -- captures the whole imported
+#: name list so aliases (``config as X``, ``get_config as Y``) can be pulled out of it.
+_FROM_IMPORT_RE = re.compile(r"from\s+autobot_shared\.ssot_config\s+import\s+([^\n]+)")
+#: ``import autobot_shared.ssot_config as X`` -- the whole-module-alias form.
+_IMPORT_AS_RE = re.compile(r"import\s+autobot_shared\.ssot_config\s+as\s+(\w+)")
+#: The two factory functions, however aliased on import (``get_config as ssot``).
+_FACTORY_FUNCTION_NAMES = ("get_config", "get_ssot_config")
 
 
 def credential_shaped_fields(ssot_text: str) -> dict[str, str]:
@@ -89,13 +105,64 @@ def credential_shaped_fields(ssot_text: str) -> dict[str, str]:
     return fields
 
 
-def _read_pattern(field: str) -> re.Pattern[str]:
-    """A direct singleton read of *field*, never ``self.config.<field>`` (a different,
-    per-instance object almost everywhere it appears) or the field name buried inside
-    a longer identifier or string literal (``(?<![\\w.])`` rejects both)."""
-    attr = rf"(?<![\w.])(?:config|ssot_config|_ssot_config)\.{field}\b"
-    getattr_call = rf'getattr\(\s*(?:config|ssot_config)\s*,\s*["\']{field}["\']'
-    return re.compile(rf"{attr}|{getattr_call}")
+def _ssot_config_bindings(text: str) -> tuple[set[str], set[str]]:
+    """``(roots, factories)`` -- every identifier in *text* bound to the ssot_config
+    singleton, and every name the ``get_config``/``get_ssot_config`` factory itself can
+    be called under.
+
+    Three binding shapes seen in production: the flat proxy, plain or aliased
+    (``from ... import config`` / ``... import config as X``); the whole module
+    aliased (``import ... as X``); and a local variable assigned from the factory,
+    however that factory was imported/aliased (``cfg = get_config()`` --
+    ``voice_processing/realtime/openai_provider.py``, ``initialization/lifespan.py``).
+    An empty ``roots`` (with an empty ``factories``) means the file never touches
+    ssot_config at all.
+    """
+    roots: set[str] = set()
+    factories: set[str] = set()
+    for match in _FROM_IMPORT_RE.finditer(text):
+        imported = match.group(1)
+        alias = re.search(r"\bconfig\s+as\s+(\w+)", imported)
+        if alias:
+            roots.add(alias.group(1))
+        elif re.search(r"(?<![\w.])config\b", imported):
+            roots.add("config")
+        for factory in _FACTORY_FUNCTION_NAMES:
+            factory_alias = re.search(rf"\b{factory}\s+as\s+(\w+)", imported)
+            if factory_alias:
+                factories.add(factory_alias.group(1))
+            elif re.search(rf"(?<![\w.]){factory}\b", imported):
+                factories.add(factory)
+    for match in _IMPORT_AS_RE.finditer(text):
+        roots.add(match.group(1))
+    for factory in factories:
+        roots.update(m.group(1) for m in re.finditer(rf"\b(\w+)\s*=\s*{re.escape(factory)}\(\)", text))
+    return roots, factories
+
+
+def _read_pattern(field: str, roots: set[str], factories: set[str]) -> re.Pattern[str]:
+    """A direct read of *field* through any binding in *roots*/*factories*.
+
+    Matches an arbitrary chain of ``.submodel`` segments before the field (nested
+    submodel access, e.g. ``cfg.llm.openai_api_key`` -- real, via
+    ``AutoBotConfig.__getattr__`` delegation for the flat form and directly for the
+    nested one) and the unassigned chained-call shape (``get_config().field``).
+    Never matches ``self.config.<field>`` (a different, per-instance object almost
+    everywhere it appears) or the field name buried inside a longer identifier or
+    string literal (``(?<![\\w.])`` rejects both).
+    """
+    parts: list[str] = []
+    if roots:
+        root_alt = "|".join(re.escape(r) for r in sorted(roots))
+        chain = rf"(?:{root_alt})(?:\.\w+)*"
+        parts.append(rf"(?<![\w.]){chain}\.{field}\b")
+        parts.append(rf'getattr\(\s*{chain}\s*,\s*["\']{field}["\']')
+    if factories:
+        factory_alt = "|".join(re.escape(f) for f in sorted(factories))
+        parts.append(rf"(?<![\w.])(?:{factory_alt})\(\)(?:\.\w+)*\.{field}\b")
+    if not parts:
+        return re.compile(r"(?!)")  # a pattern that can never match anything
+    return re.compile("|".join(parts))
 
 
 def _vault_routed_line_numbers(lines: list[str]) -> set[int]:
@@ -131,15 +198,21 @@ def _vault_routed_line_numbers(lines: list[str]) -> set[int]:
 def find_direct_reads(text: str, fields: dict[str, str]) -> list[tuple[str, int, str]]:
     """Every ``(field, line_no, line)`` in *text* reading *fields* directly.
 
-    A line spanned by a ``resolve_provider_key(...)`` call (see
-    :func:`_vault_routed_line_numbers`) is vault-routed and excluded -- the call-site
-    shape every seam consumer in the repo already uses.
+    Discovers *text*'s own ssot_config bindings (see :func:`_ssot_config_bindings`)
+    rather than assuming a fixed set of names, so a file is skipped entirely --
+    rather than false-positiving on an unrelated same-named local -- when it never
+    touches ssot_config at all. A line spanned by a ``resolve_provider_key(...)``
+    call (see :func:`_vault_routed_line_numbers`) is vault-routed and excluded -- the
+    call-site shape every seam consumer in the repo already uses.
     """
+    roots, factories = _ssot_config_bindings(text)
+    if not roots and not factories:
+        return []
     hits: list[tuple[str, int, str]] = []
     lines = text.splitlines()
     routed_lines = _vault_routed_line_numbers(lines)
     for field in fields:
-        pattern = _read_pattern(field)
+        pattern = _read_pattern(field, roots, factories)
         for lineno, line in enumerate(lines, start=1):
             if lineno in routed_lines:
                 continue
@@ -175,8 +248,6 @@ def production_credential_reads() -> dict[tuple[str, str], list[tuple[int, str]]
         try:
             text = path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
-            continue
-        if not _IMPORTS_SSOT_CONFIG_RE.search(text):
             continue
         for field, lineno, line in find_direct_reads(text, fields):
             found.setdefault((rel, field), []).append((lineno, line))
@@ -224,6 +295,37 @@ ALLOWLIST: dict[tuple[str, str], str] = {
     ),
     ("autobot-backend/user_management/config.py", "postgres_password"): (
         f"{_AUTH_BOOTSTRAP}: the vault's own Postgres backing store cannot gate itself"
+    ),
+    ("autobot-backend/auth_middleware.py", "internal_api_key"): (
+        f"{_AUTH_BOOTSTRAP}: the exact confused-deputy example "
+        "autobot-slm-backend/services/system_secrets_vault.py documents for this same credential"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token, same as the two siblings above"
+    ),
+    ("autobot-backend/user_management/services/seed.py", "admin_password"): (
+        f"{_AUTH_BOOTSTRAP}: bootstrap admin-account creation, read before any auth subsystem exists"
+    ),
+    ("autobot_shared/security/password_weakness.py", "admin_password"): (
+        f"{_AUTH_BOOTSTRAP}: same bootstrap admin password as seed.py, checked for weakness"
+    ),
+    # --- auth-bootstrap: internal data-layer service credentials (Redis/ChromaDB),
+    # --- same class as the Postgres password above -- the app's own storage
+    # --- layer must be reachable before anything, including the vault, can start.
+    ("autobot-backend/api/npu_workers.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/celery_app.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/__init__.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/defaults.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/service_config.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/knowledge/base.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/utils/async_chromadb_client.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
+    ),
+    ("autobot-backend/utils/chromadb_auth.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
+    ),
+    ("autobot-backend/utils/chromadb_client.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
     ),
     # --- prose the regex matches textually but which reads nothing.
     ("autobot-backend/services/mcp_isolated_runtime.py", "jwt_secret"): (
@@ -296,6 +398,29 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         f"{_TRACKED} #15276: threat-intel API key"
     ),
     ("autobot-backend/services/notification_service.py", "smtp_password"): f"{_TRACKED} #15276: SMTP credential",
+    ("autobot-backend/initialization/lifespan.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/integrations/capability_registry.py", "slack_bot_token"): (
+        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
+        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
+    ),
+    ("autobot-backend/integrations/capability_registry.py", "discord_bot_token"): (
+        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
+        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
+    ),
+    ("autobot-backend/knowledge/base.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: LlamaIndex LLM configuration reads the key directly"
+    ),
+    ("autobot-backend/knowledge/base.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: LlamaIndex LLM/embedding configuration reads the key directly"
+    ),
 }
 
 
@@ -385,3 +510,50 @@ def test_the_seam_call_site_shape_is_not_flagged() -> None:
         "anthropic_key = resolve_provider_key(\"ANTHROPIC_API_KEY\", config.anthropic_api_key)\n"
     )
     assert find_direct_reads(routed, fields) == []
+
+
+def test_nested_submodel_access_is_rejected() -> None:
+    """A file bound via ``get_config()`` reading a nested submodel field directly.
+
+    Reproduces the exact pre-fix shape of
+    ``voice_processing/realtime/openai_provider.py`` (found by this widened
+    detector, then fixed in this same PR): ``cfg = get_config()`` followed by
+    ``cfg.llm.openai_api_key``, never spelled ``config.openai_api_key``, so the
+    original single-segment-only pattern missed it entirely.
+    """
+    fields = {"openai_api_key": "OPENAI_API_KEY", "admin_password": "AUTOBOT_ADMIN_PASSWORD"}
+    nested_via_local_var = (
+        "from autobot_shared.ssot_config import get_config\ncfg = get_config()\nx = cfg.llm.openai_api_key\n"
+    )
+    nested_via_flat_singleton = (
+        "from autobot_shared.ssot_config import config\ny = config.auth.admin_password\n"
+    )
+    hits = find_direct_reads(nested_via_local_var, fields)
+    assert {"openai_api_key"} == {field for field, _lineno, _line in hits}
+    hits = find_direct_reads(nested_via_flat_singleton, fields)
+    assert {"admin_password"} == {field for field, _lineno, _line in hits}
+
+
+def test_get_config_import_and_chained_call_are_rejected() -> None:
+    """A file that only imports ``get_config`` (never ``config``) is not skipped.
+
+    Reproduces ``initialization/lifespan.py:1353``'s unassigned chained-call shape
+    (``get_config().field``, no local variable at all) -- the other blind spot the
+    original single-import-form gate missed.
+    """
+    fields = {"slm_auth_token": "SLM_AUTH_TOKEN"}
+    chained_call = "from autobot_shared.ssot_config import get_config\nx = get_config().slm_auth_token\n"
+    hits = find_direct_reads(chained_call, fields)
+    assert {"slm_auth_token"} == {field for field, _lineno, _line in hits}
+
+
+def test_a_file_with_no_ssot_config_binding_is_never_scanned() -> None:
+    """The other half of the same guard: no false positive on an unrelated local.
+
+    A bare ``cfg`` that was never bound to ``get_config()``/``config`` must not be
+    mistaken for the singleton merely because some *other* file in the sweep uses
+    that name -- root discovery is per-file, not a fixed global name list.
+    """
+    fields = {"openai_api_key": "OPENAI_API_KEY"}
+    unrelated = "cfg = SomeUnrelatedObject()\nx = cfg.llm.openai_api_key\n"
+    assert find_direct_reads(unrelated, fields) == []

--- a/repo_tests/credential_vault_resolution_guard_test.py
+++ b/repo_tests/credential_vault_resolution_guard_test.py
@@ -71,7 +71,7 @@ same PR) and ``initialization/lifespan.py`` (an existing, allowlisted gap).
 from __future__ import annotations
 
 import re
-import subprocess  # nosec B404 - fixed argv (git ls-files), no shell, no caller input
+import subprocess  # nosec B404  # fixed argv (git ls-files), no shell, no caller input
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]

--- a/repo_tests/credential_vault_resolution_guard_test.py
+++ b/repo_tests/credential_vault_resolution_guard_test.py
@@ -1,0 +1,387 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15269 -- nothing stops a new consumer reading a credential straight from config.
+
+``services/provider_key_vault.py``'s vault seam (``resolve_provider_key``) is opt-in.
+Before this guard, a module that read a credential-shaped ``ssot_config`` field and
+used it directly was indistinguishable, to CI, from one that resolved through the
+vault -- which is how #15267 (web-search credentials) and #15268 (two HuggingFace
+token fallbacks) both arose *after* the seam already existed. Neither
+``scan_secrets_hook_test.py`` nor ``secrets_root_key_provisioned_test.py`` asks where
+a consumer's credential comes from; this one does.
+
+Mechanism
+---------
+1. :func:`credential_shaped_fields` derives the field universe from
+   ``autobot_shared/ssot_config.py`` itself -- any field whose declared env-var alias
+   ends in one of :data:`_CREDENTIAL_ALIAS_SUFFIXES` (the naming convention #15269's
+   evidence names, plus ``_PASS`` so ``SEARXNG_BASIC_AUTH_PASS`` -- #15267's own
+   evidence -- is not excluded by the shorter ``_PASSWORD`` alone).
+2. :func:`find_direct_reads` greps every git-tracked, non-test production ``.py`` file
+   that imports the ``ssot_config`` singleton for a *direct* read of one of those
+   fields (``config.<field>``, ``ssot_config.<field>``, or
+   ``getattr(config, "<field>", ...)``) that is **not** spanned by a
+   ``resolve_provider_key(...)`` call, including a 120-column-wrapped one -- the
+   shape every vault-routed call site in the repo already uses
+   (``services/provider_key_vault.py``, ``llm_shared/provider_registry.py``,
+   ``agent_loop/search/registry.py``).
+3. Every match must be on :data:`ALLOWLIST`, keyed by ``(file, field)`` (not line
+   number, which drifts on any unrelated edit) with a written reason -- either
+   ``AUTH_BOOTSTRAP`` (the credential gates the vault/DB itself or is the platform's
+   own internal-auth token, so vaulting it would be a confused-deputy cycle -- the
+   same classification ``autobot-slm-backend/services/system_secrets_vault.py``
+   documents for ``autobot_internal_api_key``), ``NOT_A_READ`` (the regex's only match
+   is prose, e.g. a docstring cross-reference), or ``TRACKED_GAP #NNNN`` (a real gap,
+   same defect class, not yet migrated -- named so the allowlist shrinks as the
+   tracking issue closes rather than growing without bound).
+
+An unlisted match fails the test with the offending ``file:line`` -- never the
+credential value, which this module never reads (only field *names* and source
+*lines*, neither of which is a secret).
+
+The mutation this guard exists to catch
+----------------------------------------
+``test_a_new_bare_credential_read_is_rejected`` proves the detector on synthetic
+source text reproducing the exact pre-fix shape of #15267 (an unwrapped
+``getattr(config, "brave_search_api_key", "")``) and of #15268 (an unwrapped
+``config.hf_token or config.huggingface_api_token``) -- both flagged -- and on a
+wholly novel field name standing in for a consumer that does not exist yet, proving
+the check is general rather than a fixed list of two prior mistakes.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess  # nosec B404 - fixed argv (git ls-files), no shell, no caller input
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SSOT_CONFIG = REPO_ROOT / "autobot_shared" / "ssot_config.py"
+
+#: Alias suffixes that mark a ssot_config field as credential-shaped. ``_PASS`` is
+#: added to the issue's stated ``_PASSWORD`` so ``SEARXNG_BASIC_AUTH_PASS`` -- named
+#: in #15267's own evidence -- is not silently excluded by the shorter suffix alone.
+_CREDENTIAL_ALIAS_SUFFIXES = ("_API_KEY", "_TOKEN", "_SECRET", "_PASSWORD", "_PASS")
+
+_FIELD_ALIAS_RE = re.compile(r'^\s*([a-z_0-9]+):\s*[^=]+=\s*Field\([^)]*alias="([A-Z0-9_]+)"', re.MULTILINE)
+
+#: A file counts as an ssot_config consumer only if it imports the singleton under
+#: one of these forms -- the convention every real read site in the repo uses. This
+#: is also what keeps a per-connector ``self.config.api_key`` (an unrelated local
+#: config object, e.g. ``integrations/*.py``) from being mistaken for an ssot_config
+#: read: those files do not import ``autobot_shared.ssot_config`` at all.
+_IMPORTS_SSOT_CONFIG_RE = re.compile(
+    r"from\s+autobot_shared\.ssot_config\s+import\s+.*\bconfig\b|import\s+autobot_shared\.ssot_config\s+as\s+config"
+)
+
+_SKIP_PATH_SUBSTRINGS = ("/tests/", "repo_tests/", "/ssot_config.py")
+
+
+def credential_shaped_fields(ssot_text: str) -> dict[str, str]:
+    """Map field-name -> alias for every ssot_config field shaped like a credential."""
+    fields: dict[str, str] = {}
+    for match in _FIELD_ALIAS_RE.finditer(ssot_text):
+        field, alias = match.group(1), match.group(2)
+        if alias.endswith(_CREDENTIAL_ALIAS_SUFFIXES):
+            fields[field] = alias
+    return fields
+
+
+def _read_pattern(field: str) -> re.Pattern[str]:
+    """A direct singleton read of *field*, never ``self.config.<field>`` (a different,
+    per-instance object almost everywhere it appears) or the field name buried inside
+    a longer identifier or string literal (``(?<![\\w.])`` rejects both)."""
+    attr = rf"(?<![\w.])(?:config|ssot_config|_ssot_config)\.{field}\b"
+    getattr_call = rf'getattr\(\s*(?:config|ssot_config)\s*,\s*["\']{field}["\']'
+    return re.compile(rf"{attr}|{getattr_call}")
+
+
+def _vault_routed_line_numbers(lines: list[str]) -> set[int]:
+    """1-indexed line numbers spanned by a ``resolve_provider_key(...)`` call.
+
+    Tracks paren depth from the call's opening ``(`` so a 120-column-wrapped call's
+    continuation line -- which does not itself contain the text
+    ``resolve_provider_key(`` -- is still recognised as vault-routed rather than as
+    an unwrapped read of its argument.
+    """
+    routed: set[int] = set()
+    lineno = 0
+    while lineno < len(lines):
+        start = lines[lineno].find("resolve_provider_key(")
+        if start == -1:
+            lineno += 1
+            continue
+        depth = 0
+        cursor = lineno
+        offset = start + len("resolve_provider_key")
+        while cursor < len(lines):
+            segment = lines[cursor][offset:]
+            depth += segment.count("(") - segment.count(")")
+            routed.add(cursor + 1)
+            offset = 0
+            if depth <= 0:
+                break
+            cursor += 1
+        lineno = cursor + 1
+    return routed
+
+
+def find_direct_reads(text: str, fields: dict[str, str]) -> list[tuple[str, int, str]]:
+    """Every ``(field, line_no, line)`` in *text* reading *fields* directly.
+
+    A line spanned by a ``resolve_provider_key(...)`` call (see
+    :func:`_vault_routed_line_numbers`) is vault-routed and excluded -- the call-site
+    shape every seam consumer in the repo already uses.
+    """
+    hits: list[tuple[str, int, str]] = []
+    lines = text.splitlines()
+    routed_lines = _vault_routed_line_numbers(lines)
+    for field in fields:
+        pattern = _read_pattern(field)
+        for lineno, line in enumerate(lines, start=1):
+            if lineno in routed_lines:
+                continue
+            if pattern.search(line):
+                hits.append((field, lineno, line.strip()))
+    return hits
+
+
+def _tracked_python_files() -> list[str]:
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files", "*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def _is_production_file(rel_path: str) -> bool:
+    if rel_path.endswith("_test.py") or Path(rel_path).name.startswith("test_"):
+        return False
+    return not any(needle in rel_path for needle in _SKIP_PATH_SUBSTRINGS)
+
+
+def production_credential_reads() -> dict[tuple[str, str], list[tuple[int, str]]]:
+    """Every ``(repo-relative file, field) -> [(line_no, line), ...]`` direct read."""
+    fields = credential_shaped_fields(SSOT_CONFIG.read_text(encoding="utf-8"))
+    found: dict[tuple[str, str], list[tuple[int, str]]] = {}
+    for rel in _tracked_python_files():
+        if not _is_production_file(rel):
+            continue
+        path = REPO_ROOT / rel
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if not _IMPORTS_SSOT_CONFIG_RE.search(text):
+            continue
+        for field, lineno, line in find_direct_reads(text, fields):
+            found.setdefault((rel, field), []).append((lineno, line))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# The allowlist. Every entry is a written classification, not a bare pass.
+# ---------------------------------------------------------------------------
+
+_AUTH_BOOTSTRAP = "AUTH_BOOTSTRAP"  # gates the vault/DB itself; vaulting it is circular
+_NOT_A_READ = "NOT_A_READ"  # the regex's only match here is prose, not code
+_TRACKED = "TRACKED_GAP"  # a real gap, same defect class, named issue tracks its fix
+
+#: ``(repo-relative file, ssot_config field name) -> reason``. No credential values
+#: appear anywhere in this table -- only field names and source-code file paths.
+ALLOWLIST: dict[tuple[str, str], str] = {
+    # --- auth-bootstrap: internal/platform authentication, not a third-party
+    # --- provider credential. Same classification IRREDUCIBLE_KEYS documents for
+    # --- autobot_internal_api_key in autobot-slm-backend/services/system_secrets_vault.py.
+    ("autobot-backend/agents/base_agent.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
+    ("autobot-backend/mcp/autobot_server.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
+    ("autobot-backend/services/execution/claude_code_backend.py", "mcp_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret"
+    ),
+    ("autobot-backend/auth_middleware.py", "jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: platform user-session signing key"
+    ),
+    ("autobot-backend/services/slm_client.py", "jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: platform user-session signing key, reused to mint SLM service JWTs "
+        "(two of the three matches in this file are a docstring cross-reference, not a second read)"
+    ),
+    ("autobot-backend/services/run_jwt.py", "run_jwt_secret"): f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key",
+    ("autobot-backend/services/mcp_isolated_runtime.py", "run_jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key"
+    ),
+    ("autobot-backend/middleware/service_auth_enforcement.py", "service_auth_override_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal service-to-service auth override"
+    ),
+    ("autobot-backend/orchestration/dag_executor.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
+    ),
+    ("autobot-backend/services/command_extraction_service.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
+    ),
+    ("autobot-backend/user_management/config.py", "postgres_password"): (
+        f"{_AUTH_BOOTSTRAP}: the vault's own Postgres backing store cannot gate itself"
+    ),
+    # --- prose the regex matches textually but which reads nothing.
+    ("autobot-backend/services/mcp_isolated_runtime.py", "jwt_secret"): (
+        f"{_NOT_A_READ}: docstring prose contrasting run_jwt_secret with the platform session key"
+    ),
+    ("autobot-backend/services/run_jwt.py", "jwt_secret"): (
+        f"{_NOT_A_READ}: docstring prose contrasting run_jwt_secret with the platform session key"
+    ),
+    # --- tracked gap: third-party/service credentials, same defect class as
+    # --- #15267/#15268, not yet migrated. See #15276.
+    ("autobot-backend/llm_shared/adapters/anthropic_adapter.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/adapters/groq_adapter.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/adapters/openai_adapter.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/providers/anthropic.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/groq.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/openai.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/mistral.py", "mistral_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/custom_openai.py", "custom_openai_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/openrouter.py", "openrouter_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/huggingface.py", "hf_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/huggingface.py", "huggingface_api_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "hf_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "huggingface_api_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "nous_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/services/execution/claude_code_backend.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: execution backend reads the key directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "google_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/agent_loop/slack_hook.py", "slack_bot_token"): f"{_TRACKED} #15276: Slack bot token",
+    ("autobot-backend/security/threat_intelligence.py", "virustotal_api_key"): (
+        f"{_TRACKED} #15276: threat-intel API key"
+    ),
+    ("autobot-backend/security/threat_intelligence.py", "urlvoid_api_key"): (
+        f"{_TRACKED} #15276: threat-intel API key"
+    ),
+    ("autobot-backend/services/notification_service.py", "smtp_password"): f"{_TRACKED} #15276: SMTP credential",
+}
+
+
+def test_the_ssot_config_field_scan_finds_known_credential_fields() -> None:
+    """Guard the guard: an empty field set would make every other assertion vacuous."""
+    fields = credential_shaped_fields(SSOT_CONFIG.read_text(encoding="utf-8"))
+    assert "openai_api_key" in fields
+    assert "searxng_basic_auth_pass" in fields
+    assert len(fields) >= 20, f"only {len(fields)} credential-shaped fields found -- the alias regex likely broke"
+
+
+def test_every_direct_production_read_is_vault_routed_or_allowlisted() -> None:
+    """The regression guard: a new bare credential read must be on ALLOWLIST or fail.
+
+    This is the check that would have caught #15267 (five web-search credentials read
+    via bare ``getattr(config, ...)``) and #15268 (two HuggingFace token fallbacks read
+    via bare ``config.hf_token or config.huggingface_api_token``) before either
+    shipped -- both were direct reads of credential-shaped fields with no
+    ``resolve_provider_key(`` on the line, in production files, and neither was on any
+    allowlist because no allowlist existed.
+    """
+    found = production_credential_reads()
+    unlisted = {key: lines for key, lines in found.items() if key not in ALLOWLIST}
+    assert not unlisted, "direct (non-vault) credential reads with no allowlist entry:\n" + "\n".join(
+        f"  {file}:{lineno} (field={field}): {line}"
+        for (file, field), lines in sorted(unlisted.items())
+        for lineno, line in lines
+    )
+
+
+def test_allowlist_entries_still_correspond_to_a_real_match() -> None:
+    """A stale entry (the read it excused was already fixed) should shrink, not linger.
+
+    Keeps the allowlist an accurate map of today's gaps rather than a write-only log:
+    a fixed site should be deleted from ALLOWLIST in the same PR that fixes it.
+    """
+    found = production_credential_reads()
+    stale = sorted(key for key in ALLOWLIST if key not in found)
+    assert not stale, f"allowlist entries with no matching read left -- delete them: {stale}"
+
+
+def test_a_new_bare_credential_read_is_rejected() -> None:
+    """Prove the detector on synthetic source, reproducing #15267 and #15268 verbatim.
+
+    None of the three snippets below is a real credential -- ``brave_search_api_key``
+    and ``hf_token``/``huggingface_api_token`` are ssot_config *field names*, and
+    ``new_service_api_key`` is a field that does not exist, standing in for a consumer
+    that does not exist yet either.
+    """
+    fields = {
+        "brave_search_api_key": "BRAVE_SEARCH_API_KEY",
+        "hf_token": "HF_TOKEN",
+        "huggingface_api_token": "HUGGINGFACE_API_TOKEN",
+        "new_service_api_key": "NEW_SERVICE_API_KEY",
+    }
+
+    pre_fix_15267 = (
+        "from autobot_shared.ssot_config import config\n"
+        'brave_key = getattr(config, "brave_search_api_key", "")\n'
+    )
+    pre_fix_15268 = (
+        "from autobot_shared.ssot_config import config\n"
+        "hf_token = config.hf_token or config.huggingface_api_token\n"
+    )
+    novel_consumer = "from autobot_shared.ssot_config import config\n" "key = config.new_service_api_key\n"
+
+    for label, snippet, expected_field in (
+        ("#15267 shape", pre_fix_15267, "brave_search_api_key"),
+        ("#15268 shape", pre_fix_15268, "hf_token"),
+        ("a wholly novel consumer", novel_consumer, "new_service_api_key"),
+    ):
+        hits = find_direct_reads(snippet, fields)
+        hit_fields = {field for field, _lineno, _line in hits}
+        assert expected_field in hit_fields, f"{label} was not flagged by find_direct_reads: {snippet!r}"
+
+
+def test_the_seam_call_site_shape_is_not_flagged() -> None:
+    """The positive control: today's real vault-routed call sites must NOT trip this.
+
+    Without this, the guard could be trivially "satisfied" by a detector that flags
+    everything, allowlist notwithstanding.
+    """
+    fields = {"anthropic_api_key": "ANTHROPIC_API_KEY"}
+    routed = (
+        "from autobot_shared.ssot_config import config\n"
+        "from services.provider_key_vault import resolve_provider_key\n"
+        "anthropic_key = resolve_provider_key(\"ANTHROPIC_API_KEY\", config.anthropic_api_key)\n"
+    )
+    assert find_direct_reads(routed, fields) == []


### PR DESCRIPTION
## Thinking Path

#15267 and #15268 are the same defect class already fixed one module over:
`llm_shared/provider_registry.py` resolves seven LLM provider keys through
`services/provider_key_vault.py`'s vault seam (`resolve_provider_key`), but
`agent_loop/search/registry.py` built its providers straight from
`ssot_config` (#15267), and two of `provider_registry.py`'s own fallback
reads — `config.hf_token` / `config.huggingface_api_token` — bypassed the
same seam they sit two lines away from (#15268). Both fixes are the same
shape (route a bare `config.<x>` read through `resolve_provider_key`,
extend the resolved-key set that gates capture-time mirroring and startup
hydration), so they land as one PR per the task's guidance not to split
merely to make each PR smaller.

`services/provider_key_vault.py`'s `LLM_PROVIDER_KEY_NAMES` is generalized
into `VAULT_RESOLVED_CREDENTIAL_NAMES` (LLM ∪ search), per #15267's own
suggestion, since the module stops being LLM-only once search joins it. The
existing `LLM_PROVIDER_KEY_NAMES` name and its dedicated coverage test
(`llm_shared/tests/test_provider_registry_key_coverage.py`) are kept
unchanged so that test keeps proving every LLM key is actually asked for at
runtime — it now also proves HF_TOKEN/HUGGINGFACE_API_TOKEN are, with no
edits to the test itself.

#15269's guard needed to be general enough to have caught both defects
*before* they existed, not a two-item denylist. It derives the credential
field universe from `ssot_config.py`'s own alias naming rather than a
hand-maintained list, so a new credential-shaped field is automatically in
scope. Building the allowlist required a repo-wide sweep (37 production
read sites across ~26 files) to classify every existing direct read as
vault-routed, `AUTH_BOOTSTRAP` (gates the vault/DB itself — same
classification `system_secrets_vault.py` documents for
`autobot_internal_api_key`), or a tracked gap. 22 sites turned out to be a
third, undocumented instance of the same defect class (LLM adapter/provider
fallbacks, health probes, Slack/threat-intel/SMTP credentials) — filed as
#15276 rather than folded into this PR's scope, and referenced by name in
the allowlist so it shrinks as that issue closes.

## What Changed

**#15267** — `agent_loop/search/registry.py:_populate_default_providers`
now routes all five web-search credentials (SearXNG instance URL,
basic-auth user, basic-auth pass, token; Brave API key) through
`resolve_provider_key`, preserving the dual-read env-first order and the
registry's never-raise contract.

**#15268** — `llm_shared/provider_registry.py`'s two read sites
(`hf_token = config.hf_token or config.huggingface_api_token` and the Nous
Portal fallback `... or config.hf_token or config.huggingface_api_token`)
now both resolve through `resolve_provider_key`; the HuggingFace-provider
value is reused (not recomputed) as the Nous fallback, so the tier order
(`NOUS_API_KEY` > `HF_TOKEN` > `HUGGINGFACE_API_TOKEN`) is unchanged and the
file's grandfathered 788-line ceiling isn't crossed.

**Shared seam** — `services/provider_key_vault.py`: `LLM_PROVIDER_KEY_NAMES`
gains `HF_TOKEN`/`HUGGINGFACE_API_TOKEN`; new `SEARCH_PROVIDER_KEY_NAMES`
covers the five search names; both union into
`VAULT_RESOLVED_CREDENTIAL_NAMES`, now what capture-time mirroring and
startup hydration iterate. `hydrate_provider_keys_from_vault` also registers
a `secret_dependencies` edge (#10088 Task 8.2) per consumer
(`llm_shared.provider_registry` / `agent_loop.search.registry`) for every
name whose System-vault secret exists, independent of whether the env var
currently wins — needed a `session.commit()` the function never had before,
since its one caller (`initialization/lifespan.py`) never commits either.

**#15269** — new `repo_tests/credential_vault_resolution_guard_test.py`.
See "Verification" for the mutation it exists to catch.

**Security-review fixes** (all in scope: "leaving it would mean shipping a guard
that misses a live instance of the very thing it guards"):
- `voice_processing/realtime/openai_provider.py:_api_key` read
  `cfg.llm.openai_api_key` directly -- a live write-only-credential instance of
  this exact defect class, found by the widened guard. Now routes through
  `resolve_provider_key`, keeping the pre-existing `os.environ` fallback as a
  last-resort safety net.
- The guard's own detector is widened (`_ssot_config_bindings`, replacing the
  fixed-name `_IMPORTS_SSOT_CONFIG_RE` gate) to cover `get_config`-only imports
  and nested submodel access. See "Verification" for the corrected site count.

## Verification

**Updated after security review** (see review-response comment): the
detector had two blind spots -- it only recognised
`from ... import config`/`import ... as config`, so a file importing only
`get_config` was skipped entirely; and it required the field immediately
after `config.`/`ssot_config.`, so nested submodel access
(`cfg.llm.openai_api_key`, real via `AutoBotConfig.__getattr__` delegation)
was missed. Widened in `_ssot_config_bindings`/`_read_pattern` (per-file
discovery of every identifier bound to the singleton -- the flat proxy, an
import alias, a local variable assigned from `get_config()`/
`get_ssot_config()`, or the unassigned chained-call shape
`get_config().field`).

- `find_direct_reads`/`production_credential_reads` (the guard's own
  detector), re-run against this branch after the widening: **0 unlisted,
  0 stale** allowlist entries across **55** (file, field) production read
  sites (up from the pre-review 35 -- the widened sweep surfaced 21 more;
  one, `voice_processing/realtime/openai_provider.py`'s realtime-voice
  OpenAI key, was a live instance of this PR's own defect class and is
  fixed here rather than allowlisted; the other 20 are classified 13
  `AUTH_BOOTSTRAP` / 7 `TRACKED_GAP #15276`, whose body is updated to
  match).
- `test_a_new_bare_credential_read_is_rejected` reproduces the exact pre-fix
  shape of #15267 (`getattr(config, "brave_search_api_key", "")`, no
  `resolve_provider_key`) and of #15268
  (`config.hf_token or config.huggingface_api_token`) on synthetic source
  text — both flagged — plus a wholly novel field name standing in for a
  consumer that does not exist yet. `test_nested_submodel_access_is_rejected`
  and `test_get_config_import_and_chained_call_are_rejected` do the same for
  the two widened shapes, reproducing the real pre-fix
  `openai_provider.py`/`lifespan.py` lines.
  `test_the_seam_call_site_shape_is_not_flagged` and
  `test_a_file_with_no_ssot_config_binding_is_never_scanned` are the
  positive/negative controls: today's real vault-routed call sites, and an
  unrelated `cfg` never bound to the singleton, are not falsely flagged.
- `git push`'s pre-push hook ran pytest on every fast-path test file touched
  in this PR, across two pushes (the second including the review fixes) —
  **all pass** both times.
- `scripts/check_python_file_size.py` on every touched non-test file —
  clean; `llm_shared/provider_registry.py` lands at exactly its
  grandfathered 788-line ceiling (net zero growth); every other touched
  file is well under 600 lines.
- New Postgres-gated round-trip + dependency-edge tests
  (`tests/migrations/test_provider_key_vault.py`), HF/Nous precedence tests
  (`llm_shared/tests/test_hf_nous_precedence.py`), and a realtime-voice
  vault-resolution regression test (`voice_processing/realtime/
  openai_provider_test.py`) are added; CI's disposable-Postgres job
  exercises the migration-gated suite.
- No credential value appears in any new code, test, commit message, or
  this PR body — only field names and file paths.
- Filed #15278: the allowlist's `stale` check works (verified in review),
  but nothing yet caps its size or validates a `TRACKED_GAP #NNNN`
  reference against a real issue -- follow-up proposes the same shrink-only
  ratchet `check_python_file_size.py` uses, scoped to `TRACKED_GAP` entries.

## Model Used

Claude Opus 5 (1M context)

Closes #15267, #15268, #15269
