### PR TITLE
fix(deploy): CUDA torch is gated behind the vLLM flag, so GPU hosts without vLLM silently run CPU torch (#15162)

### DIFF
--- a/autobot-backend/requirements.txt
+++ b/autobot-backend/requirements.txt
@@ -42,7 +42,7 @@ boto3>=1.43.78                       # GH#9010: AWS Bedrock provider
 chromadb>=1.5.9,<2.0.0             # upper bound guards against breaking API changes; 1.5.5+ uses regenerated protos compatible with protobuf 5.x (#4053)
 protobuf>=7.36.0,<8.0.0            # cap/floor rationale lives in ../requirements.txt (#15070, #4061); this file `-r`-includes it and pip resolves the intersection, so the two lines MUST stay identical — enforced by tools/lint/check_requirements_pin_parity.py
 sentence-transformers>=6.0.0
-torch==2.13.0  # embeddings/transcriber/multimodal; installed CPU-only in the default image (#10251). GPU build via requirements-gpu.txt
+torch==2.13.0  # embeddings/transcriber/multimodal; installed CPU-only in the default image (#10251). GPU build via requirements-gpu-torch.txt (#15162)
 torchvision==0.28.0  # paired with torch 2.12.1; CPU-only by default (#10251)
 # torchaudio removed (#10251): not imported anywhere in the backend, and its 2.11.0 pin mismatched torch 2.12.0
 torchmetrics>=1.9.0  # Issue #904: Training metrics

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -8,6 +8,13 @@ backend_service_account: autobot-backend  # Phase 7: migrate service to run as t
 backend_user: autobot
 backend_group: autobot
 backend_install_dir: /opt/autobot/autobot-backend
+# Canonical git checkout on the box (#3649), matching the autobot_shared and
+# monitoring role defaults. Every code_source_dir reference in this role's
+# tasks/main.yml used to repeat the default(...) fallback with this literal inline
+# instead of relying on a role default -- nine occurrences of the same literal,
+# which is exactly what pipeline-scripts/hardcoded_values_baseline.txt exists
+# to catch (#15162). Defined here once, tasks reference the bare variable.
+code_source_dir: /opt/autobot/code_source
 backend_code_dir: "{{ backend_install_dir }}"  # Actual code location (can be overridden by playbook)
 backend_shared_standalone_dir: /opt/autobot/autobot_shared  # Standalone PYTHONPATH copy used by workers (#3649)
 backend_log_dir: /var/log/autobot

--- a/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/defaults/main.yml
@@ -162,11 +162,14 @@ backend_health_check_delay: 5          # Seconds between retries
 # Audit log file path (#8936: ensures AUTOBOT_AUDIT_LOG_FILE is always set in prod)
 backend_audit_log_file: /opt/autobot/logs/audit.log
 
-# GPU / vLLM inference (#10288)
-# vllm moved to opt-in requirements-gpu.txt (#10251/#10287) to keep the default
-# CPU image lean (it drags the CUDA toolkit + CUDA-built torch — several GB).
-# Install requirements-gpu.txt ONLY when both an NVIDIA GPU is present AND vLLM
-# is enabled for this deployment.
+# GPU / CUDA-torch / vLLM inference (#10288, #15162)
+# Two independent decisions, deliberately not coupled (#15162):
+#   - CUDA torch/torchvision (requirements-gpu-torch.txt) installs whenever a
+#     GPU is present, vLLM or not.
+#   - vllm itself (requirements-gpu.txt) moved to opt-in (#10251/#10287) to
+#     keep the default CPU image lean (it drags the CUDA toolkit + extra
+#     wheels — several GB); it installs ONLY when both a GPU is present AND
+#     vLLM is enabled for this deployment.
 #   backend_vllm_enabled: deployment opts into in-process vLLM (llm.vllm.enabled).
 #   backend_has_gpu: "auto" runs nvidia-smi at deploy time; "true"/"false" override.
 backend_vllm_enabled: false

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -539,7 +539,7 @@
 
   - name: Sync autobot-backend code from code_source
     ansible.posix.synchronize:
-      src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot-backend/"
+      src: "{{ code_source_dir }}/autobot-backend/"
       dest: "{{ backend_code_dir }}/"
       rsync_opts:
         - "--exclude=__pycache__"
@@ -589,7 +589,7 @@
 
   - name: Sync backend config directory from code_source
     ansible.posix.synchronize:
-      src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot-backend/config/"
+      src: "{{ code_source_dir }}/autobot-backend/config/"
       dest: "{{ backend_code_dir }}/config/"
       rsync_opts:
         - "--exclude=__pycache__"
@@ -604,7 +604,7 @@
   # generation, kb-event, etc.) silently failed to register. Sync them into place.
   - name: Sync plugins directory from code_source (#10294)
     ansible.posix.synchronize:
-      src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/plugins/"
+      src: "{{ code_source_dir }}/plugins/"
       dest: "{{ backend_code_dir }}/plugins/"
       rsync_opts:
         - "--exclude=__pycache__"
@@ -659,7 +659,7 @@
   # path is now a symlink to this directory, so syncing here is sufficient for all consumers.
   - name: "Backend | Sync autobot_shared to standalone PYTHONPATH dir (#3649)"
     ansible.posix.synchronize:
-      src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/autobot_shared/"
+      src: "{{ code_source_dir }}/autobot_shared/"
       dest: "{{ backend_shared_standalone_dir }}/"
       rsync_opts:
         - "--exclude=__pycache__"
@@ -681,7 +681,7 @@
 
   - name: "Backend | Sync docs directory from code_source (#4100)"
     ansible.posix.synchronize:
-      src: "{{ code_source_dir | default('/opt/autobot/code_source') }}/docs/"
+      src: "{{ code_source_dir }}/docs/"
       dest: "{{ backend_install_dir }}/../docs/"
       delete: true
       rsync_opts:
@@ -862,9 +862,9 @@
   - name: Create filtered backend requirements file
     ansible.builtin.shell:
       cmd: >-
-        bash {{ code_source_dir | default('/opt/autobot/code_source') }}/scripts/build-filtered-requirements.sh
+        bash {{ code_source_dir }}/scripts/build-filtered-requirements.sh
         {{ backend_code_dir }}/requirements.txt
-        {{ code_source_dir | default('/opt/autobot/code_source') }}
+        {{ code_source_dir }}
         > /tmp/requirements-filtered.txt
     become_user: "{{ backend_user }}"
 
@@ -911,7 +911,7 @@
   # backend code rsync).
   - name: "Backend | Install CUDA torch requirements (requirements-gpu-torch.txt) (#15162)"
     ansible.builtin.pip:
-      requirements: "{{ code_source_dir | default('/opt/autobot/code_source') }}/requirements-gpu-torch.txt"
+      requirements: "{{ code_source_dir }}/requirements-gpu-torch.txt"
       virtualenv: "{{ backend_code_dir }}/venv"
     become_user: "{{ backend_user }}"
     environment:
@@ -925,7 +925,7 @@
   # duplicate CUDA-torch download happens here.
   - name: "Backend | Install GPU/vLLM requirements (requirements-gpu.txt) (#10288)"
     ansible.builtin.pip:
-      requirements: "{{ code_source_dir | default('/opt/autobot/code_source') }}/requirements-gpu.txt"
+      requirements: "{{ code_source_dir }}/requirements-gpu.txt"
       virtualenv: "{{ backend_code_dir }}/venv"
     become_user: "{{ backend_user }}"
     environment:
@@ -944,6 +944,13 @@
       backend_vllm_installed: >-
         {{ (backend_vllm_enabled | bool) and
            (backend_gpu_available | default(false) | bool) }}
+      # "no GPU detected" only applies to the auto-probe path; an explicit
+      # backend_has_gpu override that still resolves to no GPU names the
+      # override itself, so the operator sees the actual reason rather than
+      # a probe result that never ran.
+      backend_gpu_skip_reason: >-
+        {{ 'no GPU detected' if backend_has_gpu == 'auto'
+           else 'backend_has_gpu=' ~ backend_has_gpu }}
 
   - name: "Backend | Report GPU/CUDA-torch deploy decision (#15162)"
     ansible.builtin.debug:
@@ -951,11 +958,11 @@
         GPU deploy decision: gpu_available={{ backend_gpu_available | default(false) }}
         (backend_has_gpu={{ backend_has_gpu }}) ->
         cuda_torch={{ 'installed' if backend_cuda_torch_installed
-          else 'skipped (no GPU detected)' }};
+          else 'skipped (' ~ backend_gpu_skip_reason ~ ')' }};
         vllm_enabled={{ backend_vllm_enabled | bool }} ->
         vllm={{ 'installed' if backend_vllm_installed
           else ('skipped (vLLM disabled)' if not (backend_vllm_enabled | bool)
-          else 'skipped (no GPU detected)') }}
+          else 'skipped (' ~ backend_gpu_skip_reason ~ ')') }}
 
   - name: Deploy aioredis compatibility shim for Python 3.14
     ansible.builtin.template:

--- a/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
+++ b/autobot-slm-backend/ansible/roles/backend/tasks/main.yml
@@ -882,29 +882,47 @@
     timeout: 600  # Issue #2835: prevent indefinite hang on dependency resolution conflicts
     register: pip_install_result
 
-  # GPU / vLLM extras (#10288): vllm was moved to an opt-in requirements-gpu.txt
-  # (#10251/#10287) to keep the default CPU image lean. Install it ONLY on a
-  # GPU-enabled backend that opts into vLLM, so CPU deploys stay slim.
-  - name: "Backend | Detect NVIDIA GPU for vLLM extras (#10288)"
+  # GPU / CUDA-torch / vLLM extras (#10288, #15162): the GPU probe and the
+  # CUDA-torch install answer "does this host have an NVIDIA GPU", which is
+  # independent of "does this host run in-process vLLM". Coupling them meant a
+  # GPU host that left vLLM disabled (the default) was never even probed, and
+  # silently kept the CPU-only torch from requirements.txt. vllm itself stays
+  # opt-in (#10251/#10287) since it drags the CUDA toolkit + extra wheels, but
+  # CUDA torch/torchvision install whenever a GPU is present, vLLM or not.
+  - name: "Backend | Detect NVIDIA GPU (#10288, #15162)"
     ansible.builtin.command:
       cmd: nvidia-smi --query-gpu=name --format=csv,noheader
     register: backend_nvidia_smi_result
     changed_when: false
     # nvidia-smi exits rc != 0 when no GPU is present; the result only gates the
-    # optional GPU-reqs install below, so a non-zero rc is expected on CPU nodes.
+    # optional GPU-reqs installs below, so a non-zero rc is expected on CPU nodes.
     failed_when: false
-    when:
-      - backend_vllm_enabled | bool
-      - backend_has_gpu == "auto"
+    when: backend_has_gpu == "auto"
 
-  - name: "Backend | Resolve GPU availability for vLLM extras (#10288)"
+  - name: "Backend | Resolve GPU availability (#10288, #15162)"
     ansible.builtin.set_fact:
       backend_gpu_available: "{{ (backend_nvidia_smi_result.rc | default(1)) == 0 and (backend_nvidia_smi_result.stdout | default('') | trim | length > 0) if backend_has_gpu == 'auto' else (backend_has_gpu | bool) }}"
-    when: backend_vllm_enabled | bool
 
-  # Install GPU/vLLM requirements only when vLLM is enabled AND a GPU is present.
-  # Uses the repo-root requirements-gpu.txt from code_source (sibling of the
-  # autobot-backend subtree; not part of the backend code rsync).
+  # Install CUDA-built torch/torchvision whenever a GPU is present, regardless
+  # of vLLM. This is the fix for #15162: a GPU host that does not opt into
+  # vLLM used to keep the CPU-only torch from requirements.txt with nothing
+  # reporting the downgrade. Uses the repo-root requirements-gpu-torch.txt from
+  # code_source (sibling of the autobot-backend subtree; not part of the
+  # backend code rsync).
+  - name: "Backend | Install CUDA torch requirements (requirements-gpu-torch.txt) (#15162)"
+    ansible.builtin.pip:
+      requirements: "{{ code_source_dir | default('/opt/autobot/code_source') }}/requirements-gpu-torch.txt"
+      virtualenv: "{{ backend_code_dir }}/venv"
+    become_user: "{{ backend_user }}"
+    environment:
+      PIP_DEFAULT_TIMEOUT: "120"
+    timeout: 1800  # CUDA-built torch is large
+    when: backend_gpu_available | default(false) | bool
+
+  # Install vLLM only when vLLM is enabled AND a GPU is present. vLLM remains
+  # genuinely opt-in (#10251/#10287); it pins the same torch build the task
+  # above already installs whenever backend_gpu_available is true, so no
+  # duplicate CUDA-torch download happens here.
   - name: "Backend | Install GPU/vLLM requirements (requirements-gpu.txt) (#10288)"
     ansible.builtin.pip:
       requirements: "{{ code_source_dir | default('/opt/autobot/code_source') }}/requirements-gpu.txt"
@@ -912,10 +930,32 @@
     become_user: "{{ backend_user }}"
     environment:
       PIP_DEFAULT_TIMEOUT: "120"
-    timeout: 1800  # CUDA-built torch + vllm wheels are large
+    timeout: 1800  # vllm wheels are large
     when:
       - backend_vllm_enabled | bool
       - backend_gpu_available | default(false) | bool
+
+  # Silence is the actual defect (#15162): report exactly which torch variant
+  # this deploy chose and why, so an operator can see the decision instead of
+  # inferring it from performance later.
+  - name: "Backend | Resolve GPU/CUDA-torch deploy decision (#15162)"
+    ansible.builtin.set_fact:
+      backend_cuda_torch_installed: "{{ backend_gpu_available | default(false) | bool }}"
+      backend_vllm_installed: >-
+        {{ (backend_vllm_enabled | bool) and
+           (backend_gpu_available | default(false) | bool) }}
+
+  - name: "Backend | Report GPU/CUDA-torch deploy decision (#15162)"
+    ansible.builtin.debug:
+      msg: >-
+        GPU deploy decision: gpu_available={{ backend_gpu_available | default(false) }}
+        (backend_has_gpu={{ backend_has_gpu }}) ->
+        cuda_torch={{ 'installed' if backend_cuda_torch_installed
+          else 'skipped (no GPU detected)' }};
+        vllm_enabled={{ backend_vllm_enabled | bool }} ->
+        vllm={{ 'installed' if backend_vllm_installed
+          else ('skipped (vLLM disabled)' if not (backend_vllm_enabled | bool)
+          else 'skipped (no GPU detected)') }}
 
   - name: Deploy aioredis compatibility shim for Python 3.14
     ansible.builtin.template:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -35,7 +35,8 @@ COPY constraints/shared.txt /app/constraints/shared.txt
 # torch/torchvision are excluded from the filtered list and installed explicitly from
 # the CPU index, so the default-PyPI CUDA build (libtorch_cuda.so) is never pulled into
 # this CPU image (#10251). vLLM + its CUDA stack are no longer default deps; GPU
-# deployments add them via requirements-gpu.txt.
+# deployments add CUDA torch via requirements-gpu-torch.txt and vLLM via
+# requirements-gpu.txt, independent of each other (#15162).
 COPY autobot-backend/requirements.txt /tmp/requirements.txt
 RUN grep -v -E "(autobot.shared|^-r |^-c |^torch==|^torchvision==)" /tmp/requirements.txt \
         > /app/requirements-filtered.txt \

--- a/pipeline-scripts/hardcoded_values_baseline.txt
+++ b/pipeline-scripts/hardcoded_values_baseline.txt
@@ -1251,7 +1251,6 @@
 1|other|autobot-slm-backend/ansible/roles/backend/defaults/main.yml|https://github.com/mrveiss/AutoBot-AI.git
 1|ssot|autobot-slm-backend/ansible/roles/backend/defaults/main.yml|:11434
 1|ssot|autobot-slm-backend/ansible/roles/backend/defaults/main.yml|qwen3.5:9b
-8|other|autobot-slm-backend/ansible/roles/backend/tasks/main.yml|'/opt/autobot/code_source
 1|other|autobot-slm-backend/ansible/roles/backend/tasks/main.yml|'/var/lib/autobot/celerybeat-schedule
 4|other|autobot-slm-backend/ansible/roles/backend/tasks/main.yml|120
 2|other|autobot-slm-backend/ansible/roles/backend/tasks/main.yml|60

--- a/repo_tests/backend_gpu_torch_gating_test.py
+++ b/repo_tests/backend_gpu_torch_gating_test.py
@@ -38,6 +38,9 @@ ANSIBLE_TASKS = (
     REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "backend" / "tasks" / "main.yml"
 )
 REQUIREMENTS_GPU_TORCH = REPO_ROOT / "requirements-gpu-torch.txt"
+BACKEND_DEFAULTS = (
+    REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "backend" / "defaults" / "main.yml"
+)
 REQUIREMENTS_GPU_VLLM = REPO_ROOT / "requirements-gpu.txt"
 
 
@@ -169,3 +172,29 @@ def test_requirements_gpu_file_no_longer_pins_torch_directly() -> None:
         "install path does not depend on the vLLM file"
     )
     assert any(pin.startswith("vllm") for pin in pins)
+
+
+def test_code_source_dir_is_a_role_default_not_a_repeated_inline_literal() -> None:
+    """#15162 review: the new CUDA-torch task must not grow the hardcoded-value baseline.
+
+    A GPU host's requirements path used to repeat a `code_source_dir | default(...)`
+    fallback inline on every task that needed it (nine occurrences after this fix
+    added a tenth); each repeats the same hardcoded `/opt/autobot` literal that
+    pipeline-scripts/hardcoded_values_baseline.txt tracks per-file, per-value
+    COUNT -- so a tenth occurrence is a new finding, not something the baseline
+    already excuses. The fix defines the value once, as a role default, and every
+    task references the bare variable.
+    """
+    tasks_text = ANSIBLE_TASKS.read_text(encoding="utf-8")
+    assert "code_source_dir | default(" not in tasks_text, (
+        "tasks/main.yml still repeats the inline default('/opt/autobot/code_source') "
+        "literal; it must be defined once in defaults/main.yml and referenced bare"
+    )
+
+    assert BACKEND_DEFAULTS.is_file(), f"{BACKEND_DEFAULTS} missing"
+    defaults = yaml.safe_load(BACKEND_DEFAULTS.read_text(encoding="utf-8"))
+    assert isinstance(defaults, dict)
+    assert defaults.get("code_source_dir") == "/opt/autobot/code_source", (
+        f"roles/backend/defaults/main.yml must define code_source_dir; got "
+        f"{defaults.get('code_source_dir')!r}"
+    )

--- a/repo_tests/backend_gpu_torch_gating_test.py
+++ b/repo_tests/backend_gpu_torch_gating_test.py
@@ -1,0 +1,171 @@
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15162: CUDA torch must not be gated behind the vLLM opt-in.
+
+"Does this host have an NVIDIA GPU" and "does this host run in-process vLLM"
+are different questions. Before this fix, `backend_gpu_available` was only
+ever resolved `when: backend_vllm_enabled | bool` — so a GPU host that left
+vLLM disabled (the default, `backend_vllm_enabled: false`) was never even
+probed, and the CUDA-torch install below it was unreachable. The venv kept
+the CPU-only torch from `autobot-backend/requirements.txt`, and nothing
+reported the downgrade.
+
+These assertions parse the actual ansible task list (walking block/rescue/
+always, per the established pattern in `llc_agent_cli_provisioned_test.py`)
+and inspect the real `when` conditions and requirement file contents — never
+raw substring matches against the whole file, which would go green on a
+comment.
+
+Regression this guards against: re-adding `backend_vllm_enabled | bool` to
+the GPU-probe, GPU-availability-fact, or CUDA-torch-install `when` clauses
+re-couples GPU detection to the vLLM opt-in and silently drops back to CPU
+torch on every non-vLLM GPU host.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ANSIBLE_TASKS = (
+    REPO_ROOT / "autobot-slm-backend" / "ansible" / "roles" / "backend" / "tasks" / "main.yml"
+)
+REQUIREMENTS_GPU_TORCH = REPO_ROOT / "requirements-gpu-torch.txt"
+REQUIREMENTS_GPU_VLLM = REPO_ROOT / "requirements-gpu.txt"
+
+
+def _tasks() -> list[dict[str, Any]]:
+    """Every task in the backend role, including those nested in block/rescue/always."""
+    assert ANSIBLE_TASKS.is_file(), f"{ANSIBLE_TASKS} missing — this guard would pass vacuously"
+    loaded = yaml.safe_load(ANSIBLE_TASKS.read_text(encoding="utf-8"))
+    out: list[dict[str, Any]] = []
+
+    def walk(items: Any) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            out.append(item)
+            for key in ("block", "rescue", "always"):
+                walk(item.get(key))
+
+    walk(loaded)
+    assert out, "parsed no tasks — the guard would pass on an empty set"
+    return out
+
+
+def _task_named(fragment: str) -> dict[str, Any]:
+    matches = [t for t in _tasks() if fragment in str(t.get("name", ""))]
+    assert len(matches) == 1, (
+        f"expected exactly one task named like {fragment!r}, found {len(matches)}: "
+        f"{[t.get('name') for t in matches]}"
+    )
+    return matches[0]
+
+
+def _when_text(task: dict[str, Any]) -> str:
+    """Normalise ``when:`` (string, list, or absent) to one searchable string."""
+    when = task.get("when")
+    if when is None:
+        return ""
+    if isinstance(when, list):
+        return " ".join(str(x) for x in when)
+    return str(when)
+
+
+def test_gpu_probe_is_not_gated_on_vllm() -> None:
+    """The nvidia-smi probe must run whenever backend_has_gpu == "auto", vLLM or not."""
+    task = _task_named("Detect NVIDIA GPU")
+    when_text = _when_text(task)
+    assert "backend_vllm_enabled" not in when_text, (
+        f"the GPU-probe task is still gated on backend_vllm_enabled ({when_text!r}); "
+        "a GPU host with vLLM disabled would never be probed for a GPU at all"
+    )
+    assert "backend_has_gpu" in when_text
+
+
+def test_gpu_availability_fact_is_not_gated_on_vllm() -> None:
+    """backend_gpu_available must be resolved independent of the vLLM opt-in."""
+    task = _task_named("Resolve GPU availability")
+    when_text = _when_text(task)
+    assert "backend_vllm_enabled" not in when_text, (
+        f"backend_gpu_available is still resolved only when: {when_text!r}; "
+        "a GPU host with vLLM disabled would never get backend_gpu_available=true, "
+        "which starves every consumer of that fact — not just the torch install"
+    )
+
+
+def test_cuda_torch_install_is_gated_on_gpu_only() -> None:
+    """CUDA torch/torchvision install on GPU presence alone — this is the actual fix."""
+    task = _task_named("Install CUDA torch requirements")
+    pip = task.get("ansible.builtin.pip")
+    assert isinstance(pip, dict)
+    assert "requirements-gpu-torch.txt" in str(pip.get("requirements", "")), (
+        "the CUDA-torch install task does not point at requirements-gpu-torch.txt"
+    )
+    when_text = _when_text(task)
+    assert "backend_gpu_available" in when_text
+    assert "backend_vllm_enabled" not in when_text, (
+        f"CUDA torch is still gated on backend_vllm_enabled ({when_text!r}); "
+        "a GPU host with vLLM disabled would silently keep CPU-only torch (#15162)"
+    )
+
+
+def test_vllm_install_still_requires_both_flags() -> None:
+    """vllm stays genuinely opt-in: it needs the GPU present AND vLLM enabled."""
+    task = _task_named("Install GPU/vLLM requirements")
+    pip = task.get("ansible.builtin.pip")
+    assert isinstance(pip, dict)
+    assert "requirements-gpu.txt" in str(pip.get("requirements", ""))
+    when_text = _when_text(task)
+    assert "backend_vllm_enabled" in when_text, (
+        "vllm install lost its vLLM-opt-in gate — it would now install on every GPU host"
+    )
+    assert "backend_gpu_available" in when_text, (
+        "vllm install lost its GPU gate — it would attempt to install on CPU-only hosts"
+    )
+
+
+def test_deploy_reports_the_gpu_torch_decision() -> None:
+    """Silence is the actual defect (#15162): the deploy must say what it chose and why."""
+    task = _task_named("Report GPU/CUDA-torch deploy decision")
+    debug = task.get("ansible.builtin.debug")
+    assert isinstance(debug, dict)
+    msg = str(debug.get("msg", ""))
+    for token in ("gpu_available", "cuda_torch", "vllm_enabled", "vllm"):
+        assert token in msg, f"deploy decision message is missing {token!r}: {msg!r}"
+
+
+def test_requirements_gpu_torch_file_carries_cuda_torch() -> None:
+    assert REQUIREMENTS_GPU_TORCH.is_file(), f"{REQUIREMENTS_GPU_TORCH} missing"
+    text = REQUIREMENTS_GPU_TORCH.read_text(encoding="utf-8")
+    assert "torch==" in text
+    assert "torchvision==" in text
+    assert "vllm" not in text.lower(), (
+        "requirements-gpu-torch.txt must stay vLLM-free — it installs on every GPU host, "
+        "with or without the vLLM opt-in, and must not drag vllm's extra CUDA-toolkit deps"
+    )
+
+
+def test_requirements_gpu_file_no_longer_pins_torch_directly() -> None:
+    """The vLLM-only file must not re-duplicate the CUDA-torch pin split into the new file."""
+    assert REQUIREMENTS_GPU_VLLM.is_file(), f"{REQUIREMENTS_GPU_VLLM} missing"
+    lines = [
+        line.split("#", 1)[0].strip()
+        for line in REQUIREMENTS_GPU_VLLM.read_text(encoding="utf-8").splitlines()
+    ]
+    pins = [line for line in lines if line]
+    assert not any(pin.startswith(("torch==", "torchvision==")) for pin in pins), (
+        f"requirements-gpu.txt still pins torch/torchvision directly: {pins!r}; "
+        "that pin belongs solely in requirements-gpu-torch.txt (#15162) so the GPU-only "
+        "install path does not depend on the vLLM file"
+    )
+    assert any(pin.startswith("vllm") for pin in pins)

--- a/repo_tests/backend_gpu_torch_gating_test.py
+++ b/repo_tests/backend_gpu_torch_gating_test.py
@@ -84,6 +84,24 @@ def _when_text(task: dict[str, Any]) -> str:
     return str(when)
 
 
+def _requirement_pins(text: str) -> list[str]:
+    """The actual pip-installable lines of a requirements file -- never raw text.
+
+    #15162 review: pip itself strips everything from ``#`` onward and skips
+    blank lines; a check that instead substring-matches the whole file cannot
+    tell a package pin from a comment *describing* one, and this file's header
+    comment explains the vLLM/torch split in prose, mentioning both by name.
+    Parsing it the way pip does is the only way "vllm is absent" and "vllm is
+    documented" stay distinguishable.
+    """
+    pins = []
+    for line in text.splitlines():
+        pin = line.split("#", 1)[0].strip()
+        if pin:
+            pins.append(pin)
+    return pins
+
+
 def test_gpu_probe_is_not_gated_on_vllm() -> None:
     """The nvidia-smi probe must run whenever backend_has_gpu == "auto", vLLM or not."""
     task = _task_named("Detect NVIDIA GPU")
@@ -149,23 +167,64 @@ def test_deploy_reports_the_gpu_torch_decision() -> None:
 
 def test_requirements_gpu_torch_file_carries_cuda_torch() -> None:
     assert REQUIREMENTS_GPU_TORCH.is_file(), f"{REQUIREMENTS_GPU_TORCH} missing"
-    text = REQUIREMENTS_GPU_TORCH.read_text(encoding="utf-8")
-    assert "torch==" in text
-    assert "torchvision==" in text
-    assert "vllm" not in text.lower(), (
-        "requirements-gpu-torch.txt must stay vLLM-free — it installs on every GPU host, "
-        "with or without the vLLM opt-in, and must not drag vllm's extra CUDA-toolkit deps"
+    pins = _requirement_pins(REQUIREMENTS_GPU_TORCH.read_text(encoding="utf-8"))
+    assert any(pin.startswith("torch==") for pin in pins), pins
+    assert any(pin.startswith("torchvision==") for pin in pins), pins
+    assert not any(pin.lower().startswith("vllm") for pin in pins), (
+        f"requirements-gpu-torch.txt has an actual vllm requirement line ({pins!r}); "
+        "it must stay vLLM-free -- it installs on every GPU host, with or without the "
+        "vLLM opt-in, and must not drag vllm's extra CUDA-toolkit deps"
     )
+
+
+@pytest.mark.parametrize(
+    ("contents", "expect_vllm_pin"),
+    [
+        pytest.param(
+            "\n".join(
+                [
+                    "# vLLM needs CUDA torch; this file provides it independent of vLLM (#15162).",
+                    "# See requirements-gpu.txt for the actual vllm install.",
+                    "torch==2.13.0",
+                    "torchvision==0.28.0  # CUDA build",
+                    "",
+                ]
+            ),
+            False,
+            id="vllm-only-in-prose",
+        ),
+        pytest.param(
+            "\n".join(["torch==2.13.0", "vllm>=0.27.1", ""]),
+            True,
+            id="vllm-as-a-real-requirement-line",
+        ),
+    ],
+)
+def test_requirement_pin_parse_distinguishes_prose_from_a_real_pin(
+    contents: str, expect_vllm_pin: bool
+) -> None:
+    """#15162 review: pins the exact regression a whole-text substring check invited.
+
+    A comment naming ``vllm`` (documenting the decoupling this file exists for)
+    must never fail the vLLM-free check; an actual ``vllm`` requirement line
+    always must. Both halves are asserted so neither direction can go quietly
+    wrong: a parse that is too eager passes the first case for the wrong reason,
+    one that is too lax passes the second for the wrong reason.
+    """
+    pins = _requirement_pins(contents)
+    has_vllm_pin = any(pin.lower().startswith("vllm") for pin in pins)
+    assert has_vllm_pin is expect_vllm_pin, (
+        f"parsed pins {pins!r} from {contents!r}; expected a vllm pin={expect_vllm_pin}"
+    )
+    # The trailing-comment shape used throughout this repo's requirements files
+    # (`torch==2.13.0  # CUDA build`) must still parse to a bare pin.
+    assert not any("#" in pin for pin in pins), f"a comment leaked into a parsed pin: {pins!r}"
 
 
 def test_requirements_gpu_file_no_longer_pins_torch_directly() -> None:
     """The vLLM-only file must not re-duplicate the CUDA-torch pin split into the new file."""
     assert REQUIREMENTS_GPU_VLLM.is_file(), f"{REQUIREMENTS_GPU_VLLM} missing"
-    lines = [
-        line.split("#", 1)[0].strip()
-        for line in REQUIREMENTS_GPU_VLLM.read_text(encoding="utf-8").splitlines()
-    ]
-    pins = [line for line in lines if line]
+    pins = _requirement_pins(REQUIREMENTS_GPU_VLLM.read_text(encoding="utf-8"))
     assert not any(pin.startswith(("torch==", "torchvision==")) for pin in pins), (
         f"requirements-gpu.txt still pins torch/torchvision directly: {pins!r}; "
         "that pin belongs solely in requirements-gpu-torch.txt (#15162) so the GPU-only "

--- a/requirements-gpu-torch.txt
+++ b/requirements-gpu-torch.txt
@@ -1,0 +1,23 @@
+# CUDA-built torch — OPTIONAL extra, GPU-gated but vLLM-independent (#15162)
+#
+# NOT installed by the default backend image (CPU-only torch, from
+# autobot-backend/requirements.txt, is installed there instead).
+#
+# Fixes #15162: this extra used to be bundled into requirements-gpu.txt,
+# which the ansible backend role only installed when BOTH a GPU was present
+# AND vLLM was explicitly enabled. That coupled two independent decisions —
+# "does this host have an NVIDIA GPU" and "does this host run in-process
+# vLLM" — so a GPU host that left vLLM disabled (the default) silently kept
+# CPU-only torch, with nothing reporting the downgrade. GPU-accelerated code
+# such as autobot-backend/utils/semantic_chunker_gpu.py then ran against a
+# torch build with no CUDA support.
+#
+# The ansible backend role installs this file whenever backend_gpu_available
+# is true, regardless of backend_vllm_enabled. vllm (requirements-gpu.txt)
+# pins the same torch build, so installing both together (GPU + vLLM
+# enabled) resolves torch once, not twice.
+#
+# Requires: CUDA-compatible GPU, Python 3.12.
+
+torch==2.13.0
+torchvision==0.28.0

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,10 +1,11 @@
-# GPU / vLLM inference — OPTIONAL extra (#10251)
+# vLLM inference — OPTIONAL extra (#10251, #15162)
 #
 # NOT installed by the default backend image. vLLM provides high-performance
 # in-process LLM inference (3-4x throughput, prefix caching) but requires a
 # CUDA-compatible GPU and pulls the full CUDA toolkit (cuda-toolkit, nvidia-*,
-# flashinfer, CUDA-built torch) — several GB. Installing it into the default
-# CPU image was the cause of image bloat and intermittent CI disk-full failures.
+# flashinfer) — several GB on top of CUDA torch. Installing it into the
+# default CPU image was the cause of image bloat and intermittent CI
+# disk-full failures.
 #
 # Install ONLY on GPU deployments that enable vLLM (config: llm.vllm.enabled = true):
 #     pip install -r requirements-gpu.txt
@@ -13,11 +14,12 @@
 # vllm, so the backend runs normally without this file; the provider only activates
 # when explicitly enabled and installed.
 #
+# CUDA torch itself is NOT pinned here (#15162): it lives in
+# requirements-gpu-torch.txt, which the ansible backend role installs
+# whenever a GPU is present, independent of this vLLM opt-in. vllm pins the
+# same torch build, so pip resolves it as already-satisfied when this file
+# is installed on top.
+#
 # Requires: CUDA-compatible GPU, Python 3.12.
 
 vllm>=0.27.1
-
-# vLLM pins these exact torch builds (CUDA). They intentionally override the
-# CPU torch installed in the default image when this GPU extra is used.
-torch==2.13.0
-torchvision==0.28.0

--- a/tools/lint/check_no_root_clutter.py
+++ b/tools/lint/check_no_root_clutter.py
@@ -73,6 +73,7 @@ ALLOWED_ROOT_FILES: frozenset[str] = frozenset(
         "requirements-ci-test.txt",
         "requirements-dev.txt",
         "requirements-gpu.txt",
+        "requirements-gpu-torch.txt",  # CUDA torch/torchvision extra, split from requirements-gpu.txt (#15162)
     }
 )
 


### PR DESCRIPTION
## Thinking Path

The issue and its comment together locate two couplings, not one. The visible one is at
`autobot-slm-backend/ansible/roles/backend/tasks/main.yml:917-918` (pre-fix numbering): the
CUDA-torch/vllm pip install (`requirements-gpu.txt`) runs only `when: backend_vllm_enabled |
bool and backend_gpu_available | default(false) | bool`. The deeper root cause, recorded in the
issue's one comment (parented under the umbrella #15184), is that `backend_gpu_available` is
itself only ever resolved `when: backend_vllm_enabled | bool` (old `tasks/main.yml:903`), fed by
an `nvidia-smi` probe that is *also* gated `when: backend_vllm_enabled | bool and backend_has_gpu
== "auto"` (old `tasks/main.yml:896-898`). So on a GPU host that leaves vLLM at its default
`false` (`defaults/main.yml:172`), the probe never runs, the fact is never set, `default(false)`
wins, and the CUDA-torch install is unreachable — the venv keeps CPU-only torch from
`autobot-backend/requirements.txt:45`. Fixing only the pip `when:` and leaving the fact behind
the vLLM gate would have left the bug in place one hop up, so all three tasks needed the same
change: detect and resolve GPU presence unconditionally, then let vLLM stay opt-in only for
vllm itself.

## What Changed

- `autobot-slm-backend/ansible/roles/backend/tasks/main.yml`: the `nvidia-smi` probe and the
  `backend_gpu_available` fact now resolve on `backend_has_gpu` alone — no `backend_vllm_enabled`
  in either `when:`. Added a new pip task installing `requirements-gpu-torch.txt` gated solely on
  `backend_gpu_available`. The existing `requirements-gpu.txt` (vllm) install keeps both gates —
  vllm is still genuinely opt-in and still needs a GPU. Added two closing tasks: a `set_fact` that
  computes the two outcome booleans, and a `debug` task that prints the GPU-availability input and
  both outcomes with the reason for each, so a deploy log always states which torch variant was
  chosen and why instead of leaving it to be inferred from performance.
- `requirements-gpu.txt` / `requirements-gpu-torch.txt` (new): split the single GPU manifest into
  the CUDA-torch extra (`torch`, `torchvision` — installed whenever a GPU is present) and the vLLM
  extra (`vllm` only — installed only when vLLM is also enabled). vllm's own dependency graph pins
  the same torch build, so pip resolves it as already-satisfied when both install on the same host.
- `autobot-slm-backend/ansible/roles/backend/defaults/main.yml`: updated the `backend_vllm_enabled`
  / `backend_has_gpu` comment block to describe the two now-independent decisions.
- `tools/lint/check_no_root_clutter.py`: added `requirements-gpu-torch.txt` to the root-clutter
  allowlist (same tooling-contract rationale as the existing `requirements-gpu.txt` entry).
- `repo_tests/backend_gpu_torch_gating_test.py` (new): parses the real ansible task list (walking
  `block`/`rescue`/`always`, per the existing `llc_agent_cli_provisioned_test.py` pattern) and
  asserts on the actual `when:` conditions and requirement-file contents.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` on both edited ansible YAML files — parses clean.
- `python3 compile(...)` on the edited/added Python files — parses clean.
- Line-length check (`awk 'length($0) > 120'`) on the touched region of `tasks/main.yml` — no new
  violations; the one pre-existing >120-char line (old `torch` set_fact) is untouched, confirmed
  identical against `origin/Dev_new_gui`.
- Mutation proving the new test fires: reintroduced the old coupling by adding
  `backend_vllm_enabled | bool` back into the CUDA-torch install task's `when:` in a throwaway copy
  of the file, re-parsed it with the same walker `backend_gpu_torch_gating_test.py` uses, and
  re-ran the assertion inline — it raised `AssertionError: TEST WOULD FAIL (as intended) -- vllm
  coupling detected`, i.e. `test_cuda_torch_install_is_gated_on_gpu_only` fails exactly when the
  regression is reintroduced. `test_gpu_probe_is_not_gated_on_vllm` and
  `test_gpu_availability_fact_is_not_gated_on_vllm` fire the same way against the two upstream
  couplings.
- Did not run ansible, deploy, install any package, or execute code from the codebase, per the
  task constraints; CI is the judge of record for this PR.

What the deploy now prints (both booleans and the reason for each outcome), from the new
`debug` task's `msg:`:

```
GPU deploy decision: gpu_available=<bool> (backend_has_gpu=<auto|true|false>) ->
cuda_torch=<installed|skipped (no GPU detected)>;
vllm_enabled=<bool> ->
vllm=<installed|skipped (vLLM disabled)|skipped (no GPU detected)>
```

## Model Used

Claude Sonnet 5

Closes #15162
