### PR TITLE
test(guard): ratchet the credential-vault allowlist's TRACKED_GAP count (#15278)

### DIFF
--- a/repo_tests/credential_vault_resolution_allowlist.py
+++ b/repo_tests/credential_vault_resolution_allowlist.py
@@ -1,0 +1,188 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Data module for ``repo_tests/credential_vault_resolution_guard_test.py``'s ``ALLOWLIST``.
+
+Split out from the guard itself (#15278) so the guard's own detection logic stays
+well under the 600-line file-size limit ``check_python_file_size.py`` enforces on
+everything else, mirroring how ``scripts/python_file_size_known_large.py`` was split
+from ``scripts/check_python_file_size.py`` for the identical reason (#14547).
+
+Every entry is keyed ``(repo-relative file, ssot_config field name) -> reason``, one
+of three classifications:
+
+* ``AUTH_BOOTSTRAP`` -- the credential gates the vault/DB itself, or is the
+  platform's own internal-auth token, so vaulting it would be a confused-deputy
+  cycle. Genuinely irreducible: not ratcheted.
+* ``NOT_A_READ`` -- the regex's only match here is prose (a comment or docstring),
+  not a real read. Not ratcheted; currently empty because #15280 taught the scanner
+  to strip prose before matching, so this class no longer arises there, but the
+  classification stays available for a shape that slips past that.
+* ``TRACKED_GAP #NNNN`` -- a real gap, same defect class as #15267/#15268, not yet
+  migrated through the vault seam. Tracked in #15276, and its live count is
+  ratcheted -- see ``repo_tests/credential_vault_resolution_ratchet_test.py`` --
+  because unlike the other two, this class is debt, not a durable classification.
+
+No credential values appear anywhere in this table -- only field names and
+source-code file paths, neither of which is a secret.
+"""
+
+from __future__ import annotations
+
+_AUTH_BOOTSTRAP = "AUTH_BOOTSTRAP"  # gates the vault/DB itself; vaulting it is circular
+_NOT_A_READ = "NOT_A_READ"  # the regex's only match here is prose, not code
+_TRACKED = "TRACKED_GAP"  # a real gap, same defect class, named issue tracks its fix
+
+#: ``(repo-relative file, ssot_config field name) -> reason``. No credential values
+#: appear anywhere in this table -- only field names and source-code file paths.
+ALLOWLIST: dict[tuple[str, str], str] = {
+    # --- auth-bootstrap: internal/platform authentication, not a third-party
+    # --- provider credential. Same classification IRREDUCIBLE_KEYS documents for
+    # --- autobot_internal_api_key in autobot-slm-backend/services/system_secrets_vault.py.
+    ("autobot-backend/agents/base_agent.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
+    ("autobot-backend/mcp/autobot_server.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
+    ("autobot-backend/services/execution/claude_code_backend.py", "mcp_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret"
+    ),
+    ("autobot-backend/auth_middleware.py", "jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: platform user-session signing key"
+    ),
+    ("autobot-backend/services/slm_client.py", "jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: platform user-session signing key, reused to mint SLM service JWTs"
+    ),
+    ("autobot-backend/services/run_jwt.py", "run_jwt_secret"): f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key",
+    ("autobot-backend/services/mcp_isolated_runtime.py", "run_jwt_secret"): (
+        f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key"
+    ),
+    ("autobot-backend/middleware/service_auth_enforcement.py", "service_auth_override_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal service-to-service auth override"
+    ),
+    ("autobot-backend/orchestration/dag_executor.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
+    ),
+    ("autobot-backend/services/command_extraction_service.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
+    ),
+    ("autobot-backend/user_management/config.py", "postgres_password"): (
+        f"{_AUTH_BOOTSTRAP}: the vault's own Postgres backing store cannot gate itself"
+    ),
+    ("autobot-backend/auth_middleware.py", "internal_api_key"): (
+        f"{_AUTH_BOOTSTRAP}: the exact confused-deputy example "
+        "autobot-slm-backend/services/system_secrets_vault.py documents for this same credential"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "slm_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token, same as the two siblings above"
+    ),
+    ("autobot-backend/user_management/services/seed.py", "admin_password"): (
+        f"{_AUTH_BOOTSTRAP}: bootstrap admin-account creation, read before any auth subsystem exists"
+    ),
+    ("autobot_shared/security/password_weakness.py", "admin_password"): (
+        f"{_AUTH_BOOTSTRAP}: same bootstrap admin password as seed.py, checked for weakness"
+    ),
+    # --- auth-bootstrap: internal data-layer service credentials (Redis/ChromaDB),
+    # --- same class as the Postgres password above -- the app's own storage
+    # --- layer must be reachable before anything, including the vault, can start.
+    ("autobot-backend/api/npu_workers.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/celery_app.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/__init__.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/defaults.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/config/service_config.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/knowledge/base.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
+    ("autobot-backend/utils/async_chromadb_client.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
+    ),
+    ("autobot-backend/utils/chromadb_auth.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
+    ),
+    ("autobot-backend/utils/chromadb_client.py", "chromadb_auth_token"): (
+        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
+    ),
+    # --- tracked gap: third-party/service credentials, same defect class as
+    # --- #15267/#15268, not yet migrated. See #15276.
+    ("autobot-backend/llm_shared/adapters/anthropic_adapter.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/adapters/groq_adapter.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/adapters/openai_adapter.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
+    ),
+    ("autobot-backend/llm_shared/providers/anthropic.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/groq.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/openai.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/mistral.py", "mistral_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/custom_openai.py", "custom_openai_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/openrouter.py", "openrouter_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/huggingface.py", "hf_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/huggingface.py", "huggingface_api_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "hf_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "huggingface_api_token"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/llm_shared/providers/nous_portal.py", "nous_api_key"): (
+        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
+    ),
+    ("autobot-backend/services/execution/claude_code_backend.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: execution backend reads the key directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/services/provider_health/providers.py", "google_api_key"): (
+        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
+    ),
+    ("autobot-backend/agent_loop/slack_hook.py", "slack_bot_token"): f"{_TRACKED} #15276: Slack bot token",
+    ("autobot-backend/security/threat_intelligence.py", "virustotal_api_key"): (
+        f"{_TRACKED} #15276: threat-intel API key"
+    ),
+    ("autobot-backend/security/threat_intelligence.py", "urlvoid_api_key"): (
+        f"{_TRACKED} #15276: threat-intel API key"
+    ),
+    ("autobot-backend/services/notification_service.py", "smtp_password"): f"{_TRACKED} #15276: SMTP credential",
+    ("autobot-backend/initialization/lifespan.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "groq_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/initialization/lifespan.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
+    ),
+    ("autobot-backend/integrations/capability_registry.py", "slack_bot_token"): (
+        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
+        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
+    ),
+    ("autobot-backend/integrations/capability_registry.py", "discord_bot_token"): (
+        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
+        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
+    ),
+    ("autobot-backend/knowledge/base.py", "anthropic_api_key"): (
+        f"{_TRACKED} #15276: LlamaIndex LLM configuration reads the key directly"
+    ),
+    ("autobot-backend/knowledge/base.py", "openai_api_key"): (
+        f"{_TRACKED} #15276: LlamaIndex LLM/embedding configuration reads the key directly"
+    ),
+}

--- a/repo_tests/credential_vault_resolution_guard_test.py
+++ b/repo_tests/credential_vault_resolution_guard_test.py
@@ -78,6 +78,7 @@ import subprocess  # nosec B404  # fixed argv (git ls-files), no shell, no calle
 from pathlib import Path
 
 from repo_tests.credential_vault_prose_strip import UnparseableSourceError, strip_prose
+from repo_tests.credential_vault_resolution_allowlist import ALLOWLIST
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SSOT_CONFIG = REPO_ROOT / "autobot_shared" / "ssot_config.py"
@@ -275,165 +276,12 @@ def production_credential_reads() -> dict[tuple[str, str], list[tuple[int, str]]
 
 
 # ---------------------------------------------------------------------------
-# The allowlist. Every entry is a written classification, not a bare pass.
+# ALLOWLIST lives in credential_vault_resolution_allowlist.py (#15278) -- split
+# out so this guard's own detection logic stays under the file-size limit it
+# and its siblings enforce on everything else. See that module's docstring for
+# the three classifications and the ratchet on the TRACKED_GAP one, enforced by
+# repo_tests/credential_vault_resolution_ratchet_test.py.
 # ---------------------------------------------------------------------------
-
-_AUTH_BOOTSTRAP = "AUTH_BOOTSTRAP"  # gates the vault/DB itself; vaulting it is circular
-_NOT_A_READ = "NOT_A_READ"  # the regex's only match here is prose, not code
-_TRACKED = "TRACKED_GAP"  # a real gap, same defect class, named issue tracks its fix
-
-#: ``(repo-relative file, ssot_config field name) -> reason``. No credential values
-#: appear anywhere in this table -- only field names and source-code file paths.
-ALLOWLIST: dict[tuple[str, str], str] = {
-    # --- auth-bootstrap: internal/platform authentication, not a third-party
-    # --- provider credential. Same classification IRREDUCIBLE_KEYS documents for
-    # --- autobot_internal_api_key in autobot-slm-backend/services/system_secrets_vault.py.
-    ("autobot-backend/agents/base_agent.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
-    ("autobot-backend/mcp/autobot_server.py", "mcp_token"): f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret",
-    ("autobot-backend/services/execution/claude_code_backend.py", "mcp_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal MCP server shared secret"
-    ),
-    ("autobot-backend/auth_middleware.py", "jwt_secret"): (
-        f"{_AUTH_BOOTSTRAP}: platform user-session signing key"
-    ),
-    ("autobot-backend/services/slm_client.py", "jwt_secret"): (
-        f"{_AUTH_BOOTSTRAP}: platform user-session signing key, reused to mint SLM service JWTs"
-    ),
-    ("autobot-backend/services/run_jwt.py", "run_jwt_secret"): f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key",
-    ("autobot-backend/services/mcp_isolated_runtime.py", "run_jwt_secret"): (
-        f"{_AUTH_BOOTSTRAP}: run-worker JWT signing key"
-    ),
-    ("autobot-backend/middleware/service_auth_enforcement.py", "service_auth_override_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal service-to-service auth override"
-    ),
-    ("autobot-backend/orchestration/dag_executor.py", "slm_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
-    ),
-    ("autobot-backend/services/command_extraction_service.py", "slm_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token"
-    ),
-    ("autobot-backend/user_management/config.py", "postgres_password"): (
-        f"{_AUTH_BOOTSTRAP}: the vault's own Postgres backing store cannot gate itself"
-    ),
-    ("autobot-backend/auth_middleware.py", "internal_api_key"): (
-        f"{_AUTH_BOOTSTRAP}: the exact confused-deputy example "
-        "autobot-slm-backend/services/system_secrets_vault.py documents for this same credential"
-    ),
-    ("autobot-backend/initialization/lifespan.py", "slm_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal backend-to-SLM service auth token, same as the two siblings above"
-    ),
-    ("autobot-backend/user_management/services/seed.py", "admin_password"): (
-        f"{_AUTH_BOOTSTRAP}: bootstrap admin-account creation, read before any auth subsystem exists"
-    ),
-    ("autobot_shared/security/password_weakness.py", "admin_password"): (
-        f"{_AUTH_BOOTSTRAP}: same bootstrap admin password as seed.py, checked for weakness"
-    ),
-    # --- auth-bootstrap: internal data-layer service credentials (Redis/ChromaDB),
-    # --- same class as the Postgres password above -- the app's own storage
-    # --- layer must be reachable before anything, including the vault, can start.
-    ("autobot-backend/api/npu_workers.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/celery_app.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/config/__init__.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/config/defaults.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/config/service_config.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/knowledge/base.py", "password"): f"{_AUTH_BOOTSTRAP}: Redis connection password",
-    ("autobot-backend/utils/async_chromadb_client.py", "chromadb_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
-    ),
-    ("autobot-backend/utils/chromadb_auth.py", "chromadb_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
-    ),
-    ("autobot-backend/utils/chromadb_client.py", "chromadb_auth_token"): (
-        f"{_AUTH_BOOTSTRAP}: internal ChromaDB data-layer service credential"
-    ),
-    # --- tracked gap: third-party/service credentials, same defect class as
-    # --- #15267/#15268, not yet migrated. See #15276.
-    ("autobot-backend/llm_shared/adapters/anthropic_adapter.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
-    ),
-    ("autobot-backend/llm_shared/adapters/groq_adapter.py", "groq_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
-    ),
-    ("autobot-backend/llm_shared/adapters/openai_adapter.py", "openai_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry connectivity-test path"
-    ),
-    ("autobot-backend/llm_shared/providers/anthropic.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/groq.py", "groq_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/openai.py", "openai_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/mistral.py", "mistral_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/custom_openai.py", "custom_openai_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/openrouter.py", "openrouter_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/huggingface.py", "hf_token"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/huggingface.py", "huggingface_api_token"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/nous_portal.py", "hf_token"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/nous_portal.py", "huggingface_api_token"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/llm_shared/providers/nous_portal.py", "nous_api_key"): (
-        f"{_TRACKED} #15276: Provider class's fallback for construction outside the registry"
-    ),
-    ("autobot-backend/services/execution/claude_code_backend.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: execution backend reads the key directly rather than via the registry"
-    ),
-    ("autobot-backend/services/provider_health/providers.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
-    ),
-    ("autobot-backend/services/provider_health/providers.py", "openai_api_key"): (
-        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
-    ),
-    ("autobot-backend/services/provider_health/providers.py", "google_api_key"): (
-        f"{_TRACKED} #15276: health-check probe reads config directly rather than via the registry"
-    ),
-    ("autobot-backend/agent_loop/slack_hook.py", "slack_bot_token"): f"{_TRACKED} #15276: Slack bot token",
-    ("autobot-backend/security/threat_intelligence.py", "virustotal_api_key"): (
-        f"{_TRACKED} #15276: threat-intel API key"
-    ),
-    ("autobot-backend/security/threat_intelligence.py", "urlvoid_api_key"): (
-        f"{_TRACKED} #15276: threat-intel API key"
-    ),
-    ("autobot-backend/services/notification_service.py", "smtp_password"): f"{_TRACKED} #15276: SMTP credential",
-    ("autobot-backend/initialization/lifespan.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
-    ),
-    ("autobot-backend/initialization/lifespan.py", "groq_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
-    ),
-    ("autobot-backend/initialization/lifespan.py", "openai_api_key"): (
-        f"{_TRACKED} #15276: AdapterRegistry gating check (adapter-listing only, not the LLM-call routing path)"
-    ),
-    ("autobot-backend/integrations/capability_registry.py", "slack_bot_token"): (
-        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
-        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
-    ),
-    ("autobot-backend/integrations/capability_registry.py", "discord_bot_token"): (
-        f"{_TRACKED} #15276: the third CredentialGatedRegistry sibling (see "
-        "autobot_shared/credential_gated_registry.py's own docstring) never migrated"
-    ),
-    ("autobot-backend/knowledge/base.py", "anthropic_api_key"): (
-        f"{_TRACKED} #15276: LlamaIndex LLM configuration reads the key directly"
-    ),
-    ("autobot-backend/knowledge/base.py", "openai_api_key"): (
-        f"{_TRACKED} #15276: LlamaIndex LLM/embedding configuration reads the key directly"
-    ),
-}
 
 
 def test_the_ssot_config_field_scan_finds_known_credential_fields() -> None:

--- a/repo_tests/credential_vault_resolution_ratchet_test.py
+++ b/repo_tests/credential_vault_resolution_ratchet_test.py
@@ -1,0 +1,180 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15278 -- the credential-vault-resolution allowlist's TRACKED_GAP class has no ratchet.
+
+``credential_vault_resolution_guard_test.py`` (#15269) keeps three assertions over its
+``ALLOWLIST`` (now in ``credential_vault_resolution_allowlist.py``, #15278): a sanity
+floor on the discovered credential-field count, every direct read must be allowlisted,
+and every allowlist entry must still correspond to a real read. None of those three
+caps the allowlist's overall size, so a developer could silence a brand-new violation
+by appending an entry -- the guard would go green either way. This module adds the cap
+that was missing, mirroring the shrink-only ratchet ``scripts/check_python_file_size.py``
+already uses for ``KNOWN_LARGE``: a recorded ceiling that fails the build both when the
+live count exceeds it (new debt added silently) and when it falls below it without the
+ceiling being lowered to match (debt paid down without the ratchet recording the win,
+#14498's lesson).
+
+Scope: TRACKED_GAP entries only
+--------------------------------
+``ALLOWLIST`` holds three classes, distinguished by the reason string's prefix.
+``AUTH_BOOTSTRAP`` (the credential gates the vault/DB itself, or is the platform's own
+internal-auth token) and ``NOT_A_READ`` (the regex's only match is prose) are
+classifications, not a backlog -- forcing either to shrink would eventually pressure
+someone into mis-classifying a genuinely irreducible or non-read entry just to satisfy
+a ratchet that was never about them. Only ``TRACKED_GAP`` -- real debt, tracked in
+#15276 -- is a backlog whose count belongs under a ratchet, and
+``test_auth_bootstrap_growth_does_not_move_the_tracked_gap_count`` proves the other two
+classes are exempt rather than merely asserting it in prose.
+
+What the marker check does and does not verify
+------------------------------------------------
+Every ``TRACKED_GAP`` entry's reason is expected to read ``TRACKED_GAP #<issue>: <text>``.
+``_malformed_tracked_gap_markers`` checks that *format* -- a literal ``#`` followed by
+digits, a colon, and non-empty text -- so a marker with no number, a non-numeric one, or
+a missing separator is caught. It does **not**, and cannot from inside an offline test
+run, check that the numbered issue actually exists or is still open: that needs a network
+call (``gh issue view <n>`` or the REST API), and this guard makes none, the same
+trade-off ``ratchet_base_guard_test.py`` documents for its own workflow-only checks.
+A fabricated-but-well-formed issue number (e.g. ``TRACKED_GAP #1: ...`` naming a closed
+or nonexistent issue) will pass this guard. Closing that gap is a separate, explicitly
+network-dependent job -- not something to fake a pass for here.
+"""
+
+from __future__ import annotations
+
+import re
+
+from repo_tests.credential_vault_resolution_allowlist import ALLOWLIST, _AUTH_BOOTSTRAP, _TRACKED
+
+#: The recorded TRACKED_GAP count. THIS RATCHET TURNS BOTH WAYS: raise it only by
+#: adding a new, correctly TRACKED_GAP-marked entry in the same change, and lower it
+#: whenever a TRACKED_GAP entry is fixed and removed -- never leave it stale in
+#: either direction (#15278).
+TRACKED_GAP_CEILING = 29
+
+_TRACKED_GAP_MARKER_RE = re.compile(rf"^{re.escape(_TRACKED)} #(\d+):\s+\S")
+
+
+def _tracked_gap_entries(allowlist: dict[tuple[str, str], str]) -> dict[tuple[str, str], str]:
+    """Every *allowlist* entry classified TRACKED_GAP -- the only class this ratchet tracks."""
+    return {key: reason for key, reason in allowlist.items() if reason.startswith(_TRACKED)}
+
+
+def _tracked_gap_count(allowlist: dict[tuple[str, str], str]) -> int:
+    return len(_tracked_gap_entries(allowlist))
+
+
+def _malformed_tracked_gap_markers(
+    allowlist: dict[tuple[str, str], str],
+) -> list[tuple[tuple[str, str], str]]:
+    """TRACKED_GAP entries whose reason does not match ``TRACKED_GAP #<n>: <text>``.
+
+    Format only -- see the module docstring for why issue existence/open-state is not,
+    and cannot offline be, checked here.
+    """
+    entries = _tracked_gap_entries(allowlist)
+    return [(key, reason) for key, reason in entries.items() if not _TRACKED_GAP_MARKER_RE.match(reason)]
+
+
+def _tracked_gap_verdict(live_count: int, ceiling: int) -> str | None:
+    """Message for *live_count* against the recorded *ceiling*, or None if it holds.
+
+    Mirrors ``scripts/check_python_file_size.py``'s ``_grandfathered_verdict``: the
+    ratchet turns one way only, checked in both directions.
+    """
+    if live_count > ceiling:
+        return (
+            f"TRACKED_GAP count is {live_count}, over its recorded ceiling of {ceiling}. "
+            "A new gap must be fixed, or filed against #15276 with its own TRACKED_GAP "
+            "entry and this ceiling raised in the same change -- it may not just grow "
+            "silently."
+        )
+    if live_count < ceiling:
+        return (
+            f"TRACKED_GAP count is {live_count}, under its recorded ceiling of {ceiling}. "
+            f"Lower TRACKED_GAP_CEILING to {live_count} in this file -- the ratchet only "
+            "turns down, and an unlowered ceiling re-licenses the entries just removed."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: every test below reasons over ALLOWLIST's contents.
+# ---------------------------------------------------------------------------
+
+
+def test_the_allowlist_import_is_not_empty() -> None:
+    assert ALLOWLIST, "ALLOWLIST imported empty -- every ratchet assertion below would be vacuous"
+
+
+# ---------------------------------------------------------------------------
+# The ratchet turns both ways, on the real ALLOWLIST
+# ---------------------------------------------------------------------------
+
+
+def test_the_live_tracked_gap_count_is_at_its_recorded_ceiling() -> None:
+    """The real ALLOWLIST today: neither over nor under TRACKED_GAP_CEILING."""
+    live = _tracked_gap_count(ALLOWLIST)
+    verdict = _tracked_gap_verdict(live, TRACKED_GAP_CEILING)
+    assert verdict is None, verdict
+
+
+def test_an_added_tracked_gap_entry_is_rejected() -> None:
+    """Mutation: over. A new TRACKED_GAP entry with no ceiling bump must fail."""
+    mutated = dict(ALLOWLIST)
+    mutated[("autobot-backend/new_consumer.py", "new_api_key")] = f"{_TRACKED} #99999: a brand-new, unrecorded gap"
+    verdict = _tracked_gap_verdict(_tracked_gap_count(mutated), TRACKED_GAP_CEILING)
+    assert verdict is not None and "over its recorded ceiling" in verdict, verdict
+
+
+def test_a_removed_tracked_gap_entry_with_a_stale_ceiling_is_rejected() -> None:
+    """Mutation: under. Paying down debt without lowering the ceiling must fail."""
+    mutated = dict(ALLOWLIST)
+    first_tracked_key = next(key for key, reason in ALLOWLIST.items() if reason.startswith(_TRACKED))
+    del mutated[first_tracked_key]
+    verdict = _tracked_gap_verdict(_tracked_gap_count(mutated), TRACKED_GAP_CEILING)
+    assert verdict is not None and "under its recorded ceiling" in verdict, verdict
+
+
+# ---------------------------------------------------------------------------
+# The ratchet is scoped to TRACKED_GAP -- AUTH_BOOTSTRAP/NOT_A_READ are exempt
+# ---------------------------------------------------------------------------
+
+
+def test_auth_bootstrap_growth_does_not_move_the_tracked_gap_count() -> None:
+    """Adding an AUTH_BOOTSTRAP entry must not change the count this ratchet tracks.
+
+    Forcing that class to shrink too would eventually pressure someone into
+    mis-classifying a genuinely irreducible credential just to keep this guard green.
+    """
+    mutated = dict(ALLOWLIST)
+    mutated[("autobot-backend/new_bootstrap.py", "some_password")] = f"{_AUTH_BOOTSTRAP}: irreducible, not a gap"
+    assert _tracked_gap_count(mutated) == _tracked_gap_count(ALLOWLIST)
+
+
+# ---------------------------------------------------------------------------
+# The TRACKED_GAP marker's format, not its issue's existence or open-state
+# ---------------------------------------------------------------------------
+
+
+def test_every_real_tracked_gap_marker_matches_the_required_format() -> None:
+    malformed = _malformed_tracked_gap_markers(ALLOWLIST)
+    assert not malformed, f"TRACKED_GAP entries with a malformed marker: {malformed}"
+
+
+def test_a_malformed_or_absent_issue_number_is_rejected() -> None:
+    """Mutation: three ways a marker can be silently unfixable back to an issue.
+
+    None of these fabricates a real issue number -- they exercise the *format* check
+    only, which is all this guard can do offline (see the module docstring).
+    """
+    for label, bad_reason in (
+        ("no issue number", f"{_TRACKED}: a gap with no number at all"),
+        ("non-digit issue number", f"{_TRACKED} #abc: a gap with a non-numeric marker"),
+        ("missing separator", f"{_TRACKED} #12345 a gap missing its colon"),
+    ):
+        mutated = {("autobot-backend/x.py", "x_api_key"): bad_reason}
+        malformed = _malformed_tracked_gap_markers(mutated)
+        assert malformed, f"{label!r} was not flagged: {bad_reason!r}"


### PR DESCRIPTION
## Thinking Path

`credential_vault_resolution_guard_test.py` (#15269) has three assertions over its
`ALLOWLIST`, none of which caps the allowlist's size or its `TRACKED_GAP` sub-count.
#15269 was a deliberate design choice to make enforcement review diligence rather
than a hard CI gate for the allowlist's overall shape, so this PR is an *addition*
to that guard, not a repair of it.

The fix mirrors `scripts/check_python_file_size.py`'s existing shrink-only ratchet
for `KNOWN_LARGE`: a recorded ceiling (`TRACKED_GAP_CEILING`) that fails the build
both when the live count exceeds it (new debt added silently) and when it drops
below it without the ceiling being lowered to match (debt paid down without the
ratchet recording the win -- #14498's lesson, applied here).

The ratchet is deliberately scoped to `TRACKED_GAP` only. `ALLOWLIST` also holds
`AUTH_BOOTSTRAP` (genuinely irreducible: JWT/MCP/Postgres/service-auth bootstrap
credentials) and `NOT_A_READ` (the regex's only match is prose) entries --
classifications, not a backlog. Forcing either of those to shrink would eventually
pressure someone into mis-classifying a genuinely irreducible credential just to
keep the guard green, so `test_auth_bootstrap_growth_does_not_move_the_tracked_gap_count`
proves the scope boundary rather than asserting it only in prose.

`ALLOWLIST` also moved out of the guard file into a sibling data module
(`credential_vault_resolution_allowlist.py`), mirroring how `KNOWN_LARGE` was split
into `scripts/python_file_size_known_large.py` (#14547) for the identical reason:
the guard file was already at 595 lines against the repo's 600-line limit, and
adding the ratchet's own logic there would have pushed it over -- so the guard's
detection logic stays in one file, the guard's data stays in another, and the new
ratchet test is a third.

## What Changed

- **`repo_tests/credential_vault_resolution_allowlist.py`** (new): `ALLOWLIST` and
  its three classification-marker constants, moved verbatim out of the guard test
  file. No content changed -- this is a pure extraction.
- **`repo_tests/credential_vault_resolution_guard_test.py`**: now imports
  `ALLOWLIST` from the sibling module instead of defining it inline. 595 -> 443
  lines.
- **`repo_tests/credential_vault_resolution_ratchet_test.py`** (new): the ratchet
  itself.
  - `TRACKED_GAP_CEILING = 29` -- the live count today (confirmed by grep, not by
    executing the module: `grep -c '_TRACKED} #15276' ...allowlist.py` returns 29,
    and `24` for `AUTH_BOOTSTRAP`, totalling `ALLOWLIST`'s full 53 entries).
  - `_tracked_gap_verdict(live_count, ceiling)` -- mirrors
    `check_python_file_size.py`'s `_grandfathered_verdict`: over-ceiling and
    under-ceiling each produce a distinct failure message; at-ceiling is silent.
  - `_malformed_tracked_gap_markers(allowlist)` -- every `TRACKED_GAP` entry's
    reason must match `TRACKED_GAP #<digits>: <text>`.

### Marker validation: what is checked and what is not

Only the **format** of the `TRACKED_GAP #NNNN` marker is validated offline: a
literal `#`, one or more digits, a colon, and non-empty following text. This
catches a marker with no issue number, a non-numeric one, or a missing separator.

**Not implemented, and explicitly out of scope for this guard**: whether the
numbered issue actually exists, or is still open. That needs a network call
(`gh issue view <n>` or the REST API), and this guard -- like
`ratchet_base_guard_test.py`'s own documented trade-off for its workflow-only
checks -- makes none. A well-formed but fabricated or closed issue number (e.g.
`TRACKED_GAP #1: ...`) will still pass this guard. Closing that gap is a separate,
deliberately network-dependent job, not something to fake a pass for here -- the
issue itself asked for this trade-off to be written down rather than pretended
away, and this is that write-down.

## Verification

Per the task's hard constraints, no pytest run or code execution was performed by
me directly; counts were derived by reading and by `grep -c` against the committed
files, not by importing or running the allowlist module. The repository's own
`pre-push` git hook, which runs independently on `git push`, executed
`repo_tests/credential_vault_resolution_guard_test.py` and
`repo_tests/credential_vault_resolution_ratchet_test.py` and reported
`[pre-push OK] pytest: all relevant tests pass`.

Mutations proving each direction fires (all in `credential_vault_resolution_ratchet_test.py`):

- **Over**: `test_an_added_tracked_gap_entry_is_rejected` adds a synthetic
  `TRACKED_GAP` entry (`new_api_key`, issue `#99999`) to a copy of `ALLOWLIST` and
  asserts `_tracked_gap_verdict` reports "over its recorded ceiling".
- **Under**: `test_a_removed_tracked_gap_entry_with_a_stale_ceiling_is_rejected`
  deletes one real `TRACKED_GAP` entry from a copy of `ALLOWLIST` (ceiling left at
  29) and asserts the verdict reports "under its recorded ceiling".
- **Scope exemption**: `test_auth_bootstrap_growth_does_not_move_the_tracked_gap_count`
  adds a synthetic `AUTH_BOOTSTRAP` entry and asserts the tracked-gap count is
  unchanged.
- **Malformed/absent marker**: `test_a_malformed_or_absent_issue_number_is_rejected`
  exercises three shapes -- no issue number, a non-digit issue number, and a
  missing `:` separator -- each asserted to be flagged by
  `_malformed_tracked_gap_markers`.
- **Real-data sanity**: `test_the_live_tracked_gap_count_is_at_its_recorded_ceiling`
  and `test_every_real_tracked_gap_marker_matches_the_required_format` assert the
  ratchet and the marker format both hold clean against the actual `ALLOWLIST` as
  committed.

Every touched/added file is under the repo's 600-line and 120-column limits, and
every new function is <=30 lines (verified by reading, not by running a linter).

## Model Used

Claude Opus 5 (1M context)

Closes #15278
