### PR TITLE
security(docs): replace fleet node addressing in the documentation the #3315 sweep missed (#15208)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -525,7 +525,7 @@ jobs:
         # role placeholders. Nothing watched the rest of the tree: the same addressing --
         # role-to-host mappings and database endpoints, which together read as a network
         # map -- survived in docs/archives/plans/ one folder across, because
-        # HV_SCAN_EXTENSIONS in scripts/lib/hardcoded-value-rules.sh is
+        # HV_SCAN_EXTENSIONS in `scripts/lib/hardcoded-value-rules.sh` is
         # py|ts|vue|js|sh|yml|yaml and Markdown is not in it. This has to run in a
         # REQUIRED check for the same directional reason as #14419/#14405/#14489: a
         # document that stops being scanned reports fewer findings, so the failure goes

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,7 +34,14 @@ on:
       # so the guard could not fire on the change it exists to catch.
       - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
       - '.github/actions/**'
-      - 'docs/developer/**'
+      # #15208: the documentation fleet-addressing guard reads every Markdown file
+      # under docs/ and takes its pattern from scripts/lib/hardcoded-value-rules.sh.
+      # 'docs/developer/**' (added for the guards that read that folder) is subsumed
+      # by 'docs/**'. Without the wider entry a docs-only PR -- the exact shape that
+      # reintroduces an address -- skips code-quality, and a skipped required job
+      # satisfies branch protection.
+      - 'docs/**'
+      - 'scripts/lib/**'
       - '.github/workflows/code-quality.yml'
   # NOTE: no pull_request.paths filter — this workflow ALWAYS runs on PRs so its
   # required-check context ("code-quality") always reports a conclusion. A
@@ -89,7 +96,10 @@ jobs:
               - 'autobot-backend/static/error_messages.yaml'
               - 'autobot-slm-backend/ansible/roles/backend/tasks/**'
               - '.github/actions/**'
-              - 'docs/developer/**'
+              # #15208: see the on.push.paths list above -- docs/ and the shared rule
+              # set are the documentation guard's inputs.
+              - 'docs/**'
+              - 'scripts/lib/**'
               - '.github/workflows/code-quality.yml'
 
   code-quality:
@@ -508,6 +518,24 @@ jobs:
         # literals (#13658) by path, anchor symbol and exact count, so a rename
         # cannot strand an exemption. There is no growable baseline.
         python3 tools/lint/check_no_shell_placeholder_paths.py --audit
+
+    - name: Audit documentation for fleet node addressing (#15208)
+      run: |
+        # #3315 replaced the fleet's literal node addresses in docs/architecture/ with
+        # role placeholders. Nothing watched the rest of the tree: the same addressing --
+        # role-to-host mappings and database endpoints, which together read as a network
+        # map -- survived in docs/archives/plans/ one folder across, because
+        # HV_SCAN_EXTENSIONS in scripts/lib/hardcoded-value-rules.sh is
+        # py|ts|vue|js|sh|yml|yaml and Markdown is not in it. This has to run in a
+        # REQUIRED check for the same directional reason as #14419/#14405/#14489: a
+        # document that stops being scanned reports fewer findings, so the failure goes
+        # greener rather than redder. It parses its pattern out of the shared rule set
+        # rather than restating it, aborts if that cannot be read, and fails below a
+        # discovery floor -- #15208 exists because a sweep that never looked at
+        # docs/archives/ reported a comfortable zero. Deliberate counter-examples are
+        # exempted by an in-document block marker, and a marker covering no address is
+        # itself a finding, so no exemption outlives its reason.
+        python3 tools/lint/check_docs_no_fleet_addressing.py --audit
 
     - name: Audit MCP tool permission coverage (#14494)
       run: |

--- a/docs/archives/_index.md
+++ b/docs/archives/_index.md
@@ -19,3 +19,21 @@ Dated design and implementation plans — see [plans/_index.md](plans/_index.md)
 | Document | Description |
 | --- | --- |
 | [changelog_20250822](changelog_20250822.md) | Session changelog from August 2025 |
+
+## Addressing in these documents was redacted after archival (#15208)
+
+Every plan under `plans/` was written before the placeholder convention #3315 introduced
+existed, and each one named the fleet's nodes by literal address — including
+role-to-host assignments and database endpoints, which together describe the network
+rather than any one machine. #15208 replaced those literals with the role placeholders
+defined in [../architecture/VM_ROLES.md](../architecture/VM_ROLES.md), the same form and
+the same names #3315 applied to the live documentation.
+
+Read them accordingly: **the placeholders are not what the original documents said.**
+Where an archived plan quotes source code, a configuration file or a command, a
+placeholder stands in for a literal the historical artifact contained. Nothing else in
+these documents was altered — no text was removed, and no value was blanked, so each plan
+still explains the layout it was written to explain.
+
+`tools/lint/check_docs_no_fleet_addressing.py` keeps the archives in scope from now on,
+which they were not during #3315.

--- a/docs/archives/plans/2026-01-14-service-lifecycle-manager-design.md
+++ b/docs/archives/plans/2026-01-14-service-lifecycle-manager-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Service Lifecycle Manager (SLM) Design
 
 > **Status**: Draft
@@ -20,7 +22,7 @@ Service Lifecycle Manager (SLM) is a dedicated admin machine that orchestrates t
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                   Admin Machine (new VM)                     │
-│                     172.16.168.10                            │
+│                     <slm-manager-ip>                        │
 │  ┌─────────────────────────────────────────────────────┐    │
 │  │         Service Lifecycle Manager (SLM)             │    │
 │  │  - FastAPI backend (admin-only)                     │    │
@@ -463,7 +465,7 @@ Phase 5: SWITCHBACK + CLEANUP
 2. **Run Bootstrap Script**: Installs Python, Ansible, SLM, PKI CA
 3. **Configure**: Edit `/opt/autobot-admin/config/admin.yaml`
 4. **Start Services**: `systemctl start autobot-slm autobot-reconciler`
-5. **Access UI**: `https://172.16.168.10:8443` - setup wizard
+5. **Access UI**: `https://<slm-manager-ip>:8443` - setup wizard
 
 ### Directory Structure
 
@@ -565,7 +567,7 @@ Phase 5: SWITCHBACK + CLEANUP
 
 - [x] Vue admin dashboard (`slm-admin/`)
   - Standalone Vue 3 + TypeScript + Tailwind application
-  - Deployed on 172.16.168.19 (dedicated admin host)
+  - Deployed on <slm-manager-ip> (dedicated admin host)
   - Multi-page SPA with sidebar navigation
 - [x] Fleet overview with real-time health status
   - NodeCard with health metrics and quick actions

--- a/docs/archives/plans/2026-01-14-slm-phase1-implementation.md
+++ b/docs/archives/plans/2026-01-14-slm-phase1-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Service Lifecycle Manager - Phase 1 Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -78,7 +80,7 @@ class TestSLMNodeModel:
         node = SLMNode(
             id="node-001",
             name="redis-vm",
-            ip_address="172.16.168.23",
+            ip_address="<database-ip>",
             state=NodeState.PENDING.value,
             current_role="redis",
             capability_tags=["can_be_redis", "has_ssd"],
@@ -97,7 +99,7 @@ class TestSLMNodeModel:
         node = SLMNode(
             id="node-002",
             name="frontend-vm",
-            ip_address="172.16.168.21",
+            ip_address="<frontend-ip>",
             state=NodeState.ONLINE.value,
         )
         db_session.add(node)
@@ -749,14 +751,14 @@ class TestSLMNodeCRUD:
 
     def test_get_node_by_name(self, slm_db):
         """Test retrieving node by name."""
-        slm_db.create_node(name="redis-vm", ip_address="172.16.168.23")
+        slm_db.create_node(name="redis-vm", ip_address="<database-ip>")
         node = slm_db.get_node_by_name("redis-vm")
         assert node is not None
-        assert node.ip_address == "172.16.168.23"
+        assert node.ip_address == "<database-ip>"
 
     def test_update_node_state(self, slm_db):
         """Test updating node state with transition logging."""
-        node = slm_db.create_node(name="frontend-vm", ip_address="172.16.168.21")
+        node = slm_db.create_node(name="frontend-vm", ip_address="<frontend-ip>")
         slm_db.update_node_state(
             node.id,
             NodeState.PENDING,
@@ -768,7 +770,7 @@ class TestSLMNodeCRUD:
 
     def test_state_transition_logged(self, slm_db):
         """Test that state transitions are logged."""
-        node = slm_db.create_node(name="npu-vm", ip_address="172.16.168.22")
+        node = slm_db.create_node(name="npu-vm", ip_address="<npu-ip>")
         slm_db.update_node_state(node.id, NodeState.PENDING, trigger="api")
 
         transitions = slm_db.get_state_transitions(node.id)
@@ -1474,7 +1476,7 @@ from src.slm.agent.health_collector import HealthCollector
 logger = logging.getLogger(__name__)
 
 # Default configuration
-DEFAULT_ADMIN_URL = "https://172.16.168.10:8443"
+DEFAULT_ADMIN_URL = "https://<slm-manager-ip>:8443"
 DEFAULT_HEARTBEAT_INTERVAL = 30  # seconds
 DEFAULT_BUFFER_DB = "/var/lib/autobot-agent/events.db"
 
@@ -1746,7 +1748,7 @@ mkdir -p ansible/roles/slm_agent/{tasks,templates,defaults,handlers}
 # ansible/roles/slm_agent/defaults/main.yml
 ---
 # SLM Agent configuration defaults
-slm_admin_url: "https://172.16.168.10:8443"
+slm_admin_url: "https://<slm-manager-ip>:8443"
 slm_heartbeat_interval: 30
 slm_agent_user: autobot
 slm_agent_group: autobot

--- a/docs/archives/plans/2026-01-15-slm-admin-ui-design.md
+++ b/docs/archives/plans/2026-01-15-slm-admin-ui-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM Admin UI Design
 
 > Phase 5 of Service Lifecycle Manager (Issue #726)
@@ -9,7 +11,7 @@ The SLM Admin UI is a standalone Vue 3 application providing a dedicated managem
 ## Architecture Decisions
 
 ### Deployment
-- **Host:** 172.16.168.19 (dedicated admin machine)
+- **Host:** <slm-manager-ip> (dedicated admin machine)
 - **Credentials:** autobot:autobot
 - **Port:** 5174 (to avoid conflicts)
 - **Directory:** `/home/kali/Desktop/AutoBot/slm-admin/`
@@ -173,7 +175,7 @@ export function useSlmWebSocket() {
   const events = ref<SLMEvent[]>([])
 
   const connect = () => {
-    socket.value = new WebSocket('wss://172.16.168.20:8443/v1/slm/ws')
+    socket.value = new WebSocket('wss://<backend-ip>:8443/v1/slm/ws')
     // Handle messages, reconnection, etc.
   }
 
@@ -300,7 +302,7 @@ slm-admin/
 - Adapt for standalone deployment
 
 ### Step 8: Deployment Script
-- Create sync script for 172.16.168.19
+- Create sync script for <slm-manager-ip>
 - Configure nginx/serve for production
 - Test end-to-end functionality
 
@@ -321,7 +323,7 @@ The Admin UI depends on these backend endpoints (all implemented in Phases 1-4):
 
 ## Success Criteria
 
-1. ✅ Standalone Vue 3 app running on 172.16.168.19
+1. ✅ Standalone Vue 3 app running on <slm-manager-ip>
 2. ✅ Real-time fleet health visualization
 3. ✅ Deployment wizard with Ansible integration
 4. ✅ Backup/restore functionality

--- a/docs/archives/plans/2026-01-15-slm-startup-procedure-design.md
+++ b/docs/archives/plans/2026-01-15-slm-startup-procedure-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM Startup Procedure Design
 
 > **Status**: Draft
@@ -10,14 +12,14 @@ This document defines the new simplified startup procedure for AutoBot where the
 
 ## Architecture
 
-### Admin Machine (172.16.168.19)
+### Admin Machine (<slm-manager-ip>)
 
 The admin machine is a clean, dedicated management host running only SLM-related services.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                 SLM Admin Machine                        │
-│                   172.16.168.19                          │
+│                   <slm-manager-ip>                      │
 │                                                          │
 │  ┌─────────────────┐  ┌─────────────────┐               │
 │  │  SLM Backend    │  │  SLM Admin UI   │               │
@@ -49,30 +51,30 @@ The admin machine is a clean, dedicated management host running only SLM-related
 ### Fleet Architecture
 
 ```
-172.16.168.19 (Admin/Management)
+<slm-manager-ip> (Admin/Management)
 ├── SLM Backend + Admin UI
 ├── Grafana + Prometheus (default, portable)
 ├── Ansible controller
 ├── SQLite state DB
 └── Full AutoBot codebase (distribution source)
 
-172.16.168.20 (Main AutoBot) - deployed via SLM
+<backend-ip> (Main AutoBot) - deployed via SLM
 ├── AutoBot Backend (chat, agents, LLM, etc.)
 └── VNC server
 
-172.16.168.21 (Frontend) - deployed via SLM
+<frontend-ip> (Frontend) - deployed via SLM
 └── AutoBot Vue frontend
 
-172.16.168.22 (NPU Worker) - deployed via SLM
+<npu-ip> (NPU Worker) - deployed via SLM
 └── Hardware AI acceleration
 
-172.16.168.23 (Redis) - deployed via SLM
+<database-ip> (Redis) - deployed via SLM
 └── Redis database
 
-172.16.168.24 (AI Stack) - deployed via SLM
+<aiml-ip> (AI Stack) - deployed via SLM
 └── Ollama / AI processing
 
-172.16.168.25 (Browser) - deployed via SLM
+<browser-ip> (Browser) - deployed via SLM
 └── Playwright automation
 ```
 
@@ -150,7 +152,7 @@ Minimal set (~10 packages):
          └──► slm-admin-ui.service (port 5174)
          │
          ▼
-3. Admin opens https://172.16.168.19/
+3. Admin opens https://<slm-manager-ip>/
          │
          ▼
 4. Login with admin credentials
@@ -239,8 +241,8 @@ WantedBy=slm.target
 ```
 External Access (nginx HTTPS :443)
 ─────────────────────────────────────
-https://172.16.168.19/         → SLM Admin UI
-https://172.16.168.19/api/     → SLM Backend
+https://<slm-manager-ip>/         → SLM Admin UI
+https://<slm-manager-ip>/api/     → SLM Backend
 
 Internal Only (localhost)
 ─────────────────────────────────────
@@ -251,7 +253,7 @@ Internal Only (localhost)
 ### Authentication Layers
 
 1. **Network**: Admin machine accessible only from trusted sources
-   - Dev machine (172.16.168.20)
+   - Dev machine (<backend-ip>)
    - Local network / VPN
    - Optional IP whitelist during install
 
@@ -271,7 +273,7 @@ Internal Only (localhost)
 ```nginx
 server {
     listen 443 ssl;
-    server_name 172.16.168.19;
+    server_name <slm-manager-ip>;
 
     ssl_certificate /etc/ssl/slm/cert.pem;
     ssl_certificate_key /etc/ssl/slm/key.pem;
@@ -334,7 +336,7 @@ SLM GUI: Settings → Monitoring → Location
 
 **Scenario A: All-in-one (default)**
 ```
-172.16.168.19 (Admin)
+<slm-manager-ip> (Admin)
 ├── SLM Backend + UI
 ├── Grafana (proxied through SLM)
 └── Prometheus (proxied through SLM)
@@ -342,7 +344,7 @@ SLM GUI: Settings → Monitoring → Location
 
 **Scenario B: Separate monitoring host**
 ```
-172.16.168.19 (Admin)
+<slm-manager-ip> (Admin)
 ├── SLM Backend + UI
 └── Points to external monitoring
 
@@ -394,7 +396,7 @@ prometheus_url: "http://..."
 
 [1/6] Code source:
   1) Clone from GitHub (mrveiss/AutoBot-AI)
-  2) Sync from dev machine (172.16.168.20)
+  2) Sync from dev machine (<backend-ip>)
   > 1
 
 [2/6] Branch/version:
@@ -443,7 +445,7 @@ install-slm.sh
 14. Enable and start slm.target
 15. Print access URL + credentials
 ─────────────────────────────────────
-Done! Access SLM at https://172.16.168.19/
+Done! Access SLM at https://<slm-manager-ip>/
 ```
 
 ### Unattended Defaults

--- a/docs/archives/plans/2026-01-29-issue-694-config-consolidation.md
+++ b/docs/archives/plans/2026-01-29-issue-694-config-consolidation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Issue #694: Full Configuration Consolidation Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -34,7 +36,7 @@ if [ -f "$PROJECT_ROOT/.env" ]; then
     set -a && source "$PROJECT_ROOT/.env" && set +a
 fi
 # Use env vars with fallbacks
-REMOTE_HOST="${AUTOBOT_FRONTEND_HOST:-172.16.168.21}"
+REMOTE_HOST="${AUTOBOT_FRONTEND_HOST:-<frontend-ip>}"
 ```
 
 ---
@@ -96,12 +98,12 @@ Replace lines 237-245:
 ```python
 # VM definitions for certificate generation
 VM_DEFINITIONS: Dict[str, str] = {
-    "main-host": "172.16.168.20",
-    "frontend": "172.16.168.21",
-    "npu-worker": "172.16.168.22",
-    "redis": "172.16.168.23",
-    "ai-stack": "172.16.168.24",
-    "browser": "172.16.168.25",
+    "main-host": "<backend-ip>",
+    "frontend": "<frontend-ip>",
+    "npu-worker": "<npu-ip>",
+    "redis": "<database-ip>",
+    "ai-stack": "<aiml-ip>",
+    "browser": "<browser-ip>",
 }
 ```
 
@@ -117,12 +119,12 @@ def _get_vm_definitions() -> Dict[str, str]:
     except Exception:
         # Fallback for standalone PKI tool usage
         return {
-            "main-host": "172.16.168.20",
-            "frontend": "172.16.168.21",
-            "npu-worker": "172.16.168.22",
-            "redis": "172.16.168.23",
-            "ai-stack": "172.16.168.24",
-            "browser": "172.16.168.25",
+            "main-host": "<backend-ip>",
+            "frontend": "<frontend-ip>",
+            "npu-worker": "<npu-ip>",
+            "redis": "<database-ip>",
+            "ai-stack": "<aiml-ip>",
+            "browser": "<browser-ip>",
         }
 
 VM_DEFINITIONS: Dict[str, str] = _get_vm_definitions()
@@ -159,9 +161,9 @@ def _get_default_postgres_host() -> str:
         from src.config.ssot_config import get_config
         config = get_config()
         # PostgreSQL typically runs on Redis VM in AutoBot architecture
-        return config.vm.redis if config else "172.16.168.23"
+        return config.vm.redis if config else "<database-ip>"
     except Exception:
-        return "172.16.168.23"
+        return "<database-ip>"
 ```
 
 With:
@@ -170,7 +172,7 @@ def _get_default_postgres_host() -> str:
     """
     Get default PostgreSQL host from SSOT config.
 
-    PostgreSQL runs on the Redis VM (172.16.168.23) in AutoBot architecture.
+    PostgreSQL runs on the Redis VM (<database-ip>) in AutoBot architecture.
     Issue #694: Config consolidation - uses SSOT with proper fallback.
     """
     try:
@@ -179,7 +181,7 @@ def _get_default_postgres_host() -> str:
     except Exception:
         # Fallback only if SSOT config completely unavailable
         import os
-        return os.getenv("AUTOBOT_REDIS_HOST", "172.16.168.23")
+        return os.getenv("AUTOBOT_REDIS_HOST", "<database-ip>")
 ```
 
 **Step 2: Run syntax check**
@@ -221,13 +223,13 @@ Replace lines 133-156 (the infrastructure section):
 ```python
             "infrastructure": {
                 "hosts": {
-                    "backend": "172.16.168.20",
-                    "frontend": "172.16.168.21",
-                    "redis": "172.16.168.23",
-                    "ollama": "172.16.168.20",
-                    "ai_stack": "172.16.168.24",
-                    "npu_worker": "172.16.168.22",
-                    "browser_service": "172.16.168.25"
+                    "backend": "<backend-ip>",
+                    "frontend": "<frontend-ip>",
+                    "redis": "<database-ip>",
+                    "ollama": "<backend-ip>",
+                    "ai_stack": "<aiml-ip>",
+                    "npu_worker": "<npu-ip>",
+                    "browser_service": "<browser-ip>"
                 },
                 "ports": {
                     "backend": 8001,
@@ -286,13 +288,13 @@ Add after `_load_default_config` method:
         # Fallback defaults
         return {
             "hosts": {
-                "backend": "172.16.168.20",
-                "frontend": "172.16.168.21",
-                "redis": "172.16.168.23",
+                "backend": "<backend-ip>",
+                "frontend": "<frontend-ip>",
+                "redis": "<database-ip>",
                 "ollama": "127.0.0.1",
-                "ai_stack": "172.16.168.24",
-                "npu_worker": "172.16.168.22",
-                "browser_service": "172.16.168.25",
+                "ai_stack": "<aiml-ip>",
+                "npu_worker": "<npu-ip>",
+                "browser_service": "<browser-ip>",
             },
             "ports": {
                 "backend": 8001,
@@ -582,12 +584,12 @@ fi
 # =============================================================================
 # VM Configuration (with fallbacks matching ssot_config.py)
 # =============================================================================
-AUTOBOT_BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-172.16.168.20}"
-AUTOBOT_FRONTEND_HOST="${AUTOBOT_FRONTEND_HOST:-172.16.168.21}"
-AUTOBOT_NPU_WORKER_HOST="${AUTOBOT_NPU_WORKER_HOST:-172.16.168.22}"
-AUTOBOT_REDIS_HOST="${AUTOBOT_REDIS_HOST:-172.16.168.23}"
-AUTOBOT_AI_STACK_HOST="${AUTOBOT_AI_STACK_HOST:-172.16.168.24}"
-AUTOBOT_BROWSER_SERVICE_HOST="${AUTOBOT_BROWSER_SERVICE_HOST:-172.16.168.25}"
+AUTOBOT_BACKEND_HOST="${AUTOBOT_BACKEND_HOST:-<backend-ip>}"
+AUTOBOT_FRONTEND_HOST="${AUTOBOT_FRONTEND_HOST:-<frontend-ip>}"
+AUTOBOT_NPU_WORKER_HOST="${AUTOBOT_NPU_WORKER_HOST:-<npu-ip>}"
+AUTOBOT_REDIS_HOST="${AUTOBOT_REDIS_HOST:-<database-ip>}"
+AUTOBOT_AI_STACK_HOST="${AUTOBOT_AI_STACK_HOST:-<aiml-ip>}"
+AUTOBOT_BROWSER_SERVICE_HOST="${AUTOBOT_BROWSER_SERVICE_HOST:-<browser-ip>}"
 
 # Port Configuration
 AUTOBOT_BACKEND_PORT="${AUTOBOT_BACKEND_PORT:-8001}"
@@ -698,11 +700,11 @@ Replace lines 14-24:
 SSH_KEY="$HOME/.ssh/autobot_key"
 SSH_USER="autobot"
 declare -A VMS=(
-    ["frontend"]="172.16.168.21"
-    ["npu-worker"]="172.16.168.22"
-    ["redis"]="172.16.168.23"
-    ["ai-stack"]="172.16.168.24"
-    ["browser"]="172.16.168.25"
+    ["frontend"]="<frontend-ip>"
+    ["npu-worker"]="<npu-ip>"
+    ["redis"]="<database-ip>"
+    ["ai-stack"]="<aiml-ip>"
+    ["browser"]="<browser-ip>"
 )
 ```
 
@@ -721,7 +723,7 @@ SSH_USER="$AUTOBOT_SSH_USER"
 
 **Step 2: Update hardcoded IPs in function bodies**
 
-Replace all instances like `172.16.168.21` with `${VMS["frontend"]}` etc.
+Replace all instances like `<frontend-ip>` with `${VMS["frontend"]}` etc.
 
 **Step 3: Apply same pattern to status-all-vms.sh and stop-all-vms.sh**
 
@@ -769,12 +771,12 @@ source "$SCRIPT_DIR/lib/ssot-config.sh" 2>/dev/null || source "$SCRIPT_DIR/../li
 ```
 
 2. Replace hardcoded IPs:
-   - `172.16.168.20` → `${AUTOBOT_BACKEND_HOST:-172.16.168.20}`
-   - `172.16.168.21` → `${AUTOBOT_FRONTEND_HOST:-172.16.168.21}`
-   - `172.16.168.22` → `${AUTOBOT_NPU_WORKER_HOST:-172.16.168.22}`
-   - `172.16.168.23` → `${AUTOBOT_REDIS_HOST:-172.16.168.23}`
-   - `172.16.168.24` → `${AUTOBOT_AI_STACK_HOST:-172.16.168.24}`
-   - `172.16.168.25` → `${AUTOBOT_BROWSER_SERVICE_HOST:-172.16.168.25}`
+   - `<backend-ip>` → `${AUTOBOT_BACKEND_HOST:-<backend-ip>}`
+   - `<frontend-ip>` → `${AUTOBOT_FRONTEND_HOST:-<frontend-ip>}`
+   - `<npu-ip>` → `${AUTOBOT_NPU_WORKER_HOST:-<npu-ip>}`
+   - `<database-ip>` → `${AUTOBOT_REDIS_HOST:-<database-ip>}`
+   - `<aiml-ip>` → `${AUTOBOT_AI_STACK_HOST:-<aiml-ip>}`
+   - `<browser-ip>` → `${AUTOBOT_BROWSER_SERVICE_HOST:-<browser-ip>}`
 
 **Commit after each batch of 3-4 scripts:**
 

--- a/docs/archives/plans/2026-01-29-port-cleanup-targets.md
+++ b/docs/archives/plans/2026-01-29-port-cleanup-targets.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Port Cleanup Targets for Issue #725
 
 **Related to:** mTLS Service Authentication Migration
@@ -15,7 +17,7 @@ Remove stale port references (8000, 8090) from main-host and clean up unused con
 
 ### 1. Firewall Port Ranges (via SLM/SSOT Config)
 
-**Note:** Ansible inventory files contain template values (192.168.100.0/24). The actual production network (172.16.168.0/24) is configured via SLM and SSOT config.
+**Note:** Ansible inventory files contain template values (192.168.100.0/24). The actual production network (<network-subnet>) is configured via SLM and SSOT config.
 
 **Port ranges to clean up via SLM firewall management:**
 

--- a/docs/archives/plans/2026-01-31-cache-coordinator-design.md
+++ b/docs/archives/plans/2026-01-31-cache-coordinator-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Cache Coordinator Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
@@ -470,11 +472,11 @@ async def clear_cache(cache_name: str):
 **Step 2: Test endpoints**
 
 ```bash
-# Use SSOT backend URL (172.16.168.20:8443 from config.backend_url)
+# Use SSOT backend URL (<backend-ip>:8443 from config.backend_url)
 curl http://$(python -c "from src.config.ssot_config import config; print(f'{config.vm.main}:{config.port.backend}')")/api/cache/stats
 
 # Or directly if you know the IP:
-curl https://172.16.168.20:8443/api/cache/stats
+curl https://<backend-ip>:8443/api/cache/stats
 ```
 
 **Step 3: Commit**
@@ -550,11 +552,11 @@ print(c.get_unified_stats())
 
 ```bash
 # Test API endpoint
-# Use SSOT backend URL (172.16.168.20:8443 from config.backend_url)
+# Use SSOT backend URL (<backend-ip>:8443 from config.backend_url)
 curl http://$(python -c "from src.config.ssot_config import config; print(f'{config.vm.main}:{config.port.backend}')")/api/cache/stats
 
 # Or directly if you know the IP:
-curl https://172.16.168.20:8443/api/cache/stats | jq
+curl https://<backend-ip>:8443/api/cache/stats | jq
 
 # Test SSOT config loading
 python -c "

--- a/docs/archives/plans/2026-02-02-agent-llm-config-implementation.md
+++ b/docs/archives/plans/2026-02-02-agent-llm-config-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Agent LLM Configuration Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -1002,7 +1004,7 @@ from services.slm_client import init_slm_client, shutdown_slm_client
 In lifespan startup:
 ```python
 # Initialize SLM client for agent config (Issue #760)
-slm_url = os.getenv("SLM_URL", "http://172.16.168.19:8000")
+slm_url = os.getenv("SLM_URL", "http://<slm-manager-ip>:8000")
 slm_token = os.getenv("SLM_AUTH_TOKEN")
 await init_slm_client(slm_url, slm_token)
 logger.info("SLM client initialized")

--- a/docs/archives/plans/2026-02-02-config-registry-consolidation-design.md
+++ b/docs/archives/plans/2026-02-02-config-registry-consolidation-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Config Registry Consolidation Design
 
 > **Issue:** [#751 - Consolidate Common Utilities](https://github.com/mrveiss/AutoBot-AI/issues/751)
@@ -35,7 +37,7 @@ ConfigRegistry.get_section("redis")                 # Full section as dict
 ConfigRegistry.get("redis.port", default=6379)      # With fallback
 
 # Writing config (admin/startup only)
-ConfigRegistry.set("redis.host", "172.16.168.23")
+ConfigRegistry.set("redis.host", "<database-ip>")
 ConfigRegistry.set_section("redis", {"host": "...", "port": 6379})
 
 # Cache management
@@ -46,7 +48,7 @@ ConfigRegistry.clear_cache()                        # Clear all cached
 ### Redis Storage Structure
 
 ```
-autobot:config:redis.host     → "172.16.168.23"
+autobot:config:redis.host     → "<database-ip>"
 autobot:config:redis.port     → "6379"
 autobot:config:backend.port   → "8001"
 autobot:config:*              → (namespace prefix for all config)
@@ -69,14 +71,14 @@ Redis (autobot:config:*)
     ↓ (if unavailable/missing)
 Environment Variable (AUTOBOT_REDIS_HOST)
     ↓ (if not set)
-Hardcoded Default (172.16.168.23)
+Hardcoded Default (<database-ip>)
 ```
 
 ### Key Naming Convention
 
 | Config Key | Env Variable | Default |
 |------------|--------------|---------|
-| `redis.host` | `AUTOBOT_REDIS_HOST` | `172.16.168.23` |
+| `redis.host` | `AUTOBOT_REDIS_HOST` | `<database-ip>` |
 | `redis.port` | `AUTOBOT_REDIS_PORT` | `6379` |
 | `backend.port` | `AUTOBOT_BACKEND_PORT` | `8001` |
 
@@ -156,7 +158,7 @@ def get(cls, key: str, default=None):
 
 1. **Single source of truth across all VMs** - All 6 services read from same Redis config
 2. **Runtime reconfiguration** - Update config in Redis without service restarts
-3. **Uses existing infrastructure** - Leverages Redis at 172.16.168.23
+3. **Uses existing infrastructure** - Leverages Redis at <database-ip>
 4. **Deferred resolution** - Solves circular import problem elegantly
 5. **Extensible** - Pattern extends naturally to service discovery
 

--- a/docs/archives/plans/2026-02-02-config-registry-implementation.md
+++ b/docs/archives/plans/2026-02-02-config-registry-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Config Registry Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -80,7 +82,7 @@ USAGE:
     from src.config.registry import ConfigRegistry
 
     # Get single value with fallback
-    redis_host = ConfigRegistry.get("redis.host", "172.16.168.23")
+    redis_host = ConfigRegistry.get("redis.host", "<database-ip>")
 
     # Get section as dict
     redis_config = ConfigRegistry.get_section("redis")
@@ -242,7 +244,7 @@ git commit -m "feat(config): add ConfigRegistry core with basic get (#751)"
 
         with patch.object(ConfigRegistry, "_fetch_from_redis", return_value=None):
             with patch.dict(os.environ, {"AUTOBOT_REDIS_HOST": "10.0.0.99"}, clear=True):
-                result = ConfigRegistry.get("redis.host", default="172.16.168.23")
+                result = ConfigRegistry.get("redis.host", default="<database-ip>")
                 assert result == "10.0.0.99"
 
     def test_env_var_key_conversion(self):
@@ -383,7 +385,7 @@ class TestConfigRegistrySections:
 
         # Pre-populate cache with section values
         ConfigRegistry._cache = {
-            "redis.host": "172.16.168.23",
+            "redis.host": "<database-ip>",
             "redis.port": "6379",
             "redis.database": "0",
             "backend.port": "8001",
@@ -394,7 +396,7 @@ class TestConfigRegistrySections:
 
         result = ConfigRegistry.get_section("redis")
         assert result == {
-            "host": "172.16.168.23",
+            "host": "<database-ip>",
             "port": "6379",
             "database": "0",
         }
@@ -516,7 +518,7 @@ class TestConfigRegistryDefaults:
             with patch.dict(os.environ, {}, clear=True):
                 # Should get default from registry_defaults
                 result = ConfigRegistry.get("redis.host")
-                assert result == "172.16.168.23"
+                assert result == "<database-ip>"
 ```
 
 ### Step 2: Run test to verify it fails
@@ -545,25 +547,25 @@ Issue: #751 - Consolidate Common Utilities
 # VM IP addresses (6-VM distributed architecture)
 REGISTRY_DEFAULTS = {
     # VM IPs
-    "vm.main": "172.16.168.20",
-    "vm.frontend": "172.16.168.21",
-    "vm.npu": "172.16.168.22",
-    "vm.redis": "172.16.168.23",
-    "vm.aistack": "172.16.168.24",
-    "vm.browser": "172.16.168.25",
+    "vm.main": "<backend-ip>",
+    "vm.frontend": "<frontend-ip>",
+    "vm.npu": "<npu-ip>",
+    "vm.redis": "<database-ip>",
+    "vm.aistack": "<aiml-ip>",
+    "vm.browser": "<browser-ip>",
     "vm.ollama": "127.0.0.1",
     # Convenience aliases
-    "redis.host": "172.16.168.23",
+    "redis.host": "<database-ip>",
     "redis.port": "6379",
-    "backend.host": "172.16.168.20",
+    "backend.host": "<backend-ip>",
     "backend.port": "8001",
-    "frontend.host": "172.16.168.21",
+    "frontend.host": "<frontend-ip>",
     "frontend.port": "5173",
-    "npu.host": "172.16.168.22",
+    "npu.host": "<npu-ip>",
     "npu.port": "8081",
-    "aistack.host": "172.16.168.24",
+    "aistack.host": "<aiml-ip>",
     "aistack.port": "8080",
-    "browser.host": "172.16.168.25",
+    "browser.host": "<browser-ip>",
     "browser.port": "3000",
     # LLM defaults
     "llm.default_model": "qwen3.5:9b",
@@ -664,7 +666,7 @@ Key changes:
 - Remove `def _get_ssot_config()` function (~20 lines)
 - Remove `_ssot = _get_ssot_config()` line
 - Add `from src.config.registry import ConfigRegistry`
-- Replace `_ssot.redis.host if _ssot else "172.16.168.23"` with `ConfigRegistry.get("redis.host", "172.16.168.23")`
+- Replace `_ssot.redis.host if _ssot else "<database-ip>"` with `ConfigRegistry.get("redis.host", "<database-ip>")`
 
 ### Step 3: Run existing tests to verify no regression
 
@@ -979,7 +981,7 @@ For simple config access without full SSOT initialization:
 ```python
 from src.config.registry import ConfigRegistry
 
-redis_host = ConfigRegistry.get("redis.host", "172.16.168.23")
+redis_host = ConfigRegistry.get("redis.host", "<database-ip>")
 ```
 ```
 

--- a/docs/archives/plans/2026-02-02-phase3-implementation.md
+++ b/docs/archives/plans/2026-02-02-phase3-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Phase 3: Service Discovery & Agent Config Migration Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -43,14 +45,14 @@ class TestServiceDiscoveryCache:
     def test_cache_hit_returns_url(self):
         """Cache returns URL for known service."""
         cache = ServiceDiscoveryCache(ttl_seconds=60)
-        cache.set("redis", {"url": "http://172.16.168.23:6379", "healthy": True})
+        cache.set("redis", {"url": "http://<database-ip>:6379", "healthy": True})
         result = cache.get("redis")
-        assert result == "http://172.16.168.23:6379"
+        assert result == "http://<database-ip>:6379"
 
     def test_cache_expires_after_ttl(self):
         """Cache entry expires after TTL."""
         cache = ServiceDiscoveryCache(ttl_seconds=1)
-        cache.set("redis", {"url": "http://172.16.168.23:6379", "healthy": True})
+        cache.set("redis", {"url": "http://<database-ip>:6379", "healthy": True})
         time.sleep(1.1)
         assert cache.get("redis") is None
 ```
@@ -164,9 +166,9 @@ class TestDiscoverService:
     async def test_discover_service_from_cache(self):
         """Returns URL from cache when available."""
         with patch("backend.services.slm_client._discovery_cache") as mock_cache:
-            mock_cache.get.return_value = "http://172.16.168.23:6379"
+            mock_cache.get.return_value = "http://<database-ip>:6379"
             url = await discover_service("redis")
-            assert url == "http://172.16.168.23:6379"
+            assert url == "http://<database-ip>:6379"
             mock_cache.get.assert_called_once_with("redis")
 
     @pytest.mark.asyncio

--- a/docs/archives/plans/2026-02-02-service-discovery-design.md
+++ b/docs/archives/plans/2026-02-02-service-discovery-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Dynamic Service Discovery and Per-Node Configuration Design
 
 > **Issue:** [#760](https://github.com/mrveiss/AutoBot-AI/issues/760)
@@ -86,11 +88,11 @@ New file `api/discovery.py`:
 ```json
 {
     "service_name": "autobot-backend",
-    "host": "172.16.168.20",
+    "host": "<backend-ip>",
     "port": 8001,
     "protocol": "http",
     "endpoint_path": "/api",
-    "url": "https://172.16.168.20:8443/api",
+    "url": "https://<backend-ip>:8443/api",
     "healthy": true,
     "node_id": "node-main"
 }

--- a/docs/archives/plans/2026-02-03-code-intelligence-enhancements.md
+++ b/docs/archives/plans/2026-02-03-code-intelligence-enhancements.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Code Intelligence Enhancements Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -997,7 +999,7 @@ Expected: Files synced successfully
 
 **Step 2: Verify in browser**
 
-Navigate to: `http://172.16.168.21:5173/analytics/code-intelligence`
+Navigate to: `http://<frontend-ip>:5173/analytics/code-intelligence`
 Expected: Code Intelligence dashboard loads with health score gauges
 
 **Step 3: Test analysis**

--- a/docs/archives/plans/2026-02-03-phase4-migration.md
+++ b/docs/archives/plans/2026-02-03-phase4-migration.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Phase 4: Service Discovery Migration & Agent Management UI
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -16,7 +18,7 @@
 - Modify: `backend/services/slm_client.py`
 
 **Problem:**
-Line 38 has `DEFAULT_SLM_URL = "http://172.16.168.19:8000"` - hardcoded SLM URL.
+Line 38 has `DEFAULT_SLM_URL = "http://<slm-manager-ip>:8000"` - hardcoded SLM URL.
 
 **Solution:**
 The SLM URL is special - it's the bootstrap service that can't use discover_service() (chicken-and-egg). Use environment variable with no hardcoded fallback.
@@ -25,7 +27,7 @@ The SLM URL is special - it's the bootstrap service that can't use discover_serv
 
 Change:
 ```python
-DEFAULT_SLM_URL = "http://172.16.168.19:8000"
+DEFAULT_SLM_URL = "http://<slm-manager-ip>:8000"
 ```
 
 To:
@@ -137,13 +139,13 @@ function getEnv(key: string, defaultValue: string): string {
 }
 
 vm: {
-  main: getEnv('VITE_BACKEND_HOST', '172.16.168.20'),
-  frontend: getEnv('VITE_FRONTEND_HOST', '172.16.168.21'),
-  npu: getEnv('VITE_NPU_WORKER_HOST', '172.16.168.22'),
-  redis: getEnv('VITE_REDIS_HOST', '172.16.168.23'),
-  ai: getEnv('VITE_AI_STACK_HOST', '172.16.168.24'),
-  browser: getEnv('VITE_BROWSER_HOST', '172.16.168.25'),
-  slm: getEnv('VITE_SLM_HOST', '172.16.168.19'),
+  main: getEnv('VITE_BACKEND_HOST', '<backend-ip>'),
+  frontend: getEnv('VITE_FRONTEND_HOST', '<frontend-ip>'),
+  npu: getEnv('VITE_NPU_WORKER_HOST', '<npu-ip>'),
+  redis: getEnv('VITE_REDIS_HOST', '<database-ip>'),
+  ai: getEnv('VITE_AI_STACK_HOST', '<aiml-ip>'),
+  browser: getEnv('VITE_BROWSER_HOST', '<browser-ip>'),
+  slm: getEnv('VITE_SLM_HOST', '<slm-manager-ip>'),
 },
 ```
 

--- a/docs/archives/plans/2026-02-03-role-based-code-sync-design.md
+++ b/docs/archives/plans/2026-02-03-role-based-code-sync-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Role-Based Code Sync Design
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -17,7 +19,7 @@
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
 │                     CODE-SOURCE NODE (role: code-version-watcher)        │
-│                              172.16.168.20                                │
+│                              <backend-ip>                                │
 │  ┌────────────────────────────────────────────────────────────────────┐  │
 │  │ • Git repository (only git-connected node)                         │  │
 │  │ • Post-commit hook notifies SLM of new versions                    │  │
@@ -29,7 +31,7 @@
                                   │ 2. SLM pulls code
                                   ▼
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                          SLM SERVER (172.16.168.19)                      │
+│                          SLM SERVER (<slm-manager-ip>)                   │
 │  ┌────────────────────────────────────────────────────────────────────┐  │
 │  │ CODE CACHE         │ VERSION REGISTRY    │ ROLE REGISTRY           │  │
 │  │ /var/lib/slm/code/ │ tracks all node     │ role→paths mapping      │  │

--- a/docs/archives/plans/2026-02-04-code-intelligence-dashboard-implementation.md
+++ b/docs/archives/plans/2026-02-04-code-intelligence-dashboard-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Code Intelligence Dashboard Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -1738,7 +1740,7 @@ git commit -m "feat(frontend): add tabbed interface and file scan to CodeIntelli
 
 **Step 2: Test in browser**
 
-1. Navigate to `http://172.16.168.21:5173/analytics/code-intelligence`
+1. Navigate to `http://<frontend-ip>:5173/analytics/code-intelligence`
 2. Verify score cards display after clicking Analyze
 3. Verify tabs switch correctly
 4. Verify findings display in table with expandable rows

--- a/docs/archives/plans/2026-02-04-error-monitoring-dashboard-design.md
+++ b/docs/archives/plans/2026-02-04-error-monitoring-dashboard-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Error Monitoring Dashboard Design
 
 **Issue:** #563 - [Frontend] Error Monitoring Dashboard - 13 Endpoints
@@ -6,7 +8,7 @@
 
 ## Overview
 
-Implement comprehensive Error Monitoring Dashboard backend in SLM server (172.16.168.19) with 13 REST endpoints, plus frontend integration in slm-admin.
+Implement comprehensive Error Monitoring Dashboard backend in SLM server (<slm-manager-ip>) with 13 REST endpoints, plus frontend integration in slm-admin.
 
 ## Backend Endpoints
 

--- a/docs/archives/plans/2026-02-05-bug-prediction-realtime-trends.md
+++ b/docs/archives/plans/2026-02-05-bug-prediction-realtime-trends.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Bug Prediction Real-Time Trends Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -432,7 +434,7 @@ Expected: Files synced successfully
 
 **Step 2: Open dashboard in browser**
 
-Navigate to: `http://172.16.168.21:5173` and open Bug Prediction Dashboard
+Navigate to: `http://<frontend-ip>:5173` and open Bug Prediction Dashboard
 Expected: Dashboard loads
 
 **Step 3: Verify live badge appears**

--- a/docs/archives/plans/2026-02-05-folder-restructure-design.md
+++ b/docs/archives/plans/2026-02-05-folder-restructure-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Folder Restructure Design
 
 > **HISTORICAL NOTE**: This document describes the initial flat infrastructure structure.
@@ -19,7 +21,7 @@
 │
 ├── # DEPLOYABLE COMPONENTS
 │
-├── autobot-backend/           # Deploys to 172.16.168.20 (Main)
+├── autobot-backend/           # Deploys to <backend-ip> (Main)
 │   ├── api/                        # FastAPI endpoints
 │   ├── services/                   # Business logic
 │   ├── models/                     # SQLAlchemy models
@@ -31,13 +33,13 @@
 │   ├── requirements.txt            # Python dependencies
 │   └── README.md                   # Deployment instructions
 │
-├── autobot-frontend/          # Deploys to 172.16.168.20 (Main)
+├── autobot-frontend/          # Deploys to <backend-ip> (Main)
 │   ├── src/                        # Vue source
 │   ├── public/                     # Static assets
 │   ├── package.json                # Node dependencies
 │   └── README.md
 │
-├── autobot-slm-backend/            # Deploys to 172.16.168.19 (SLM)
+├── autobot-slm-backend/            # Deploys to <slm-manager-ip> (SLM)
 │   ├── api/                        # FastAPI endpoints
 │   ├── services/                   # Sync orchestrator, etc.
 │   ├── models/                     # Fleet models
@@ -47,20 +49,20 @@
 │   ├── requirements.txt
 │   └── README.md
 │
-├── autobot-slm-frontend/           # Deploys to 172.16.168.21 (Frontend VM)
+├── autobot-slm-frontend/           # Deploys to <frontend-ip> (Frontend VM)
 │   ├── src/                        # Vue source
 │   ├── public/
 │   ├── package.json
 │   └── README.md
 │
-├── autobot-npu-worker/             # Deploys to 172.16.168.22 (NPU)
+├── autobot-npu-worker/             # Deploys to <npu-ip> (NPU)
 │   ├── workers/                    # NPU worker processes
 │   ├── models/                     # AI models
 │   ├── main.py
 │   ├── requirements.txt            # OpenVINO, torch, etc.
 │   └── README.md
 │
-├── autobot-browser-worker/         # Deploys to 172.16.168.25 (Browser)
+├── autobot-browser-worker/         # Deploys to <browser-ip> (Browser)
 │   ├── services/                   # Playwright services
 │   ├── main.py
 │   ├── requirements.txt            # Playwright, etc.
@@ -219,12 +221,12 @@ Root-level data folders to migrate:
 
 | Component | Machine | IP | Command |
 |-----------|---------|-----|---------|
-| `autobot-backend/` | Main | 172.16.168.20 | `sync-to-vm.sh main autobot-backend/` |
-| `autobot-frontend/` | Main | 172.16.168.20 | `sync-to-vm.sh main autobot-frontend/` |
-| `autobot-slm-backend/` | SLM | 172.16.168.19 | `sync-to-vm.sh slm autobot-slm-backend/` |
-| `autobot-slm-frontend/` | Frontend VM | 172.16.168.21 | `sync-to-vm.sh frontend autobot-slm-frontend/` |
-| `autobot-npu-worker/` | NPU | 172.16.168.22 | `sync-to-vm.sh npu autobot-npu-worker/` |
-| `autobot-browser-worker/` | Browser | 172.16.168.25 | `sync-to-vm.sh browser autobot-browser-worker/` |
+| `autobot-backend/` | Main | <backend-ip> | `sync-to-vm.sh main autobot-backend/` |
+| `autobot-frontend/` | Main | <backend-ip> | `sync-to-vm.sh main autobot-frontend/` |
+| `autobot-slm-backend/` | SLM | <slm-manager-ip> | `sync-to-vm.sh slm autobot-slm-backend/` |
+| `autobot-slm-frontend/` | Frontend VM | <frontend-ip> | `sync-to-vm.sh frontend autobot-slm-frontend/` |
+| `autobot-npu-worker/` | NPU | <npu-ip> | `sync-to-vm.sh npu autobot-npu-worker/` |
+| `autobot-browser-worker/` | Browser | <browser-ip> | `sync-to-vm.sh browser autobot-browser-worker/` |
 | `autobot_shared/` | (all backends) | - | Deployed with each backend |
 
 **Sync script location:** `infrastructure/shared/scripts/sync-to-vm.sh`

--- a/docs/archives/plans/2026-02-05-npu-worker-pool-design.md
+++ b/docs/archives/plans/2026-02-05-npu-worker-pool-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # NPU Multi-Worker Load Balancing & Pool Management
 
 **Issue**: #168
@@ -11,7 +13,7 @@ Implement health-aware load balancing across multiple NPU workers for improved t
 
 ## Current State
 
-- Single `NPUWorkerClient` at `172.16.168.22:8081`
+- Single `NPUWorkerClient` at `<npu-ip>:8081`
 - Basic task queue via `NPUTaskQueue` with Redis backing
 - No load balancing or failover capabilities
 - Existing YAML configuration structure in `config/npu_workers.yaml`
@@ -61,7 +63,7 @@ NPUWorkerClient instances (existing, one per worker)
 
 **Key fields per worker**:
 - `id`: Unique worker identifier (e.g., `npu-worker-vm2`)
-- `url`: Worker endpoint (e.g., `http://172.16.168.22:8081`)
+- `url`: Worker endpoint (e.g., `http://<npu-ip>:8081`)
 - `priority`: 1-10 (higher = preferred, used for failover ordering)
 - `enabled`: Boolean to enable/disable workers
 - `max_concurrent_tasks`: Worker capacity limit
@@ -387,7 +389,7 @@ async def test_routing_accuracy():
   "workers": [
     {
       "id": "npu-worker-vm2",
-      "url": "http://172.16.168.22:8081",
+      "url": "http://<npu-ip>:8081",
       "priority": 10,
       "enabled": true,
       "healthy": true,
@@ -399,7 +401,7 @@ async def test_routing_accuracy():
     },
     {
       "id": "windows-npu-worker-main",
-      "url": "http://172.16.168.20:8082",
+      "url": "http://<backend-ip>:8082",
       "priority": 5,
       "enabled": true,
       "healthy": true,

--- a/docs/archives/plans/2026-02-05-npu-worker-pool-implementation.md
+++ b/docs/archives/plans/2026-02-05-npu-worker-pool-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # NPU Multi-Worker Pool Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -145,14 +147,14 @@ def test_load_worker_config_success():
         "workers": [
             {
                 "id": "worker-1",
-                "url": "http://172.16.168.22:8081",
+                "url": "http://<npu-ip>:8081",
                 "priority": 10,
                 "enabled": True,
                 "max_concurrent_tasks": 4,
             },
             {
                 "id": "worker-2",
-                "url": "http://172.16.168.20:8082",
+                "url": "http://<backend-ip>:8082",
                 "priority": 5,
                 "enabled": False,
                 "max_concurrent_tasks": 2,
@@ -349,7 +351,7 @@ async def test_npu_worker_pool_initialization():
         "workers": [
             {
                 "id": "worker-1",
-                "url": "http://172.16.168.22:8081",
+                "url": "http://<npu-ip>:8081",
                 "priority": 10,
                 "enabled": True,
                 "max_concurrent_tasks": 4,
@@ -2348,13 +2350,13 @@ NPUTaskQueue → NPUWorkerPool → NPUWorkerClient instances
 ```yaml
 workers:
   - id: npu-worker-vm2
-    url: http://172.16.168.22:8081
+    url: http://<npu-ip>:8081
     priority: 10
     enabled: true
     max_concurrent_tasks: 4
 
   - id: windows-npu-worker
-    url: http://172.16.168.20:8082
+    url: http://<backend-ip>:8082
     priority: 5
     enabled: true
     max_concurrent_tasks: 4
@@ -2403,7 +2405,7 @@ Get per-worker health states.
   "workers": [
     {
       "id": "npu-worker-vm2",
-      "url": "http://172.16.168.22:8081",
+      "url": "http://<npu-ip>:8081",
       "priority": 10,
       "enabled": true,
       "healthy": true,

--- a/docs/archives/plans/2026-02-05-slm-user-management-design.md
+++ b/docs/archives/plans/2026-02-05-slm-user-management-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM User Management System Design
 
 **Issue:** #576 - User Management happens on SLM system
@@ -13,37 +15,37 @@ Migrate all user management functionality from main AutoBot backend to SLM serve
 ### Two User Databases
 
 ```
-┌──────────────────────────────────────────────────────┐
-│ PostgreSQL Server 1: SLM Server (172.16.168.19:5432)│
-│                                                      │
-│ ┌──────────────────────────────────────────────┐   │
-│ │ Database: slm_users (local)                  │   │
-│ │ Purpose: SLM fleet management access         │   │
-│ │ Users: Fleet admins, DevOps, system admins   │   │
-│ │ Auth: SLM authenticates locally              │   │
-│ └──────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────┐
+│ PostgreSQL Server 1: SLM Server (<slm-manager-ip>:5432)│
+│                                                        │
+│ ┌──────────────────────────────────────────────┐       │
+│ │ Database: slm_users (local)                  │       │
+│ │ Purpose: SLM fleet management access         │       │
+│ │ Users: Fleet admins, DevOps, system admins   │       │
+│ │ Auth: SLM authenticates locally              │       │
+│ └──────────────────────────────────────────────┘       │
+└────────────────────────────────────────────────────────┘
 
-┌──────────────────────────────────────────────────────┐
-│ PostgreSQL Server 2: Redis VM (172.16.168.23:5432)  │
-│                                                      │
-│ ┌──────────────────────────────────────────────┐   │
-│ │ Database: autobot_users (shared)             │   │
-│ │ Purpose: AutoBot application functionality   │   │
-│ │ Users: Chat users, tool users, end-users     │   │
-│ │ Auth: Frontend/Main VM authenticate here    │   │
-│ └──────────────────────────────────────────────┘   │
-└──────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────┐
+│ PostgreSQL Server 2: Redis VM (<database-ip>:5432)     │
+│                                                        │
+│ ┌──────────────────────────────────────────────┐       │
+│ │ Database: autobot_users (shared)             │       │
+│ │ Purpose: AutoBot application functionality   │       │
+│ │ Users: Chat users, tool users, end-users     │       │
+│ │ Auth: Frontend/Main VM authenticate here     │       │
+│ └──────────────────────────────────────────────┘       │
+└────────────────────────────────────────────────────────┘
 ```
 
 ### Connection Matrix
 
 | Component | Connects To | Purpose |
 |-----------|-------------|---------|
-| **SLM Server** | `172.16.168.19:5432/slm_users` | Own auth |
-| **SLM Server** | `172.16.168.23:5432/autobot_users` | Manage AutoBot users |
-| **Frontend VM** | `172.16.168.23:5432/autobot_users` | User auth |
-| **Main Backend** | `172.16.168.23:5432/autobot_users` | User auth |
+| **SLM Server** | `<slm-manager-ip>:5432/slm_users` | Own auth |
+| **SLM Server** | `<database-ip>:5432/autobot_users` | Manage AutoBot users |
+| **Frontend VM** | `<database-ip>:5432/autobot_users` | User auth |
+| **Main Backend** | `<database-ip>:5432/autobot_users` | User auth |
 
 ### Benefits
 
@@ -94,15 +96,15 @@ TO:   /home/kali/Desktop/AutoBot/slm-server/user_management/
 
 ```python
 def get_slm_engine():
-    """SLM local database (172.16.168.19:5432/slm_users)"""
+    """SLM local database (<slm-manager-ip>:5432/slm_users)"""
     return create_async_engine(
-        f"postgresql+asyncpg://{user}:{pwd}@172.16.168.19:5432/slm_users"
+        f"postgresql+asyncpg://{user}:{pwd}@<slm-manager-ip>:5432/slm_users"
     )
 
 def get_autobot_engine():
-    """AutoBot user database (172.16.168.23:5432/autobot_users)"""
+    """AutoBot user database (<database-ip>:5432/autobot_users)"""
     return create_async_engine(
-        f"postgresql+asyncpg://{user}:{pwd}@172.16.168.23:5432/autobot_users"
+        f"postgresql+asyncpg://{user}:{pwd}@<database-ip>:5432/autobot_users"
     )
 ```
 
@@ -112,11 +114,11 @@ def get_autobot_engine():
 class UserService:
     async def create_slm_user(self, db: AsyncSession, user_data):
         """Create user in SLM database"""
-        # db connected to 172.16.168.19
+        # db connected to <slm-manager-ip>
 
     async def create_autobot_user(self, db: AsyncSession, user_data):
         """Create user in AutoBot database"""
-        # db connected to 172.16.168.23
+        # db connected to <database-ip>
 ```
 
 ### Files to Delete from AutoBot
@@ -130,7 +132,7 @@ class UserService:
 ### SLM API Endpoints
 
 ```
-SLM Server: http://172.16.168.19:8000/api/
+SLM Server: http://<slm-manager-ip>:8000/api/
 
 ┌─────────────────────────────────────────────────────┐
 │ SLM Admin User Management (Local DB)                │
@@ -168,7 +170,7 @@ SLM Server: http://172.16.168.19:8000/api/
 ```
 User → SLM Admin UI → POST /api/slm-auth/login
                       ↓
-                SLM checks 172.16.168.19:5432/slm_users
+                SLM checks <slm-manager-ip>:5432/slm_users
                       ↓
                 Returns JWT token
 ```
@@ -177,7 +179,7 @@ User → SLM Admin UI → POST /api/slm-auth/login
 ```
 User → Frontend UI → POST /api/auth/login
                      ↓
-           Main Backend checks 172.16.168.23:5432/autobot_users
+           Main Backend checks <database-ip>:5432/autobot_users
                      ↓
                 Returns JWT token
 ```
@@ -187,7 +189,7 @@ User → Frontend UI → POST /api/auth/login
 ```python
 # autobot-backend/api/auth.py
 async def login(username, password):
-    # Connect to 172.16.168.23:5432/autobot_users
+    # Connect to <database-ip>:5432/autobot_users
     async with get_autobot_db_session() as db:
         user = await authenticate_user(db, username, password)
         return create_jwt_token(user)
@@ -202,7 +204,7 @@ async def create_autobot_user(
     user_data: UserCreate,
     current_admin: User = Depends(require_slm_admin)
 ):
-    # Connect to REMOTE database (172.16.168.23)
+    # Connect to REMOTE database (<database-ip>)
     async with get_autobot_db_session() as db:
         user = await user_service.create_user(db, user_data)
 
@@ -219,7 +221,7 @@ async def create_autobot_user(
 ```
 SLM creates user
     ↓
-Writes to 172.16.168.23:5432/autobot_users
+Writes to <database-ip>:5432/autobot_users
     ↓
 Frontend/Main Backend reads from same database
     ↓
@@ -278,7 +280,7 @@ Update `slm-admin/src/views/settings/admin/UserManagementSettings.vue`:
 const API_BASE = '/autobot-api'
 
 // NEW: Calls SLM backend with dual user management
-const SLM_API_BASE = 'http://172.16.168.19:8000/api'
+const SLM_API_BASE = 'http://<slm-manager-ip>:8000/api'
 
 // Two user management sections:
 // 1. SLM Admins
@@ -329,17 +331,17 @@ Minimal changes - just update API connection:
 ```typescript
 // autobot-frontend/src/stores/auth.ts
 // No changes - still connects to Main Backend
-const API_BASE = 'https://172.16.168.20:8443/api'
+const API_BASE = 'https://<backend-ip>:8443/api'
 
-// Main Backend now connects to 172.16.168.23:5432/autobot_users
+// Main Backend now connects to <database-ip>:5432/autobot_users
 // Frontend doesn't need to know about SLM
 ```
 
 ## Implementation Phases
 
 ### Phase 1: Database Setup
-- [ ] Create `slm_users` database on SLM Server (172.16.168.19:5432)
-- [ ] Create `autobot_users` database on Redis VM (172.16.168.23:5432)
+- [ ] Create `slm_users` database on SLM Server (<slm-manager-ip>:5432)
+- [ ] Create `autobot_users` database on Redis VM (<database-ip>:5432)
 - [ ] Run Alembic migrations on both databases
 - [ ] Create initial SLM admin user
 
@@ -350,7 +352,7 @@ const API_BASE = 'https://172.16.168.20:8443/api'
 - [ ] Create SLM API endpoints (`/api/slm-users`, `/api/autobot-users`)
 
 ### Phase 3: AutoBot Backend Updates
-- [ ] Update `autobot-backend/api/auth.py` to connect to `172.16.168.23:5432/autobot_users`
+- [ ] Update `autobot-backend/api/auth.py` to connect to `<database-ip>:5432/autobot_users`
 - [ ] Remove `src/user_management/` from AutoBot
 - [ ] Remove `autobot-backend/api/user_management/` from AutoBot
 - [ ] Update SSOT config for PostgreSQL connections

--- a/docs/archives/plans/2026-02-05-slm-user-management-implementation.md
+++ b/docs/archives/plans/2026-02-05-slm-user-management-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM User Management Migration Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -15,12 +17,12 @@
 ### Task 1.1: Install PostgreSQL on SLM Server
 
 **Files:**
-- System: Install PostgreSQL on 172.16.168.19
+- System: Install PostgreSQL on <slm-manager-ip>
 
 **Step 1: SSH into SLM server**
 
 ```bash
-ssh autobot@172.16.168.19
+ssh autobot@<slm-manager-ip>
 ```
 
 **Step 2: Install PostgreSQL**
@@ -72,12 +74,12 @@ Expected: PostgreSQL version info
 ### Task 1.2: Setup AutoBot Users Database on Redis VM
 
 **Files:**
-- System: Configure PostgreSQL on 172.16.168.23
+- System: Configure PostgreSQL on <database-ip>
 
 **Step 1: SSH into Redis VM**
 
 ```bash
-ssh autobot@172.16.168.23
+ssh autobot@<database-ip>
 ```
 
 **Step 2: Verify PostgreSQL is installed**
@@ -101,7 +103,7 @@ EOF
 
 ```bash
 sudo nano /etc/postgresql/14/main/pg_hba.conf
-# Add: host autobot_users autobot_user_admin 172.16.168.0/24 md5
+# Add: host autobot_users autobot_user_admin <network-subnet> md5
 sudo nano /etc/postgresql/14/main/postgresql.conf
 # Set: listen_addresses = '*'
 sudo systemctl restart postgresql
@@ -110,8 +112,8 @@ sudo systemctl restart postgresql
 **Step 5: Test remote connection from SLM**
 
 ```bash
-# From SLM server (172.16.168.19)
-psql -h 172.16.168.23 -U autobot_user_admin -d autobot_users -c "SELECT version();"
+# From SLM server (<slm-manager-ip>)
+psql -h <database-ip> -U autobot_user_admin -d autobot_users -c "SELECT version();"
 ```
 
 Expected: PostgreSQL version info
@@ -228,8 +230,8 @@ Create: `slm-server/user_management/config.py`
 Dual Database Configuration for SLM User Management
 
 Two PostgreSQL databases:
-1. slm_users (local on 172.16.168.19) - SLM admin users
-2. autobot_users (remote on 172.16.168.23) - AutoBot application users
+1. slm_users (local on <slm-manager-ip>) - SLM admin users
+2. autobot_users (remote on <database-ip>) - AutoBot application users
 """
 
 import os
@@ -277,7 +279,7 @@ def get_slm_db_config() -> DatabaseConfig:
 def get_autobot_db_config() -> DatabaseConfig:
     """Get AutoBot remote database configuration (on Redis VM)."""
     return DatabaseConfig(
-        host=os.getenv("AUTOBOT_POSTGRES_HOST", "172.16.168.23"),
+        host=os.getenv("AUTOBOT_POSTGRES_HOST", "<database-ip>"),
         port=int(os.getenv("AUTOBOT_POSTGRES_PORT", "5432")),
         database=os.getenv("AUTOBOT_POSTGRES_DB", "autobot_users"),
         user=os.getenv("AUTOBOT_POSTGRES_USER", "autobot_user_admin"),
@@ -773,7 +775,7 @@ Expected: All tables created in `autobot_users` database
 psql -h 127.0.0.1 -U slm_admin -d slm_users -c "\dt"
 
 # AutoBot database
-psql -h 172.16.168.23 -U autobot_user_admin -d autobot_users -c "\dt"
+psql -h <database-ip> -U autobot_user_admin -d autobot_users -c "\dt"
 ```
 
 Expected: List of all user management tables
@@ -806,7 +808,7 @@ Create: `slm-server/api/slm_users.py`
 """
 SLM Admin User Management API
 
-Manages users in the local SLM database (172.16.168.19:5432/slm_users).
+Manages users in the local SLM database (<slm-manager-ip>:5432/slm_users).
 These are fleet administrators who can access the SLM admin dashboard.
 """
 
@@ -993,7 +995,7 @@ Create: `slm-server/api/autobot_users.py`
 """
 AutoBot User Management API
 
-Manages users in the remote AutoBot database (172.16.168.23:5432/autobot_users).
+Manages users in the remote AutoBot database (<database-ip>:5432/autobot_users).
 These are application users who can access AutoBot chat and tools.
 """
 
@@ -1160,7 +1162,7 @@ def get_autobot_user_engine() -> AsyncEngine:
     """Get or create AutoBot user database engine."""
     global _engine
     if _engine is None:
-        host = os.getenv("AUTOBOT_POSTGRES_HOST", "172.16.168.23")
+        host = os.getenv("AUTOBOT_POSTGRES_HOST", "<database-ip>")
         port = int(os.getenv("AUTOBOT_POSTGRES_PORT", "5432"))
         database = os.getenv("AUTOBOT_POSTGRES_DB", "autobot_users")
         user = os.getenv("AUTOBOT_POSTGRES_USER", "autobot_user_admin")
@@ -1223,7 +1225,7 @@ cd /home/kali/Desktop/AutoBot
 python -m uvicorn backend.main:app --host 0.0.0.0 --port 8001
 
 # Test login endpoint
-curl -X POST https://172.16.168.20:8443/api/auth/login \
+curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "testuser", "password": "testpass"}'
 ```
@@ -1295,7 +1297,7 @@ Change the API base from AutoBot to SLM:
 const API_BASE = '/autobot-api'
 
 // NEW
-const SLM_API_BASE = 'http://172.16.168.19:8000/api'
+const SLM_API_BASE = 'http://<slm-manager-ip>:8000/api'
 ```
 
 **Step 2: Add dual user management state**
@@ -1439,7 +1441,7 @@ onMounted(async () => {
 ./scripts/utilities/sync-to-vm.sh frontend slm-admin/src/ /home/autobot/AutoBot/slm-admin/src/
 
 # Open in browser
-# Navigate to: http://172.16.168.21:5173/settings/admin/users
+# Navigate to: http://<frontend-ip>:5173/settings/admin/users
 ```
 
 **Step 7: Commit**
@@ -1467,7 +1469,7 @@ Add PostgreSQL configuration for AutoBot users:
 
 ```bash
 # AutoBot User Database (on Redis VM)
-AUTOBOT_POSTGRES_HOST=172.16.168.23
+AUTOBOT_POSTGRES_HOST=<database-ip>
 AUTOBOT_POSTGRES_PORT=5432
 AUTOBOT_POSTGRES_DB=autobot_users
 AUTOBOT_POSTGRES_USER=autobot_user_admin
@@ -1489,7 +1491,7 @@ SLM_POSTGRES_USER=slm_admin
 SLM_POSTGRES_PASSWORD=<GENERATE_SECURE_PASSWORD>
 
 # AutoBot Remote Database (on Redis VM)
-AUTOBOT_POSTGRES_HOST=172.16.168.23
+AUTOBOT_POSTGRES_HOST=<database-ip>
 AUTOBOT_POSTGRES_PORT=5432
 AUTOBOT_POSTGRES_DB=autobot_users
 AUTOBOT_POSTGRES_USER=autobot_user_admin
@@ -1604,7 +1606,7 @@ Expected:
 psql -h 127.0.0.1 -U slm_admin -d slm_users -c "SELECT username, is_admin FROM users;"
 
 # AutoBot database
-psql -h 172.16.168.23 -U autobot_user_admin -d autobot_users -c "SELECT username, is_admin FROM users;"
+psql -h <database-ip> -U autobot_user_admin -d autobot_users -c "SELECT username, is_admin FROM users;"
 ```
 
 **Step 4: Commit**
@@ -1624,7 +1626,7 @@ git commit -m "feat(slm): Add admin user creation script (#576)"
 **Step 1: Test SLM admin login**
 
 ```bash
-curl -X POST http://172.16.168.19:8000/api/slm-auth/login \
+curl -X POST http://<slm-manager-ip>:8000/api/slm-auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "slm_admin", "password": "ChangeMe123!"}'
 ```
@@ -1634,7 +1636,7 @@ Expected: JWT token
 **Step 2: Test AutoBot user login**
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/auth/login \
+curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "autobot_admin", "password": "ChangeMe123!"}'
 ```
@@ -1645,12 +1647,12 @@ Expected: JWT token
 
 ```bash
 # Get SLM admin token
-SLM_TOKEN=$(curl -s -X POST http://172.16.168.19:8000/api/slm-auth/login \
+SLM_TOKEN=$(curl -s -X POST http://<slm-manager-ip>:8000/api/slm-auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "slm_admin", "password": "ChangeMe123!"}' | jq -r '.access_token')
 
 # Create AutoBot user from SLM
-curl -X POST http://172.16.168.19:8000/api/autobot-users \
+curl -X POST http://<slm-manager-ip>:8000/api/autobot-users \
   -H "Authorization: Bearer $SLM_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1666,7 +1668,7 @@ Expected: Created user JSON
 **Step 4: Test AutoBot can authenticate new user**
 
 ```bash
-curl -X POST https://172.16.168.20:8443/api/auth/login \
+curl -X POST https://<backend-ip>:8443/api/auth/login \
   -H "Content-Type: application/json" \
   -d '{"username": "testuser", "password": "TestPass123!"}'
 ```
@@ -1675,7 +1677,7 @@ Expected: JWT token (proves AutoBot reads from same database)
 
 **Step 5: Test SLM admin UI**
 
-1. Open browser: http://172.16.168.21:5173
+1. Open browser: http://<frontend-ip>:5173
 2. Login as SLM admin
 3. Navigate to Settings → User Management
 4. Verify two tabs: "SLM Administrators" and "AutoBot Users"
@@ -1720,13 +1722,13 @@ Add section on PostgreSQL databases:
 AutoBot uses two PostgreSQL databases for user management:
 
 ### 1. SLM Users Database
-- **Location:** SLM Server (172.16.168.19:5432)
+- **Location:** SLM Server (<slm-manager-ip>:5432)
 - **Database:** `slm_users`
 - **Purpose:** Fleet administrator authentication
 - **Managed by:** SLM server
 
 ### 2. AutoBot Users Database
-- **Location:** Redis VM (172.16.168.23:5432)
+- **Location:** Redis VM (<database-ip>:5432)
 - **Database:** `autobot_users`
 - **Purpose:** Application user authentication
 - **Managed by:** SLM server (remotely)
@@ -1737,7 +1739,7 @@ AutoBot uses two PostgreSQL databases for user management:
 Add to `.env`:
 
 ```
-AUTOBOT_POSTGRES_HOST=172.16.168.23
+AUTOBOT_POSTGRES_HOST=<database-ip>
 AUTOBOT_POSTGRES_PORT=5432
 AUTOBOT_POSTGRES_DB=autobot_users
 AUTOBOT_POSTGRES_USER=autobot_user_admin
@@ -1752,7 +1754,7 @@ SLM_POSTGRES_DB=slm_users
 SLM_POSTGRES_USER=slm_admin
 SLM_POSTGRES_PASSWORD=<password>
 
-AUTOBOT_POSTGRES_HOST=172.16.168.23
+AUTOBOT_POSTGRES_HOST=<database-ip>
 AUTOBOT_POSTGRES_DB=autobot_users
 AUTOBOT_POSTGRES_USER=autobot_user_admin
 AUTOBOT_POSTGRES_PASSWORD=<password>
@@ -1881,8 +1883,8 @@ git push
 
 ## Success Criteria Checklist
 
-- [ ] SLM PostgreSQL database created on 172.16.168.19:5432
-- [ ] AutoBot PostgreSQL database created on 172.16.168.23:5432
+- [ ] SLM PostgreSQL database created on <slm-manager-ip>:5432
+- [ ] AutoBot PostgreSQL database created on <database-ip>:5432
 - [ ] All user management code migrated to `slm-server/user_management/`
 - [ ] Dual database configuration working (two engines)
 - [ ] Alembic migrations applied to both databases

--- a/docs/archives/plans/2026-02-06-phase1-folder-restructure.md
+++ b/docs/archives/plans/2026-02-06-phase1-folder-restructure.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Phase 1: Create Folder Structure - Implementation Plan
 
 > **HISTORICAL NOTE**: This document describes the initial flat infrastructure structure.
@@ -219,7 +221,7 @@ Update `autobot-slm-backend/README.md` to add deployment info at the top:
 ```markdown
 # AutoBot SLM Backend
 
-> **Deploys to:** 172.16.168.19 (SLM Server)
+> **Deploys to:** <slm-manager-ip> (SLM Server)
 
 [rest of existing content]
 ```
@@ -257,7 +259,7 @@ Update `autobot-slm-frontend/README.md`:
 ```markdown
 # AutoBot SLM Frontend
 
-> **Deploys to:** 172.16.168.21 (Frontend VM)
+> **Deploys to:** <frontend-ip> (Frontend VM)
 
 [rest of existing content]
 ```
@@ -294,7 +296,7 @@ Create/update `autobot-frontend/README.md`:
 ```markdown
 # AutoBot User Frontend
 
-> **Deploys to:** 172.16.168.20 (Main Server)
+> **Deploys to:** <backend-ip> (Main Server)
 
 Vue 3 + TypeScript chat interface for AutoBot.
 
@@ -408,7 +410,7 @@ Create `autobot-backend/README.md`:
 ```markdown
 # AutoBot User Backend
 
-> **Deploys to:** 172.16.168.20 (Main Server)
+> **Deploys to:** <backend-ip> (Main Server)
 
 Core AutoBot backend - AI agents, chat workflows, and API endpoints.
 
@@ -510,7 +512,7 @@ Create `autobot-npu-worker/main.py`:
 # Author: mrveiss
 """AutoBot NPU Worker - Hardware AI acceleration service.
 
-Deploys to: 172.16.168.22 (NPU VM)
+Deploys to: <npu-ip> (NPU VM)
 
 This is a stub for Phase 1. NPU-specific code will be extracted
 from autobot-backend in a future phase.
@@ -547,7 +549,7 @@ Create `autobot-npu-worker/README.md`:
 ```markdown
 # AutoBot NPU Worker
 
-> **Deploys to:** 172.16.168.22 (NPU VM)
+> **Deploys to:** <npu-ip> (NPU VM)
 
 Hardware AI acceleration worker using Intel NPU/OpenVINO.
 
@@ -570,7 +572,7 @@ Create `autobot-browser-worker/main.py`:
 # Author: mrveiss
 """AutoBot Browser Worker - Playwright automation service.
 
-Deploys to: 172.16.168.25 (Browser VM)
+Deploys to: <browser-ip> (Browser VM)
 
 This is a stub for Phase 1. Browser-specific code will be extracted
 from autobot-backend in a future phase.
@@ -605,7 +607,7 @@ Create `autobot-browser-worker/README.md`:
 ```markdown
 # AutoBot Browser Worker
 
-> **Deploys to:** 172.16.168.25 (Browser VM)
+> **Deploys to:** <browser-ip> (Browser VM)
 
 Playwright-based browser automation worker.
 

--- a/docs/archives/plans/2026-02-06-postgresql-user-management-deployment.md
+++ b/docs/archives/plans/2026-02-06-postgresql-user-management-deployment.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # PostgreSQL User Management Database Deployment
 
 **Issue:** #786
@@ -8,30 +10,30 @@
 
 This document describes the deployment of PostgreSQL databases for user management in the AutoBot platform. The architecture uses a dual-database approach:
 
-1. **SLM Server Database** (172.16.168.19) - Local SLM admin users
-2. **AutoBot Users Database** (172.16.168.23/Redis VM) - Remote application users
+1. **SLM Server Database** (<slm-manager-ip>) - Local SLM admin users
+2. **AutoBot Users Database** (<database-ip>/Redis VM) - Remote application users
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                      SLM Server (172.16.168.19)                 │
-│  ┌─────────────────┐    ┌─────────────────────────────────────┐ │
-│  │  PostgreSQL     │    │          SLM Backend                │ │
-│  │  ├─ slm         │◄───│  (asyncpg + SQLAlchemy)             │ │
-│  │  └─ slm_users   │    │                                     │ │
-│  └─────────────────┘    └─────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│                      SLM Server (<slm-manager-ip>)                 │
+│  ┌─────────────────┐    ┌─────────────────────────────────────┐    │
+│  │  PostgreSQL     │    │          SLM Backend                │    │
+│  │  ├─ slm         │◄───│  (asyncpg + SQLAlchemy)             │    │
+│  │  └─ slm_users   │    │                                     │    │
+│  └─────────────────┘    └─────────────────────────────────────┘    │
+└────────────────────────────────────────────────────────────────────┘
                               │
                               │ Remote connection
                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      Redis VM (172.16.168.23)                    │
-│  ┌─────────────────┐                                            │
-│  │  PostgreSQL     │                                            │
-│  │  └─ autobot_users│                                           │
-│  └─────────────────┘                                            │
-└─────────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────┐
+│                      Redis VM (<database-ip>)                      │
+│  ┌──────────────────┐                                              │
+│  │  PostgreSQL      │                                              │
+│  │  └─ autobot_users│                                              │
+│  └──────────────────┘                                              │
+└────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Database Configuration
@@ -48,7 +50,7 @@ SLM_DATABASE_URL="postgresql+asyncpg://slm_app@127.0.0.1:5432/slm"
 SLM_USERS_DATABASE_URL="postgresql+asyncpg://slm_app@127.0.0.1:5432/slm_users"
 
 # AutoBot application users database (on Redis VM)
-AUTOBOT_USERS_DATABASE_URL="postgresql+asyncpg://autobot_app@172.16.168.23:5432/autobot_users"
+AUTOBOT_USERS_DATABASE_URL="postgresql+asyncpg://autobot_app@<database-ip>:5432/autobot_users"
 
 # Connection pool settings
 SLM_DB_POOL_SIZE=20
@@ -133,7 +135,7 @@ All migrations have been updated for PostgreSQL compatibility:
 ### Database Health Endpoint
 
 ```bash
-curl http://172.16.168.19:8000/api/health/database
+curl http://<slm-manager-ip>:8000/api/health/database
 ```
 
 **Response:**
@@ -147,7 +149,7 @@ curl http://172.16.168.19:8000/api/health/database
 ### General Health Endpoint
 
 ```bash
-curl http://172.16.168.19:8000/api/health
+curl http://<slm-manager-ip>:8000/api/health
 ```
 
 **Response:**

--- a/docs/archives/plans/2026-02-07-bootstrap-slm-design.md
+++ b/docs/archives/plans/2026-02-07-bootstrap-slm-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM Bootstrap Script Design
 
 **Issue:** #789
@@ -16,7 +18,7 @@
 ./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh [OPTIONS]
 
 Options:
-  -h, --host HOST       Target host (default: 172.16.168.19)
+  -h, --host HOST       Target host (default: <slm-manager-ip>)
   -u, --user USER       SSH user with sudo (required)
   -k, --key PATH        SSH key path (tries ~/.ssh/id_rsa first)
   -p, --password        Prompt for SSH password (fallback if no key)
@@ -29,13 +31,13 @@ Options:
 
 ```bash
 # With SSH key
-./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h 172.16.168.19
+./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h <slm-manager-ip>
 
 # With password prompt
-./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h 172.16.168.19 -p
+./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h <slm-manager-ip> -p
 
 # Custom admin password
-./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h 172.16.168.19 --admin-password
+./infrastructure/autobot-slm-backend/scripts/bootstrap-slm.sh -u root -h <slm-manager-ip> --admin-password
 ```
 
 ## Target Architecture
@@ -46,7 +48,7 @@ nginx (:443 HTTPS, :80 redirect)
   └── /api/* → proxy to uvicorn (:8000)
 ```
 
-All-in-one deployment on SLM node (172.16.168.19).
+All-in-one deployment on SLM node (<slm-manager-ip>).
 
 ## Directory Structure on Target
 
@@ -127,7 +129,7 @@ The `autobot_admin` user is normally disabled and only enabled during key/cert r
 - Create Python venv: `/opt/autobot/autobot-slm-backend/venv/`
 - Install requirements: `pip install -r requirements.txt`
 - Generate `.env` config:
-  - `REDIS_HOST=172.16.168.23`
+  - `REDIS_HOST=<database-ip>`
   - `REDIS_PORT=6379`
   - `SECRET_KEY=<generated>`
   - `DATABASE_URL=sqlite:///data/slm.db`
@@ -171,7 +173,7 @@ The `autobot_admin` user is normally disabled and only enabled during key/cert r
 
 Display:
 
-- SLM URL: `https://172.16.168.19`
+- SLM URL: `https://<slm-manager-ip>`
 - Admin username: `admin`
 - Admin password: `<generated or provided>`
 - `autobot_admin` password: `<SAVE THIS - displayed once>`
@@ -204,7 +206,7 @@ Re-run behavior:
 
 ## Dependencies
 
-**Redis:** Assumes Redis available at 172.16.168.23:6379. SLM should gracefully handle Redis unavailability (future enhancement).
+**Redis:** Assumes Redis available at <database-ip>:6379. SLM should gracefully handle Redis unavailability (future enhancement).
 
 ## Files to Create
 

--- a/docs/archives/plans/2026-02-18-skills-system.md
+++ b/docs/archives/plans/2026-02-18-skills-system.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # AutoBot Skills System Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -2181,13 +2183,13 @@ Replace `#TBD` in all commits with the actual issue number:
 sudo systemctl restart autobot-backend
 
 # Wait for startup (~60s)
-ssh autobot@172.16.168.19 'curl -sk https://172.16.168.20:8443/api/skills/governance'
+ssh autobot@<slm-manager-ip> 'curl -sk https://<backend-ip>:8443/api/skills/governance'
 # Expected: {"mode": "semi_auto", "gap_detection_enabled": true, ...}
 
-ssh autobot@172.16.168.19 'curl -sk https://172.16.168.20:8443/api/skills/drafts'
+ssh autobot@<slm-manager-ip> 'curl -sk https://<backend-ip>:8443/api/skills/drafts'
 # Expected: []
 
-ssh autobot@172.16.168.19 'curl -sk -X POST https://172.16.168.20:8443/api/skills/repos \
+ssh autobot@<slm-manager-ip> 'curl -sk -X POST https://<backend-ip>:8443/api/skills/repos \
   -H "Content-Type: application/json" \
   -d "{\"name\":\"community\",\"url\":\"mcp://skills.example.com\",\"repo_type\":\"mcp\"}"'
 # Expected: {"id": "...", "name": "community", "status": "registered"}

--- a/docs/archives/plans/2026-02-24-ui-improvements.md
+++ b/docs/archives/plans/2026-02-24-ui-improvements.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # UI Improvements Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -770,12 +772,12 @@ After builds pass, sync to VMs:
 **SLM frontend → .19:**
 ```bash
 # (check existing sync script for SLM frontend path)
-ssh autobot@172.16.168.19 "sudo systemctl restart autobot-slm-frontend 2>/dev/null || true"
+ssh autobot@<slm-manager-ip> "sudo systemctl restart autobot-slm-frontend 2>/dev/null || true"
 ```
 
 **Main frontend → .21:**
 ```bash
 cd /home/kali/Desktop/AutoBot/autobot-frontend
 npm run build
-./autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh 172.16.168.21 dist/ /opt/autobot/autobot-frontend/dist/
+./autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh <frontend-ip> dist/ /opt/autobot/autobot-frontend/dist/
 ```

--- a/docs/archives/plans/2026-03-02-streaming-tts-implementation.md
+++ b/docs/archives/plans/2026-03-02-streaming-tts-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Streaming Sentence-Level TTS Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -588,7 +590,7 @@ import json
 import websockets
 
 async def test():
-    async with websockets.connect("wss://172.16.168.20:8443/api/voice/stream", ssl=...) as ws:
+    async with websockets.connect("wss://<backend-ip>:8443/api/voice/stream", ssl=...) as ws:
         # Should receive initial state
         msg = await ws.recv()
         print("State:", msg)

--- a/docs/archives/plans/2026-03-04-node-decommission-design.md
+++ b/docs/archives/plans/2026-03-04-node-decommission-design.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # SLM Node Decommission Feature
 
 **Date:** 2026-03-04
@@ -196,7 +198,7 @@ Opened from NodeCard action menu -> "Decommission".
 ```
 +---------------------------------------------+
 |  ! Decommission Node: 04-NPU-Worker        |
-|  IP: 172.16.168.22                          |
+|  IP: <npu-ip>                          |
 |                                             |
 |  This will permanently remove all AutoBot   |
 |  software and data from this node.          |

--- a/docs/archives/plans/2026-03-04-node-decommission-plan.md
+++ b/docs/archives/plans/2026-03-04-node-decommission-plan.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Node Decommission Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -156,7 +158,7 @@ UI Layout:
 ## Task 8: Sync, build, and verify end-to-end
 
 **Step 1:** Sync backend to .19: `sync-to-vm.sh 19 autobot-slm-backend /opt/autobot/autobot-slm-backend`
-**Step 2:** Restart: `ssh autobot@172.16.168.19 "sudo systemctl restart autobot-slm-backend"`
+**Step 2:** Restart: `ssh autobot@<slm-manager-ip> "sudo systemctl restart autobot-slm-backend"`
 **Step 3:** Verify playbook exists on .19
 **Step 4:** Sync frontend to .21 + build
 **Step 5:** Test preflight: `curl -sk .../api/nodes/04-NPU-Worker/decommission/preflight`

--- a/docs/archives/plans/2026-03-06-interactive-browser-control-implementation.md
+++ b/docs/archives/plans/2026-03-06-interactive-browser-control-implementation.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Interactive Browser Control Implementation Plan
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
@@ -50,7 +52,7 @@ async function navInteractionResponse(page) {
 
 **Step 2: Verify file is valid**
 
-Run: `ssh autobot@172.16.168.25 "node -c /opt/autobot/autobot-browser-worker/playwright-server.js"`
+Run: `ssh autobot@<browser-ip> "node -c /opt/autobot/autobot-browser-worker/playwright-server.js"`
 
 Expected: No syntax errors
 
@@ -97,7 +99,7 @@ app.post('/click', async (req, res) => {
 
 **Step 2: Test manually**
 
-Run: `ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/click -H 'Content-Type: application/json' -d '{\"x\":100,\"y\":100}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d.get('viewportWidth'))"`
+Run: `ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/click -H 'Content-Type: application/json' -d '{\"x\":100,\"y\":100}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d.get('viewportWidth'))"`
 
 Expected: `True 1280` (or similar viewport width)
 
@@ -139,7 +141,7 @@ app.post('/scroll', async (req, res) => {
 
 **Step 2: Test manually**
 
-Run: `ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/scroll -H 'Content-Type: application/json' -d '{\"deltaY\":300}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
+Run: `ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/scroll -H 'Content-Type: application/json' -d '{\"deltaY\":300}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
 
 Expected: `True`
 
@@ -205,11 +207,11 @@ app.post('/hover', async (req, res) => {
 
 **Step 3: Test both**
 
-Run: `ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/type -H 'Content-Type: application/json' -d '{\"text\":\"hello\"}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
+Run: `ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/type -H 'Content-Type: application/json' -d '{\"text\":\"hello\"}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
 
 Expected: `True`
 
-Run: `ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/hover -H 'Content-Type: application/json' -d '{\"x\":200,\"y\":200}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
+Run: `ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/hover -H 'Content-Type: application/json' -d '{\"x\":200,\"y\":200}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'])"`
 
 Expected: `True`
 
@@ -248,7 +250,7 @@ Apply the same pattern to: `/screenshot`, `/back`, `/forward`, `/reload`.
 
 **Step 2: Test that navigate still works with new response shape**
 
-Run: `ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/navigate -H 'Content-Type: application/json' -d '{\"url\":\"https://example.com\"}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d.get('viewportWidth'), d.get('url'))"`
+Run: `ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/navigate -H 'Content-Type: application/json' -d '{\"url\":\"https://example.com\"}'" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['success'], d.get('viewportWidth'), d.get('url'))"`
 
 Expected: `True 1280 https://example.com/` (or similar)
 
@@ -270,19 +272,19 @@ git commit -m "feat(browser): add viewport dimensions to all navPage responses (
 **Step 1: Sync file to .25**
 
 ```bash
-rsync -avz autobot-browser-worker/playwright-server.js autobot@172.16.168.25:/opt/autobot/autobot-browser-worker/playwright-server.js
+rsync -avz autobot-browser-worker/playwright-server.js autobot@<browser-ip>:/opt/autobot/autobot-browser-worker/playwright-server.js
 ```
 
 **Step 2: Restart service on .25**
 
 ```bash
-ssh autobot@172.16.168.25 "sudo systemctl restart autobot-playwright"
+ssh autobot@<browser-ip> "sudo systemctl restart autobot-playwright"
 ```
 
 **Step 3: Verify service is running and endpoints work**
 
 ```bash
-ssh autobot@172.16.168.25 "systemctl is-active autobot-playwright && curl -s http://localhost:3000/health | python3 -c 'import sys,json; print(json.load(sys.stdin))'"
+ssh autobot@<browser-ip> "systemctl is-active autobot-playwright && curl -s http://localhost:3000/health | python3 -c 'import sys,json; print(json.load(sys.stdin))'"
 ```
 
 Expected: `active` and `{'status': 'healthy', ...}`
@@ -290,11 +292,11 @@ Expected: `active` and `{'status': 'healthy', ...}`
 **Step 4: Smoke test all new endpoints**
 
 ```bash
-ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/navigate -H 'Content-Type: application/json' -d '{\"url\":\"https://example.com\"}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"navigate:\", d[\"success\"], d.get(\"viewportWidth\"))'"
-ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/click -H 'Content-Type: application/json' -d '{\"x\":100,\"y\":100}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"click:\", d[\"success\"])'"
-ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/scroll -H 'Content-Type: application/json' -d '{\"deltaY\":300}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"scroll:\", d[\"success\"])'"
-ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/type -H 'Content-Type: application/json' -d '{\"text\":\"test\"}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"type:\", d[\"success\"])'"
-ssh autobot@172.16.168.25 "curl -s -X POST http://localhost:3000/hover -H 'Content-Type: application/json' -d '{\"x\":200,\"y\":200}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"hover:\", d[\"success\"])'"
+ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/navigate -H 'Content-Type: application/json' -d '{\"url\":\"https://example.com\"}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"navigate:\", d[\"success\"], d.get(\"viewportWidth\"))'"
+ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/click -H 'Content-Type: application/json' -d '{\"x\":100,\"y\":100}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"click:\", d[\"success\"])'"
+ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/scroll -H 'Content-Type: application/json' -d '{\"deltaY\":300}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"scroll:\", d[\"success\"])'"
+ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/type -H 'Content-Type: application/json' -d '{\"text\":\"test\"}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"type:\", d[\"success\"])'"
+ssh autobot@<browser-ip> "curl -s -X POST http://localhost:3000/hover -H 'Content-Type: application/json' -d '{\"x\":200,\"y\":200}' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(\"hover:\", d[\"success\"])'"
 ```
 
 Expected: All print `True`
@@ -720,13 +722,13 @@ Expected: Build succeeds with no errors
 **Step 3: Sync to frontend VM (.21)**
 
 ```bash
-./autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh 172.16.168.21 /home/kali/Desktop/AutoBot/autobot-frontend /opt/autobot/autobot-frontend
-ssh autobot@172.16.168.21 "cd /opt/autobot/autobot-frontend && npm run build"
+./autobot-infrastructure/shared/scripts/utilities/sync-to-vm.sh <frontend-ip> /home/kali/Desktop/AutoBot/autobot-frontend /opt/autobot/autobot-frontend
+ssh autobot@<frontend-ip> "cd /opt/autobot/autobot-frontend && npm run build"
 ```
 
 **Step 4: Verify in browser**
 
-Navigate to `https://172.16.168.21/knowledge/research` — status should show "Connected" on mount.
+Navigate to `https://<frontend-ip>/knowledge/research` — status should show "Connected" on mount.
 
 Navigate to the chat browser tab — click on a screenshot and verify the page responds.
 

--- a/docs/archives/plans/LAYER_SEPARATION_DELETIONS.md
+++ b/docs/archives/plans/LAYER_SEPARATION_DELETIONS.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../../architecture/VM_ROLES.md) for role definitions.
+
 # Layer Separation - Files Marked for Deletion
 
 **Related Issue:** #729 - Migrate admin functionality from main frontend/backend to SLM
@@ -19,7 +21,7 @@ This document tracks backend files that have been marked for deletion as part of
 
 ### autobot-backend/api/slm/ (Entire Directory)
 All files in this directory are non-functional after `backend/services/slm/` removal.
-SLM server (172.16.168.19) provides equivalent functionality.
+SLM server (<slm-manager-ip>) provides equivalent functionality.
 
 - [ ] `autobot-backend/api/slm/stateful.py` - See `slm-server/api/stateful.py`
 - [ ] `autobot-backend/api/slm/nodes.py` - See `slm-server/api/nodes.py`
@@ -46,7 +48,7 @@ SLM server (172.16.168.19) provides equivalent functionality.
 ## Verification Checklist
 
 Before deleting the remaining files, verify:
-- [ ] SLM server (172.16.168.19) is operational
+- [ ] SLM server (<slm-manager-ip>) is operational
 - [ ] All SLM endpoints accessible via SLM server
 - [ ] No frontend components calling backend SLM endpoints
 - [ ] No other backend services depending on these files

--- a/docs/changelog/2025-10-04-xterm-upgrade.md
+++ b/docs/changelog/2025-10-04-xterm-upgrade.md
@@ -3,6 +3,8 @@ tags: [type/reference, status/current, component/frontend]
 date: 2025-10-04
 ---
 
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # xterm.js Terminal Upgrade Implementation Summary
 
 **Date:** 2025-10-04
@@ -55,12 +57,12 @@ Successfully upgraded AutoBot terminal system from custom div-based rendering to
   - Store integration for global host state
   - Dark mode support
 - **Hosts:**
-  1. Main (WSL Backend) - 172.16.168.20
-  2. VM1 (Frontend) - 172.16.168.21
-  3. VM2 (NPU Worker) - 172.16.168.22
-  4. VM3 (Redis) - 172.16.168.23
-  5. VM4 (AI Stack) - 172.16.168.24
-  6. VM5 (Browser) - 172.16.168.25
+  1. Main (WSL Backend) - <backend-ip>
+  2. VM1 (Frontend) - <frontend-ip>
+  3. VM2 (NPU Worker) - <npu-ip>
+  4. VM3 (Redis) - <database-ip>
+  5. VM4 (AI Stack) - <aiml-ip>
+  6. VM5 (Browser) - <browser-ip>
 
 ### 2. Specialized Terminals
 
@@ -222,7 +224,7 @@ Update `src/router/index.ts` to import and use new components.
 
 ### 4. Test Locally First
 ```bash
-# On Frontend VM (172.16.168.21)
+# On Frontend VM (<frontend-ip>)
 cd /home/autobot/autobot-vue
 npm run dev
 

--- a/docs/developer/HARDCODING_PREVENTION.md
+++ b/docs/developer/HARDCODING_PREVENTION.md
@@ -47,6 +47,8 @@ GITHUB_BASE_REF=Dev_new_gui bash pipeline-scripts/check-hardcoded-values-pr.sh
 
 **What it blocks** (by category, see hook source for full patterns):
 
+<!-- fleet-addressing-exempt: states the address range this hook detects; the range is the rule -->
+
 - Hardcoded VM IPs (`172.16.168.19-25`)
 - Hardcoded infrastructure ports in URL context
 - Magic numbers that should use constants from `threshold_constants.py`
@@ -65,8 +67,10 @@ GITHUB_BASE_REF=Dev_new_gui bash pipeline-scripts/check-hardcoded-values-pr.sh
 - Any file under `repo_tests/` (#15273) — that directory is test-support code by construction, so a non-test-named helper module living there (e.g. one holding fixture constants shared by several `*_test.py` siblings) gets the same exemption on the strength of its DIRECTORY rather than its filename. The same file outside `repo_tests/` is still scanned.
 - Lines containing `config.`, `getenv`, `CONFIG[`, or `AUTOBOT_` (already routed through SSOT)
 - Comments (any line starting with `#` / `//` / ` *`)
-- File types other than `.py` / `.ts` / `.vue` (Markdown, YAML, JSON, etc. are not scanned at all — Ansible inventories and docs are explicitly out of scope)
+- File types other than `.py` / `.ts` / `.vue` (YAML, JSON, etc. are not scanned at all — Ansible inventories are explicitly out of scope). Markdown is not scanned by *this* hook; since #15208 `docs/**/*.md` is gated by `tools/lint/check_docs_no_fleet_addressing.py`, which looks for fleet node addresses only and reads its pattern from the same `HV_VM_IP` rule this hook uses.
 - `192.168.x.x` and `127.0.0.x` literals (RFC 1918 example space and loopback — used in SSRF guards, network-tooling examples, test fixtures, i18n placeholders)
+
+<!-- fleet-addressing-exempt: quotes the exact call the hook's `getenv` filter lets through, which is the false negative being described -->
 
 **Known limitation (tracked in #6725 follow-up):** the hook's line filter currently skips any line containing the substring `getenv`, so a literal IP fallback inside `os.getenv("AUTOBOT_REDIS_HOST", "172.16.168.23")` is *not* flagged. This is the false-negative an AST-aware Python rewrite would close. The locked-in test `test_allows_code_using_ssot_config` documents this behavior so any future tightening has a clear regression target.
 
@@ -83,6 +87,8 @@ GITHUB_BASE_REF=Dev_new_gui bash pipeline-scripts/check-hardcoded-values-pr.sh
 - `Literal[value=/^(https?:\/\/)?172\.16\.168\.\d+/]` — bare IP literals or HTTP(S) URLs containing them
 - `TemplateElement[value.cooked=/172\.16\.168\.\d+/]` — IP inside a template literal
 
+<!-- fleet-addressing-exempt: quotes the literals the ESLint selectors above match; a counter-example without them demonstrates nothing -->
+
 Catches:
 - `const x = '172.16.168.20'`
 - `const x = 'http://172.16.168.21:5173'`
@@ -92,9 +98,53 @@ Catches:
 Doesn't trigger on:
 - `127.0.0.1` (loopback — single-host install default)
 - `192.168.x.x` (RFC 1918 example space — used in tests, SSRF guards, i18n placeholders)
-- IPs in `.json` locale files, `.md` docs, generated types (not in lint scope)
+- IPs in `.json` locale files, generated types (not in lint scope). Markdown under `docs/` is gated separately by `tools/lint/check_docs_no_fleet_addressing.py` (#15208).
 
 Test fixtures live in `autobot-frontend/eslint-tests/` (excluded from production lint by design — see `eslint-tests/README.md`).
+
+### Documentation fleet-addressing guard (Issue #15208)
+
+`tools/lint/check_docs_no_fleet_addressing.py` gates `docs/**/*.md`, which none of the
+detectors above reach: `HV_SCAN_EXTENSIONS` in `scripts/lib/hardcoded-value-rules.sh` is
+`py|ts|vue|js|sh|yml|yaml`, and Markdown is not in it. #3315 redacted
+`docs/architecture/` by hand; with nothing watching, the same addressing survived in
+`docs/archives/plans/` until #15208.
+
+It carries no copy of the range. It parses the `HV_VM_IP` assignment out of
+`scripts/lib/hardcoded-value-rules.sh`, so code and documentation share one definition of
+"a fleet address" and a renumbered fleet updates both at once. A missing or unparseable
+rule set aborts the run rather than reporting clean.
+
+```bash
+# Sweep every Markdown file under docs/
+python3 tools/lint/check_docs_no_fleet_addressing.py --audit
+
+# Check specific files (the pre-commit entry point takes argv)
+python3 tools/lint/check_docs_no_fleet_addressing.py docs/runbooks/CODE_UPDATE.md
+```
+
+Replace a finding with the role placeholder for its node — see
+[VM_ROLES.md](../architecture/VM_ROLES.md) — matching the form #3315 established
+(`<backend-ip>`, `<database-ip>`, `<network-subnet>`, and so on).
+
+**Deliberate counter-examples** are exempted by a Markdown comment introducing the block
+that needs it, not by a filename in a list:
+
+```markdown
+<!-- fleet-addressing-exempt: why this block must keep the literal -->
+
+- the block the marker introduces
+```
+
+`fleet-addressing-exempt-file` exempts a whole document. Either marker is a finding when
+the text it covers carries no address, so an exemption cannot outlive its reason. This
+page uses three block markers, for the sections that document the detection patterns
+themselves.
+
+The audit reports how many files it reached and fails below a floor, because a sweep
+whose glob stops matching reports "no offenders" over nothing at all — which is exactly
+how the gap #15208 names went unnoticed for months.
+
 
 ### Generic CI wrapper for any pre-commit hook (Issue #6785)
 

--- a/docs/developer/SINGLE_HOST_DEPLOYMENT.md
+++ b/docs/developer/SINGLE_HOST_DEPLOYMENT.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Single-Host AutoBot Deployment
 
 **Issue #2961** | Last updated: 2026-04-12
@@ -373,7 +375,7 @@ ss -tlnp | grep 8001   # Verify uvicorn is actually bound
 
 **Symptom:** Backend logs show `ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 6379)`.
 
-**Cause A:** `AUTOBOT_REDIS_HOST` not set, defaulting to multi-host IP (e.g., `172.16.168.23`).
+**Cause A:** `AUTOBOT_REDIS_HOST` not set, defaulting to multi-host IP (e.g., `<database-ip>`).
 
 ```bash
 grep AUTOBOT_REDIS_HOST /etc/autobot/backend.env

--- a/docs/runbooks/SINGLE_HOST_DEPLOYMENT.md
+++ b/docs/runbooks/SINGLE_HOST_DEPLOYMENT.md
@@ -1,3 +1,5 @@
+> **IP addresses** in this document use role placeholders (e.g. `<backend-ip>`). Replace with your actual VM IPs. See [VM_ROLES.md](../architecture/VM_ROLES.md) for role definitions.
+
 # Runbook: Single-Host AutoBot Deployment
 
 **Issue #2961** | Last updated: 2026-04-08
@@ -429,7 +431,7 @@ ansible-playbook \
 To migrate from single-host to distributed deployment:
 
 1. Create separate VMs for each role
-2. Update `/etc/autobot/.env` with real IPs (e.g., `AUTOBOT_BACKEND_HOST=172.16.168.10`)
+2. Update `/etc/autobot/.env` with real IPs (e.g., `AUTOBOT_BACKEND_HOST=<backend-ip>`)
 3. Create `inventory/fleet.yml` with host groups
 4. Run provisioning against new inventory:
    ```bash

--- a/tools/lint/check_code_quality_guard_reach.py
+++ b/tools/lint/check_code_quality_guard_reach.py
@@ -57,6 +57,7 @@ _GUARDED_CHECKERS = (
     "tools/lint/check_ci_system_package_provisioning.py",
     "tools/lint/check_composite_action_step_keys.py",
     "tools/lint/check_requirements_pin_parity.py",
+    "tools/lint/check_docs_no_fleet_addressing.py",
 )
 
 _FILTER_BULLET_RE = re.compile(r"^\s*-\s*'([^']+)'\s*$")

--- a/tools/lint/check_docs_no_fleet_addressing.py
+++ b/tools/lint/check_docs_no_fleet_addressing.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""#15208 — no Markdown document under ``docs/`` may carry a literal fleet node address.
+
+#3315 replaced the fleet's literal node addresses in ``docs/architecture/`` with the
+role placeholders defined in ``docs/architecture/VM_ROLES.md``. Nothing stopped the
+next document from writing a literal again, and nothing looked outside the folder that
+sweep happened to target: the addressing survived for months in ``docs/archives/plans/``,
+one directory across, together with the role-to-host and database-endpoint mappings that
+make an address list into a network map.
+
+WHY NO EXISTING GUARD SEES THIS. ``scripts/lib/hardcoded-value-rules.sh`` — the union
+detector behind both ``pipeline-scripts/detect-hardcoded-values.sh`` and the
+``pre-commit-hardcoded-values`` hook — scans ``HV_SCAN_EXTENSIONS`` only, and that list
+is ``py|ts|vue|js|sh|yml|yaml``. Markdown is not in it, and the frontend
+``no-hardcoded-vm-ip`` ESLint rule and ``check_no_hardcoded_ip_fallbacks.py`` are
+narrower still (TypeScript literals, Python ``os.getenv`` fallbacks). Documentation had
+no gate at all, which is exactly why the exposure aged rather than being caught.
+
+THE PATTERN IS NOT COPIED. This module holds no address literal of its own; it parses
+the ``HV_VM_IP`` assignment out of ``scripts/lib/hardcoded-value-rules.sh`` and reuses
+it. One definition of "a fleet address" serves code and documentation, so a renumbered
+fleet updates both guards at once — and a second, drifting copy of the range cannot come
+into existence here. A missing or unparseable source aborts loudly, the same doctrine
+that file applies to its own dependencies: an unread pattern and an empty one are
+indistinguishable to every caller.
+
+WHAT IS DELIBERATE STAYS, BY STRUCTURE NOT BY FILENAME. Some documents cite an address
+on purpose — ``docs/developer/HARDCODING_PREVENTION.md`` documents the very regexes the
+hardcoded-value hook and the ESLint rule match, and a counter-example with the literal
+removed stops demonstrating anything. Those are exempted by an HTML comment placed in
+the document, scoping the exemption to the block it introduces::
+
+    <!-- fleet-addressing-exempt: documents the pattern the hook matches -->
+
+    - Hardcoded VM IPs (`<the literal range>`)
+
+A whole file may be exempted with ``fleet-addressing-exempt-file``. The exemption is a
+*parsed Markdown block marker*, not a path in a list: it lives beside the text it
+excuses, it states its reason there, it moves with the text, and it cannot silently
+widen to cover a leak that lands later in the same file. A marker introducing a block
+that carries no address is itself a finding — a stranded exemption is a stale claim.
+
+REACH FLOOR. The audit reports how many Markdown files it reached and fails below
+``DISCOVERY_FLOOR``. A sweep whose glob stops matching finds no offenders and reports
+success, which is indistinguishable from a clean tree; #15208 exists because a sweep
+that never looked at ``docs/archives/`` reported exactly that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pathlib
+import re
+import sys
+from typing import Iterable, NamedTuple
+
+# Plain stdlib logging, deliberately (#1082). This runs as a bare script inside a lint
+# job, and `autobot_shared.logging_manager` would drag config loading into it.
+logger = logging.getLogger(__name__)
+
+DOCS_DIR = "docs"
+SELF_REL = "tools/lint/check_docs_no_fleet_addressing.py"
+RULES_REL = "scripts/lib/hardcoded-value-rules.sh"
+ROLES_DOC = "docs/architecture/VM_ROLES.md"
+
+# docs/ held 811 Markdown files when this guard landed. The floor sits well below that
+# so ordinary archival churn does not trip it, and well above zero so a broken glob does.
+DISCOVERY_FLOOR = 600
+
+#: What this guard reads, for tools/lint/check_code_quality_guard_reach.py
+#: (#14550/#14551). The sweep covers every Markdown file under docs/; the two entries
+#: are the real files standing for its two inputs — the archived tree #3315 never
+#: reached, and the rule set the address pattern is parsed from. Both must be covered
+#: by code-quality.yml's `backend` path filter: a PR touching only documentation would
+#: otherwise skip the job, and a skipped required job satisfies branch protection —
+#: so the guard could not fire on the change it exists to catch.
+GUARD_INPUT_PATHS = ("docs/archives/_index.md", RULES_REL)
+
+EXEMPT_BLOCK = "fleet-addressing-exempt"
+EXEMPT_FILE = "fleet-addressing-exempt-file"
+
+_HV_VM_IP_ASSIGNMENT = re.compile(r"^HV_VM_IP='(?P<pattern>[^']+)'", re.MULTILINE)
+_MARKER_RE = re.compile(r"<!--\s*(?P<kind>fleet-addressing-exempt(?:-file)?)\s*:(?P<reason>[^>]*?)-->")
+_FENCE_RE = re.compile(r"^\s*(?P<fence>```+|~~~+)")
+
+
+class Finding(NamedTuple):
+    """One offending line: repo-relative path, 1-based line number, and its text."""
+
+    path: str
+    lineno: int
+    text: str
+
+
+class Block(NamedTuple):
+    """A Markdown block: its 1-based start line and its lines."""
+
+    start: int
+    lines: list[str]
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root, derived from this file's location (``tools/lint/`` is two deep)."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def fleet_address_pattern(base: pathlib.Path | None = None) -> re.Pattern[str]:
+    """The canonical fleet-address regex, read from the shared hardcoded-value rules.
+
+    Raises ``RuntimeError`` rather than falling back: a guard that cannot load its
+    pattern must fail, not report a comfortable zero.
+    """
+    base = base or repo_root()
+    source = base / RULES_REL
+    try:
+        text = source.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"cannot read the canonical rule set at {RULES_REL}: {exc}") from exc
+    match = _HV_VM_IP_ASSIGNMENT.search(text)
+    if not match:
+        raise RuntimeError(f"no HV_VM_IP assignment found in {RULES_REL} — the guard has no pattern to apply")
+    return re.compile(match.group("pattern"))
+
+
+def discover_markdown_files(base: pathlib.Path | None = None) -> list[pathlib.Path]:
+    """Every tracked-shaped ``*.md`` under ``docs/``."""
+    base = base or repo_root()
+    docs = base / DOCS_DIR
+    if not docs.is_dir():
+        return []
+    return sorted(p for p in docs.rglob("*.md") if p.is_file())
+
+
+def split_blocks(lines: list[str]) -> list[Block]:
+    """Split Markdown into blank-line-separated blocks, keeping fenced code whole."""
+    blocks: list[Block] = []
+    current: list[str] = []
+    start = 1
+    fence: str | None = None
+    for index, line in enumerate(lines, start=1):
+        fence = _next_fence_state(line, fence)
+        if fence is None and not line.strip():
+            if current:
+                blocks.append(Block(start, current))
+                current = []
+            continue
+        if not current:
+            start = index
+        current.append(line)
+    if current:
+        blocks.append(Block(start, current))
+    return blocks
+
+
+def _next_fence_state(line: str, fence: str | None) -> str | None:
+    """Track whether *line* opens or closes a fenced code block."""
+    match = _FENCE_RE.match(line)
+    if not match:
+        return fence
+    marker = match.group("fence")
+    if fence is None:
+        return marker
+    return None if marker[0] == fence[0] and len(marker) >= len(fence) else fence
+
+
+def _marker_kind(block: Block) -> str | None:
+    """The exemption kind a block declares, when the block is only that marker."""
+    joined = "\n".join(block.lines).strip()
+    match = _MARKER_RE.fullmatch(joined)
+    return match.group("kind") if match else None
+
+
+def scan_document(rel: str, text: str, pattern: re.Pattern[str]) -> tuple[list[Finding], list[str]]:
+    """Findings and stranded-exemption problems for one document."""
+    lines = text.split("\n")
+    if _MARKER_RE.search(text) and any(_marker_kind(b) == EXEMPT_FILE for b in split_blocks(lines)):
+        return [], _stranded_file(rel, lines, pattern)
+    findings: list[Finding] = []
+    problems: list[str] = []
+    pending: str | None = None
+    for block in split_blocks(lines):
+        kind = _marker_kind(block)
+        if kind is not None:
+            pending = kind
+            continue
+        hits = _block_hits(rel, block, pattern)
+        if pending == EXEMPT_BLOCK and not hits:
+            problems.append(
+                f"{rel}:{block.start}: stranded {EXEMPT_BLOCK} marker — "
+                "the block it covers carries no address"
+            )
+        if pending != EXEMPT_BLOCK:
+            findings.extend(hits)
+        pending = None
+    return findings, problems
+
+
+def _stranded_file(rel: str, lines: list[str], pattern: re.Pattern[str]) -> list[str]:
+    """A file-level exemption over a file with no address is a stale claim."""
+    if any(pattern.search(line) for line in lines):
+        return []
+    return [f"{rel}: stranded {EXEMPT_FILE} marker — the file carries no address"]
+
+
+def _block_hits(rel: str, block: Block, pattern: re.Pattern[str]) -> list[Finding]:
+    """Every offending line inside one block."""
+    return [
+        Finding(rel, block.start + index, line.strip())
+        for index, line in enumerate(block.lines)
+        if pattern.search(line)
+    ]
+
+
+def check_paths(
+    paths: Iterable[pathlib.Path], base: pathlib.Path, pattern: re.Pattern[str]
+) -> tuple[list[Finding], list[str]]:
+    """Scan the given Markdown files. An unreadable file is a problem, never a skip."""
+    findings: list[Finding] = []
+    problems: list[str] = []
+    for path in paths:
+        rel = str(path.relative_to(base)) if path.is_relative_to(base) else str(path)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            problems.append(f"{rel}: unreadable ({exc}) — skipping it would let a leak hide behind an I/O error")
+            continue
+        hits, stranded = scan_document(rel, text, pattern)
+        findings.extend(hits)
+        problems.extend(stranded)
+    return findings, problems
+
+
+def _format_findings(findings: list[Finding]) -> str:
+    """One ``path:line`` per finding. The matched text is deliberately not echoed."""
+    return "\n".join(f"  {f.path}:{f.lineno}" for f in findings)
+
+
+def _leak_problem(findings: list[Finding]) -> str:
+    """The operator-facing message for a set of address findings."""
+    files = len({f.path for f in findings})
+    return (
+        f"{len(findings)} line(s) across {files} document(s) carry a literal fleet node address:\n"
+        + _format_findings(findings)
+        + f"\n\nReplace each with the role placeholder for its node — see {ROLES_DOC} — as #3315 did "
+        f"for docs/architecture/. Where the literal is a deliberate counter-example, introduce the "
+        f"block with an inline <!-- {EXEMPT_BLOCK}: reason --> marker stating why (#15208)."
+    )
+
+
+def audit(base: pathlib.Path | None = None) -> tuple[int, list[str]]:
+    """Sweep every Markdown file under ``docs/``. Returns (files reached, problems)."""
+    base = base or repo_root()
+    problems: list[str] = []
+    pattern = fleet_address_pattern(base)
+    files = discover_markdown_files(base)
+    if len(files) < DISCOVERY_FLOOR:
+        problems.append(
+            f"discovery returned only {len(files)} Markdown file(s) under {DOCS_DIR}/ "
+            f"(floor {DISCOVERY_FLOOR}) — the sweep broke, so a clean result below would assert nothing."
+        )
+    findings, scan_problems = check_paths(files, base, pattern)
+    problems.extend(scan_problems)
+    if findings:
+        problems.append(_leak_problem(findings))
+    return len(files), problems
+
+
+def _selected_paths(paths: list[str], base: pathlib.Path) -> list[pathlib.Path]:
+    """Resolve CLI paths to existing Markdown files."""
+    resolved = [pathlib.Path(p) if pathlib.Path(p).is_absolute() else base / p for p in paths]
+    return [p for p in resolved if p.suffix == ".md" and p.is_file()]
+
+
+def configure_logging() -> None:
+    """Attach a stderr handler so findings actually reach the developer."""
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+
+def _run(args: argparse.Namespace, base: pathlib.Path) -> tuple[str, list[str]]:
+    """Execute the requested scope, returning (scope description, problems)."""
+    if args.audit:
+        reached, problems = audit(base)
+        return f"{reached} Markdown file(s) under {DOCS_DIR}/", problems
+    selected = _selected_paths(args.paths, base)
+    findings, problems = check_paths(selected, base, fleet_address_pattern(base))
+    if findings:
+        problems.append(_leak_problem(findings))
+    return f"{len(selected)} given file(s)", problems
+
+
+def main(argv: list[str]) -> int:
+    configure_logging()
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--audit", action="store_true", help=f"sweep every Markdown file under {DOCS_DIR}/")
+    parser.add_argument("paths", nargs="*", help="Markdown files to check")
+    args = parser.parse_args(argv)
+    if not args.audit and not args.paths:
+        parser.error("nothing to do — pass --audit or one or more paths")
+    base = repo_root()
+    try:
+        scope, problems = _run(args, base)
+    except RuntimeError as exc:
+        logger.error("fleet-addressing audit ABORTED: %s (#15208).", exc)
+        return 1
+    if problems:
+        logger.error("%s", "\n\n".join(problems))
+        logger.error("\nfleet-addressing audit FAILED over %s (#15208).", scope)
+        return 1
+    logger.info("fleet-addressing audit clean over %s (#15208).", scope)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/lint/check_docs_no_fleet_addressing_test.py
+++ b/tools/lint/check_docs_no_fleet_addressing_test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# Copyright 2025-2026 mrveiss
+# SPDX-License-Identifier: Apache-2.0
+# AutoBot - AI-Powered Automation Platform
+# Author: mrveiss
+"""Discrimination tests for the #15208 documentation fleet-addressing guard.
+
+No fixture here quotes a fleet address. Each one is *derived* from the canonical
+``HV_VM_IP`` pattern the guard itself loads, so this file cannot drift from the rule
+it tests and adds no second copy of the range to the repository — the same reason the
+guard parses the pattern instead of restating it.
+
+The reach-floor tests are the contrast mutation for the sweep: narrowing discovery back
+to a single directory, the way #3315's sweep was scoped, must fail on the floor rather
+than report a comfortable "no offenders" over a handful of files.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import textwrap
+
+import pytest
+
+from tools.lint import check_docs_no_fleet_addressing as guard
+
+RULES_BODY = "HV_VM_IP='{pattern}'\n"
+
+
+def _canonical_pattern() -> str:
+    """The fleet-address regex as the repository defines it, read once."""
+    return guard.fleet_address_pattern().pattern
+
+
+def _sample_address() -> str:
+    """A literal that the canonical pattern matches, built from the pattern itself."""
+    literal = re.sub(r"\[0-9\]\+$", "17", _canonical_pattern().replace("\\", ""))
+    assert guard.fleet_address_pattern().search(literal), literal
+    return literal
+
+
+def _base(tmp_path: pathlib.Path, docs: dict[str, str]) -> pathlib.Path:
+    """A miniature repository: the canonical rule set plus the given documents."""
+    rules = tmp_path / guard.RULES_REL
+    rules.parent.mkdir(parents=True, exist_ok=True)
+    rules.write_text(RULES_BODY.format(pattern=_canonical_pattern()), encoding="utf-8")
+    for rel, body in docs.items():
+        path = tmp_path / guard.DOCS_DIR / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(body), encoding="utf-8")
+    return tmp_path
+
+
+def _padding(count: int, prefix: str = "pad") -> dict[str, str]:
+    """Enough clean documents to clear the discovery floor."""
+    return {f"{prefix}/doc_{i}.md": "# Clean\n\nNothing to see.\n" for i in range(count)}
+
+
+def _scan(text: str):
+    return guard.scan_document("docs/x.md", text, guard.fleet_address_pattern())
+
+
+# ── detection ────────────────────────────────────────────────────────────────
+
+
+def test_flags_a_literal_address_in_prose():
+    findings, problems = _scan(f"# Doc\n\nRedis runs on {_sample_address()} in the fleet.\n")
+    assert [f.lineno for f in findings] == [3]
+    assert problems == []
+
+
+def test_flags_a_literal_address_inside_a_fenced_code_block():
+    body = f"# Doc\n\n```bash\nssh autobot@{_sample_address()}\n```\n"
+    findings, _ = _scan(body)
+    assert [f.lineno for f in findings] == [4]
+
+
+def test_a_role_placeholder_is_not_a_finding():
+    findings, problems = _scan("# Doc\n\nRedis runs on `<database-ip>` in the fleet.\n")
+    assert findings == []
+    assert problems == []
+
+
+def test_findings_never_echo_the_matched_address():
+    findings, _ = _scan(f"# Doc\n\nRedis runs on {_sample_address()}.\n")
+    rendered = guard._format_findings(findings)
+    assert _sample_address() not in rendered
+    assert "docs/x.md:3" in rendered
+
+
+# ── structural exemptions ────────────────────────────────────────────────────
+
+
+def test_block_marker_exempts_the_block_it_introduces():
+    body = (
+        "# Doc\n\n"
+        f"<!-- {guard.EXEMPT_BLOCK}: documents the pattern the hook matches -->\n\n"
+        f"- Hardcoded VM IPs (`{_sample_address()}`)\n"
+    )
+    findings, problems = _scan(body)
+    assert findings == []
+    assert problems == []
+
+
+def test_block_marker_does_not_cover_a_later_block():
+    body = (
+        "# Doc\n\n"
+        f"<!-- {guard.EXEMPT_BLOCK}: counter-example -->\n\n"
+        f"- Hardcoded VM IPs (`{_sample_address()}`)\n\n"
+        f"The database endpoint is {_sample_address()}:5432.\n"
+    )
+    findings, _ = _scan(body)
+    assert [f.lineno for f in findings] == [7]
+
+
+def test_stranded_block_marker_is_a_finding():
+    body = f"# Doc\n\n<!-- {guard.EXEMPT_BLOCK}: nothing here -->\n\nOrdinary prose.\n"
+    _, problems = _scan(body)
+    assert any("stranded" in p for p in problems)
+
+
+def test_file_marker_exempts_the_whole_file():
+    body = (
+        f"<!-- {guard.EXEMPT_FILE}: this document is the rule's own reference -->\n\n"
+        f"# Doc\n\nOne {_sample_address()} here and another {_sample_address()} there.\n"
+    )
+    findings, problems = _scan(body)
+    assert findings == []
+    assert problems == []
+
+
+def test_stranded_file_marker_is_a_finding():
+    body = f"<!-- {guard.EXEMPT_FILE}: stale claim -->\n\n# Doc\n\nNo address at all.\n"
+    _, problems = _scan(body)
+    assert any("stranded" in p for p in problems)
+
+
+# ── pattern provenance ───────────────────────────────────────────────────────
+
+
+def test_pattern_comes_from_the_canonical_rule_set(tmp_path):
+    base = _base(tmp_path, {})
+    assert guard.fleet_address_pattern(base).pattern == _canonical_pattern()
+
+
+def test_missing_rule_set_aborts_rather_than_reporting_clean(tmp_path):
+    (tmp_path / guard.DOCS_DIR).mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="cannot read the canonical rule set"):
+        guard.fleet_address_pattern(tmp_path)
+
+
+def test_rule_set_without_the_assignment_aborts(tmp_path):
+    rules = tmp_path / guard.RULES_REL
+    rules.parent.mkdir(parents=True, exist_ok=True)
+    rules.write_text("# no assignment here\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="no HV_VM_IP assignment"):
+        guard.fleet_address_pattern(tmp_path)
+
+
+# ── reach floor (the contrast mutation) ──────────────────────────────────────
+
+
+def test_audit_is_clean_when_the_floor_is_met_and_nothing_offends(tmp_path):
+    base = _base(tmp_path, _padding(guard.DISCOVERY_FLOOR))
+    reached, problems = guard.audit(base)
+    assert reached == guard.DISCOVERY_FLOOR
+    assert problems == []
+
+
+def test_audit_fails_on_the_floor_when_discovery_is_narrowed(tmp_path, monkeypatch):
+    """#3315's scope, applied to this guard: a sweep that stops finding files must fail.
+
+    Discovery is narrowed to one subdirectory — the shape of the original sweep — over a
+    tree that contains no offender at all. Without the floor the run reports success
+    having checked almost nothing, which is the failure #15208 was filed for.
+    """
+    base = _base(tmp_path, {**_padding(guard.DISCOVERY_FLOOR), **_padding(3, prefix="architecture")})
+    monkeypatch.setattr(
+        guard,
+        "discover_markdown_files",
+        lambda b=None: sorted((base / guard.DOCS_DIR / "architecture").rglob("*.md")),
+    )
+    reached, problems = guard.audit(base)
+    assert reached == 3
+    assert any("floor" in p for p in problems)
+
+
+def test_audit_fails_on_the_floor_when_docs_is_absent(tmp_path):
+    base = _base(tmp_path, {})
+    reached, problems = guard.audit(base)
+    assert reached == 0
+    assert any("floor" in p for p in problems)
+
+
+# ── the repository itself ────────────────────────────────────────────────────
+
+
+def test_repository_documentation_carries_no_unexempted_fleet_address():
+    reached, problems = guard.audit()
+    assert reached >= guard.DISCOVERY_FLOOR
+    assert problems == [], "\n\n".join(problems)
+
+
+def test_main_reports_a_nonzero_exit_for_a_leaking_file(tmp_path, monkeypatch):
+    base = _base(tmp_path, {"leak.md": f"# Doc\n\nEndpoint {_sample_address()}:5432.\n"})
+    monkeypatch.setattr(guard, "repo_root", lambda: base)
+    assert guard.main([str(base / guard.DOCS_DIR / "leak.md")]) == 1


### PR DESCRIPTION
Closes #15208

## Thinking Path

**The count first.** A private-range grep over `docs/` at `origin/Dev_new_gui` returns 61
files, but most of those are RFC 1918 illustration space, loopback, or a documentation
placeholder. Narrowing to the fleet's own /24 — the range `scripts/lib/hardcoded-value-rules.sh`
itself names as `HV_VM_IP` — gives **37 files, 286 occurrences across 276 lines**. That
reconciles exactly with the issue: 33 under `docs/archives/plans/`, 2 in `docs/developer/`,
1 in `docs/runbooks/`, 1 in `docs/changelog/`. Nothing was already delivered
(`git log --grep "#15208"` on the base is empty).

**Redact vs keep.** The rule applied is the one `tools/lint/check_no_hardcoded_ip_fallbacks.py`
already states in its own source: only the deployment range is an exposure; RFC 1918 example
space and loopback are legitimate by project convention. Under that rule 36 files hold
addressing that maps this fleet's roles to hosts and names database endpoints, and are
redacted. One file — `docs/developer/HARDCODING_PREVENTION.md`, 6 occurrences — documents the
detection patterns the hardcoded-value hook and the frontend ESLint rule match. A
counter-example with the literal removed stops demonstrating anything, so its occurrences stay
and are annotated in place, which is the exception the issue's own acceptance criteria allow.
The 24 non-fleet private addresses elsewhere in `docs/` (documentation-reserved and
example-space ranges, including a Hyper-V networking guide whose whole subject is a template
subnet) are deliberate examples and are untouched.

**The convention is #3315's, read from #3315.** `da8cdb5527` is the sweep. Its replacement
vocabulary — a `<role-ip>` placeholder per node, a single placeholder for the subnet, the
gateway named as a role — and the exact note line it added to its densest files are reused
verbatim. No second convention was invented. One placeholder choice was not covered by that
sweep (a node that predates the current numbering); it is resolved from each document's own
context, and lands on the role the surrounding prose names.

**These are archives, so the redaction is recorded.** Rewriting a historical plan in place is
right — the alternative leaves a permanent, public exposure to preserve a document nobody is
maintaining, and `docs/_config.yml` excludes `archives` from the site, so nothing rendered
changes. But a reader must not take a placeholder for what the original said, especially where
an archived plan *quotes historical source code*. The placeholders are self-describing rather
than a mask, so meaning survives; `docs/archives/_index.md` now states plainly that the
substitution happened after archival and that nothing else was altered. **This does not settle
git history**, where every original value remains. That is the repository owner's call, as the
issue's comment says, and nothing here touches it.

**One guard, extended in reach rather than duplicated.** #3315 shipped no guard, so there was
none to extend; the three that exist (`hardcoded-value-rules.sh`, the ESLint rule,
`check_no_hardcoded_ip_fallbacks.py`) all stop at code. Rather than add a fourth copy of the
range, the new check *parses the pattern out of the shared rule set*, so code and documentation
share one definition and a renumbered fleet updates both at once.

## What Changed

| Area | Change |
| --- | --- |
| 33 archived plans, 1 changelog entry, 2 deployment docs | Literal node addresses replaced with #3315's role placeholders; the note line that sweep used added to each file touched |
| 8 ASCII diagram rows | Re-aligned to their box borders, which the substitution would otherwise have left ragged (2 boxes had pre-existing drift and are now square) |
| `docs/developer/HARDCODING_PREVENTION.md` | 6 occurrences kept as deliberate counter-examples, each block annotated with an inline exemption marker; the "Markdown is not scanned at all" statement corrected, and the new guard documented |
| `docs/archives/_index.md` | Records that addressing was redacted **after** archival, so a placeholder is not read as the original text |
| `tools/lint/check_docs_no_fleet_addressing.py` (new) | Gates `docs/**/*.md`. Parses `HV_VM_IP` out of `scripts/lib/hardcoded-value-rules.sh` and aborts if it cannot; splits each document into Markdown blocks (fenced code kept whole) rather than matching raw characters; exemptions are block markers living beside the text they excuse, and a marker covering no address is itself a finding. Findings report `path:line` and never echo the matched value |
| `tools/lint/check_docs_no_fleet_addressing_test.py` (new) | 17 discrimination tests. No fixture quotes an address — each is derived from the canonical pattern the guard loads, so the test file adds no second copy of the range |
| `.github/workflows/code-quality.yml` | New required `--audit` step; `backend` path filter widened from `docs/developer/**` to `docs/**` and `scripts/lib/**` in both the push list and the `changes` filter |
| `tools/lint/check_code_quality_guard_reach.py` | New guard registered, so its `GUARD_INPUT_PATHS` coverage is re-proved rather than assumed |

**Reach floor and its contrast mutation.** The audit fails below `DISCOVERY_FLOOR = 600` of the
811 Markdown files under `docs/`. The mutation that proves the floor is *this issue's own
failure re-enacted*: `test_audit_fails_on_the_floor_when_discovery_is_narrowed` scopes discovery
to a single subdirectory — the shape of #3315's sweep — over a tree containing **no offender at
all**, and asserts the run reports a floor problem rather than a clean pass over 3 files. A
second mutation (`docs/` absent entirely) asserts the same for zero. Without the floor both
report success, which is exactly how this gap survived.

## Verification

| Check | Result |
| --- | --- |
| Fleet addresses remaining in `docs/`, excluding the annotated counter-examples | 0 |
| Guard run against the branch | clean over **811** files, floor 600 |
| Guard behaviour, exercised on synthetic fixtures outside the repo | prose hit, fenced-code hit, placeholder ignored, block marker scoped to its own block only, stranded block marker flagged, file marker + stranded file marker, findings never echo the value, floor met → clean, floor narrowed → fails |
| Missing / unparseable rule set | aborts non-zero rather than reporting clean |
| Guard-reach coverage, using the meta-guard's own glob translation | both `GUARD_INPUT_PATHS` entries covered by the widened filter |
| Every `VM_ROLES.md` link added, resolved on disk | 37/37 resolve |
| Function length ≤ 30 lines; line length ≤ 120; file size vs `MAX_LINES = 600` | pass (309 lines, no ratchet entry needed) |
| ASCII diagram rows touched | measured against their box borders, all square |

Per the task constraints no pytest run and no execution of repository code was performed; the
guard's logic was exercised on a copy outside the tree, against synthetic fixtures, and CI runs
the suite.

**Out of scope, filed separately:** the same fleet range appears in **132 tracked files outside
`docs/`** (82 Markdown, and the rest configuration, service templates and test fixtures where an
address may be functional rather than descriptive). The issue's acceptance criteria are
`docs/`-scoped and that population is a different risk class, so it is reported rather than
swept here.

## Model Used

Claude Opus 5 (1M context)
