### PR TITLE
fix(test): retry a starved heartbeat window instead of failing or skipping it (#15266)

### DIFF
--- a/autobot-backend/code_intelligence/shared/process_offload_test.py
+++ b/autobot-backend/code_intelligence/shared/process_offload_test.py
@@ -49,7 +49,12 @@ from typing import NamedTuple
 
 import pytest
 
-from autobot_shared.perf_work_budget import assert_within_baseline_ratio, recording_work_units
+from autobot_shared.perf_work_budget import (
+    MeasurementStarved,
+    assert_within_baseline_ratio,
+    measure_with_starvation_retry,
+    recording_work_units,
+)
 from code_intelligence.shared import process_offload
 from code_intelligence.shared.process_offload import (
     run_directory_scan,
@@ -121,6 +126,13 @@ _IDLE_BASELINE_WINDOW_SECONDS = 0.3
 
 #: Fewest ticks a window may contribute before its median describes anything.
 _MIN_TICKS_PER_WINDOW = 10
+
+#: Bounded retries for a window that starved (#15266): fewer than
+#: _MIN_TICKS_PER_WINDOW ticks says the runner was too busy to take THIS
+#: measurement, not that the code regressed. Small and FIXED, never widened —
+#: see ``measure_with_starvation_retry`` for why a starved window is retried
+#: while a measured-and-failed ratio never is.
+_MAX_STARVATION_RETRIES = 3
 
 #: How far the heartbeat may drift above its own idle baseline while a scan runs
 #: in another process. Measured over three runs on the #15221 host: 1.009, 1.016
@@ -268,15 +280,21 @@ async def _tick_latency_during_scan(force_thread: bool) -> _TickLatency:
     await shutdown_scan_pool()
     process_offload._pool_unavailable_reason = None
 
-    assert len(busy) >= _MIN_TICKS_PER_WINDOW, (
-        f"the heartbeat produced {len(busy)} ticks while the scan ran — fewer than "
-        f"{_MIN_TICKS_PER_WINDOW}, so there is no median to compare and the "
-        "measurement is meaningless"
-    )
-    assert len(idle) >= _MIN_TICKS_PER_WINDOW, (
-        f"the heartbeat produced {len(idle)} ticks on the idle loop — fewer than "
-        f"{_MIN_TICKS_PER_WINDOW}, so there is no baseline to compare against"
-    )
+    # A short window is starved, not regressed (#15266): raising
+    # MeasurementStarved rather than asserting lets the caller retry a bounded
+    # number of times instead of either failing on ordinary runner load or
+    # skipping past a real regression. See measure_with_starvation_retry.
+    if len(busy) < _MIN_TICKS_PER_WINDOW:
+        raise MeasurementStarved(
+            f"the heartbeat produced {len(busy)} ticks while the scan ran — fewer than "
+            f"{_MIN_TICKS_PER_WINDOW}, so there is no median to compare and the "
+            "measurement is meaningless"
+        )
+    if len(idle) < _MIN_TICKS_PER_WINDOW:
+        raise MeasurementStarved(
+            f"the heartbeat produced {len(idle)} ticks on the idle loop — fewer than "
+            f"{_MIN_TICKS_PER_WINDOW}, so there is no baseline to compare against"
+        )
     return _TickLatency(_median_ms(busy), _median_ms(idle), len(busy), len(idle), unavailable)
 
 
@@ -291,9 +309,30 @@ async def test_a_scan_in_a_process_does_not_delay_the_event_loop():
 
     Compared within the test rather than against a fixed threshold, so a loaded
     CI runner shifts both numbers together instead of flaking.
+
+    A WINDOW TOO SHORT TO MEDIAN IS A RETRY, NOT A SKIP OR A PASS (#15266). A
+    contended runner can starve the heartbeat below ``_MIN_TICKS_PER_WINDOW``
+    before either scan even starts, and that says nothing about the code below —
+    but neither does silently passing nor silently skipping past it, which is
+    how a real regression would hide. ``measure_with_starvation_retry`` retakes
+    the window up to ``_MAX_STARVATION_RETRIES`` times and only THEN fails, with
+    a message naming persistent starvation rather than a budget breach. It
+    cannot mask a genuine regression: it retries `_tick_latency_during_scan`
+    only on ``MeasurementStarved`` (an empty window), never on the ratio
+    assertions below, which run outside this call and fail on their first and
+    only attempt — a scan that measurably delays the loop fails here every
+    time, retries or not.
     """
-    in_thread = await _tick_latency_during_scan(force_thread=True)
-    in_process = await _tick_latency_during_scan(force_thread=False)
+    in_thread = await measure_with_starvation_retry(
+        lambda: _tick_latency_during_scan(force_thread=True),
+        max_attempts=_MAX_STARVATION_RETRIES,
+        what="in-thread heartbeat window",
+    )
+    in_process = await measure_with_starvation_retry(
+        lambda: _tick_latency_during_scan(force_thread=False),
+        max_attempts=_MAX_STARVATION_RETRIES,
+        what="in-process heartbeat window",
+    )
 
     if in_process.pool_unavailable:
         pytest.skip(f"process pool unavailable here: {in_process.pool_unavailable}")

--- a/autobot-backend/code_intelligence/shared/process_offload_test.py
+++ b/autobot-backend/code_intelligence/shared/process_offload_test.py
@@ -221,6 +221,47 @@ def _median_ms(samples: list[float]) -> float:
     return ordered[len(ordered) // 2] * 1000.0
 
 
+def _raise_if_a_window_starved(busy: list[float], idle: list[float]) -> None:
+    """Tell a blockage regression apart from ordinary runner contention (#15266).
+
+    The idle windows bracket the busy one in time (see
+    ``_tick_latency_during_scan``), so if they are healthy while the busy
+    window is not, nothing external explains it — the scan itself is what
+    stopped the loop. That is total blockage, the worst-case version of the
+    exact regression #12866 exists to catch, and it must fail on the spot, as
+    an ordinary ``AssertionError``, never retried: retrying a real regression
+    is how a real regression hides, and averaging it away is worse than
+    failing loudly with a slower message.
+
+    Either window short with no such asymmetry to pin on the scan — both
+    starved, or only the idle one — says the loop was generally unable to
+    keep up rather than blocked specifically by the scan. That is the
+    ordinary-contention case ``measure_with_starvation_retry`` exists for, so
+    it raises ``MeasurementStarved`` instead: retried, not failed outright.
+    See that function's docstring for why it cannot make this call by itself.
+    """
+    busy_starved = len(busy) < _MIN_TICKS_PER_WINDOW
+    idle_starved = len(idle) < _MIN_TICKS_PER_WINDOW
+
+    if busy_starved and not idle_starved:
+        raise AssertionError(
+            f"the heartbeat produced only {len(busy)} ticks while the scan ran, "
+            f"against {len(idle)} on the surrounding idle loop — the loop was "
+            "healthy before and after the scan, so the scan itself is what "
+            "stopped it. That is total blockage, not a starved runner, and "
+            "this failure is not retried."
+        )
+    if busy_starved or idle_starved:
+        starved_where = "the scan window" if busy_starved else "the idle window"
+        raise MeasurementStarved(
+            f"{starved_where} produced too few ticks to median (busy={len(busy)}, "
+            f"idle={len(idle)}, need >= {_MIN_TICKS_PER_WINDOW} each) — nothing "
+            "singles out the scan as the cause, so this looks like a generally "
+            "starved runner rather than a blockage, and is retried rather than "
+            "failed outright"
+        )
+
+
 async def _tick_latency_during_scan(force_thread: bool) -> _TickLatency:
     """Time a 5 ms heartbeat while a GIL-bound scan runs, and on the quiet loop.
 
@@ -280,21 +321,10 @@ async def _tick_latency_during_scan(force_thread: bool) -> _TickLatency:
     await shutdown_scan_pool()
     process_offload._pool_unavailable_reason = None
 
-    # A short window is starved, not regressed (#15266): raising
-    # MeasurementStarved rather than asserting lets the caller retry a bounded
-    # number of times instead of either failing on ordinary runner load or
-    # skipping past a real regression. See measure_with_starvation_retry.
-    if len(busy) < _MIN_TICKS_PER_WINDOW:
-        raise MeasurementStarved(
-            f"the heartbeat produced {len(busy)} ticks while the scan ran — fewer than "
-            f"{_MIN_TICKS_PER_WINDOW}, so there is no median to compare and the "
-            "measurement is meaningless"
-        )
-    if len(idle) < _MIN_TICKS_PER_WINDOW:
-        raise MeasurementStarved(
-            f"the heartbeat produced {len(idle)} ticks on the idle loop — fewer than "
-            f"{_MIN_TICKS_PER_WINDOW}, so there is no baseline to compare against"
-        )
+    # #15266's review: a starved window and a blockage regression are not
+    # the same thing, and only the surrounding idle windows can tell them
+    # apart — see _raise_if_a_window_starved.
+    _raise_if_a_window_starved(busy, idle)
     return _TickLatency(_median_ms(busy), _median_ms(idle), len(busy), len(idle), unavailable)
 
 
@@ -310,18 +340,28 @@ async def test_a_scan_in_a_process_does_not_delay_the_event_loop():
     Compared within the test rather than against a fixed threshold, so a loaded
     CI runner shifts both numbers together instead of flaking.
 
-    A WINDOW TOO SHORT TO MEDIAN IS A RETRY, NOT A SKIP OR A PASS (#15266). A
-    contended runner can starve the heartbeat below ``_MIN_TICKS_PER_WINDOW``
-    before either scan even starts, and that says nothing about the code below —
-    but neither does silently passing nor silently skipping past it, which is
-    how a real regression would hide. ``measure_with_starvation_retry`` retakes
-    the window up to ``_MAX_STARVATION_RETRIES`` times and only THEN fails, with
-    a message naming persistent starvation rather than a budget breach. It
-    cannot mask a genuine regression: it retries `_tick_latency_during_scan`
-    only on ``MeasurementStarved`` (an empty window), never on the ratio
-    assertions below, which run outside this call and fail on their first and
-    only attempt — a scan that measurably delays the loop fails here every
-    time, retries or not.
+    A WINDOW TOO SHORT TO MEDIAN IS A RETRY, NOT A SKIP OR A PASS — BUT ONLY IF
+    NOTHING PINS THE SHORTFALL ON THE SCAN (#15266, and its own review). A
+    runner can starve the heartbeat below ``_MIN_TICKS_PER_WINDOW`` before
+    either scan even starts, which says nothing about the code below — but
+    neither does silently passing nor silently skipping past it, which is how
+    a real regression would hide. ``measure_with_starvation_retry`` retakes
+    that window up to ``_MAX_STARVATION_RETRIES`` times and only THEN fails,
+    with a message naming persistent starvation rather than a budget breach.
+
+    A near-empty window is NOT always that ambiguous, though: total blockage —
+    the scan stalling the loop so completely almost nothing gets measured — is
+    the worst-case version of the exact regression #12866 exists to catch, and
+    it produces a near-empty window too. ``_raise_if_a_window_starved`` tells
+    the two apart using the idle windows that bracket the scan: if they are
+    healthy while only the scan window is not, nothing external explains it,
+    so that raises a plain, non-retried ``AssertionError`` instead of
+    ``MeasurementStarved`` — scored on its first and only attempt, exactly like
+    the ratio assertions below, which run outside this call and are never
+    retried either way. Retrying is reserved for the case with no such
+    asymmetry: both windows short, or only the idle one — a scan that
+    measurably delays or blocks the loop fails here every time, retries or
+    not.
     """
     in_thread = await measure_with_starvation_retry(
         lambda: _tick_latency_during_scan(force_thread=True),
@@ -351,6 +391,76 @@ async def test_a_scan_in_a_process_does_not_delay_the_event_loop():
         _TICK_BUDGET_VS_IDLE,
         f"5ms heartbeat during an offloaded scan ({in_process.busy_ticks} ticks " f"vs {in_process.idle_ticks} idle)",
     )
+
+
+def test_scan_only_starvation_is_an_assertion_error_not_measurement_starved():
+    """The blockage regression's signature: idle healthy, busy near-empty (#15266).
+
+    Pins ``_raise_if_a_window_starved``'s discrimination directly: this must
+    NOT be ``MeasurementStarved``, or a caller retrying only that type would
+    retry the worst-case regression instead of failing on it immediately.
+    """
+    busy = [0.005]
+    idle = [0.005] * _MIN_TICKS_PER_WINDOW
+
+    with pytest.raises(AssertionError) as excinfo:
+        _raise_if_a_window_starved(busy, idle)
+
+    assert not isinstance(excinfo.value, MeasurementStarved), (
+        "scan-only starvation must raise a plain AssertionError, not "
+        "MeasurementStarved, or measure_with_starvation_retry will retry a "
+        "real regression"
+    )
+    assert "not retried" in str(excinfo.value)
+
+
+def test_both_windows_starved_is_measurement_starved_and_retryable():
+    """No asymmetry to pin on the scan: ordinary contention, not a blockage."""
+    with pytest.raises(MeasurementStarved):
+        _raise_if_a_window_starved([0.005], [0.005])
+
+
+def test_idle_only_starved_is_also_measurement_starved():
+    """The busy window was fine — nothing implicates the scan either."""
+    busy = [0.005] * _MIN_TICKS_PER_WINDOW
+    idle = [0.005]
+    with pytest.raises(MeasurementStarved):
+        _raise_if_a_window_starved(busy, idle)
+
+
+def test_two_healthy_windows_raise_nothing():
+    busy = [0.005] * _MIN_TICKS_PER_WINDOW
+    idle = [0.005] * _MIN_TICKS_PER_WINDOW
+    _raise_if_a_window_starved(busy, idle)  # must not raise
+
+
+async def test_scan_only_starvation_fails_on_the_first_attempt_without_retrying():
+    """The case that matters most (#15266's review): no 3x-slower detour."""
+    calls = 0
+
+    async def measure():
+        nonlocal calls
+        calls += 1
+        _raise_if_a_window_starved([0.005], [0.005] * _MIN_TICKS_PER_WINDOW)
+
+    with pytest.raises(AssertionError, match="not retried"):
+        await measure_with_starvation_retry(measure, max_attempts=_MAX_STARVATION_RETRIES, what="scan-only")
+
+    assert calls == 1, "a blockage regression must fail on its first attempt, never retried"
+
+
+async def test_both_windows_starved_retries_to_the_bounded_ceiling():
+    calls = 0
+
+    async def measure():
+        nonlocal calls
+        calls += 1
+        _raise_if_a_window_starved([0.005], [0.005])
+
+    with pytest.raises(AssertionError, match="starved on all"):
+        await measure_with_starvation_retry(measure, max_attempts=_MAX_STARVATION_RETRIES, what="both-starved")
+
+    assert calls == _MAX_STARVATION_RETRIES, "ordinary contention retries to the ceiling, not once"
 
 
 async def test_the_responsiveness_budget_cannot_pass_without_a_measurement():

--- a/autobot_shared/perf_work_budget.py
+++ b/autobot_shared/perf_work_budget.py
@@ -261,11 +261,33 @@ async def measure_with_starvation_retry(
     assertion then fails — a real regression — that is a plain `AssertionError`,
     not `MeasurementStarved`, and this function does not catch it. It propagates
     on the first attempt. Retrying is scoped exclusively to "could this window
-    be measured at all", so a genuine regression can never be masked by
-    landing on a lucky retry, and a starved attempt can never be scored as a
-    pass — starvation only ever produces a retry or, on the last attempt, a
-    distinct failure message naming persistent starvation rather than a
-    budget breach.
+    be measured at all", so a starved attempt can never be scored as a pass —
+    starvation only ever produces a retry or, on the last attempt, a distinct
+    failure message naming persistent starvation rather than a budget breach.
+
+    THE PART THIS FUNCTION CANNOT GUARANTEE ON ITS OWN, stated because a review
+    of #15266 found it violated: whether "a genuine regression can never be
+    masked" also holds depends on `measure` raising `MeasurementStarved` ONLY
+    for a window the ENVIRONMENT emptied, never for one the operation under
+    test emptied itself. A total-blockage regression — the code under test
+    stalling the loop so completely that almost nothing gets measured — looks
+    identical, from inside `measure`, to a runner too busy to schedule the
+    heartbeat at all: both are "too few samples". A caller that raises
+    `MeasurementStarved` on tick count alone, with no other signal, will retry
+    that regression up to `max_attempts` times and still fail in the end —
+    this function raises unconditionally once every attempt is exhausted, so
+    the failure is never silently green — but the final message reads as
+    environmental contention when it was actually the worst possible
+    regression, and it takes `max_attempts` times as long to say so. A caller
+    whose "operation under test" and "environment" can both empty the same
+    window must discriminate the two BEFORE raising `MeasurementStarved`, not
+    leave it to this function, which has no way to tell them apart from a
+    tick count alone. `process_offload_test.py::_raise_if_a_window_starved` is
+    the worked example: it brackets the measurement with an idle window on
+    each side and raises `MeasurementStarved` only when the idle window is
+    ALSO starved; a busy window starved while the idle windows are healthy
+    means the operation under test emptied it, which is scored as an
+    immediate, non-retried `AssertionError` instead.
     """
     last_reason: str | None = None
     for _attempt in range(1, max_attempts + 1):

--- a/autobot_shared/perf_work_budget.py
+++ b/autobot_shared/perf_work_budget.py
@@ -49,12 +49,15 @@ the finding, not the obstacle.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Awaitable, Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import TypeVar
 
 REFERENCE_WORKLOAD_ITERATIONS = 20_000
 REFERENCE_WORKLOAD_SAMPLES = 9
+
+_T = TypeVar("_T")
 
 # The junit sink for reported measurements, set per test by
 # `recording_work_units()` so call sites need not thread a fixture through.
@@ -221,4 +224,58 @@ def assert_within_baseline_ratio(
         f"{report}. This is a ratio against a baseline measured on the same loop "
         f"moments earlier, not a wall-clock ceiling — runner load moves both "
         f"terms, so investigate the code, do not raise it."
+    )
+
+
+class MeasurementStarved(Exception):
+    """A measurement window could not collect enough samples to mean anything.
+
+    Raised by a caller's measurement callable, never by this module — the
+    caller is the one that knows how many samples its window needs. Deliberately
+    NOT an `AssertionError`: `measure_with_starvation_retry` catches only this
+    type, so a real assertion failure inside the callable (a regression the
+    measurement *did* complete and then failed) is never mistaken for a window
+    that produced no measurement at all, and is never retried or swallowed.
+    """
+
+
+async def measure_with_starvation_retry(
+    measure: Callable[[], Awaitable[_T]],
+    *,
+    max_attempts: int,
+    what: str,
+) -> _T:
+    """Retry `measure` a small bounded number of times if its window starves (#15266).
+
+    A window that could not collect enough samples is neither a pass nor a
+    failure — it is a runner that was too busy to take the measurement at all,
+    which says nothing about the code under test. Failing outright on that
+    reports an environment condition as a code regression (#15221's second
+    sighting); silently skipping is how a real regression hides (the
+    unreachable `pytest.skip` fixed in #15248). Retrying a small, FIXED number
+    of times distinguishes "momentarily busy" from "persistently starved": if
+    every attempt starves, this still raises, because persistent starvation is
+    a fact worth a red, not noise to average away.
+
+    WHAT THIS DOES NOT RETRY, and must not: if `measure` completes and its own
+    assertion then fails — a real regression — that is a plain `AssertionError`,
+    not `MeasurementStarved`, and this function does not catch it. It propagates
+    on the first attempt. Retrying is scoped exclusively to "could this window
+    be measured at all", so a genuine regression can never be masked by
+    landing on a lucky retry, and a starved attempt can never be scored as a
+    pass — starvation only ever produces a retry or, on the last attempt, a
+    distinct failure message naming persistent starvation rather than a
+    budget breach.
+    """
+    last_reason: str | None = None
+    for _attempt in range(1, max_attempts + 1):
+        try:
+            return await measure()
+        except MeasurementStarved as starved:
+            last_reason = str(starved)
+    raise AssertionError(
+        f"{what}: starved on all {max_attempts} attempts, last reason: "
+        f"{last_reason} — the event loop was persistently unable to produce a "
+        "usable measurement window, not merely busy once; this is distinct "
+        "from a measured budget breach, which fails on its first attempt"
     )

--- a/autobot_shared/perf_work_budget_test.py
+++ b/autobot_shared/perf_work_budget_test.py
@@ -12,11 +12,17 @@ marker-excluded selection whose benchmarks they underwrite.
 import pytest
 
 from autobot_shared.perf_work_budget import (
+    MeasurementStarved,
     assert_within_work_budget,
     measure_reference_ms,
+    measure_with_starvation_retry,
     recording_work_units,
     reference_workload,
 )
+
+# Only the classes below hold coroutine tests; the ones above are plain sync
+# functions and this marker is a no-op for them (#15266).
+pytestmark = pytest.mark.asyncio
 
 
 class TestWorkBudgetHarness:
@@ -66,3 +72,72 @@ class TestWorkBudgetHarness:
             pass
         # No recorder installed: the assertion still works and reports nowhere.
         assert_within_work_budget(measure_reference_ms(), 1000.0, "unrecorded measurement")
+
+
+class TestStarvationRetry:
+    """``measure_with_starvation_retry``: a starved window retries, a real
+    measured failure never does (#15266). The retry exists so a window too
+    short to hold a median is neither a false pass (silently skipped) nor a
+    false regression (failed on ordinary runner load) — see
+    ``process_offload_test.py::test_a_scan_in_a_process_does_not_delay_the_event_loop``
+    for the call site this was built for.
+    """
+
+    async def test_succeeds_without_retry_when_the_first_attempt_is_not_starved(self):
+        calls = 0
+
+        async def measure():
+            nonlocal calls
+            calls += 1
+            return "measured"
+
+        result = await measure_with_starvation_retry(measure, max_attempts=3, what="unstarved")
+        assert result == "measured"
+        assert calls == 1, "a clean first attempt must not be retried"
+
+    async def test_retries_a_starved_window_and_succeeds_once_it_is_not(self):
+        calls = 0
+
+        async def measure():
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise MeasurementStarved(f"attempt {calls} starved")
+            return "measured on the third attempt"
+
+        result = await measure_with_starvation_retry(measure, max_attempts=3, what="eventually unstarved")
+        assert result == "measured on the third attempt"
+        assert calls == 3
+
+    async def test_persistent_starvation_fails_after_the_bounded_ceiling(self):
+        """Starvation on every attempt still goes red — this is not a skip."""
+        calls = 0
+
+        async def measure():
+            nonlocal calls
+            calls += 1
+            raise MeasurementStarved(f"attempt {calls} starved")
+
+        with pytest.raises(AssertionError, match="starved on all 3 attempts"):
+            await measure_with_starvation_retry(measure, max_attempts=3, what="persistently starved")
+        assert calls == 3, "the ceiling is bounded, not unbounded"
+
+    async def test_a_measured_regression_is_never_retried_or_masked(self):
+        """The mutation argument (#15266): a real regression fails on attempt one.
+
+        ``MeasurementStarved`` is the ONLY exception this retries. A plain
+        ``AssertionError`` — what a completed measurement raises when its own
+        ratio budget fails, e.g. the ~1.994x reading a forced in-process scan
+        produces against the 1.5 budget — propagates immediately. It can never
+        land on a lucky retry and can never be averaged away by one.
+        """
+        calls = 0
+
+        async def measure():
+            nonlocal calls
+            calls += 1
+            raise AssertionError("1.994x its own idle baseline (budget 1.5)")
+
+        with pytest.raises(AssertionError, match="1.994x"):
+            await measure_with_starvation_retry(measure, max_attempts=3, what="regressed")
+        assert calls == 1, "a measured regression must not be retried"


### PR DESCRIPTION
## Thinking Path

`_MIN_TICKS_PER_WINDOW = 10` in `process_offload_test.py` exists to reject a
measurement window too short to hold a median — a sound precondition. But it
rejected by *failing*, which reports a contended CI runner as a code
regression: exactly the confusion #15221 was filed about, one layer down
(#15221's reopening comment traces this).

Both obvious branches are wrong. Skipping is how a real regression hides —
`pytest.skip` in this same file was already found unreachable once and fixed
in #15248, and reintroducing a skip path would undo that. Failing calls a
busy runner a regression, which is the defect under repair. A measurement
that could not be taken is neither a pass nor a failure — it is a retry.
Retake the window a small bounded number of times, and fail only if every
attempt starves. That distinguishes "this runner was momentarily busy" from
"this event loop is persistently starved", and only the second deserves a red.

The retry is scoped as narrowly as possible: it wraps only the "could this
window be measured at all" precondition inside `_tick_latency_during_scan`,
never the ratio assertions in the test body. Those run outside the retry
call entirely, so a genuine regression is scored on its first and only
attempt, exactly as before.

## What Changed

- `autobot_shared/perf_work_budget.py`: added `MeasurementStarved` (an
  `Exception`, deliberately not an `AssertionError`, so it can never be
  confused with — or accidentally catch — a real ratio-budget failure) and
  `measure_with_starvation_retry(measure, *, max_attempts, what)`, a general
  async retry helper for any contention site whose measurement window can
  legitimately come up empty. It catches only `MeasurementStarved`; on
  persistent starvation it raises `AssertionError` with a message naming
  starvation explicitly, distinct from a budget-breach message.
- `autobot-backend/code_intelligence/shared/process_offload_test.py`:
  `_tick_latency_during_scan` now raises `MeasurementStarved` instead of
  asserting when a window under-fills. The test wraps each of its two
  measurement calls (`force_thread=True`/`False`) in
  `measure_with_starvation_retry` with a new bounded constant,
  `_MAX_STARVATION_RETRIES = 3`. The test's own docstring states why this is
  a retry and not a skip or a pass, per #15221's reopening comment.
- `autobot_shared/perf_work_budget_test.py`: added `TestStarvationRetry`,
  covering a clean first attempt (no retry), an eventually-successful retry,
  persistent starvation reaching the bounded ceiling and still failing, and
  — the mutation argument — a plain `AssertionError` (what a completed
  measurement raises on a real regression, worded like the ~1.994x reading a
  forced in-process scan produces against the 1.5 budget) propagating on
  its *first* attempt, never retried or masked.

`_TICK_BUDGET_VS_IDLE = 1.5` is untouched. `_MIN_TICKS_PER_WINDOW = 10` is
untouched — the precondition itself is correct; only what happens when it
isn't met has changed.

## Verification

Read, not run, per the hard constraint (this is a timing test on the CI
runner itself):

- `_tick_latency_during_scan` still performs its cleanup
  (`shutdown_scan_pool`, `beat.cancel()`, resetting
  `_pool_unavailable_reason`) before raising `MeasurementStarved`, so each
  retry attempt starts from clean state — unchanged from the prior
  `assert`'s position in the function.
- `measure_with_starvation_retry` catches only `MeasurementStarved`. The
  ratio assertions (`in_process.busy_ms < in_thread.busy_ms * 0.75` and
  `assert_within_baseline_ratio(...)`) execute in the test body, entirely
  outside any retry call — a regression there raises a plain
  `AssertionError` on the only attempt taken, with no retry loop in scope to
  catch or repeat it.
- Mutation argument (forcing the scan in-process previously produced
  `1.994x its own idle baseline` against the 1.5 budget, per #15221's
  closure comment): that failure happens inside `assert_within_baseline_ratio`,
  called directly in the test body — never wrapped by
  `measure_with_starvation_retry` — so it still fails on first measurement,
  unaffected by this change. `TestStarvationRetry::test_a_measured_regression_is_never_retried_or_masked`
  encodes this directly with a synthetic `AssertionError` worded the same way.
- Persistent starvation: `TestStarvationRetry::test_persistent_starvation_fails_after_the_bounded_ceiling`
  proves a `measure` that always raises `MeasurementStarved` is called
  exactly `max_attempts` times and then raises `AssertionError` naming
  "starved on all N attempts" — bounded, not silently swallowed, not a skip.
- The pre-push hook ran `pytest` on both touched test files against this
  branch and reported all relevant tests passing (see push output on this
  branch).
- `ruff check` and `black --check` both pass clean on all three touched
  files; every touched file is well under the 600-line cap
  (`perf_work_budget.py` 281, `perf_work_budget_test.py` 143,
  `process_offload_test.py` 423).

Closes #15221 pending confirmation on the reopener's own criteria (a
deliberately-starved run reaching a verdict rather than erroring on the
precondition, and the retry-vs-skip-vs-pass distinction stated in the test
itself) — leaving that issue for the reopener to close by hand per repo
convention, since `Closes` keywords do not fire on `Dev_new_gui`.

## Model Used

Claude Sonnet 5


Closes #15266
Refs #15221 — this is the fix that its reopening comment set as the condition for closing again.
