### PR TITLE
fix(guard): stop the credential-resolution guard from reading docstrings (#15280)

### DIFF
--- a/autobot-backend/voice_processing/realtime/openai_provider.py
+++ b/autobot-backend/voice_processing/realtime/openai_provider.py
@@ -60,15 +60,16 @@ class OpenAIRealtimeProvider(RealtimeVoiceProvider):
     def _api_key() -> str:
         """Return the OpenAI API key: env (via ssot_config), then the System vault.
 
-        Exactly two tiers -- no third ``os.environ.get(...)`` fallback. The
-        ssot_config field this method reads below is itself populated straight from
+        Exactly two tiers -- no third ``os.environ.get(...)`` fallback.
+        ``cfg.llm.openai_api_key`` is itself populated straight from
         ``os.environ``/``.env`` at load, so once it is non-empty an unconditional
         literal ``os.environ`` re-read could only ever repeat the same value:
         nothing in this codebase mutates ``os.environ`` for ``OPENAI_API_KEY`` at
         runtime, and a process's environment does not change out from under it
         externally, so the two can never diverge within one process lifetime. A
         prior revision of this method carried such a tail; it was dead code that
-        could not fire, removed rather than kept as a decoration (#15269 review).
+        could not fire, removed rather than kept as a decoration (#15269 review,
+        #15280: naming the field here no longer trips the resolution-path guard).
 
         Found during #15269's guard sweep: a key captured through the setup wizard
         resolved for every other OpenAI consumer but silently failed realtime voice

--- a/repo_tests/credential_vault_prose_strip.py
+++ b/repo_tests/credential_vault_prose_strip.py
@@ -1,0 +1,82 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Blank comments and docstrings out of Python source before a text-based scan.
+
+Split out of ``credential_vault_resolution_guard_test.py`` (#15280) to keep that
+guard under its line budget -- :func:`strip_prose` is a general "make a
+text-matching scanner blind to prose" pass, not something credential-specific.
+
+A real credential read cannot live inside a comment or a docstring: Python never
+evaluates either as anything but a no-op. Blanking them before the guard's regex
+runs can therefore only remove false positives, never hide a genuine read. The
+real shape #15267 shipped, ``getattr(config, "brave_search_api_key", "")``, is a
+string used as a call *argument*, not a floating statement -- :func:`strip_prose`
+leaves it untouched, so the guard's regex still catches it.
+"""
+
+from __future__ import annotations
+
+import io
+import tokenize
+
+#: Token types that only delimit statements/lines, never contribute a statement's
+#: own content -- excluded when deciding whether a STRING token opens a new
+#: statement (a docstring), so a blank line or an indent/dedent never resets that.
+_STATEMENT_JOINERS = (tokenize.NL, tokenize.INDENT, tokenize.DEDENT, tokenize.ENCODING)
+
+
+class UnparseableSourceError(RuntimeError):
+    """A file failed to tokenize.
+
+    Raised, not swallowed: every tracked production ``.py`` file is assumed to be
+    valid Python, so a tokenize failure means that assumption broke, which the
+    caller must surface rather than paper over by skipping the file -- silently
+    skipping is the exact shape of bug this repo keeps finding (#15280).
+    """
+
+
+def _blank(lines: list[str], start: tuple[int, int], end: tuple[int, int]) -> None:
+    """Overwrite ``lines[start:end]`` (tokenize's 1-indexed, end-exclusive span)
+    with spaces, leaving every newline untouched -- so blanking a multi-line
+    token never shifts any later token's reported line number.
+    """
+    start_row, start_col = start
+    end_row, end_col = end
+    for row in range(start_row, end_row + 1):
+        line = lines[row - 1]
+        has_nl = line.endswith("\n")
+        body_len = len(line) - (1 if has_nl else 0)
+        lo = start_col if row == start_row else 0
+        hi = end_col if row == end_row else body_len
+        lines[row - 1] = line[:lo] + " " * (hi - lo) + line[hi:]
+
+
+def strip_prose(text: str) -> str:
+    """Blank every comment and *floating* string statement in *text*.
+
+    "Floating" means the STRING token is a whole statement by itself -- a module,
+    class or function docstring, or any other bare string used as an inline
+    comment -- detected as a STRING immediately preceded by a statement boundary
+    and immediately followed by NEWLINE. A string used as a call *argument* (see
+    the module docstring) is a different shape and is left untouched.
+    """
+    lines = text.splitlines(keepends=True)
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, SyntaxError, IndentationError) as exc:
+        raise UnparseableSourceError(str(exc)) from exc
+    at_stmt_start = True
+    for index, tok in enumerate(tokens):
+        if tok.type == tokenize.COMMENT:
+            _blank(lines, tok.start, tok.end)
+            continue
+        if tok.type == tokenize.STRING and at_stmt_start:
+            rest = tokens[index + 1 :]
+            next_tok = next((t for t in rest if t.type not in (tokenize.COMMENT, tokenize.NL)), None)
+            if next_tok is None or next_tok.type in (tokenize.NEWLINE, tokenize.ENDMARKER):
+                _blank(lines, tok.start, tok.end)
+        if tok.type not in _STATEMENT_JOINERS + (tokenize.COMMENT,):
+            at_stmt_start = tok.type == tokenize.NEWLINE
+    return "".join(lines)

--- a/repo_tests/credential_vault_prose_strip_test.py
+++ b/repo_tests/credential_vault_prose_strip_test.py
@@ -1,0 +1,43 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+""":func:`strip_prose` blanks prose without touching an executable string (#15280).
+
+``credential_vault_resolution_guard_test.py`` trusts this module to remove
+false-positive prose matches without also erasing the one string shape that IS a
+real credential read -- a ``getattr(cfg, "field", ...)`` field-name literal. Both
+are proven here in isolation so a regression in either shows up at this module's
+own test, not buried inside the much larger guard suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+from repo_tests.credential_vault_prose_strip import UnparseableSourceError, strip_prose
+
+
+def test_a_module_docstring_is_blanked_but_line_numbers_are_preserved() -> None:
+    text = '"""Mentions cfg.llm.openai_api_key in prose."""\n\nx = 1\n'
+    stripped = strip_prose(text)
+    assert "openai_api_key" not in stripped
+    assert stripped.count("\n") == text.count("\n")
+    assert stripped.splitlines()[2] == "x = 1"
+
+
+def test_a_comment_is_blanked() -> None:
+    text = "x = 1  # mentions cfg.llm.openai_api_key\n"
+    assert "openai_api_key" not in strip_prose(text)
+
+
+def test_a_getattr_field_name_literal_survives_stripping() -> None:
+    """The #15267 shape: a string used as a call argument, not a floating
+    statement, is code -- not prose -- and must not be blanked.
+    """
+    text = 'brave_key = getattr(config, "brave_search_api_key", "")\n'
+    assert strip_prose(text) == text
+
+
+def test_a_file_that_fails_to_tokenize_raises_rather_than_returning_something() -> None:
+    with pytest.raises(UnparseableSourceError):
+        strip_prose("def f(:\n    pass\n")

--- a/repo_tests/credential_vault_resolution_guard_test.py
+++ b/repo_tests/credential_vault_resolution_guard_test.py
@@ -27,12 +27,15 @@ Mechanism
    themselves, for the un-assigned chained-call shape (``get_config().field``, seen in
    ``initialization/lifespan.py``). An empty result means the file never touches
    ssot_config at all.
-3. :func:`find_direct_reads` greps every git-tracked, non-test production ``.py`` file
-   for a *direct* read of one of those fields through any binding
-   :func:`_ssot_config_bindings` found -- ``config.<field>``, ``cfg.llm.<field>``
-   (nested submodel access, real inside ``ssot_config.py``'s own
-   ``AutoBotConfig.__getattr__`` delegation), ``get_config().auth.<field>`` (chained,
-   unassigned), or ``getattr(config, "<field>", ...)`` -- that is **not** spanned by a
+3. :func:`find_direct_reads` first blanks every comment and docstring
+   (:func:`~repo_tests.credential_vault_prose_strip.strip_prose`, #15280 -- a real
+   read can never live in either) then greps every git-tracked, non-test
+   production ``.py`` file for a *direct* read of
+   one of those fields through any binding :func:`_ssot_config_bindings` found --
+   ``config.<field>``, ``cfg.llm.<field>`` (nested submodel access, real inside
+   ``ssot_config.py``'s own ``AutoBotConfig.__getattr__`` delegation),
+   ``get_config().auth.<field>`` (chained, unassigned), or
+   ``getattr(config, "<field>", ...)`` -- that is **not** spanned by a
    ``resolve_provider_key(...)`` call, including a 120-column-wrapped one -- the shape
    every vault-routed call site in the repo already uses
    (``services/provider_key_vault.py``, ``llm_shared/provider_registry.py``,
@@ -73,6 +76,8 @@ from __future__ import annotations
 import re
 import subprocess  # nosec B404  # fixed argv (git ls-files), no shell, no caller input
 from pathlib import Path
+
+from repo_tests.credential_vault_prose_strip import UnparseableSourceError, strip_prose
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SSOT_CONFIG = REPO_ROOT / "autobot_shared" / "ssot_config.py"
@@ -198,26 +203,32 @@ def _vault_routed_line_numbers(lines: list[str]) -> set[int]:
 def find_direct_reads(text: str, fields: dict[str, str]) -> list[tuple[str, int, str]]:
     """Every ``(field, line_no, line)`` in *text* reading *fields* directly.
 
-    Discovers *text*'s own ssot_config bindings (see :func:`_ssot_config_bindings`)
-    rather than assuming a fixed set of names, so a file is skipped entirely --
-    rather than false-positiving on an unrelated same-named local -- when it never
-    touches ssot_config at all. A line spanned by a ``resolve_provider_key(...)``
-    call (see :func:`_vault_routed_line_numbers`) is vault-routed and excluded -- the
-    call-site shape every seam consumer in the repo already uses.
+    Scans with comments and docstrings blanked first
+    (:func:`~repo_tests.credential_vault_prose_strip.strip_prose`, #15280) -- a
+    real read can never live in either, so this only removes false positives, not
+    a genuine one. Discovers *text*'s own ssot_config bindings (see
+    :func:`_ssot_config_bindings`) rather than assuming a fixed set of names, so a
+    file is skipped entirely -- rather than false-positiving on an unrelated
+    same-named local -- when it never touches ssot_config at all. A line spanned
+    by a ``resolve_provider_key(...)`` call (see :func:`_vault_routed_line_numbers`)
+    is vault-routed and excluded -- the call-site shape every seam consumer in the
+    repo already uses. Reported line text is *text*'s own, not the blanked copy.
     """
-    roots, factories = _ssot_config_bindings(text)
+    scan_text = strip_prose(text)
+    roots, factories = _ssot_config_bindings(scan_text)
     if not roots and not factories:
         return []
     hits: list[tuple[str, int, str]] = []
-    lines = text.splitlines()
-    routed_lines = _vault_routed_line_numbers(lines)
+    original_lines = text.splitlines()
+    scan_lines = scan_text.splitlines()
+    routed_lines = _vault_routed_line_numbers(scan_lines)
     for field in fields:
         pattern = _read_pattern(field, roots, factories)
-        for lineno, line in enumerate(lines, start=1):
+        for lineno, scan_line in enumerate(scan_lines, start=1):
             if lineno in routed_lines:
                 continue
-            if pattern.search(line):
-                hits.append((field, lineno, line.strip()))
+            if pattern.search(scan_line):
+                hits.append((field, lineno, original_lines[lineno - 1].strip()))
     return hits
 
 
@@ -238,7 +249,12 @@ def _is_production_file(rel_path: str) -> bool:
 
 
 def production_credential_reads() -> dict[tuple[str, str], list[tuple[int, str]]]:
-    """Every ``(repo-relative file, field) -> [(line_no, line), ...]`` direct read."""
+    """Every ``(repo-relative file, field) -> [(line_no, line), ...]`` direct read.
+
+    A file that fails to tokenize (see :class:`UnparseableSourceError`) fails this
+    call outright, with the offending path attached, rather than being silently
+    skipped -- #15280.
+    """
     fields = credential_shaped_fields(SSOT_CONFIG.read_text(encoding="utf-8"))
     found: dict[tuple[str, str], list[tuple[int, str]]] = {}
     for rel in _tracked_python_files():
@@ -249,7 +265,11 @@ def production_credential_reads() -> dict[tuple[str, str], list[tuple[int, str]]
             text = path.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        for field, lineno, line in find_direct_reads(text, fields):
+        try:
+            reads = find_direct_reads(text, fields)
+        except UnparseableSourceError as exc:
+            raise UnparseableSourceError(f"{rel}: {exc}") from exc
+        for field, lineno, line in reads:
             found.setdefault((rel, field), []).append((lineno, line))
     return found
 
@@ -277,8 +297,7 @@ ALLOWLIST: dict[tuple[str, str], str] = {
         f"{_AUTH_BOOTSTRAP}: platform user-session signing key"
     ),
     ("autobot-backend/services/slm_client.py", "jwt_secret"): (
-        f"{_AUTH_BOOTSTRAP}: platform user-session signing key, reused to mint SLM service JWTs "
-        "(two of the three matches in this file are a docstring cross-reference, not a second read)"
+        f"{_AUTH_BOOTSTRAP}: platform user-session signing key, reused to mint SLM service JWTs"
     ),
     ("autobot-backend/services/run_jwt.py", "run_jwt_secret"): f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key",
     ("autobot-backend/services/mcp_isolated_runtime.py", "run_jwt_secret"): (
@@ -326,13 +345,6 @@ ALLOWLIST: dict[tuple[str, str], str] = {
     ),
     ("autobot-backend/utils/chromadb_client.py", "chromadb_auth_token"): (
         f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
-    ),
-    # --- prose the regex matches textually but which reads nothing.
-    ("autobot-backend/services/mcp_isolated_runtime.py", "jwt_secret"): (
-        f"{_NOT_A_READ}: docstring prose contrasting run_jwt_secret with the platform session key"
-    ),
-    ("autobot-backend/services/run_jwt.py", "jwt_secret"): (
-        f"{_NOT_A_READ}: docstring prose contrasting run_jwt_secret with the platform session key"
     ),
     # --- tracked gap: third-party/service credentials, same defect class as
     # --- #15267/#15268, not yet migrated. See #15276.
@@ -557,3 +569,27 @@ def test_a_file_with_no_ssot_config_binding_is_never_scanned() -> None:
     fields = {"openai_api_key": "OPENAI_API_KEY"}
     unrelated = "cfg = SomeUnrelatedObject()\nx = cfg.llm.openai_api_key\n"
     assert find_direct_reads(unrelated, fields) == []
+
+
+def test_prose_naming_a_field_is_not_reported_but_a_real_read_in_it_still_is() -> None:
+    """The exclusion this guard adds (#15280) must not be over-broad.
+
+    One fixture carries both shapes for the same field: a module docstring naming
+    it in prose (the exact shape #15277 hit on
+    ``voice_processing/realtime/openai_provider.py``, reworded there to unblock
+    CI) and, a few lines later, a real, unrouted ``cfg.llm.<field>`` read. Only
+    the second may be reported -- proving the exclusion is scoped to prose, not
+    to the field name wherever it appears.
+    """
+    fields = {"openai_api_key": "OPENAI_API_KEY"}
+    mixed = (
+        '"""Explains why ``cfg.llm.openai_api_key`` is read directly below."""\n'
+        "\n"
+        "from autobot_shared.ssot_config import get_config\n"
+        "\n"
+        "# cfg.llm.openai_api_key is read once, right here:\n"
+        "cfg = get_config()\n"
+        "value = cfg.llm.openai_api_key\n"
+    )
+    hits = find_direct_reads(mixed, fields)
+    assert [lineno for _field, lineno, _line in hits] == [7]


### PR DESCRIPTION
Closes #15280

## Thinking Path

The guard scanned raw source text with a regex, so a dotted credential token
inside a docstring or comment was indistinguishable from a real
`cfg.llm.<field>` read -- exactly what happened to
`voice_processing/realtime/openai_provider.py`'s `_api_key` docstring in
PR #15277, which had to reword prose naming a field it was documenting.

A real credential read can never live inside a comment or a docstring, so
excluding both is strictly a false-positive reduction. The one thing it must
not do is narrow what counts as a read: `_read_pattern`'s `getattr(cfg,
"field", ...)` shape (the real form #15267 shipped) matches a string literal
used as a call *argument*. Blanking every `STRING` token indiscriminately
(the "cheaper equivalent" the issue suggested) would blank that literal too
and silently reopen #15267's exact bypass -- confirmed by hand before writing
any repo code (`getattr(config, "brave_search_api_key", "")` loses its field
name entirely once quotes are stripped).

So the pass is narrower than "every STRING token": it blanks comments and
*floating* string statements only -- a `STRING` token immediately preceded by
a statement boundary and followed by `NEWLINE`, i.e. a module/class/function
docstring or any other bare string used as an inline comment. A `getattr`
argument is never a floating statement, so it survives untouched and the
detector's existing regression tests (`test_a_new_bare_credential_read_is_rejected`
and friends) still pass unmodified.

Mechanism: `tokenize`, not `ast`. Tokenizing keeps the change to "where the
regex looks" without touching `_read_pattern`, `_ssot_config_bindings`, or any
of the binding-discovery logic PR #15277 widened -- an AST rewrite would have
meant re-deriving the read-detection semantics in a second representation, the
exact duplication the issue warns against. Blanking (not deleting) each
token's span keeps every surviving line's number identical to the source, so
`find_direct_reads`'s existing line-number-based reporting needs no change.

Unparseable-file decision: fails loudly. `strip_prose` re-raises
`tokenize.TokenError`/`SyntaxError`/`IndentationError` as
`UnparseableSourceError`, left uncaught by `production_credential_reads`
(after attaching the offending path) rather than skipped -- every tracked
production `.py` file is assumed to be valid Python, so a tokenize failure
means that assumption broke, which the sweep must surface. Silently skipping
is the exact defect class #15280 itself is about.

The new logic lives in `repo_tests/credential_vault_prose_strip.py` rather
than inline in the guard, because the guard file was already at 559/600
lines and the task's own budget said to split rather than grandfather past
the cap; it also gives the tokenize logic (and the getattr-survives
regression) its own focused test file.

## What Changed

- New `repo_tests/credential_vault_prose_strip.py`: `strip_prose()` blanks
  comments and floating string statements via `tokenize`; `UnparseableSourceError`
  for a file that fails to tokenize.
- New `repo_tests/credential_vault_prose_strip_test.py`: docstring/comment
  blanking, the getattr-literal-survives regression, and the raise-on-unparseable
  behaviour, in isolation from the much larger guard suite.
- `repo_tests/credential_vault_resolution_guard_test.py`: `find_direct_reads`
  scans `strip_prose(text)` instead of raw text (reported line text still
  comes from the original, unblanked source); `production_credential_reads`
  re-raises `UnparseableSourceError` with the offending file path attached;
  Mechanism docstring updated; new
  `test_prose_naming_a_field_is_not_reported_but_a_real_read_in_it_still_is`
  carries a docstring mention *and* a real unrouted read of the same field in
  one fixture, so the exclusion is proven not to be over-broad; removed the
  two `NOT_A_READ` allowlist entries (`mcp_isolated_runtime.py`/`jwt_secret`,
  `run_jwt.py`/`jwt_secret`) that existed only because of this exact prose
  false positive, and dropped the now-stale "two of three matches are a
  docstring" parenthetical on the `slm_client.py` entry (the real read is now
  the only match).
- `autobot-backend/voice_processing/realtime/openai_provider.py`: restored
  `_api_key`'s docstring to name `cfg.llm.openai_api_key` plainly instead of
  the euphemistic phrasing PR #15277 used to unblock CI -- the concrete proof
  the fix works, since it is once again exactly what tripped the guard before.

## Verification

- `black --check`, `isort --check`, `flake8` clean on all four touched files
  (line-length and pre-existing formatting deltas elsewhere in the guard file,
  present on `Dev_new_gui` before this change too, are untouched).
- `python3 -m py_compile` on all four files.
- The `pre-push` hook ran pytest on the three affected test files
  (`openai_provider_test.py`, `credential_vault_prose_strip_test.py`,
  `credential_vault_resolution_guard_test.py`) and reported all passing.
- Full-tree sweep reproduced via the guard's own `production_credential_reads()`:
  53 allowlist entries (55 before, minus the two removed `NOT_A_READ` entries),
  0 unlisted, 0 stale -- the guard still reports clean against the real tree.
- Isolated logic simulation (before touching the repo file) confirmed the
  `getattr(config, "brave_search_api_key", "")` shape from #15267 still
  matches after stripping, and that a docstring/comment mention of a field
  does not, in the same fixture as a real unrouted read.

## Model Used

Claude Opus 5 (1M context)
