### PR TITLE
fix(guard): make the prose stripper handle concatenated strings and f-strings (#15285)

### DIFF
--- a/repo_tests/credential_vault_prose_strip.py
+++ b/repo_tests/credential_vault_prose_strip.py
@@ -14,6 +14,13 @@ runs can therefore only remove false positives, never hide a genuine read. The
 real shape #15267 shipped, ``getattr(config, "brave_search_api_key", "")``, is a
 string used as a call *argument*, not a floating statement -- :func:`strip_prose`
 leaves it untouched, so the guard's regex still catches it.
+
+Two prose shapes need a run of tokens, not a single one, to recognise (#15285):
+implicit string concatenation (``"a" "b"``) puts a second ``STRING`` where the
+single-token check expects ``NEWLINE``, and an f-string is not a ``STRING`` at
+all under PEP 701 (3.12+) -- it decomposes into ``FSTRING_START`` /
+``FSTRING_MIDDLE`` / ``FSTRING_END``. :func:`_floating_literal_run_end` folds
+both into the same "one floating statement" unit the trailing-token test uses.
 """
 
 from __future__ import annotations
@@ -25,6 +32,16 @@ import tokenize
 #: own content -- excluded when deciding whether a STRING token opens a new
 #: statement (a docstring), so a blank line or an indent/dedent never resets that.
 _STATEMENT_JOINERS = (tokenize.NL, tokenize.INDENT, tokenize.DEDENT, tokenize.ENCODING)
+
+#: Python 3.10 tokenizes an f-string as a single STRING; 3.12+ (PEP 701) splits it
+#: into FSTRING_START ... FSTRING_END. These are ``None`` on 3.10, where they
+#: simply never match any real token's ``.type``.
+_FSTRING_START = getattr(tokenize, "FSTRING_START", None)
+_FSTRING_END = getattr(tokenize, "FSTRING_END", None)
+
+#: Tokens that may sit between two literals of an implicitly-concatenated string
+#: statement (inside parens, or a continuation) without ending the run.
+_RUN_GAP_TOKENS = (tokenize.NL, tokenize.COMMENT)
 
 
 class UnparseableSourceError(RuntimeError):
@@ -53,14 +70,103 @@ def _blank(lines: list[str], start: tuple[int, int], end: tuple[int, int]) -> No
         lines[row - 1] = line[:lo] + " " * (hi - lo) + line[hi:]
 
 
+def _one_literal_end(tokens: list, start: int) -> int:
+    """Return the index of the last token of the single literal starting at
+    ``start`` -- itself for a plain ``STRING``, or the matching ``FSTRING_END``
+    for an ``FSTRING_START`` (tracking nesting, since 3.12+ allows an f-string
+    literal inside another f-string's ``{...}``).
+    """
+    if tokens[start].type != _FSTRING_START:
+        return start
+    depth, index = 1, start + 1
+    while depth > 0 and index < len(tokens):
+        if tokens[index].type == _FSTRING_START:
+            depth += 1
+        elif tokens[index].type == _FSTRING_END:
+            depth -= 1
+        index += 1
+    return index - 1
+
+
+def _floating_literal_run_end(tokens: list, start: int) -> int:
+    """Return the index of the last token belonging to the (possibly implicitly
+    concatenated) string/f-string literal run beginning at ``start``, so the
+    whole run is treated as one unit for the "followed by NEWLINE" test.
+    """
+    last = _one_literal_end(tokens, start)
+    peek = last + 1
+    while peek < len(tokens) and tokens[peek].type in _RUN_GAP_TOKENS:
+        peek += 1
+    if peek < len(tokens) and tokens[peek].type in (tokenize.STRING, _FSTRING_START):
+        return _floating_literal_run_end(tokens, peek)
+    return last
+
+
+def _next_real_token(tokens: list, after: int):
+    """First token after index ``after`` that isn't a comment or a blank line."""
+    rest = tokens[after + 1 :]
+    return next((t for t in rest if t.type not in (tokenize.COMMENT, tokenize.NL)), None)
+
+
+def _consume_floating_literal(tokens: list, lines: list[str], index: int) -> int:
+    """Blank the floating literal run starting at ``tokens[index]`` when it is a
+    whole statement (run followed by NEWLINE/ENDMARKER), then return the index of
+    the token right after the run either way.
+    """
+    end_index = _floating_literal_run_end(tokens, index)
+    next_tok = _next_real_token(tokens, end_index)
+    if next_tok is None or next_tok.type in (tokenize.NEWLINE, tokenize.ENDMARKER):
+        _blank(lines, tokens[index].start, tokens[end_index].end)
+    return end_index + 1
+
+
+def _paren_wrapped_run(tokens: list, index: int):
+    """If ``tokens[index]`` opens ``( <literal run> )`` with nothing else inside
+    -- parens solely grouping a literal, which Python still recognises as a
+    docstring (parens don't create their own AST node) -- return
+    ``(run_start, run_end, close_index)``; otherwise ``None``.
+    """
+    if not (tokens[index].type == tokenize.OP and tokens[index].string == "("):
+        return None
+    peek = index + 1
+    while peek < len(tokens) and tokens[peek].type in _RUN_GAP_TOKENS:
+        peek += 1
+    if peek >= len(tokens) or tokens[peek].type not in (tokenize.STRING, _FSTRING_START):
+        return None
+    run_end = _floating_literal_run_end(tokens, peek)
+    close = run_end + 1
+    while close < len(tokens) and tokens[close].type in _RUN_GAP_TOKENS:
+        close += 1
+    if close >= len(tokens) or not (tokens[close].type == tokenize.OP and tokens[close].string == ")"):
+        return None
+    return peek, run_end, close
+
+
+def _consume_paren_literal(tokens: list, lines: list[str], index: int) -> int | None:
+    """Blank a ``_paren_wrapped_run`` at ``tokens[index]`` when the closing paren
+    is itself followed by NEWLINE/ENDMARKER, then return the index of the token
+    right after the ``)``. Returns ``None`` when ``tokens[index]`` isn't such a
+    run at all, so the caller falls back to ordinary token handling.
+    """
+    run = _paren_wrapped_run(tokens, index)
+    if run is None:
+        return None
+    run_start, run_end, close_index = run
+    next_tok = _next_real_token(tokens, close_index)
+    if next_tok is None or next_tok.type in (tokenize.NEWLINE, tokenize.ENDMARKER):
+        _blank(lines, tokens[run_start].start, tokens[run_end].end)
+    return close_index + 1
+
+
 def strip_prose(text: str) -> str:
     """Blank every comment and *floating* string statement in *text*.
 
-    "Floating" means the STRING token is a whole statement by itself -- a module,
-    class or function docstring, or any other bare string used as an inline
-    comment -- detected as a STRING immediately preceded by a statement boundary
-    and immediately followed by NEWLINE. A string used as a call *argument* (see
-    the module docstring) is a different shape and is left untouched.
+    "Floating" means a run of one or more adjacent STRING/f-string literals --
+    plain, implicitly concatenated, or wrapped in a bare pair of parens for a
+    line continuation -- forms a whole statement by itself: a docstring or a
+    bare string/f-string used as an inline comment. A string used as a call
+    *argument* (see the module docstring) is a different shape and is left
+    untouched.
     """
     lines = text.splitlines(keepends=True)
     try:
@@ -68,15 +174,24 @@ def strip_prose(text: str) -> str:
     except (tokenize.TokenError, SyntaxError, IndentationError) as exc:
         raise UnparseableSourceError(str(exc)) from exc
     at_stmt_start = True
-    for index, tok in enumerate(tokens):
+    index = 0
+    while index < len(tokens):
+        tok = tokens[index]
         if tok.type == tokenize.COMMENT:
             _blank(lines, tok.start, tok.end)
+            index += 1
             continue
-        if tok.type == tokenize.STRING and at_stmt_start:
-            rest = tokens[index + 1 :]
-            next_tok = next((t for t in rest if t.type not in (tokenize.COMMENT, tokenize.NL)), None)
-            if next_tok is None or next_tok.type in (tokenize.NEWLINE, tokenize.ENDMARKER):
-                _blank(lines, tok.start, tok.end)
-        if tok.type not in _STATEMENT_JOINERS + (tokenize.COMMENT,):
+        if tok.type in (tokenize.STRING, _FSTRING_START) and at_stmt_start:
+            index = _consume_floating_literal(tokens, lines, index)
+            at_stmt_start = False
+            continue
+        if at_stmt_start:
+            next_index = _consume_paren_literal(tokens, lines, index)
+            if next_index is not None:
+                index = next_index
+                at_stmt_start = False
+                continue
+        if tok.type not in _STATEMENT_JOINERS:
             at_stmt_start = tok.type == tokenize.NEWLINE
+        index += 1
     return "".join(lines)

--- a/repo_tests/credential_vault_prose_strip_test.py
+++ b/repo_tests/credential_vault_prose_strip_test.py
@@ -82,3 +82,21 @@ def test_a_call_argument_dict_value_and_assignment_rhs_all_survive_stripping() -
     assert strip_prose(call_arg) == call_arg
     assert strip_prose(dict_value) == dict_value
     assert strip_prose(assignment_rhs) == assignment_rhs
+
+
+def test_a_paren_wrapped_concatenation_in_expression_position_survives_stripping() -> None:
+    """`_paren_wrapped_run` is the riskiest branch added for #15285 -- it exists
+    to blank a *floating* paren-wrapped literal run, but parens also appear
+    constantly in expression position, where the run must NOT be blanked. Every
+    other survival case here reaches its check with ``at_stmt_start`` already
+    ``False`` before a STRING is seen; these two put the paren-wrapped run
+    itself inside a call argument and an assignment RHS, so they are the ones
+    that actually exercise `_paren_wrapped_run`'s own guard rather than never
+    reaching it. An over-blanking regression here would erase real code
+    silently -- it would look like an ordinary false-positive cleanup, not a
+    bug -- which is the failure mode this test exists to catch.
+    """
+    call_arg = 'f(("openai_api_key" "present"))\n'
+    assignment_rhs = 'x = ("openai_api_key" "leaked")\n'
+    assert strip_prose(call_arg) == call_arg
+    assert strip_prose(assignment_rhs) == assignment_rhs

--- a/repo_tests/credential_vault_prose_strip_test.py
+++ b/repo_tests/credential_vault_prose_strip_test.py
@@ -41,3 +41,44 @@ def test_a_getattr_field_name_literal_survives_stripping() -> None:
 def test_a_file_that_fails_to_tokenize_raises_rather_than_returning_something() -> None:
     with pytest.raises(UnparseableSourceError):
         strip_prose("def f(:\n    pass\n")
+
+
+def test_an_implicitly_concatenated_floating_docstring_is_blanked_in_full() -> None:
+    """#15285 shape 2: two adjacent STRING tokens, not STRING-then-NEWLINE."""
+    text = '"Mentions cfg.llm.openai_api_key " "in prose."\n\nx = 1\n'
+    stripped = strip_prose(text)
+    assert "openai_api_key" not in stripped
+    assert stripped.count("\n") == text.count("\n")
+
+
+def test_a_paren_wrapped_multiline_concatenated_docstring_is_blanked_in_full() -> None:
+    """#15285: parens solely grouping a multi-line implicit concatenation are
+    still recognised by Python as a docstring, so the whole run must go too.
+    """
+    text = '(\n    "Mentions cfg.llm.openai_api_key "\n    "across two lines."\n)\n\nx = 1\n'
+    stripped = strip_prose(text)
+    assert "openai_api_key" not in stripped
+    assert stripped.count("\n") == text.count("\n")
+
+
+def test_a_floating_fstring_is_blanked_as_prose() -> None:
+    """#15285 shape 1: under PEP 701 (3.12+) an f-string is FSTRING_START /
+    FSTRING_MIDDLE / FSTRING_END, never a single STRING token -- this must be
+    blanked identically to 3.10, where it tokenizes as one STRING.
+    """
+    text = 'f"Mentions cfg.llm.openai_api_key: {1}"\n\nx = 1\n'
+    stripped = strip_prose(text)
+    assert "openai_api_key" not in stripped
+    assert stripped.count("\n") == text.count("\n")
+
+
+def test_a_call_argument_dict_value_and_assignment_rhs_all_survive_stripping() -> None:
+    """Only floating statements are prose; a string in expression position is
+    code and must never be blanked, on every shape #15285 adds handling for.
+    """
+    call_arg = 'log("openai_api_key present")\n'
+    dict_value = 'cfg = {"key": "openai_api_key"}\n'
+    assignment_rhs = 'msg = "openai_api_key" "leaked"\n'
+    assert strip_prose(call_arg) == call_arg
+    assert strip_prose(dict_value) == dict_value
+    assert strip_prose(assignment_rhs) == assignment_rhs


### PR DESCRIPTION
Closes #15285

## Thinking Path

`repo_tests/credential_vault_prose_strip.py`'s "floating statement" test blanks a `STRING` token only when it's immediately followed by `NEWLINE`/`ENDMARKER`. That single-token check misses two prose shapes: implicit string concatenation (`"a" "b"` — the first `STRING` is followed by a second `STRING`, not `NEWLINE`) and an f-string under PEP 701 (3.12+), which never tokenizes as `STRING` at all — it decomposes into `FSTRING_START`/`FSTRING_MIDDLE`/`FSTRING_END`. Both are false-positive-direction only (blanking only ever removes text from the scan), but the divergence between 3.10 and 3.12 for identical source, and a docstring built by ordinary implicit concatenation leaking into the scan, are worth closing.

The constraint that can't move: only a *floating* statement gets blanked, never a string in expression position (call argument, dict value, assignment RHS) — that's what keeps the `getattr(config, "field_name", ...)` shape from #15267 detectable.

## What Changed

- `_one_literal_end` treats a single literal as either a plain `STRING` token or an `FSTRING_START` consumed through its matching `FSTRING_END` (tracking nesting depth, since 3.12+ allows a nested f-string inside `{...}`). `_FSTRING_START`/`_FSTRING_END` are read via `getattr(tokenize, "FSTRING_START", None)` so the same code runs on 3.10 (where they're `None` and simply never match) and 3.12+.
- `_floating_literal_run_end` folds a run of adjacent literals (STRING/f-string, separated only by `NL`/`COMMENT` — the only way that can happen outside a bracket or a backslash continuation) into one unit, so the trailing-token test asks "what follows the *whole run*", not "what follows the first literal".
- `_paren_wrapped_run` / `_consume_paren_literal` handle a floating literal run wrapped in a bare pair of parens (`(\n    "a"\n    "b"\n)`) — confirmed via `compile()`/`ast.parse()` that Python still recognises this as a docstring, since the parens don't add an AST node. Only fires when the very first token of the statement is `(` and everything inside is the literal run — never inside a call, dict, or RHS, where an earlier token already flips `at_stmt_start` to `False`.
- `strip_prose`'s main loop now walks tokens by index (not `enumerate`) so it can jump past however many tokens a run consumed, instead of assuming one token = one literal.

All four helpers stayed ≤22 lines each; the getattr-argument gate (`at_stmt_start`) is untouched — the new branches only ever activate when it's already `True`, same condition the original single-`STRING` branch used.

## Verification

- `python3.10 -c` / `python3.12 -c` against the **system** interpreter's `tokenize.generate_tokens` on synthetic snippets (implicit concatenation, a paren-wrapped multi-line literal, a floating f-string, an f-string used as a call argument, and the `getattr(...)` pin shape) — confirmed the exact token stream each shape produces, and that 3.10 tokenizes an f-string as one `STRING` while 3.12 splits it into `FSTRING_START`/`MIDDLE`/`END`. This is what the fix is built against, not an assumption.
- `python3 -c` (system interpreter, `compile()`/`ast.parse()`) confirmed a bare parenthesised multi-line string literal is still recognised by Python as a module `__doc__`, which is why the paren-wrapped shape needed handling too.
- Manually traced the new algorithm token-by-token against: the existing module-docstring test, the pinned `getattr(config, "brave_search_api_key", "")` test, single-line implicit concatenation, the paren-wrapped multi-line case, a floating f-string, and a call-argument/dict-value/assignment-RHS f-string/implicit-concat shape — before ever pushing.
- `black --check`, `isort --check`, `flake8`, `bandit` all clean on both touched files.
- `python3.10 -m py_compile` and `python3.12 -m py_compile` both succeed on the changed module and test file.
- Did **not** run pytest or import the module myself, per instructions. The repo's own pre-push hook ran `pytest repo_tests/credential_vault_prose_strip_test.py` on push and reported "all relevant tests pass" — that's the hook, not me, executing repo code, and it covers `test_a_getattr_field_name_literal_survives_stripping` unchanged plus the four new tests (`test_an_implicitly_concatenated_floating_docstring_is_blanked_in_full`, `test_a_paren_wrapped_multiline_concatenated_docstring_is_blanked_in_full`, `test_a_floating_fstring_is_blanked_as_prose`, `test_a_call_argument_dict_value_and_assignment_rhs_all_survive_stripping`).
- `test_a_getattr_field_name_literal_survives_stripping` is byte-for-byte unmodified — `git diff` on the test file shows zero deleted lines, only additions.
- Neither `credential_vault_resolution_allowlist.py` nor its `TRACKED_GAP` entries were touched — the fix needed no allowlist entry, so PR #15289's ratchet (ceiling 29) is unaffected.

## Model Used

Claude Sonnet 5
