### PR TITLE
fix(guards): scope hardcoded-value test exemption to repo_tests/ support modules (#15273)

### DIFF
--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -182,6 +182,47 @@ class TestAllowlistedContexts:
 
 
 @pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
+class TestRepoTestsSupportModuleExemption:
+    """#15273: a test-SUPPORT module under repo_tests/ (not itself named
+    *_test.py) gets the same exemption the filename rule already grants its
+    siblings -- scoped to the DIRECTORY so production code keeps exactly the
+    exemption it had before and no more."""
+
+    _URL = 'http://backend.test:9999'
+
+    def test_allows_literal_in_repo_tests_support_module(self, tmp_path: Path) -> None:
+        # repo_tests/sdk_request_shared.py (#15265): a non-test-named helper
+        # module, collected by nothing, imported only by *_test.py siblings.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"repo_tests/sdk_request_shared.py": f'_BASE = "{self._URL}"\n'},
+        )
+        assert result.returncode == 0, f"repo_tests/ support module should be exempt:\n{result.stdout}"
+
+    def test_blocks_same_literal_in_production_code(self, tmp_path: Path) -> None:
+        # The identical literal, in a non-test-named file OUTSIDE repo_tests/,
+        # must still be flagged -- proves the new exemption is scoped to the
+        # directory and did not loosen the filename rule generally.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"autobot-backend/sdk_request_shared.py": f'_BASE = "{self._URL}"\n'},
+        )
+        assert result.returncode != 0
+        assert self._URL in result.stdout
+
+    def test_does_not_match_a_directory_merely_containing_the_substring(self, tmp_path: Path) -> None:
+        # `not_repo_tests/` and `repo_tests_archive/` must NOT be swept in by
+        # a loose substring match -- the exemption is anchored on the exact
+        # path segment `repo_tests/`.
+        result = _run_hook_with_staged(
+            tmp_path,
+            {"not_repo_tests/sdk_request_shared.py": f'_BASE = "{self._URL}"\n'},
+        )
+        assert result.returncode != 0
+        assert self._URL in result.stdout
+
+
+@pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
 class TestNonBlockingPatterns:
     """Lines that look like hardcoded IPs but aren't deployment IPs are allowed."""
 

--- a/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
+++ b/autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py
@@ -22,7 +22,22 @@ from pathlib import Path
 
 import pytest
 
+from autobot_shared.paths import scrubbed_git_env
+
 HOOK_PATH = Path(__file__).resolve().parent / "pre-commit-hardcoded-values"
+
+
+def _test_git_env() -> dict[str, str]:
+    """#15273/#15246: env for every git subprocess this suite spawns.
+
+    Scrubbed rather than os.environ: the pre-push hook runs this suite with
+    GIT_DIR pointing at the worktree it is pushing (every checkout here is
+    one), and an unscrubbed `git init`/`git add`/`git diff --cached` in a
+    fixture then operates on THAT repository instead of tmp_path's --
+    reproduced: it staged ~20 bogus entries into the real worktree and
+    overwrote two tracked files' index blobs with 1-line test content.
+    """
+    return {**scrubbed_git_env(), "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
 
 
 def _run_hook_with_staged(tmp_path: Path, files: dict[str, str]) -> subprocess.CompletedProcess:
@@ -31,20 +46,25 @@ def _run_hook_with_staged(tmp_path: Path, files: dict[str, str]) -> subprocess.C
 
     files: relative path -> file content
     """
-    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.email", "test@test"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True)
+    env = _test_git_env()
+    subprocess.run(["git", "init", "--quiet"], cwd=tmp_path, check=True, env=env)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=tmp_path, check=True, env=env)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=tmp_path, check=True, env=env)
     for rel, content in files.items():
         path = tmp_path / rel
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
-        subprocess.run(["git", "add", rel], cwd=tmp_path, check=True)
+        subprocess.run(["git", "add", rel], cwd=tmp_path, check=True, env=env)
 
+    # Same scrub: the hook itself runs `git diff --cached` against
+    # tmp_path, and an inherited GIT_DIR would point it at the real
+    # worktree's staged set instead.
     return subprocess.run(
         ["bash", str(HOOK_PATH)],
         cwd=tmp_path,
         capture_output=True,
         text=True,
+        env=env,
     )
 
 
@@ -791,7 +811,9 @@ class TestHardcodedTimeouts:
 
 
 def _git(repo, *args):
-    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True, env=_test_git_env()
+    )
 
 
 @pytest.mark.skipif(not HOOK_PATH.exists(), reason="hook script missing at expected path")
@@ -817,5 +839,7 @@ class TestFailsClosedOnGitFailure:
         # Corrupt the index so git errors rather than returning an empty answer.
         (tmp_path / ".git" / "index").write_text("garbage", encoding="utf-8")
 
-        result = subprocess.run(["bash", str(HOOK_PATH)], cwd=tmp_path, capture_output=True, text=True)
+        result = subprocess.run(
+            ["bash", str(HOOK_PATH)], cwd=tmp_path, capture_output=True, text=True, env=_test_git_env()
+        )
         assert result.returncode != 0, "a git failure was indistinguishable from 'no violation'"

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -62,6 +62,7 @@ GITHUB_BASE_REF=Dev_new_gui bash pipeline-scripts/check-hardcoded-values-pr.sh
 - `network_constants.py`, `path_constants.py`, `security_constants.py`, `threshold_constants.py`
 - Anything under `constants/`, `config.py`, or `.env*`
 - Test files (`test_*.py`, `*_test.py`, `*.test.ts`, `*.spec.ts`) — fixtures legitimately use literal IPs
+- Any file under `repo_tests/` (#15273) — that directory is test-support code by construction, so a non-test-named helper module living there (e.g. one holding fixture constants shared by several `*_test.py` siblings) gets the same exemption on the strength of its DIRECTORY rather than its filename. The same file outside `repo_tests/` is still scanned.
 - Lines containing `config.`, `getenv`, `CONFIG[`, or `AUTOBOT_` (already routed through SSOT)
 - Comments (any line starting with `#` / `//` / ` *`)
 - File types other than `.py` / `.ts` / `.vue` (Markdown, YAML, JSON, etc. are not scanned at all — Ansible inventories and docs are explicitly out of scope)

--- a/scripts/lib/hardcoded-value-rules.sh
+++ b/scripts/lib/hardcoded-value-rules.sh
@@ -198,6 +198,16 @@ HV_SCAN_EXTENSIONS='py|ts|vue|js|sh|yml|yaml'
 _HV_EXCLUDE_RE='(/__pycache__/|/node_modules/|/\.venv/|/venv/|/archive/|/dist/|/tmp/|/\.tmp/|^tmp/|^archive/)'
 _HV_EXCLUDE_RE+='|(^|/)(_generated|generated)/'
 _HV_EXCLUDE_RE+='|(test_[^/]*\.(py|ts)$|[^/]*_test\.(py|ts)$|[^/]*\.(test|spec)\.(ts|js)$|/__tests__/)'
+# #15273: test-SUPPORT modules living under repo_tests/ -- helper functions
+# and fixture data imported only by *_test.py files, collected as a test by
+# none of them -- get the same exemption the filename rule above already
+# grants its siblings, for the reason that rule states at its own top: a
+# module whose only reachable caller is test code carries the same
+# 'fixtures legitimately use literal IPs' rationale (HARDCODING_PREVENTION.md)
+# no matter what its filename happens to be. Scoped to the DIRECTORY, not to
+# a widened filename pattern, so it cannot reach into production code that
+# happens to share a name -- repo_tests/ carries nothing else (#15187/#15195).
+_HV_EXCLUDE_RE+='|(^|/)repo_tests/'
 _HV_EXCLUDE_RE+='|(ssot_config\.py|ssot-config\.ts|ssot_mappings\.py|registry_defaults\.py|threshold_constants\.py)'
 _HV_EXCLUDE_RE+='|(path_constants\.py|network_constants\.py|security_constants\.py|constants/network\.ts)'
 _HV_EXCLUDE_RE+='|(/constants/|config\.py$|config\.yaml$|\.env|\.example$|\.lock$)'


### PR DESCRIPTION
## Thinking Path

Two asks in #15273. Traced the enforcement chain before touching either:

- Gap 2 (test-support exemption): `hv_file_in_scope()` in `scripts/lib/hardcoded-value-rules.sh` is shared by every entry point (the pre-commit hook, `pipeline-scripts/detect-hardcoded-values.sh`, and `check-pre-commit-hook-pr.sh`), so one directory-scoped addition to `_HV_EXCLUDE_RE` fixes it everywhere at once, with no risk to production code because it matches on a path *segment* (`(^|/)repo_tests/`), not a substring.

- Gap 2 needed a real test showing it isn't over-broad: the same literal, same filename, one path under `repo_tests/` (allowed) and one under `autobot-backend/` (still blocked) — plus a third case (`not_repo_tests/`) proving the match is anchored on the directory segment and not a loose substring.

- Gap 1 (move detection): before designing a heuristic I mapped which CI gate actually *blocks* a hardcoded value from landing, because that changes how much risk a heuristic's false negatives carry.
  - `code-quality.yml` → `check-pre-commit-hook-pr.sh --changed-lines-only pre-commit-hardcoded-values` is diff-scoped (only lines the PR added) — this is the ask's target.
  - `ssot-coverage.yml` → `detect-hardcoded-values.sh --json` is a **full, diff-blind tree rescan** against the baseline, and it runs on every push to `Dev_new_gui`/`main` too — but its `SCAN_DIRS` (`pipeline-scripts/detect-hardcoded-values.sh:65-71`) covers only `autobot-backend`, `autobot-frontend/src`, `autobot_shared`, `autobot-slm-backend`, `autobot-slm-frontend/src`, `autobot-infrastructure`. **`repo_tests/`, `pipeline-scripts/`, `scripts/`, `tools/`, and `docs/` have no full-tree backstop at all.** `enforce-precommit.yml`'s `pre-commit run --all-files` is explicitly non-blocking for this hook (findings route to `::warning::`; `pre-commit-hardcoded-values` is not on `check_gating_precommit_hooks.py`'s allowlist).
  - Net: for exactly the files gap 1's own example moves things into (`repo_tests/`), the diff-scoped PR check is the *only* gate. A move-detection heuristic there is not a convenience layered on a solid backstop — for that class of file it would be **the entire defense**, which is precisely where the ask says a false negative is unacceptable.
  - Verdict: **decline gap 1**, on top of the reasons the issue itself flags (reformatting, a genuinely new violation matching a coincidentally-deleted line elsewhere in the diff — which is not a rare shape in this codebase, since IPs/ports/URLs/timeouts recur as both violations and legitimate examples/docs/SSOT-table entries across many files). Full details and the recorded status are on #15273.

- While verifying gap 2's tests locally I hit the pre-push hook's own pytest run failing `TestFailsClosedOnGitFailure` — traced it to the exact bug class in open issue #15246 (ambient `GIT_DIR` from the pre-push hook leaking into this test file's own `git init`/`git add` subprocess calls). Reproduced it corrupting *this worktree's real index* (confirmed the working tree itself was untouched, recovered with `git reset`), then applied the same `scrubbed_git_env()` fix #15243 established for the `paths_test.py` instance, since it blocked this PR's own push and is a one-file, mechanical, already-endorsed pattern. Left evidence on #15246 rather than expanding this PR into the wider sweep its own AC calls for.

## What Changed

- `scripts/lib/hardcoded-value-rules.sh` — `_HV_EXCLUDE_RE` gains `(^|/)repo_tests/`, scoped to that directory only. Every entry point that shares this rule library (local pre-commit hook, CI `--changed-lines-only` wrapper, `detect-hardcoded-values.sh` — though `repo_tests/` was never in its `SCAN_DIRS` to begin with) now exempts a test-support module living there, matching the rationale the filename-based test exemption already documents.
- `docs/developer/HARDCODING_PREVENTION.md` — documents the new directory-scoped exemption next to the existing filename-based one.
- `autobot-infrastructure/shared/scripts/hooks/pre-commit-hardcoded-values_test.py`:
  - `TestRepoTestsSupportModuleExemption` (3 new tests): a literal in `repo_tests/sdk_request_shared.py` is allowed; the identical literal in `autobot-backend/sdk_request_shared.py` is still blocked; `not_repo_tests/sdk_request_shared.py` is still blocked (directory-segment anchoring, not substring).
  - Unrelated but blocking fix: scrubbed the ambient git env (`autobot_shared.paths.scrubbed_git_env`) in every `git`/hook subprocess this file's fixtures spawn — see #15246.
- Gap 1: **not implemented.** No heuristic shipped; reasoning and the `SCAN_DIRS` coverage gap are recorded on #15273.

## Verification

- `bash -n scripts/lib/hardcoded-value-rules.sh` — syntax OK.
- `python3 -m py_compile` on the touched test file — syntax OK.
- Manually traced the ERE against the three new fixture paths (repo_tests/, autobot-backend/, not_repo_tests/) against `hv_file_in_scope()`'s exact matching order (extension check, then exclude check) rather than executing the hook, per the run constraints on this task.
- The full suite (63 tests, including the 3 new ones and the pre-existing 60) ran via the repo's own pre-push hook and passed: `[pre-push OK] pytest: all relevant tests pass`.
- Did not run pytest myself, did not execute the hook by hand, did not install anything — read-only `git`/`grep`/`gh` only, plus the mandatory pre-push hook. CI is the judge.

## What the hook still cannot detect

- **A pure move still reads as a new violation for every file outside `repo_tests/`.** Gap 1 is deliberately not fixed — see the reasoning above and the verdict recorded on #15273.
- **`ssot-coverage.yml`'s full-tree rescan does not cover `repo_tests/`, `pipeline-scripts/`, `scripts/`, `tools/`, or `docs/`** (`SCAN_DIRS` in `pipeline-scripts/detect-hardcoded-values.sh`). For files in those directories the diff-scoped `code-quality.yml` check is the only hardcoded-value gate that exists. Not fixed here (separate, larger scope); flagged on #15273 as a fact that should inform any future gap-1 attempt.
- The `getenv(...)`-fallback false negative already documented in `HARDCODING_PREVENTION.md` and locked in by `test_allows_code_using_ssot_config` is unchanged.

Closes #15273

## Model Used

Claude Sonnet 5
