### PR TITLE
fix(test-guards): print(subject()), class-level skip, and utilities/ shebang coverage

### DIFF
--- a/repo_tests/collected_test_model.py
+++ b/repo_tests/collected_test_model.py
@@ -153,18 +153,23 @@ def collectable_tests(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunct
     Module-level ``test_*`` functions, and ``test_*`` methods of ``Test*``
     classes. A method of any other class is not collected, so its return value
     is nobody's verdict.
+
+    A method carries its enclosing class's decorators on ``class_decorator_list``
+    (empty for a module-level function), because the AST gives no parent
+    pointer and ``is_declared_not_running`` needs to see a class-level
+    ``@pytest.mark.skip`` that the method itself never spells out (#15263).
     """
     functions, classes = prefixes()
     found: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
     for node in tree.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            node.class_decorator_list = []  # type: ignore[attr-defined]
             found.append(node)
         elif isinstance(node, ast.ClassDef) and node.name.startswith(classes):
-            found.extend(
-                child
-                for child in node.body
-                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
-            )
+            for child in node.body:
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    child.class_decorator_list = node.decorator_list  # type: ignore[attr-defined]
+                    found.append(child)
     return [node for node in found if node.name.startswith(functions)]
 
 
@@ -354,7 +359,15 @@ DECLARED_NOT_RUNNING = frozenset({"skip", "skipif", "xfail"})
 
 
 def is_declared_not_running(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    for decorator in function.decorator_list:
+    """True if the function OR its enclosing ``Test*`` class declares a skip.
+
+    A method under a class-level ``@pytest.mark.skip`` never repeats the
+    decorator on itself, but pytest still honours the class's — so a method's
+    own ``decorator_list`` alone is not enough (#15263).
+    """
+    own = function.decorator_list
+    inherited = getattr(function, "class_decorator_list", [])
+    for decorator in (*own, *inherited):
         node = decorator.func if isinstance(decorator, ast.Call) else decorator
         name = node.attr if isinstance(node, ast.Attribute) else getattr(node, "id", "")
         if name in DECLARED_NOT_RUNNING:
@@ -366,9 +379,13 @@ def does_nothing(statement: ast.stmt) -> bool:
     """True for a statement that cannot observe, change or check anything.
 
     ``pass``, ``...``, a bare string (docstring, or a comment written as one)
-    and ``print(...)`` — the four ways a body can be written out in full and
-    still run no check. ``print`` is matched only as a bare name: an attribute
-    call such as ``reporter.print(...)`` is somebody's method and may do work.
+    and ``print(literal, ...)`` — the four ways a body can be written out in
+    full and still run no check. ``print`` is matched only as a bare name: an
+    attribute call such as ``reporter.print(...)`` is somebody's method and
+    may do work. ``print(subject())`` is not a no-op either: the argument is
+    evaluated before ``print`` ever runs, so it is a real call that can raise
+    — the same "a call is a real check" principle this module applies
+    everywhere else — and only a literal argument leaves nothing evaluated.
     """
     if isinstance(statement, ast.Pass):
         return True
@@ -381,6 +398,8 @@ def does_nothing(statement: ast.stmt) -> bool:
         isinstance(value, ast.Call)
         and isinstance(value.func, ast.Name)
         and value.func.id == "print"
+        and not value.keywords
+        and all(isinstance(arg, ast.Constant) for arg in value.args)
     )
 
 

--- a/repo_tests/git_hooks_executable_test.py
+++ b/repo_tests/git_hooks_executable_test.py
@@ -30,6 +30,20 @@ Reach floors are asserted throughout: an empty glob reports "no offenders"
 while having checked nothing, which is the same shape of bug as the one under
 guard. Extensionless files are asserted specifically — the whole of #14891 was
 a walk that saw only ``*.sh``.
+
+``autobot-infrastructure/shared/scripts/utilities`` joined the swept directories
+in #15264, closing the gap that let #15253's 22 stale modes happen in the first
+place. That directory is not the same shape as the other two, though: it also
+holds standalone Python tools that carry ``#!/usr/bin/env python3`` purely as
+convention — meant to be run ``python3 tool.py``, never ``./tool.py`` — and the
+rule's own premise does not hold for them. This is not a guess: the same pattern
+holds across the whole repository, 536 tracked ``.py`` files declare a shebang
+while tracked ``100644``, against 25 that are ``100755``. So a Python file's
+shebang under ``.../utilities`` is not read as a claim of executability here —
+scoped to that one directory, because the two original directories carry no such
+file today and this guard's job is not to relax their coverage. Every ``.sh``
+file and every extensionless file in ``utilities`` is still held to both
+directions of the rule.
 """
 
 from __future__ import annotations
@@ -47,8 +61,14 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _HOOK_DIRS = (
     "tools/git-hooks",
     "autobot-infrastructure/shared/scripts/hooks",
+    "autobot-infrastructure/shared/scripts/utilities",
 )
 _INSTALLERS = ("scripts/install-git-hooks.sh",)
+
+# Only this directory holds standalone Python tools whose shebang is
+# convention rather than a claim (see module docstring) — scoped here, not
+# lifted repo-wide, so the two original directories keep full coverage.
+_PY_SHEBANG_NOT_A_CLAIM_UNDER = "autobot-infrastructure/shared/scripts/utilities/"
 
 # Files that must be present and executable. Named individually so a walk that
 # reaches files but not *these* files still fails (#14909's three offenders,
@@ -97,31 +117,43 @@ def _first_line(rel: str) -> str:
         return ""
 
 
+def _shebang_claims_executable(rel: str) -> bool:
+    """False for a ``.py`` shebang where it is convention, not a claim (#15264)."""
+    if not _first_line(rel).startswith("#!"):
+        return False
+    return not (rel.startswith(_PY_SHEBANG_NOT_A_CLAIM_UNDER) and rel.endswith(".py"))
+
+
 _MODES = _tracked_modes()
-_SHEBANGED = {rel for rel in _MODES if _first_line(rel).startswith("#!")}
+_SHEBANGED = {rel for rel in _MODES if _shebang_claims_executable(rel)}
+_UTILITIES = {rel for rel in _MODES if rel.startswith(_PY_SHEBANG_NOT_A_CLAIM_UNDER)}
 
 
 def test_the_sweep_actually_reached_the_hook_directories() -> None:
     """Discovery floor. An empty listing asserts nothing while reading as clean.
 
-    Four independent floors, because any one of them can be satisfied by a sweep
+    Five independent floors, because any one of them can be satisfied by a sweep
     that is still broken: the file count catches a path list that stopped
     matching, the shebang count catches a reader that returns "" for everything
     (which would make every later assertion vacuously true), the named set
-    catches a sweep that reaches files but not the ones this guard is about, and
-    the extensionless count catches the #14891 trap of a walk that only ever
-    sees ``*.sh``.
+    catches a sweep that reaches files but not the ones this guard is about, the
+    extensionless count catches the #14891 trap of a walk that only ever sees
+    ``*.sh``, and the ``utilities`` count catches ``_HOOK_DIRS`` losing that
+    entry — dropping it collapses the count to zero, since ``git ls-files -s``
+    then never returns a single path under it (#15264).
     """
-    assert len(_MODES) >= 46, (
+    assert len(_MODES) >= 127, (
         f"only {len(_MODES)} tracked files under {_HOOK_DIRS} — the path list is "
         "no longer reaching the hook directories"
     )
     # Floors sit AT the measured count rather than below it for headroom, so a
     # retired hook has to come here and say so. Measured on this branch:
-    # 46 tracked, 25 shebanged, 22 of them extensionless.
-    assert len(_SHEBANGED) >= 25, (
-        f"only {len(_SHEBANGED)} files declare a shebang — the reader has regressed "
-        "and every assertion below would pass having checked nothing"
+    # 127 tracked (81 of them under utilities/), 47 shebanged and read as a
+    # claim, 22 of those extensionless.
+    assert len(_SHEBANGED) >= 47, (
+        f"only {len(_SHEBANGED)} files declare a shebang read as a claim — the "
+        "reader has regressed and every assertion below would pass having "
+        "checked nothing"
     )
     missing = sorted(_REQUIRED - set(_MODES))
     assert not missing, f"these hooks are no longer tracked at all: {missing}"
@@ -130,6 +162,12 @@ def test_the_sweep_actually_reached_the_hook_directories() -> None:
     assert len(extensionless) >= 22, (
         f"only {len(extensionless)} extensionless executables found — the sweep has "
         "narrowed to files with a suffix, which is exactly the gap #14891 closed"
+    )
+
+    assert len(_UTILITIES) >= 81, (
+        f"only {len(_UTILITIES)} tracked files found under "
+        f"{_PY_SHEBANG_NOT_A_CLAIM_UNDER!r} — the walk has stopped reaching "
+        "utilities/, which is exactly where #15253's 22 stale modes lived (#15264)"
     )
 
 

--- a/repo_tests/tests_that_execute_nothing_test.py
+++ b/repo_tests/tests_that_execute_nothing_test.py
@@ -207,6 +207,9 @@ def test_the_detector_finds_an_empty_body_and_spares_a_real_one() -> None:
         "def test_a():\n    subject()\n"
     ), "a call is a real check — it can raise, which is a thin assertion but a real one"
     assert not empty_bodies(
+        "def test_a():\n    print(subject())\n"
+    ), "print(subject()) evaluates subject() first — a real call, not print('literal') (#15263)"
+    assert not empty_bodies(
         "def test_a():\n    assert subject()\n"
     ), "an assertion is a body"
     assert not empty_bodies(
@@ -228,6 +231,14 @@ def test_the_detector_finds_an_empty_body_and_spares_a_real_one() -> None:
         assert not empty_bodies(
             f"import pytest\n\n\n@pytest.mark.{marker}\ndef test_a():\n    pass\n"
         ), f"`{marker}` declares the test does not run — that is honest, not misleading"
+    for marker in ("skip", 'skipif(True, reason="x")', "xfail"):
+        assert not empty_bodies(
+            "import pytest\n\n\n"
+            f"@pytest.mark.{marker}\nclass TestX:\n    def test_a(self):\n        pass\n"
+        ), (
+            f"a class-level `{marker}` exempts its methods the same as a method-level "
+            "one — the method never repeats a decorator it inherits (#15263)"
+        )
     assert empty_bodies(
         "import pytest\n\n\n@pytest.mark.asyncio\nasync def test_a():\n    pass\n"
     ), "an unrelated marker does not excuse an empty body — asyncio still runs it"


### PR DESCRIPTION
Closes #15263, #15264

## Thinking Path

Both issues are false-positive-direction fixes to repo guards, found in review of prior guard PRs (#15254, #15253/#15262), same scope and risk — one PR.

**#15263** — `does_nothing()` matched any `print(...)` call as a no-op regardless of argument, so `print(subject())` (a real call that can raise) was indistinguishable from `print("literal")`. `is_declared_not_running()` only read a method's own `decorator_list`, never the enclosing `Test*` class's, so a method honestly exempted by a class-level `@pytest.mark.skip` was flagged anyway. Fixed in the classifier per the issue's explicit instruction — no exemption-list entries added.

**#15264** — `_HOOK_DIRS` covered `tools/git-hooks` and `.../scripts/hooks` but not `.../scripts/utilities`, where #15262 had just hand-repaired 22 stale modes. Extending it naively surfaced a real wrinkle the issue didn't anticipate: `utilities/` also holds 51 standalone Python tools carrying `#!/usr/bin/env python3` purely as convention (never meant for `./tool.py` invocation) — a pattern confirmed repo-wide at 536:25 non-executable:executable for shebang'd `.py` files. Applying the "shebang implies executable" direction unscoped would have flagged all 51 against a deliberate, pre-existing convention that has nothing to do with the #14909 hook regression. So a Python shebang under `utilities/` is read as a claim only there — scoped to that one directory — while `.sh` and any extensionless files keep full coverage, and the two original directories are untouched (neither carries such a file today, so nothing there is relaxed).

## What Changed

- `repo_tests/collected_test_model.py`:
  - `does_nothing()` now requires every `print(...)` argument to be an `ast.Constant` (and no keywords) to count as a no-op — `print(subject())` no longer matches.
  - `collectable_tests()` now attaches each method's enclosing class's `decorator_list` as `class_decorator_list` (AST carries no parent pointer), and `is_declared_not_running()` checks both the function's own decorators and the inherited ones.
- `repo_tests/tests_that_execute_nothing_test.py`: two new self-test cases in `test_the_detector_finds_an_empty_body_and_spares_a_real_one` — `print(subject())` is not flagged, and a class-level `@pytest.mark.skip`/`skipif`/`xfail` exempts its methods.
- `repo_tests/git_hooks_executable_test.py`:
  - `_HOOK_DIRS` gains `autobot-infrastructure/shared/scripts/utilities`.
  - `_shebang_claims_executable()` excludes `.py` files under that directory from the "shebang implies executable" set only (the converse direction — `100755` implies a shebang on line 1 — is unscoped and unaffected).
  - Reach floors raised: `_MODES >= 127` (was 46), `_SHEBANGED >= 47` (was 25), plus a new `_UTILITIES >= 81` floor specific to the new directory.
  - Module docstring documents the scoping decision and its repo-wide evidence.

## Verification

- `python3 -c "import ast; ast.parse(...)"` on all three touched files — syntax OK.
- Manually traced `does_nothing`/`is_declared_not_running` against every new/existing self-test case in `tests_that_execute_nothing_test.py`.
- Measured at current `Dev_new_gui` base via `git ls-files -s`:
  - `utilities/`: 81 tracked files, 22 `100755` (all `.sh`, all shebanged on line 1), 59 `100644` (51 of them `.py` with a shebang — the convention noted above; 8 with neither).
  - Converse check requested by #15264: **zero** files in `utilities/` tracked `100755` without a shebang — nothing to report or stop on.
  - Primary direction after the `.py` exclusion: **zero** offenders (was 51 before scoping the exclusion — confirms the exclusion is load-bearing, not decorative).
  - Mutation proof for the new reach floor: dropping `autobot-infrastructure/shared/scripts/utilities` from `_HOOK_DIRS` makes `git ls-files -s` never return a path under that prefix, so `_UTILITIES` collapses to 0, failing `assert len(_UTILITIES) >= 81`.
  - Repo-wide shebang'd `.py` mode split (evidence for the scoping decision): 536 `100644` vs 25 `100755`.
- The repo's own pre-push hook ran `pytest` on all three touched files during `git push` and reported all relevant tests passing.
- File line counts (cap 600): `collected_test_model.py` 423, `tests_that_execute_nothing_test.py` 244, `git_hooks_executable_test.py` 300.

## Model Used

Claude Sonnet 5 (claude-sonnet-5)
